### PR TITLE
S6-05b-1: client-side ZIP export for Job evidence

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "fflate": "^0.8.2",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -4041,6 +4042,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts"
   },
   "dependencies": {
+    "fflate": "^0.8.2",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -10,7 +10,8 @@ import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
 import { getAudits, getJob } from "@/lib/api";
-import { buildJobEvidenceBundle, downloadJobEvidenceBundle } from "@/lib/export/jobEvidenceBundle";
+import { buildJobEvidenceBundle } from "@/lib/export/jobEvidenceBundle";
+import { buildJobEvidenceZip, downloadZip, makeJobEvidenceZipFilename } from "@/lib/export/jobEvidenceZip";
 import { Job } from "@/lib/types";
 
 export default function JobDetailPage() {
@@ -36,10 +37,11 @@ export default function JobDetailPage() {
     try {
       const audits = await getAudits(job.id);
       const bundle = buildJobEvidenceBundle(job, audits);
-      downloadJobEvidenceBundle(bundle, job.id);
+      const zip = buildJobEvidenceZip(bundle);
+      downloadZip(zip, makeJobEvidenceZipFilename(job.id));
       setToast({
         tone: "success",
-        message: `Bundle exportado com ${bundle.artifacts.length} arquivo(s).`,
+        message: "ZIP de evidencias exportado com sucesso.",
       });
     } catch (err) {
       setToast({

--- a/frontend/src/lib/export/jobEvidenceZip.ts
+++ b/frontend/src/lib/export/jobEvidenceZip.ts
@@ -1,0 +1,47 @@
+import { strToU8, zipSync } from "fflate";
+import type { JobEvidenceBundle } from "./jobEvidenceBundle";
+
+function sanitizeJobId(jobId: string): string {
+  return jobId.replace(/[^a-zA-Z0-9._-]+/g, "_");
+}
+
+function formatZipTimestamp(date: Date): string {
+  // 2026-02-26T17:02:39.123Z -> 20260226T170239Z
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+export function makeJobEvidenceZipFilename(jobId: string, generatedAt: Date = new Date()): string {
+  const safeJobId = sanitizeJobId(jobId);
+  const ts = formatZipTimestamp(generatedAt);
+  return `${safeJobId}_${ts}.zip`;
+}
+
+export function buildJobEvidenceZip(bundle: JobEvidenceBundle): Uint8Array {
+  // Keep order and file names from the bundle.
+  const files: Record<string, Uint8Array> = {};
+  for (const artifact of bundle.artifacts) {
+    files[artifact.filename] = strToU8(artifact.content);
+  }
+  return zipSync(files, { level: 6 });
+}
+
+export function downloadZip(zipBytes: Uint8Array, filename: string): void {
+  if (typeof window === "undefined") return;
+
+  const arrayBuffer = new ArrayBuffer(zipBytes.byteLength);
+  new Uint8Array(arrayBuffer).set(zipBytes);
+  const blob = new Blob([arrayBuffer], { type: "application/zip" });
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## S6-05b-1 - ZIP client-side para export de evidencias do Job

### O que foi feito
- Adicionada camada nova jobEvidenceZip com:
  - uildJobEvidenceZip(bundle)
  - makeJobEvidenceZipFilename(jobId, generatedAt)
  - downloadZip(zipBytes, filename)
- Mantido uildJobEvidenceBundle() sem refatoracao estrutural.
- Botao **Exportar evidencias** em /jobs/[id] agora baixa um unico arquivo .zip.

### Validacao
- 
pm test --silent (PASS)
- 
pm run build (PASS)

### Observacao de deps hygiene
- 
pm i fflate reportou 2 vulnerabilities (1 moderate, 1 high).
- Nao foi executado 
pm audit fix --force para evitar upgrades disruptivos nesta entrega.

Closes #14
Refs #11