### PR TITLE
Sprint 6 P0: XML validation findings/evidence v1.1 + exception workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Plataforma de compliance e simulaÃ§Ã£o CBS/IBS (Reforma 2026): validaÃ§Ã�
 - Em API Mode, toda request envia `Authorization: Bearer <token>` e `X-Tenant-Id: <tenant>`.
 - Login real depende de backend/credenciais validos no ambiente.
 - `mickbap/tribultz-console-navigator` fica somente como referencia/export do Lovable (nao canonical).
+
+## Status Sprint 6 (P0)
+- Validacao XML com evidencias auditaveis em `/validate-xml` (NFS-e primeiro, NF-e suportado).
+- Contrato Findings + Evidence v1.1 implementado (types + schema + example payload).
+- Regras MVP aplicadas (FATAL: CST/cClassTrib/CodigoServico; ALERT: NCM e beneficios/creditos).
+- Workflow de excecao implementado em `/exceptions` (OPEN -> APPROVED/REJECTED) com eventos no audit.
 <!-- SPRINT4-START -->
 ## Runbook rapido (Dev/QA) - Chat Fiscal MVP
 

--- a/docs/sprints/S6_P0_delivery_report.md
+++ b/docs/sprints/S6_P0_delivery_report.md
@@ -1,0 +1,52 @@
+# Sprint 6 P0 - XML Validation + Exception Workflow
+
+## Scope entregue
+- Contrato Findings + Evidence v1.1 em TypeScript (`frontend/src/lib/types.ts`) e JSON Schema (`frontend/src/lib/validation/findings-evidence-v1.1.schema.json`).
+- Exemplo de payload v1.1 (`frontend/src/lib/validation/fixtures/findings-evidence-v1.1.example.json`).
+- Fixtures XML:
+  - `frontend/src/lib/validation/fixtures/nfse-ok.xml`
+  - `frontend/src/lib/validation/fixtures/nfse-com-erros.xml`
+  - `frontend/src/lib/validation/fixtures/nfe-smoke.xml`
+- Engine de validação XML (funções puras) em `frontend/src/lib/validation/xmlRules.ts`.
+- Testes unitários de regras e determinismo em `frontend/src/lib/validation/xmlRules.test.ts`.
+- Tela de validação XML em `frontend/src/app/validate-xml/page.tsx`.
+- Workflow de exceção (abertura + fila coordenador + decisão) em `frontend/src/app/exceptions/page.tsx`.
+- Integração mock/API adapter para validação XML e exceções em `frontend/src/lib/api.ts` e `frontend/src/lib/mock.ts`.
+- Navegação atualizada (`frontend/src/components/layout/Sidebar.tsx`) e detalhes de job/audit atualizados.
+
+## Regras MVP implementadas
+- FATAL:
+  - `CST` exatamente 3 dígitos.
+  - `cClassTrib` exatamente 6 dígitos.
+  - `CodigoServico` exatamente 6 dígitos.
+- ALERT:
+  - Revisão de NCM.
+  - Revisão de benefícios/créditos.
+
+Todos os findings geram `where` e `evidence_ids`, com evidência de fonte (`xml`/`print`).
+
+## Workflow de exceção
+- Operador abre exceção a partir de um finding com justificativa obrigatória.
+- Entidade `ExceptionRequest` com status `OPEN|APPROVED|REJECTED` no mock storage.
+- Coordenador decide em `/exceptions` com comentário opcional.
+- Eventos registrados no audit (`exception_opened`, `exception_approved`, `exception_rejected`), com retenção contratual MVP (`5y-contractual`).
+
+## Multi-tenant/API Mode
+- Adapter mantém headers em todas as requests API Mode:
+  - `Authorization: Bearer <token>`
+  - `X-Tenant-Id: <tenant>`
+
+## Comandos executados
+- `cd frontend && npm install`
+- `cd frontend && npm run test:rules` (PASS)
+- `cd frontend && npm run build` (PASS)
+
+## DoD Sprint 6 P0 checklist
+- [x] Colar/upload XML -> validar -> findings com evidências.
+- [x] Links/atalhos para Job e Audit no resultado.
+- [x] Abrir exceção por finding (justificativa obrigatória).
+- [x] Aprovar/reprovar exceção na fila do coordenador.
+- [x] Audit registra eventos de exceção.
+- [x] Mock determinístico por XML + tipo.
+- [x] Testes unitários das regras fatais.
+- [x] README atualizado com instruções e payload v1.1.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,12 @@
-﻿# TRIBULTZ Console v2 (Sprint 5)
+﻿# TRIBULTZ Console v2 (Sprint 6)
 
-Frontend Next.js (App Router + TypeScript + Tailwind) com **Mock Mode ON por padrão** e integração opcional com API FastAPI.
+Frontend Next.js (App Router + TypeScript + Tailwind) com Mock Mode ON por padrao e integracao opcional com API FastAPI.
 
 ## Requisitos
 - Node 20+
 - npm 10+
 
-## Instalação
+## Instalacao
 ```bash
 npm install
 ```
@@ -22,12 +22,17 @@ Acesse `http://localhost:3000/login` e clique em **Entrar (Demo)**.
 npm run build
 ```
 
-## Modos de execução
+## Testes unitarios (regras XML)
+```bash
+npm run test:rules
+```
+
+## Modos de execucao
 
 ### Mock Mode (default ON)
 - Funciona sem backend.
-- Simula chat, jobs e audit de forma determinística.
-- Simula transição de job `RUNNING -> SUCCESS`.
+- Simula chat, jobs, audit e excecoes de forma deterministica.
+- Simula transicao de job `RUNNING -> SUCCESS`.
 
 ### API Mode
 1. Configure `NEXT_PUBLIC_API_BASE_URL` no `.env.local`:
@@ -36,7 +41,7 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 ```
 2. Em `/login`, use **Entrar (API)** com `email`, `password` e tenant.
 3. O login usa `POST /api/v1/auth/login` e salva `access_token` no storage.
-4. Em `/settings`, você também pode ajustar tenant/token manualmente.
+4. Em `/settings`, voce tambem pode ajustar tenant/token manualmente.
 
 Toda request em API Mode envia:
 - `Authorization: Bearer <token>`
@@ -45,24 +50,62 @@ Toda request em API Mode envia:
 ## Fluxo principal de demo
 `Login -> Dashboard -> Chat -> Validar CBS/IBS -> Job -> Audit`
 
+## Sprint 6 (P0): Validacao XML + Excecoes
+- Nova rota: `/validate-xml` (NFS-e primeiro; NF-e suportado).
+- Contrato Findings + Evidence v1.1:
+  - Schema: `src/lib/validation/findings-evidence-v1.1.schema.json`
+  - Exemplo: `src/lib/validation/fixtures/findings-evidence-v1.1.example.json`
+- Regras MVP:
+  - FATAL: `CST` 3 digitos, `cClassTrib` 6 digitos, `CodigoServico` 6 digitos.
+  - ALERT: revisao de NCM e beneficios/creditos (placeholder explicativo).
+- Workflow de excecao:
+  - Operador abre excecao no finding (justificativa obrigatoria).
+  - Coordenador decide em `/exceptions` (aprovar/reprovar + comentario).
+  - Eventos de excecao sao registrados no audit.
+
+### Exemplo de payload v1.1
+```json
+{
+  "job": { "id": "job_xml_a12f0b31", "created_at": "2026-02-25T00:00:00.000Z", "tenant_id": "tenant-a" },
+  "audit": { "id": "audit_xml_a12f0b31", "job_id": "job_xml_a12f0b31", "events": [] },
+  "findings": [
+    {
+      "id": "F_CST_LEN",
+      "severity": "FATAL",
+      "rule_id": "CST_3_DIGITS",
+      "title": "CST inválido (esperado 3 dígitos)",
+      "where": { "field": "CST", "xpath": "/NFS-e/infNfse//CST", "snippet": "<CST>12</CST>" },
+      "recommendation": "Corrigir no ERP e reemitir (com justificativa se necessário).",
+      "evidence_ids": ["E_XML_CST_LEN"]
+    }
+  ],
+  "evidences": [
+    { "id": "E_XML_CST_LEN", "type": "xml", "label": "Trecho XML — CST", "xpath": "/NFS-e/infNfse//CST", "snippet": "<CST>12</CST>" }
+  ]
+}
+```
+
 ## Legado
