### PR TITLE
Sprint 6 P1: Closing dashboard + Job evidence export

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts"
   },
   "dependencies": {

--- a/frontend/src/app/closing/page.tsx
+++ b/frontend/src/app/closing/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { Skeleton } from "@/components/common/Skeleton";
+import { Toast } from "@/components/common/Toast";
+import { getAudits, getJobs, listExceptionRequests } from "@/lib/api";
+import { createClosingSnapshot } from "@/lib/closing/aggregate";
+import { AuditLog, ExceptionRequest, Job } from "@/lib/types";
+
+export default function ClosingPage() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [audits, setAudits] = useState<AuditLog[]>([]);
+  const [exceptions, setExceptions] = useState<ExceptionRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([getJobs(), getAudits(), listExceptionRequests()])
+      .then(([jobsData, auditsData, exceptionsData]) => {
+        setJobs(jobsData);
+        setAudits(auditsData);
+        setExceptions(exceptionsData);
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const snapshot = useMemo(() => createClosingSnapshot({ jobs, audits, exceptions }), [jobs, audits, exceptions]);
+
+  return (
+    <section className="space-y-5">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold text-slate-900">Painel de Fechamento</h1>
+        <p className="text-sm text-slate-500">Janela de 7 dias com consolidacao de jobs, auditoria e excecoes.</p>
+        <p className="text-xs text-slate-400">
+          Janela ativa: {new Date(snapshot.since).toLocaleString()} ate {new Date(snapshot.until).toLocaleString()}
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">Fatals detectados (7d)</p>
+          <p className="mt-2 text-3xl font-bold">{loading ? "..." : snapshot.counts.fatalFindings}</p>
+        </article>
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">Excecoes abertas (7d)</p>
+          <p className="mt-2 text-3xl font-bold">{loading ? "..." : snapshot.counts.openExceptions}</p>
+          <Link href="/exceptions" className="mt-2 inline-block text-xs text-tribultz-700 hover:underline">
+            Abrir fila de excecoes
+          </Link>
+        </article>
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">Jobs executados (7d)</p>
+          <p className="mt-2 text-3xl font-bold">{loading ? "..." : snapshot.counts.jobsExecuted}</p>
+          <Link href="/jobs" className="mt-2 inline-block text-xs text-tribultz-700 hover:underline">
+            Abrir lista de jobs
+          </Link>
+        </article>
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">Audits recentes (7d)</p>
+          <p className="mt-2 text-3xl font-bold">{loading ? "..." : snapshot.counts.recentAudits}</p>
+          <Link href="/audit" className="mt-2 inline-block text-xs text-tribultz-700 hover:underline">
+            Abrir auditoria
+          </Link>
+        </article>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <section className="rounded-xl border border-slate-200 bg-white p-4">
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Ultimos jobs (7d)</h2>
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : snapshot.recentJobs.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum job na janela.</p>
+          ) : (
+            <ul className="space-y-2">
+              {snapshot.recentJobs.map((row) => (
+                <li key={row.id} className="rounded border border-slate-100 p-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <Link href={`/jobs/${row.id}`} className="text-sm font-medium text-tribultz-700 hover:underline">
+                      {row.id}
+                    </Link>
+                    <span className="text-xs text-slate-500">{row.status}</span>
+                  </div>
+                  <p className="text-xs text-slate-500">{new Date(row.createdAt).toLocaleString()}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-4">
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Ultimos audits (7d)</h2>
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : snapshot.recentAuditRows.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum audit na janela.</p>
+          ) : (
+            <ul className="space-y-2">
+              {snapshot.recentAuditRows.map((row) => (
+                <li key={row.id} className="rounded border border-slate-100 p-2">
+                  <p className="text-sm font-medium text-slate-800">{row.action}</p>
+                  <p className="text-xs text-slate-500">{new Date(row.createdAt).toLocaleString()}</p>
+                  <div className="mt-1 flex flex-wrap gap-3">
+                    <Link href={`/audit?audit_id=${encodeURIComponent(row.id)}`} className="text-xs text-tribultz-700 hover:underline">
+                      Ver audit
+                    </Link>
+                    {row.jobId ? (
+                      <Link href={`/jobs/${row.jobId}`} className="text-xs text-tribultz-700 hover:underline">
+                        Abrir job
+                      </Link>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-4">
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Excecoes abertas (7d)</h2>
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : snapshot.openExceptionRows.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhuma excecao aberta na janela.</p>
+          ) : (
+            <ul className="space-y-2">
+              {snapshot.openExceptionRows.map((row) => (
+                <li key={row.id} className="rounded border border-slate-100 p-2">
+                  <p className="text-sm font-medium text-slate-800">{row.id}</p>
+                  <p className="text-xs text-slate-500">
+                    job_id: {row.job_id} | finding_id: {row.finding_id}
+                  </p>
+                  <div className="mt-1 flex flex-wrap gap-3">
+                    <Link href="/exceptions" className="text-xs text-tribultz-700 hover:underline">
+                      Ver excecoes
+                    </Link>
+                    <Link href={`/jobs/${row.job_id}`} className="text-xs text-tribultz-700 hover:underline">
+                      Abrir job
+                    </Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      {error ? <Toast message={error} tone="error" onClose={() => setError(null)} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 
 const links = [
   { href: "/dashboard", label: "Painel" },
+  { href: "/closing", label: "Fechamento" },
   { href: "/validate-xml", label: "Validar XML" },
   { href: "/chat", label: "Chat" },
   { href: "/jobs", label: "Jobs" },

--- a/frontend/src/lib/closing/aggregate.test.ts
+++ b/frontend/src/lib/closing/aggregate.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createClosingSnapshot } from "./aggregate";
+import { AuditLog, ExceptionRequest, Job } from "../types";
+
+const NOW = new Date("2026-02-26T16:00:00.000Z");
+
+function makeJob(id: string, createdAt: string, fatalCount: number): Job {
+  return {
+    id,
+    tenantId: "tenant-a",
+    jobType: "xml_validation",
+    status: "SUCCESS",
+    createdAt,
+    updatedAt: createdAt,
+    input: {},
+    output: {},
+    evidence: [],
+    findings: Array.from({ length: fatalCount }, (_, i) => ({
+      id: `f-${id}-${i + 1}`,
+      severity: "FATAL",
+      rule_id: "RULE_X",
+      title: "Fatal",
+      where: {},
+      recommendation: "Fix",
+      evidence_ids: [],
+    })),
+  };
+}
+
+function makeAudit(id: string, createdAt: string): AuditLog {
+  return {
+    id,
+    tenantId: "tenant-a",
+    action: "validation_succeeded",
+    createdAt,
+    payload: {},
+  };
+}
+
+function makeException(id: string, createdAt: string, status: ExceptionRequest["status"]): ExceptionRequest {
+  return {
+    id,
+    tenant_id: "tenant-a",
+    job_id: "job-a",
+    finding_id: "finding-1",
+    rule_id: "RULE_X",
+    justification: "Need exception",
+    status,
+    created_by: "operator.demo",
+    created_at: createdAt,
+  };
+}
+
+test("createClosingSnapshot calcula metricas da janela de 7 dias", () => {
+  const jobs = [
+    makeJob("job-1", "2026-02-26T10:00:00.000Z", 2),
+    makeJob("job-2", "2026-02-22T10:00:00.000Z", 1),
+    makeJob("job-old", "2026-02-10T10:00:00.000Z", 5),
+  ];
+  const audits = [
+    makeAudit("audit-1", "2026-02-25T10:00:00.000Z"),
+    makeAudit("audit-old", "2026-02-01T10:00:00.000Z"),
+  ];
+  const exceptions = [
+    makeException("exc-open", "2026-02-24T10:00:00.000Z", "OPEN"),
+    makeException("exc-approved", "2026-02-24T12:00:00.000Z", "APPROVED"),
+    makeException("exc-old-open", "2026-01-20T12:00:00.000Z", "OPEN"),
+  ];
+
+  const snapshot = createClosingSnapshot({ jobs, audits, exceptions, now: NOW });
+
+  assert.equal(snapshot.counts.jobsExecuted, 2);
+  assert.equal(snapshot.counts.fatalFindings, 3);
+  assert.equal(snapshot.counts.recentAudits, 1);
+  assert.equal(snapshot.counts.openExceptions, 1);
+  assert.deepEqual(
+    snapshot.recentJobs.map((row) => row.id),
+    ["job-1", "job-2"],
+  );
+  assert.deepEqual(
+    snapshot.openExceptionRows.map((row) => row.id),
+    ["exc-open"],
+  );
+});

--- a/frontend/src/lib/closing/aggregate.ts
+++ b/frontend/src/lib/closing/aggregate.ts
@@ -1,0 +1,83 @@
+import { AuditLog, ExceptionRequest, Job } from "../types";
+
+export type ClosingSnapshot = {
+  since: string;
+  until: string;
+  counts: {
+    fatalFindings: number;
+    openExceptions: number;
+    jobsExecuted: number;
+    recentAudits: number;
+  };
+  recentJobs: Job[];
+  recentAuditRows: AuditLog[];
+  openExceptionRows: ExceptionRequest[];
+};
+
+type ClosingInput = {
+  jobs: Job[];
+  audits: AuditLog[];
+  exceptions: ExceptionRequest[];
+  now?: Date;
+  days?: number;
+  listLimit?: number;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toTs(value: string | undefined): number | null {
+  if (!value) return null;
+  const ts = new Date(value).getTime();
+  return Number.isNaN(ts) ? null : ts;
+}
+
+function inWindow(ts: number | null, startTs: number, endTs: number): boolean {
+  return ts !== null && ts >= startTs && ts <= endTs;
+}
+
+function byDateDesc<T>(rows: T[], getDate: (row: T) => string): T[] {
+  return [...rows].sort((a, b) => {
+    const aTs = toTs(getDate(a)) ?? 0;
+    const bTs = toTs(getDate(b)) ?? 0;
+    return bTs - aTs;
+  });
+}
+
+export function createClosingSnapshot({
+  jobs,
+  audits,
+  exceptions,
+  now = new Date(),
+  days = 7,
+  listLimit = 5,
+}: ClosingInput): ClosingSnapshot {
+  const endTs = now.getTime();
+  const startTs = endTs - days * DAY_MS;
+  const since = new Date(startTs).toISOString();
+  const until = now.toISOString();
+
+  const jobsInWindow = jobs.filter((job) => inWindow(toTs(job.createdAt), startTs, endTs));
+  const auditsInWindow = audits.filter((row) => inWindow(toTs(row.createdAt), startTs, endTs));
+  const openExceptionsInWindow = exceptions.filter(
+    (row) => row.status === "OPEN" && inWindow(toTs(row.created_at), startTs, endTs),
+  );
+
+  const fatalFindings = jobsInWindow.reduce((total, job) => {
+    const current = (job.findings ?? []).filter((finding) => finding.severity === "FATAL").length;
+    return total + current;
+  }, 0);
+
+  return {
+    since,
+    until,
+    counts: {
+      fatalFindings,
+      openExceptions: openExceptionsInWindow.length,
+      jobsExecuted: jobsInWindow.length,
+      recentAudits: auditsInWindow.length,
+    },
+    recentJobs: byDateDesc(jobsInWindow, (job) => job.createdAt).slice(0, listLimit),
+    recentAuditRows: byDateDesc(auditsInWindow, (row) => row.createdAt).slice(0, listLimit),
+    openExceptionRows: byDateDesc(openExceptionsInWindow, (row) => row.created_at).slice(0, listLimit),
+  };
+}

--- a/frontend/src/lib/export/jobEvidenceBundle.test.ts
+++ b/frontend/src/lib/export/jobEvidenceBundle.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildJobEvidenceBundle } from "./jobEvidenceBundle";
+import { AuditLog, Job } from "../types";
+
+function makeJob(xml?: string): Job {
+  return {
+    id: "job-tenant-a-0001",
+    tenantId: "tenant-a",
+    jobType: "xml_validation",
+    status: "SUCCESS",
+    createdAt: "2026-02-26T12:00:00.000Z",
+    updatedAt: "2026-02-26T12:00:02.000Z",
+    input: xml ? { document_type: "NFSE", xml } : { document_type: "NFSE" },
+    output: { status: "PASS" },
+    evidence: [{ type: "job", job_id: "job-tenant-a-0001", href: "/jobs/job-tenant-a-0001", label: "Job" }],
+    findings: [
+      {
+        id: "F_1",
+        severity: "FATAL",
+        rule_id: "RULE_FATAL",
+        title: "Campo invalido",
+        where: { xpath: "/NFSe/Servico" },
+        recommendation: "Corrigir campo",
+        evidence_ids: ["E_1"],
+      },
+    ],
+  };
+}
+
+const audits: AuditLog[] = [
+  {
+    id: "audit-job-tenant-a-0001",
+    tenantId: "tenant-a",
+    jobId: "job-tenant-a-0001",
+    action: "validation_succeeded",
+    createdAt: "2026-02-26T12:00:03.000Z",
+    payload: { status: "SUCCESS" },
+  },
+];
+
+test("buildJobEvidenceBundle inclui xml.xml quando XML existe", () => {
+  const bundle = buildJobEvidenceBundle(makeJob("<root />"), audits, new Date("2026-02-26T16:00:00.000Z"));
+  const files = bundle.artifacts.map((item) => item.filename);
+
+  assert.deepEqual(files, ["job.json", "audit.json", "findings.json", "evidences.json", "summary.md", "xml.xml"]);
+  assert.match(bundle.summaryMarkdown, /job_id: job-tenant-a-0001/);
+  assert.match(bundle.summaryMarkdown, /xml_included: yes/);
+});
+
+test("buildJobEvidenceBundle nao inclui xml.xml quando XML nao existe", () => {
+  const bundle = buildJobEvidenceBundle(makeJob(), audits, new Date("2026-02-26T16:00:00.000Z"));
+  const files = bundle.artifacts.map((item) => item.filename);
+
+  assert.deepEqual(files, ["job.json", "audit.json", "findings.json", "evidences.json", "summary.md"]);
+  assert.match(bundle.summaryMarkdown, /xml_included: no/);
+});

--- a/frontend/src/lib/export/jobEvidenceBundle.ts
+++ b/frontend/src/lib/export/jobEvidenceBundle.ts
@@ -1,0 +1,98 @@
+import { AuditLog, Job } from "../types";
+
+export type JobEvidenceArtifact = {
+  filename: string;
+  mimeType: string;
+  content: string;
+};
+
+export type JobEvidenceBundle = {
+  artifacts: JobEvidenceArtifact[];
+  summaryMarkdown: string;
+};
+
+function toJson(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function maybeString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function extractXmlContent(job: Job): string | null {
+  const inputXml = maybeString(job.input.xml);
+  if (inputXml) return inputXml;
+
+  const inputPayloadXml = maybeString(asRecord(job.input.payload)?.xml);
+  if (inputPayloadXml) return inputPayloadXml;
+
+  const outputXml = maybeString(asRecord(job.output)?.xml);
+  if (outputXml) return outputXml;
+
+  const outputPayloadXml = maybeString(asRecord(asRecord(job.output)?.payload)?.xml);
+  if (outputPayloadXml) return outputPayloadXml;
+
+  return null;
+}
+
+export function buildJobEvidenceBundle(job: Job, audits: AuditLog[], generatedAt: Date = new Date()): JobEvidenceBundle {
+  const findings = job.findings ?? [];
+  const evidences = job.evidence ?? [];
+  const xmlContent = extractXmlContent(job);
+  const nowIso = generatedAt.toISOString();
+
+  const summaryLines = [
+    "# Job Evidence Bundle",
+    "",
+    `- generated_at: ${nowIso}`,
+    `- job_id: ${job.id}`,
+    `- tenant_id: ${job.tenantId}`,
+    `- status: ${job.status}`,
+    `- findings_total: ${findings.length}`,
+    `- evidences_total: ${evidences.length}`,
+    `- audits_total: ${audits.length}`,
+    `- xml_included: ${xmlContent ? "yes" : "no"}`,
+    "",
+    "## Files",
+    "- job.json",
+    "- audit.json",
+    "- findings.json",
+    "- evidences.json",
+    "- summary.md",
+    ...(xmlContent ? ["- xml.xml"] : ["- xml.xml (not available in payload)"]),
+  ];
+  const summaryMarkdown = `${summaryLines.join("\n")}\n`;
+
+  const artifacts: JobEvidenceArtifact[] = [
+    { filename: "job.json", mimeType: "application/json", content: toJson(job) },
+    { filename: "audit.json", mimeType: "application/json", content: toJson(audits) },
+    { filename: "findings.json", mimeType: "application/json", content: toJson(findings) },
+    { filename: "evidences.json", mimeType: "application/json", content: toJson(evidences) },
+    { filename: "summary.md", mimeType: "text/markdown", content: summaryMarkdown },
+  ];
+
+  if (xmlContent) {
+    artifacts.push({ filename: "xml.xml", mimeType: "application/xml", content: xmlContent });
+  }
+
+  return { artifacts, summaryMarkdown };
+}
+
+export function downloadJobEvidenceBundle(bundle: JobEvidenceBundle, jobId: string): void {
+  if (typeof window === "undefined") return;
+  for (const artifact of bundle.artifacts) {
+    const blob = new Blob([artifact.content], { type: `${artifact.mimeType};charset=utf-8` });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${jobId}-${artifact.filename}`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }
+}


### PR DESCRIPTION
## Sprint 6 P1 - S6-04 + S6-05

### S6-04 Painel de fechamento (minimo)
- /closing com cards (7 dias): fatals, excecoes abertas, jobs executados, audits recentes
- Links diretos para detalhes (jobs/audits/excecoes)

### S6-05 Export evidencias (MVP)
- Botao 'Exportar evidencias' no Job
- Mock gera bundle (job/audit/findings/evidences/xml + summary.md)

### Aceite
- Mock Mode funcionando end-to-end
- Build ok