-- `/validate` redireciona para `/chat`.
+- `/validate` redireciona para `/validate-xml`.
 - `/report` redireciona para `/jobs`.
 
 ## Estrutura principal
 - `src/app/login`
 - `src/app/dashboard`
 - `src/app/chat`
+- `src/app/validate-xml`
 - `src/app/jobs`
 - `src/app/jobs/[id]`
 - `src/app/audit`
+- `src/app/exceptions`
 - `src/app/settings`
 - `src/components/*`
 - `src/lib/api.ts`
 - `src/lib/mock.ts`
 - `src/lib/types.ts`
 - `src/lib/storage.ts`
+- `src/lib/validation/*`
+
 ## Governanca de repositorio
 - Repositorio canonical do produto: `mickbap/tribultz`.
 - `mickbap/tribultz-console-navigator` e apenas referencia/export do Lovable.
-

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-config-next": "16.1.6",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.20.6",
         "typescript": "^5"
       }
     },
@@ -310,6 +311,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3031,6 +3474,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -7455,6 +7940,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -24,6 +25,7 @@
     "eslint-config-next": "16.1.6",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.20.6",
     "typescript": "^5"
   }
 }

--- a/frontend/src/app/audit/page.tsx
+++ b/frontend/src/app/audit/page.tsx
@@ -11,6 +11,7 @@ import { AuditLog } from "@/lib/types";
 function AuditContent() {
   const searchParams = useSearchParams();
   const jobIdFromUrl = searchParams.get("job_id") ?? "";
+  const auditIdFromUrl = searchParams.get("audit_id") ?? "";
 
   const [audits, setAudits] = useState<AuditLog[]>([]);
   const [loading, setLoading] = useState(true);
@@ -21,12 +22,19 @@ function AuditContent() {
 
   useEffect(() => {
     setLoading(true);
-    setQuery(jobIdFromUrl);
-    getAudits(jobIdFromUrl || undefined)
-      .then(setAudits)
+    setQuery(jobIdFromUrl || auditIdFromUrl);
+    const load = auditIdFromUrl ? getAudits() : getAudits(jobIdFromUrl || undefined);
+    load
+      .then((rows) => {
+        if (auditIdFromUrl) {
+          setAudits(rows.filter((row) => row.id === auditIdFromUrl));
+          return;
+        }
+        setAudits(rows);
+      })
       .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false));
-  }, [jobIdFromUrl]);
+  }, [jobIdFromUrl, auditIdFromUrl]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/frontend/src/app/exceptions/page.tsx
+++ b/frontend/src/app/exceptions/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { JsonViewer } from "@/components/common/JsonViewer";
+import { Skeleton } from "@/components/common/Skeleton";
+import { Toast } from "@/components/common/Toast";
+import { decideExceptionRequest, listExceptionRequests } from "@/lib/api";
+import { ExceptionRequest } from "@/lib/types";
+
+export default function ExceptionsPage() {
+  const [rows, setRows] = useState<ExceptionRequest[]>([]);
+  const [selected, setSelected] = useState<ExceptionRequest | null>(null);
+  const [decisionComment, setDecisionComment] = useState("");
+  const [filter, setFilter] = useState<"ALL" | "OPEN" | "APPROVED" | "REJECTED">("OPEN");
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState<{ tone: "success" | "error" | "info"; msg: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function reload(): Promise<void> {
+    setLoading(true);
+    try {
+      const data = await listExceptionRequests();
+      setRows(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Falha ao carregar exceções.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void reload();
+  }, []);
+
+  const filtered = useMemo(
+    () => (filter === "ALL" ? rows : rows.filter((r) => r.status === filter)),
+    [rows, filter],
+  );
+
+  async function decide(status: "APPROVED" | "REJECTED"): Promise<void> {
+    if (!selected) return;
+    try {
+      await decideExceptionRequest(selected.id, {
+        status,
+        decision_comment: decisionComment.trim() || undefined,
+        decided_by: "coordenador.demo",
+      });
+      setToast({ tone: "success", msg: `Exceção ${status === "APPROVED" ? "aprovada" : "reprovada"} com sucesso.` });
+      setSelected(null);
+      setDecisionComment("");
+      await reload();
+    } catch (err) {
+      setToast({ tone: "error", msg: err instanceof Error ? err.message : "Falha ao decidir exceção." });
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">Fila de exceções</h1>
+        <p className="text-sm text-slate-500">Workflow Operador → Coordenador com trilha de auditoria.</p>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {(["OPEN", "APPROVED", "REJECTED", "ALL"] as const).map((opt) => (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => setFilter(opt)}
+            className={`rounded border px-3 py-1.5 text-sm ${filter === opt ? "border-tribultz-600 bg-tribultz-50 text-tribultz-700" : "border-slate-300"}`}
+          >
+            {opt}
+          </button>
+        ))}
+      </div>
+
+      <section className="rounded-xl border border-slate-200 bg-white p-4">
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <p className="text-sm text-slate-500">Nenhuma exceção encontrada.</p>
+        ) : (
+          <div className="scroll-thin overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-left text-slate-500">
+                  <th className="px-2 py-2">ID</th>
+                  <th className="px-2 py-2">Job</th>
+                  <th className="px-2 py-2">Finding</th>
+                  <th className="px-2 py-2">Status</th>
+                  <th className="px-2 py-2">Criada em</th>
+                  <th className="px-2 py-2">Ação</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((item) => (
+                  <tr key={item.id} className="border-b border-slate-100">
+                    <td className="px-2 py-2 font-mono text-xs">{item.id}</td>
+                    <td className="px-2 py-2 font-mono text-xs">{item.job_id}</td>
+                    <td className="px-2 py-2 font-mono text-xs">{item.finding_id}</td>
+                    <td className="px-2 py-2">{item.status}</td>
+                    <td className="px-2 py-2 text-slate-600">{new Date(item.created_at).toLocaleString()}</td>
+                    <td className="px-2 py-2">
+                      <button
+                        type="button"
+                        onClick={() => setSelected(item)}
+                        className="text-tribultz-700 hover:underline"
+                      >
+                        Detalhar
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {selected ? (
+        <div className="fixed inset-0 z-40 bg-slate-900/40" role="dialog" aria-modal="true">
+          <div className="mx-auto mt-10 w-[95%] max-w-2xl rounded-2xl border border-slate-200 bg-white p-4 shadow-xl">
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold text-slate-800">Detalhe da exceção</p>
+                <p className="text-xs font-mono text-slate-500">{selected.id}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelected(null)}
+                className="rounded border border-slate-300 px-2 py-1 text-xs"
+              >
+                Fechar
+              </button>
+            </div>
+
+            <JsonViewer
+              title="Payload da exceção"
+              data={{
+                ...selected,
+                retention_requirement: "5 anos (contractual MVP: armazenado e exportável)",
+              }}
+            />
+
+            {selected.status === "OPEN" ? (
+              <div className="mt-3 space-y-2">
+                <label className="block text-sm">
+                  <span className="mb-1 block text-slate-600">Comentário da decisão</span>
+                  <textarea
+                    value={decisionComment}
+                    onChange={(e) => setDecisionComment(e.target.value)}
+                    className="min-h-20 w-full rounded border border-slate-300 p-2 text-sm"
+                    placeholder="Registrar base da aprovação/reprovação."
+                  />
+                </label>
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void decide("REJECTED")}
+                    className="rounded border border-red-300 bg-red-50 px-3 py-1.5 text-sm text-red-700"
+                  >
+                    Reprovar
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void decide("APPROVED")}
+                    className="rounded border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-sm text-emerald-700"
+                  >
+                    Aprovar
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <Toast message={error} tone="error" onClose={() => setError(null)} /> : null}
+      {toast ? <Toast message={toast.msg} tone={toast.tone} onClose={() => setToast(null)} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -82,12 +82,33 @@ export default function JobDetailPage() {
             )}
           </section>
 
+          {job.findings?.length ? (
+            <section className="rounded-xl border border-slate-200 bg-white p-4">
+              <h2 className="mb-2 text-sm font-semibold text-slate-700">Findings da validação</h2>
+              <ul className="space-y-2">
+                {job.findings.map((finding) => (
+                  <li key={finding.id} className="rounded border border-slate-200 p-2 text-sm">
+                    <p className="font-semibold">
+                      {finding.severity} - {finding.title}
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      rule_id: {finding.rule_id} | finding_id: {finding.id}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
           <section className="rounded-xl border border-slate-200 bg-white p-4">
             <h2 className="text-sm font-semibold text-slate-700">Evidências</h2>
             <EvidenceList evidence={job.evidence} />
-            <div className="mt-3">
+            <div className="mt-3 flex flex-wrap gap-4">
               <Link href={`/audit?job_id=${job.id}`} className="text-sm font-medium text-tribultz-700 hover:underline">
                 Abrir auditoria relacionada
+              </Link>
+              <Link href="/exceptions" className="text-sm font-medium text-tribultz-700 hover:underline">
+                Abrir fila de exceções
               </Link>
             </div>
           </section>

--- a/frontend/src/app/validate-xml/page.tsx
+++ b/frontend/src/app/validate-xml/page.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import Link from "next/link";
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import { Skeleton } from "@/components/common/Skeleton";
+import { Toast } from "@/components/common/Toast";
+import { getJob, openExceptionRequest, validateXml } from "@/lib/api";
+import { Finding, Job, ValidateXmlRequest, ValidationEvidence, ValidationResultV11, XmlDocumentType } from "@/lib/types";
+
+function severityClasses(severity: Finding["severity"]): string {
+  if (severity === "FATAL") {
+    return "border-red-300 bg-red-50 text-red-800";
+  }
+  return "border-amber-300 bg-amber-50 text-amber-800";
+}
+
+function severityLabel(severity: Finding["severity"]): string {
+  return severity === "FATAL" ? "FATAL (bloqueante)" : "ALERT";
+}
+
+function shortSnippet(value?: string): string {
+  if (!value) return "Sem trecho disponível.";
+  return value.length > 300 ? `${value.slice(0, 297)}...` : value;
+}
+
+function validateInput(xml: string): string | null {
+  if (!xml.trim()) return "Informe um XML para validar.";
+  if (!xml.includes("<") || !xml.includes(">")) return "Conteúdo não parece XML válido.";
+  return null;
+}
+
+export default function ValidateXmlPage() {
+  const [documentType, setDocumentType] = useState<XmlDocumentType>("NFSE");
+  const [xmlText, setXmlText] = useState("");
+  const [source, setSource] = useState<"paste" | "upload">("paste");
+  const [result, setResult] = useState<ValidationResultV11 | null>(null);
+  const [job, setJob] = useState<Job | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [openingExceptionFor, setOpeningExceptionFor] = useState<Finding | null>(null);
+  const [justification, setJustification] = useState("");
+  const [toast, setToast] = useState<{ tone: "success" | "error" | "info"; msg: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const evidenceMap = useMemo(() => {
+    const map = new Map<string, ValidationEvidence>();
+    for (const ev of result?.evidences ?? []) {
+      map.set(ev.id, ev);
+    }
+    return map;
+  }, [result]);
+
+  const fatalCount = useMemo(
+    () => result?.findings.filter((f) => f.severity === "FATAL").length ?? 0,
+    [result],
+  );
+
+  async function onFileChange(event: ChangeEvent<HTMLInputElement>): Promise<void> {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    setXmlText(text);
+    setSource("upload");
+  }
+
+  async function refreshJob(jobId: string): Promise<void> {
+    try {
+      const next = await getJob(jobId);
+      if (next) setJob(next);
+    } catch {
+      // best-effort status refresh
+    }
+  }
+
+  async function onSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setToast(null);
+
+    const validationError = validateInput(xmlText);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    setResult(null);
+    setJob(null);
+
+    try {
+      const payload: ValidateXmlRequest = {
+        document_type: documentType,
+        xml: xmlText,
+        source,
+      };
+      const response = await validateXml(payload);
+      setResult(response);
+      await refreshJob(response.job.id);
+      window.setTimeout(() => {
+        void refreshJob(response.job.id);
+      }, 2000);
+      setToast({ tone: "success", msg: "Validação executada com sucesso." });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Falha ao validar XML.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitException(): Promise<void> {
+    if (!result || !openingExceptionFor) return;
+    if (!justification.trim()) {
+      setToast({ tone: "error", msg: "Justificativa obrigatória para abrir exceção." });
+      return;
+    }
+    try {
+      await openExceptionRequest({
+        job_id: result.job.id,
+        finding_id: openingExceptionFor.id,
+        rule_id: openingExceptionFor.rule_id,
+        justification: justification.trim(),
+        created_by: "operador.demo",
+      });
+      setOpeningExceptionFor(null);
+      setJustification("");
+      setToast({ tone: "success", msg: "Exceção aberta e enviada para fila do coordenador." });
+      await refreshJob(result.job.id);
+    } catch (err) {
+      setToast({ tone: "error", msg: err instanceof Error ? err.message : "Falha ao abrir exceção." });
+    }
+  }
+
+  function copySnippet(snippet?: string): void {
+    if (!snippet) return;
+    navigator.clipboard
+      .writeText(snippet)
+      .then(() => setToast({ tone: "info", msg: "Trecho copiado." }))
+      .catch(() => setToast({ tone: "error", msg: "Não foi possível copiar o trecho." }));
+  }
+
+  return (
+    <section className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">Validar XML</h1>
+        <p className="text-sm text-slate-500">
+          NFS-e primeiro (NF-e suportado). Toda inconsistência gera finding com evidência rastreável.
+        </p>
+      </header>
+
+      <form onSubmit={onSubmit} className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="grid gap-3 md:grid-cols-[14rem_1fr]">
+          <label className="text-sm">
+            <span className="mb-1 block text-slate-500">Tipo do documento</span>
+            <select
+              value={documentType}
+              onChange={(e) => setDocumentType(e.target.value as XmlDocumentType)}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+            >
+              <option value="NFSE">NFS-e</option>
+              <option value="NFE">NF-e</option>
+            </select>
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-slate-500">Upload XML</span>
+            <input
+              type="file"
+              accept=".xml,text/xml"
+              onChange={(e) => void onFileChange(e)}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+            />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="mb-1 block text-slate-500">Cole o XML</span>
+          <textarea
+            value={xmlText}
+            onChange={(e) => {
+              setXmlText(e.target.value);
+              setSource("paste");
+            }}
+            placeholder="<NFS-e>...</NFS-e>"
+            className="min-h-56 w-full rounded-lg border border-slate-300 p-3 font-mono text-xs"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-lg bg-tribultz-600 px-4 py-2 text-sm font-semibold text-white hover:bg-tribultz-700 disabled:opacity-70"
+          >
+            {loading ? "Validando..." : "Validar"}
+          </button>
+          {result ? (
+            <>
+              <Link href={`/jobs/${result.job.id}`} className="text-sm font-medium text-tribultz-700 hover:underline">
+                Abrir Job
+              </Link>
+              <Link
+                href={`/audit?job_id=${encodeURIComponent(result.job.id)}`}
+                className="text-sm font-medium text-tribultz-700 hover:underline"
+              >
+                Abrir Audit
+              </Link>
+            </>
+          ) : null}
+        </div>
+      </form>
+
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-28 w-full" />
+        </div>
+      ) : null}
+
+      {result ? (
+        <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4">
+          <div className={`rounded-lg border p-3 text-sm ${fatalCount > 0 ? "border-red-300 bg-red-50" : "border-emerald-300 bg-emerald-50"}`}>
+            <p className="font-semibold">
+              {fatalCount > 0
+                ? `Bloqueio visual ativo: ${fatalCount} finding(s) FATAL.`
+                : "Sem bloqueios FATAL. Exceções ALERT podem seguir com justificativa."}
+            </p>
+            <p className="text-xs text-slate-600">
+              Job: <span className="font-mono">{result.job.id}</span> | Audit: <span className="font-mono">{result.audit.id}</span>
+              {job ? ` | Status do job: ${job.status}` : ""}
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {result.findings.map((finding) => {
+              const evidences = finding.evidence_ids.map((id) => evidenceMap.get(id)).filter(Boolean) as ValidationEvidence[];
+              return (
+                <article key={finding.id} className={`rounded-xl border p-3 ${severityClasses(finding.severity)}`}>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide">{severityLabel(finding.severity)}</p>
+                      <h2 className="text-base font-semibold">{finding.title}</h2>
+                      <p className="text-xs">
+                        rule_id: <span className="font-mono">{finding.rule_id}</span> | finding_id:{" "}
+                        <span className="font-mono">{finding.id}</span>
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setOpeningExceptionFor(finding)}
+                      className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100"
+                    >
+                      Abrir exceção
+                    </button>
+                  </div>
+
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    <div className="rounded border border-slate-200 bg-white p-2 text-xs text-slate-700">
+                      <p>
+                        <span className="font-semibold">Campo:</span> {finding.where.field ?? "-"}
+                      </p>
+                      <p className="break-all">
+                        <span className="font-semibold">XPath:</span> {finding.where.xpath ?? "-"}
+                      </p>
+                      <p className="font-semibold">Trecho:</p>
+                      <pre className="scroll-thin max-h-28 overflow-auto rounded bg-slate-100 p-2 text-[11px]">
+                        {shortSnippet(finding.where.snippet)}
+                      </pre>
+                    </div>
+                    <div className="rounded border border-slate-200 bg-white p-2 text-xs text-slate-700">
+                      <p className="font-semibold">Recomendação</p>
+                      <p>{finding.recommendation}</p>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 space-y-2">
+                    <p className="text-xs font-semibold">Evidências de fonte</p>
+                    {evidences.length === 0 ? (
+                      <p className="text-xs">Sem evidências vinculadas.</p>
+                    ) : (
+                      evidences.map((ev) => (
+                        <div key={ev.id} className="rounded border border-slate-200 bg-white p-2 text-xs text-slate-700">
+                          <p>
+                            <span className="font-semibold">{ev.label}</span> ({ev.type}) [{ev.id}]
+                          </p>
+                          {ev.xpath ? <p className="break-all">XPath: {ev.xpath}</p> : null}
+                          {ev.snippet ? (
+                            <>
+                              <pre className="scroll-thin mt-1 max-h-24 overflow-auto rounded bg-slate-100 p-2 text-[11px]">
+                                {shortSnippet(ev.snippet)}
+                              </pre>
+                              <button
+                                type="button"
+                                onClick={() => copySnippet(ev.snippet)}
+                                className="mt-1 rounded border border-slate-300 px-2 py-1 text-[11px] font-semibold hover:bg-slate-100"
+                              >
+                                Copiar snippet
+                              </button>
+                            </>
+                          ) : null}
+                          {ev.href ? (
+                            <p className="mt-1">
+                              <a className="text-tribultz-700 underline" href={ev.href}>
+                                Abrir link de evidência
+                              </a>
+                            </p>
+                          ) : null}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {!loading && !result ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-5 text-sm text-slate-500">
+          Cole ou envie um XML e clique em Validar para gerar findings e evidências.
+        </div>
+      ) : null}
+
+      {openingExceptionFor ? (
+        <div className="fixed inset-0 z-40 bg-slate-900/40" role="dialog" aria-modal="true">
+          <div className="mx-auto mt-12 w-[94%] max-w-xl rounded-2xl border border-slate-200 bg-white p-4 shadow-xl">
+            <h3 className="text-lg font-semibold text-slate-900">Abrir exceção</h3>
+            <p className="text-xs text-slate-500">
+              finding_id <span className="font-mono">{openingExceptionFor.id}</span> | rule_id{" "}
+              <span className="font-mono">{openingExceptionFor.rule_id}</span>
+            </p>
+            <label className="mt-3 block text-sm">
+              <span className="mb-1 block text-slate-600">Justificativa (obrigatória)</span>
+              <textarea
+                value={justification}
+                onChange={(e) => setJustification(e.target.value)}
+                className="min-h-24 w-full rounded-lg border border-slate-300 p-2 text-sm"
+                placeholder="Descreva motivo, base legal e plano de correção."
+              />
+            </label>
+            <div className="mt-3 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setOpeningExceptionFor(null);
+                  setJustification("");
+                }}
+                className="rounded border border-slate-300 px-3 py-1.5 text-sm"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={() => void submitException()}
+                className="rounded bg-tribultz-600 px-3 py-1.5 text-sm font-semibold text-white"
+              >
+                Enviar para aprovação
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <Toast message={error} tone="error" onClose={() => setError(null)} /> : null}
+      {toast ? <Toast message={toast.msg} tone={toast.tone} onClose={() => setToast(null)} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/app/validate/page.tsx
+++ b/frontend/src/app/validate/page.tsx
@@ -1,5 +1,5 @@
 ﻿import { redirect } from "next/navigation";
 
 export default function ValidateLegacyPage() {
-  redirect("/chat");
+  redirect("/validate-xml");
 }

--- a/frontend/src/components/chat/EvidenceList.tsx
+++ b/frontend/src/components/chat/EvidenceList.tsx
@@ -1,6 +1,7 @@
 ﻿"use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { Evidence } from "@/lib/types";
 
 function iconFor(type: Evidence["type"]): string {
@@ -9,6 +10,10 @@ function iconFor(type: Evidence["type"]): string {
       return "JB";
     case "audit":
       return "AU";
+    case "xml":
+      return "XML";
+    case "print":
+      return "PR";
     case "file":
       return "AR";
     case "link":
@@ -18,35 +23,70 @@ function iconFor(type: Evidence["type"]): string {
   }
 }
 
-function hrefFor(item: Evidence): string {
+function hrefFor(item: Evidence): string | null {
   if (item.type === "job" && item.job_id) return `/jobs/${item.job_id}`;
   if (item.type === "audit") {
     if (item.audit_id) return `/audit?audit_id=${encodeURIComponent(item.audit_id)}`;
     if (item.job_id) return `/audit?job_id=${encodeURIComponent(item.job_id)}`;
   }
-  return item.href || "#";
+  if (item.href) return item.href;
+  return null;
 }
 
 export function EvidenceList({ evidence }: { evidence: Evidence[] }) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
   if (!evidence.length) return null;
+
   return (
-    <ul className="mt-3 flex flex-wrap gap-2" aria-label="Evidências">
-      {evidence.map((item, idx) => (
-        <li key={`${item.type}-${item.href}-${idx}`}>
-          <Link
-            href={hrefFor(item)}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-1 text-sm text-slate-700 hover:border-tribultz-400 hover:text-tribultz-700"
-          >
-            <span
-              aria-hidden
-              className="inline-grid h-5 w-5 place-items-center rounded-full bg-slate-100 text-[10px] font-semibold text-slate-600"
-            >
-              {iconFor(item.type)}
-            </span>
-            <span>{item.label}</span>
-          </Link>
-        </li>
-      ))}
+    <ul className="mt-3 space-y-2" aria-label="Evidências">
+      {evidence.map((item, idx) => {
+        const href = hrefFor(item);
+        const key = `${item.id ?? item.label}-${idx}`;
+
+        return (
+          <li key={key} className="rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-700">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                aria-hidden
+                className="inline-grid h-5 w-7 place-items-center rounded-full bg-slate-100 px-1 text-[10px] font-semibold text-slate-600"
+              >
+                {iconFor(item.type)}
+              </span>
+              <span className="font-medium">{item.label}</span>
+              {item.id ? <span className="font-mono text-xs text-slate-500">[{item.id}]</span> : null}
+              {href ? (
+                <Link href={href} className="text-tribultz-700 hover:underline">
+                  Abrir
+                </Link>
+              ) : null}
+            </div>
+
+            {item.xpath ? <p className="mt-1 text-xs text-slate-500">XPath: {item.xpath}</p> : null}
+            {item.snippet ? (
+              <div className="mt-1">
+                <pre className="scroll-thin max-h-20 overflow-auto rounded bg-slate-100 p-2 text-[11px]">{item.snippet}</pre>
+                <button
+                  type="button"
+                  onClick={() => {
+                    navigator.clipboard
+                      .writeText(item.snippet ?? "")
+                      .then(() => {
+                        setCopiedId(key);
+                        window.setTimeout(() => setCopiedId((curr) => (curr === key ? null : curr)), 1200);
+                      })
+                      .catch(() => {
+                        setCopiedId(null);
+                      });
+                  }}
+                  className="mt-1 rounded border border-slate-300 px-2 py-1 text-xs hover:bg-slate-100"
+                >
+                  {copiedId === key ? "Copiado" : "Copiar snippet"}
+                </button>
+              </div>
+            ) : null}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,9 +5,11 @@ import { usePathname } from "next/navigation";
 
 const links = [
   { href: "/dashboard", label: "Painel" },
+  { href: "/validate-xml", label: "Validar XML" },
   { href: "/chat", label: "Chat" },
   { href: "/jobs", label: "Jobs" },
   { href: "/audit", label: "Auditoria" },
+  { href: "/exceptions", label: "Exceções" },
   { href: "/settings", label: "Configurações" },
 ];
 

--- a/frontend/src/lib/mock.ts
+++ b/frontend/src/lib/mock.ts
@@ -1,12 +1,29 @@
-﻿import { AuditLog, ChatApiResponse, ChatMessage, ChatRequest, Conversation, Evidence, Job, JobStatus } from "./types";
+﻿import {
+  AuditLog,
+  ChatApiResponse,
+  ChatMessage,
+  ChatRequest,
+  Conversation,
+  ExceptionDecision,
+  ExceptionRequest,
+  Job,
+  JobStatus,
+  ValidateXmlRequest,
+  ValidationResultV11,
+} from "./types";
+import { validateXmlWithRules } from "./validation/xmlRules";
 
-type MockJob = Job & { readyAt?: number };
+type MockJob = Job & {
+  readyAt?: number;
+  pendingValidation?: ValidationResultV11;
+};
 
 type MockState = {
   counter: number;
   conversations: Conversation[];
   jobs: MockJob[];
   audits: AuditLog[];
+  exceptions: ExceptionRequest[];
 };
 
 const TENANT_COUNT = 20;
@@ -65,7 +82,6 @@ function bootstrapState(tenantId: string): MockState {
     const statuses: JobStatus[] = ["SUCCESS", "FAILED", "RUNNING", "QUEUED"];
     const status = statuses[Math.floor(rand() * statuses.length)];
     const createdAt = new Date(Date.now() - (i + 1) * 3_600_000).toISOString();
-    const evidence: Evidence[] = [{ type: "job", job_id: id, href: `/jobs/${id}`, label: "Job de validação" }];
 
     jobs.push({
       id,
@@ -93,7 +109,7 @@ function bootstrapState(tenantId: string): MockState {
         status === "SUCCESS"
           ? `## Relatório\n\nValidação concluída para **INV-${1000 + i}** com status **PASS**.`
           : null,
-      evidence,
+      evidence: [{ type: "job", job_id: id, href: `/jobs/${id}`, label: "Job de validação" }],
       readyAt: status === "RUNNING" ? Date.now() + 90_000 + i * 250 : undefined,
     });
 
@@ -132,29 +148,67 @@ function bootstrapState(tenantId: string): MockState {
     conversations,
     jobs,
     audits,
+    exceptions: [],
   };
 }
 
-function syncTransitions(state: MockState): MockState {
-  const changed = state.jobs.some((job) => job.status === "RUNNING" && job.readyAt && job.readyAt <= Date.now());
-  if (!changed) return state;
+function upsertConversation(state: MockState, conversation: Conversation): void {
+  const idx = state.conversations.findIndex((c) => c.id === conversation.id);
+  if (idx === -1) state.conversations.unshift(conversation);
+  else state.conversations[idx] = conversation;
+}
 
-  const updatedJobs = state.jobs.map((job) => {
-    if (job.status === "RUNNING" && job.readyAt && job.readyAt <= Date.now()) {
+function addAudit(state: MockState, row: AuditLog): void {
+  state.audits.unshift(row);
+}
+
+function syncTransitions(state: MockState): MockState {
+  const now = Date.now();
+  let changed = false;
+
+  const jobs = state.jobs.map((job) => {
+    if (job.status === "RUNNING" && job.readyAt && job.readyAt <= now) {
+      changed = true;
+      const succeededOutput = job.pendingValidation
+        ? {
+            status: "PASS",
+            contract_version: "findings-evidence-v1.1",
+            findings: job.pendingValidation.findings,
+            evidences: job.pendingValidation.evidences,
+          }
+        : { status: "PASS", calculated_cbs: "0.00", calculated_ibs: "0.00" };
+
       return {
         ...job,
         status: "SUCCESS" as const,
         updatedAt: nowIso(),
         readyAt: undefined,
-        output: { status: "PASS", calculated_cbs: "0.00", calculated_ibs: "0.00" },
-        reportMarkdown: "## Relatório\n\nProcessamento concluído com sucesso.",
+        pendingValidation: undefined,
+        output: succeededOutput,
+        reportMarkdown: job.pendingValidation
+          ? "## Resultado\n\nValidação XML concluída com evidências auditáveis."
+          : "## Relatório\n\nProcessamento concluído com sucesso.",
+        findings: job.pendingValidation?.findings ?? job.findings,
         evidence: [
-          ...job.evidence,
+          ...(job.pendingValidation?.evidences.map((ev) => ({
+            id: ev.id,
+            type: ev.type,
+            label: ev.label,
+            href: ev.href,
+            xpath: ev.xpath,
+            snippet: ev.snippet,
+          })) ?? job.evidence),
           {
             type: "audit" as const,
             audit_id: `audit-${job.id}`,
             href: `/audit?job_id=${job.id}`,
             label: "Audit log",
+          },
+          {
+            type: "job" as const,
+            job_id: job.id,
+            href: `/jobs/${job.id}`,
+            label: "Job",
           },
         ],
       };
@@ -162,9 +216,13 @@ function syncTransitions(state: MockState): MockState {
     return job;
   });
 
+  if (!changed) {
+    return state;
+  }
+
   const existingAuditIds = new Set(state.audits.map((a) => a.id));
   const newAudits: AuditLog[] = [];
-  for (const job of updatedJobs) {
+  for (const job of jobs) {
     if (job.status === "SUCCESS") {
       const auditId = `audit-${job.id}`;
       if (!existingAuditIds.has(auditId)) {
@@ -182,8 +240,17 @@ function syncTransitions(state: MockState): MockState {
 
   return {
     ...state,
-    jobs: updatedJobs,
+    jobs,
     audits: [...newAudits, ...state.audits],
+  };
+}
+
+function makeMessage(role: "user" | "assistant", markdown: string): ChatMessage {
+  return {
+    id: `msg-${role}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    role,
+    markdown,
+    createdAt: nowIso(),
   };
 }
 
@@ -206,7 +273,7 @@ export async function mockPostChatMessage(tenantId: string, payload: ChatRequest
   const message = payload.message.trim();
   const isValidate = /validate|validar|cbs|ibs/i.test(message);
 
-  let conversation =
+  const conversation =
     state.conversations.find((c) => c.id === payload.conversation_id) ??
     {
       id: `conv-${tenantId}-${String(state.counter++).padStart(4, "0")}`,
@@ -215,13 +282,7 @@ export async function mockPostChatMessage(tenantId: string, payload: ChatRequest
       messages: [] as ChatMessage[],
     };
 
-  const userMsg: ChatMessage = {
-    id: `msg-${tenantId}-${String(state.counter++).padStart(5, "0")}`,
-    role: "user",
-    markdown: message,
-    createdAt: nowIso(),
-  };
-  conversation.messages.push(userMsg);
+  conversation.messages.push(makeMessage("user", message));
 
   if (isValidate) {
     const jobId = `job-${tenantId}-live-${String(state.counter++).padStart(4, "0")}`;
@@ -256,15 +317,19 @@ export async function mockPostChatMessage(tenantId: string, payload: ChatRequest
       "- **Recomendação prática:** acompanhe o job até SUCCESS.",
     ].join("\n");
 
-    const assistant: ChatMessage = {
-      id: `msg-${tenantId}-${String(state.counter++).padStart(5, "0")}`,
-      role: "assistant",
-      markdown: assistantMarkdown,
-      evidence: job.evidence,
-      createdAt: nowIso(),
-    };
+    const assistant = makeMessage("assistant", assistantMarkdown);
+    assistant.evidence = job.evidence;
     conversation.messages.push(assistant);
     conversation.updatedAt = nowIso();
+
+    addAudit(state, {
+      id: `audit-${jobId}-created`,
+      tenantId,
+      jobId,
+      action: "chat_validation_started",
+      createdAt: nowIso(),
+      payload: { source: "chat", message },
+    });
 
     upsertConversation(state, conversation);
     saveState(tenantId, state);
@@ -279,13 +344,7 @@ export async function mockPostChatMessage(tenantId: string, payload: ChatRequest
   }
 
   const reply = "Posso ajudar com validações fiscais. Clique em **Validar CBS/IBS** para iniciar.";
-  const assistant: ChatMessage = {
-    id: `msg-${tenantId}-${String(state.counter++).padStart(5, "0")}`,
-    role: "assistant",
-    markdown: reply,
-    createdAt: nowIso(),
-  };
-  conversation.messages.push(assistant);
+  conversation.messages.push(makeMessage("assistant", reply));
   conversation.updatedAt = nowIso();
 
   upsertConversation(state, conversation);
@@ -298,10 +357,65 @@ export async function mockPostChatMessage(tenantId: string, payload: ChatRequest
   };
 }
 
-function upsertConversation(state: MockState, conversation: Conversation): void {
-  const idx = state.conversations.findIndex((c) => c.id === conversation.id);
-  if (idx === -1) state.conversations.unshift(conversation);
-  else state.conversations[idx] = conversation;
+export async function mockValidateXml(tenantId: string, payload: ValidateXmlRequest): Promise<ValidationResultV11> {
+  const state = loadState(tenantId);
+  const validation = validateXmlWithRules({
+    tenantId,
+    documentType: payload.document_type,
+    xml: payload.xml,
+  });
+
+  const current = state.jobs.find((j) => j.id === validation.job.id);
+  const findings = validation.findings;
+  const evidence = validation.evidences.map((ev) => ({
+    id: ev.id,
+    type: ev.type,
+    label: ev.label,
+    href: ev.href,
+    xpath: ev.xpath,
+    snippet: ev.snippet,
+  }));
+
+  const job: MockJob = {
+    id: validation.job.id,
+    tenantId,
+    jobType: "xml_validation",
+    status: "RUNNING",
+    createdAt: current?.createdAt ?? validation.job.created_at,
+    updatedAt: nowIso(),
+    input: {
+      document_type: payload.document_type,
+      source: payload.source ?? "paste",
+    },
+    output: null,
+    reportMarkdown: "## Resultado\n\nValidação em processamento.",
+    evidence,
+    findings,
+    readyAt: Date.now() + 1500,
+    pendingValidation: validation,
+  };
+
+  if (current) {
+    const idx = state.jobs.findIndex((j) => j.id === job.id);
+    state.jobs[idx] = job;
+  } else {
+    state.jobs.unshift(job);
+  }
+
+  addAudit(state, {
+    id: `${validation.audit.id}-started`,
+    tenantId,
+    jobId: validation.job.id,
+    action: "xml_validation_started",
+    createdAt: nowIso(),
+    payload: {
+      document_type: payload.document_type,
+      findings_total: validation.findings.length,
+    },
+  });
+
+  saveState(tenantId, state);
+  return validation;
 }
 
 export async function mockListJobs(tenantId: string): Promise<Job[]> {
@@ -319,4 +433,88 @@ export async function mockListAudits(tenantId: string, jobId?: string): Promise<
   const filtered = jobId ? state.audits.filter((log) => log.jobId === jobId) : state.audits;
   return [...filtered].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 }
+
+export async function mockOpenException(
+  tenantId: string,
+  payload: {
+    job_id: string;
+    finding_id: string;
+    rule_id: string;
+    justification: string;
+    created_by: string;
+  },
+): Promise<ExceptionRequest> {
+  const state = loadState(tenantId);
+  const item: ExceptionRequest = {
+    id: `exc-${tenantId}-${String(state.counter++).padStart(5, "0")}`,
+    tenant_id: tenantId,
+    job_id: payload.job_id,
+    finding_id: payload.finding_id,
+    rule_id: payload.rule_id,
+    justification: payload.justification,
+    status: "OPEN",
+    created_by: payload.created_by,
+    created_at: nowIso(),
+  };
+  state.exceptions.unshift(item);
+  addAudit(state, {
+    id: `audit-${item.id}-opened`,
+    tenantId,
+    jobId: payload.job_id,
+    action: "exception_opened",
+    createdAt: nowIso(),
+    payload: {
+      exception_id: item.id,
+      finding_id: item.finding_id,
+      rule_id: item.rule_id,
+      retention: "5y-contractual",
+    },
+  });
+  saveState(tenantId, state);
+  return item;
+}
+
+export async function mockListExceptions(tenantId: string): Promise<ExceptionRequest[]> {
+  const state = loadState(tenantId);
+  return [...state.exceptions].sort((a, b) => b.created_at.localeCompare(a.created_at));
+}
+
+export async function mockDecideException(
+  tenantId: string,
+  exceptionId: string,
+  decision: ExceptionDecision,
+): Promise<ExceptionRequest> {
+  const state = loadState(tenantId);
+  const idx = state.exceptions.findIndex((row) => row.id === exceptionId);
+  if (idx === -1) {
+    throw new Error(`Exceção ${exceptionId} não encontrada.`);
+  }
+  const current = state.exceptions[idx];
+  const next: ExceptionRequest = {
+    ...current,
+    status: decision.status,
+    decided_by: decision.decided_by,
+    decided_at: nowIso(),
+    decision_comment: decision.decision_comment,
+  };
+  state.exceptions[idx] = next;
+
+  addAudit(state, {
+    id: `audit-${exceptionId}-${decision.status.toLowerCase()}`,
+    tenantId,
+    jobId: current.job_id,
+    action: decision.status === "APPROVED" ? "exception_approved" : "exception_rejected",
+    createdAt: nowIso(),
+    payload: {
+      exception_id: exceptionId,
+      decision_comment: decision.decision_comment ?? "",
+      decided_by: decision.decided_by,
+      retention: "5y-contractual",
+    },
+  });
+
+  saveState(tenantId, state);
+  return next;
+}
+
 

--- a/frontend/src/lib/validation/findings-evidence-v1.1.schema.json
+++ b/frontend/src/lib/validation/findings-evidence-v1.1.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tribultz.local/schemas/findings-evidence-v1.1.json",
+  "title": "Findings + Evidence v1.1",
+  "type": "object",
+  "required": ["job", "audit", "findings", "evidences"],
+  "properties": {
+    "job": {
+      "type": "object",
+      "required": ["id", "created_at", "tenant_id"],
+      "properties": {
+        "id": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "tenant_id": { "type": "string" }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["id", "job_id", "events"],
+      "properties": {
+        "id": { "type": "string" },
+        "job_id": { "type": "string" },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "action", "created_at", "payload"],
+            "properties": {
+              "id": { "type": "string" },
+              "action": { "type": "string" },
+              "created_at": { "type": "string", "format": "date-time" },
+              "payload": { "type": "object" }
+            }
+          }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "severity", "rule_id", "title", "where", "recommendation", "evidence_ids"],
+        "properties": {
+          "id": { "type": "string" },
+          "severity": { "enum": ["FATAL", "ALERT"] },
+          "rule_id": { "type": "string" },
+          "title": { "type": "string" },
+          "where": {
+            "type": "object",
+            "properties": {
+              "field": { "type": "string" },
+              "xpath": { "type": "string" },
+              "snippet": { "type": "string" }
+            }
+          },
+          "recommendation": { "type": "string" },
+          "evidence_ids": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "evidences": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "label"],
+        "properties": {
+          "id": { "type": "string" },
+          "type": { "enum": ["xml", "link", "print", "job", "audit"] },
+          "label": { "type": "string" },
+          "href": { "type": "string" },
+          "xpath": { "type": "string" },
+          "snippet": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/lib/validation/fixtures/findings-evidence-v1.1.example.json
+++ b/frontend/src/lib/validation/fixtures/findings-evidence-v1.1.example.json
@@ -1,0 +1,24 @@
+{
+  "job": { "id": "job_xml_a12f0b31", "created_at": "2026-02-25T00:00:00.000Z", "tenant_id": "tenant-a" },
+  "audit": { "id": "audit_xml_a12f0b31", "job_id": "job_xml_a12f0b31", "events": [] },
+  "findings": [
+    {
+      "id": "F_CST_LEN",
+      "severity": "FATAL",
+      "rule_id": "CST_3_DIGITS",
+      "title": "CST inválido (esperado 3 dígitos)",
+      "where": { "field": "CST", "xpath": "/NFS-e/infNfse//CST", "snippet": "<CST>12</CST>" },
+      "recommendation": "Corrigir no ERP e reemitir (com justificativa se necessário).",
+      "evidence_ids": ["E_XML_CST_LEN"]
+    }
+  ],
+  "evidences": [
+    {
+      "id": "E_XML_CST_LEN",
+      "type": "xml",
+      "label": "Trecho XML — CST",
+      "xpath": "/NFS-e/infNfse//CST",
+      "snippet": "<CST>12</CST>"
+    }
+  ]
+}

--- a/frontend/src/lib/validation/fixtures/nfe-smoke.xml
+++ b/frontend/src/lib/validation/fixtures/nfe-smoke.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc>
+  <NFe>
+    <infNFe>
+      <det>
+        <prod>
+          <NCM>27101932</NCM>
+        </prod>
+        <imposto>
+          <ICMS>
+            <ICMS00>
+              <CST>060</CST>
+              <cClassTrib>123456</cClassTrib>
+            </ICMS00>
+          </ICMS>
+        </imposto>
+      </det>
+      <infAdic>
+        <CodigoServico>654321</CodigoServico>
+      </infAdic>
+    </infNFe>
+  </NFe>
+</nfeProc>

--- a/frontend/src/lib/validation/fixtures/nfse-com-erros.xml
+++ b/frontend/src/lib/validation/fixtures/nfse-com-erros.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NFS-e>
+  <infNfse>
+    <PrestacaoServico>
+      <Servico>
+        <CodigoServico>1234</CodigoServico>
+        <cClassTrib>65432</cClassTrib>
+        <CST>12</CST>
+        <NCM>84713012</NCM>
+      </Servico>
+    </PrestacaoServico>
+  </infNfse>
+</NFS-e>

--- a/frontend/src/lib/validation/fixtures/nfse-ok.xml
+++ b/frontend/src/lib/validation/fixtures/nfse-ok.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NFS-e>
+  <infNfse>
+    <PrestacaoServico>
+      <Servico>
+        <CodigoServico>123456</CodigoServico>
+        <cClassTrib>654321</cClassTrib>
+        <CST>090</CST>
+        <NCM>84713012</NCM>
+      </Servico>
+    </PrestacaoServico>
+  </infNfse>
+</NFS-e>

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validateXmlWithRules } from "./xmlRules";
+
+function fixture(name: string): string {
+  return readFileSync(join(process.cwd(), "src/lib/validation/fixtures", name), "utf-8");
+}
+
+test("NFSe com erros gera findings FATAL esperados", () => {
+  const result = validateXmlWithRules({
+    tenantId: "tenant-a",
+    documentType: "NFSE",
+    xml: fixture("nfse-com-erros.xml"),
+  });
+
+  const ids = result.findings.map((f) => f.id);
+  assert.deepEqual(ids.slice(0, 3), ["F_CST_LEN", "F_CCLASSTRIB_LEN", "F_SERVICE_CODE_LEN"]);
+  assert.equal(result.findings.filter((f) => f.severity === "FATAL").length, 3);
+});
+
+test("NFSe ok não gera FATAL", () => {
+  const result = validateXmlWithRules({
+    tenantId: "tenant-a",
+    documentType: "NFSE",
+    xml: fixture("nfse-ok.xml"),
+  });
+  assert.equal(result.findings.some((f) => f.severity === "FATAL"), false);
+  assert.equal(result.findings.some((f) => f.severity === "ALERT"), true);
+});
+
+test("NF-e smoke retorna estrutura mínima de job/audit/evidências", () => {
+  const result = validateXmlWithRules({
+    tenantId: "tenant-b",
+    documentType: "NFE",
+    xml: fixture("nfe-smoke.xml"),
+  });
+  assert.ok(result.job.id.startsWith("job_xml_"));
+  assert.ok(result.audit.id.startsWith("audit_xml_"));
+  assert.ok(result.evidences.length > 0);
+});
+
+test("determinismo: mesmo XML + tipo gera mesmos finding ids e ordem", () => {
+  const xml = fixture("nfse-com-erros.xml");
+  const a = validateXmlWithRules({
+    tenantId: "tenant-a",
+    documentType: "NFSE",
+    xml,
+  });
+  const b = validateXmlWithRules({
+    tenantId: "tenant-a",
+    documentType: "NFSE",
+    xml,
+  });
+  assert.deepEqual(
+    a.findings.map((f) => ({ id: f.id, severity: f.severity, rule: f.rule_id })),
+    b.findings.map((f) => ({ id: f.id, severity: f.severity, rule: f.rule_id })),
+  );
+  assert.deepEqual(
+    a.evidences.map((e) => ({ id: e.id, type: e.type, xpath: e.xpath })),
+    b.evidences.map((e) => ({ id: e.id, type: e.type, xpath: e.xpath })),
+  );
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -1,0 +1,247 @@
+import type {
+  Finding,
+  FindingSeverity,
+  ValidationAuditRef,
+  ValidationEvidence,
+  ValidationJobRef,
+  ValidationResultV11,
+  XmlDocumentType,
+} from "@/lib/types";
+
+export type ValidationInput = {
+  tenantId: string;
+  documentType: XmlDocumentType;
+  xml: string;
+};
+
+function fnv1a32(value: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function firstTag(xml: string, tags: string[]): { tag: string; value: string; snippet: string; index: number } | null {
+  for (const tag of tags) {
+    const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i");
+    const match = re.exec(xml);
+    if (match) {
+      return {
+        tag,
+        value: String(match[1] ?? "").trim(),
+        snippet: match[0],
+        index: match.index,
+      };
+    }
+  }
+  return null;
+}
+
+function inferXpath(tag: string, documentType: XmlDocumentType): string {
+  const base = documentType === "NFSE" ? "/NFS-e/infNfse" : "/nfeProc/NFe/infNFe";
+  return `${base}//${tag}`;
+}
+
+function makeEvidenceId(seed: string): string {
+  return `E_XML_${seed}`;
+}
+
+function makeFinding(args: {
+  id: string;
+  severity: FindingSeverity;
+  ruleId: string;
+  title: string;
+  field: string;
+  xpath?: string;
+  snippet?: string;
+  evidenceId: string;
+  recommendation?: string;
+}): Finding {
+  return {
+    id: args.id,
+    severity: args.severity,
+    rule_id: args.ruleId,
+    title: args.title,
+    where: {
+      field: args.field,
+      xpath: args.xpath,
+      snippet: args.snippet,
+    },
+    recommendation: args.recommendation ?? "Corrigir no ERP e reemitir (com justificativa se necessário).",
+    evidence_ids: [args.evidenceId],
+  };
+}
+
+function makeEvidence(args: {
+  id: string;
+  type: ValidationEvidence["type"];
+  label: string;
+  href?: string;
+  xpath?: string;
+  snippet?: string;
+}): ValidationEvidence {
+  return {
+    id: args.id,
+    type: args.type,
+    label: args.label,
+    href: args.href,
+    xpath: args.xpath,
+    snippet: args.snippet,
+  };
+}
+
+export function validateXmlWithRules(input: ValidationInput): ValidationResultV11 {
+  const xml = input.xml.trim();
+  const fingerprint = fnv1a32(`${input.documentType}|${xml}`);
+  const jobId = `job_xml_${fingerprint}`;
+  const auditId = `audit_xml_${fingerprint}`;
+
+  const findings: Finding[] = [];
+  const evidences: ValidationEvidence[] = [];
+  const evidenceById = new Set<string>();
+
+  const cst = firstTag(xml, ["CST"]);
+  const cClassTrib = firstTag(xml, ["cClassTrib"]);
+  const serviceCode = firstTag(xml, ["CodigoServico", "cServ", "codigoServico"]);
+  const ncm = firstTag(xml, ["NCM"]);
+
+  const fields = [
+    {
+      findingId: "F_CST_LEN",
+      ruleId: "CST_3_DIGITS",
+      title: "CST inválido (esperado 3 dígitos)",
+      field: "CST",
+      source: cst,
+      test: (value: string) => /^\d{3}$/.test(value),
+    },
+    {
+      findingId: "F_CCLASSTRIB_LEN",
+      ruleId: "CCLASSTRIB_6_DIGITS",
+      title: "cClassTrib inválido (esperado 6 dígitos)",
+      field: "cClassTrib",
+      source: cClassTrib,
+      test: (value: string) => /^\d{6}$/.test(value),
+    },
+    {
+      findingId: "F_SERVICE_CODE_LEN",
+      ruleId: "SERVICE_CODE_6_DIGITS",
+      title: "Código de serviço inválido (esperado 6 dígitos)",
+      field: "CodigoServico",
+      source: serviceCode,
+      test: (value: string) => /^\d{6}$/.test(value),
+    },
+  ] as const;
+
+  for (const row of fields) {
+    const evId = makeEvidenceId(row.findingId.replace(/^F_/, ""));
+    const xpath = row.source ? inferXpath(row.source.tag, input.documentType) : inferXpath(row.field, input.documentType);
+    const snippet = row.source?.snippet ?? `<!-- Campo ${row.field} não encontrado no XML -->`;
+    const value = row.source?.value ?? "";
+    if (!row.test(value)) {
+      findings.push(
+        makeFinding({
+          id: row.findingId,
+          severity: "FATAL",
+          ruleId: row.ruleId,
+          title: row.title,
+          field: row.field,
+          xpath,
+          snippet,
+          evidenceId: evId,
+        }),
+      );
+    }
+    if (!evidenceById.has(evId)) {
+      evidences.push(
+        makeEvidence({
+          id: evId,
+          type: "xml",
+          label: `Trecho XML — ${row.field}`,
+          xpath,
+          snippet,
+        }),
+      );
+      evidenceById.add(evId);
+    }
+  }
+
+  const ncmEvId = makeEvidenceId("NCM_INFO");
+  evidences.push(
+    makeEvidence({
+      id: ncmEvId,
+      type: "xml",
+      label: "NCM (avaliação informativa)",
+      xpath: ncm ? inferXpath(ncm.tag, input.documentType) : inferXpath("NCM", input.documentType),
+      snippet: ncm?.snippet ?? "<!-- NCM não encontrado -->",
+    }),
+  );
+  findings.push(
+    makeFinding({
+      id: "A_NCM_REVIEW",
+      severity: "ALERT",
+      ruleId: "NCM_PLACEHOLDER",
+      title: "Revisar NCM conforme classificação fiscal vigente",
+      field: "NCM",
+      xpath: ncm ? inferXpath(ncm.tag, input.documentType) : inferXpath("NCM", input.documentType),
+      snippet: ncm?.snippet,
+      evidenceId: ncmEvId,
+      recommendation: "Conferir classificação fiscal (NCM) e manter evidência de suporte.",
+    }),
+  );
+
+  const benefitEvId = makeEvidenceId("BENEFITS_INFO");
+  evidences.push(
+    makeEvidence({
+      id: benefitEvId,
+      type: "print",
+      label: "Checklist de benefícios/créditos",
+      snippet: "Validar benefícios e créditos aplicáveis antes do fechamento.",
+    }),
+  );
+  findings.push(
+    makeFinding({
+      id: "A_BENEFITS_REVIEW",
+      severity: "ALERT",
+      ruleId: "BENEFITS_PLACEHOLDER",
+      title: "Revisar benefícios e créditos aplicáveis",
+      field: "beneficios_creditos",
+      evidenceId: benefitEvId,
+      recommendation: "Documentar justificativa fiscal para benefícios e créditos utilizados.",
+    }),
+  );
+
+  const job: ValidationJobRef = {
+    id: jobId,
+    created_at: nowIso(),
+    tenant_id: input.tenantId,
+  };
+  const audit: ValidationAuditRef = {
+    id: auditId,
+    job_id: jobId,
+    events: [
+      {
+        id: `evt_${fingerprint}_created`,
+        action: "xml_validation_started",
+        created_at: nowIso(),
+        payload: {
+          document_type: input.documentType,
+          findings_total: findings.length,
+          fatals: findings.filter((f) => f.severity === "FATAL").length,
+        },
+      },
+    ],
+  };
+
+  return {
+    job,
+    audit,
+    findings,
+    evidences,
+  };
+}


### PR DESCRIPTION
## Sprint 6 P0 - XML Validation + Evidence + Exceptions

### Objetivo
Validar escrituração/fechamento com evidência XML auditável e workflow de exceção aprovável.

### Entregas P0
- Contrato Findings + Evidence v1.1 em TypeScript + schema + fixture JSON.
- Tela `/validate-xml` com textarea/upload, seletor NFS-e/NF-e, findings, evidências e atalhos Job/Audit.
- Engine de regras MVP (FATAL + ALERT) com mock determinístico.
- Workflow de exceção Operador -> Coordenador em `/exceptions` com eventos no audit.
- Adapter API/Mock com headers multi-tenant preservados em API Mode.

### Arquivos-chave
- `frontend/src/lib/types.ts`
- `frontend/src/lib/validation/findings-evidence-v1.1.schema.json`
- `frontend/src/lib/validation/fixtures/findings-evidence-v1.1.example.json`
- `frontend/src/lib/validation/xmlRules.ts`
- `frontend/src/lib/validation/xmlRules.test.ts`
- `frontend/src/app/validate-xml/page.tsx`
- `frontend/src/app/exceptions/page.tsx`
- `frontend/src/lib/mock.ts`
- `frontend/src/lib/api.ts`
- `docs/sprints/S6_P0_delivery_report.md`

### DoD checklist (Sprint 6 P0)
- [x] Fluxo demo-ready: colar/upload XML -> validar -> findings/evidências -> abrir exceção -> aprovar/reprovar -> ver Audit/Job.
- [x] Fixtures e mocks determinísticos.
- [x] Testes unitários das regras fatais.
- [x] Documentação no README + exemplo payload v1.1.
- [x] API Mode mantém `Authorization` + `X-Tenant-Id` em requests via adapter.

### Comandos executados
- `cd frontend && npm install`
- `cd frontend && npm run test:rules` (PASS)
- `cd frontend && npm run build` (PASS)

### Evidência visual (descrição de telas)
- `/validate-xml`: findings FATAL/ALERT com `where` (field/xpath/snippet) e botão `Abrir exceção`.
- `/exceptions`: fila OPEN/APPROVED/REJECTED e decisão com comentário.

### Observação de escopo
- Governança preservada no repo canonical `mickbap/tribultz`.