### PR TITLE
S6-05b-2: add API adapter placeholder for evidence ZIP export

### DIFF
--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -9,9 +9,8 @@ import { MarkdownRenderer } from "@/components/common/MarkdownRenderer";
 import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
-import { getAudits, getJob } from "@/lib/api";
-import { buildJobEvidenceBundle } from "@/lib/export/jobEvidenceBundle";
-import { buildJobEvidenceZip, downloadZip, makeJobEvidenceZipFilename } from "@/lib/export/jobEvidenceZip";
+import { exportJobEvidenceZip, getJob } from "@/lib/api";
+import { downloadZip } from "@/lib/export/jobEvidenceZip";
 import { Job } from "@/lib/types";
 
 export default function JobDetailPage() {
@@ -35,10 +34,8 @@ export default function JobDetailPage() {
     if (!job || exporting) return;
     setExporting(true);
     try {
-      const audits = await getAudits(job.id);
-      const bundle = buildJobEvidenceBundle(job, audits);
-      const zip = buildJobEvidenceZip(bundle);
-      downloadZip(zip, makeJobEvidenceZipFilename(job.id));
+      const zip = await exportJobEvidenceZip(job.id);
+      downloadZip(zip.bytes, zip.filename);
       setToast({
         tone: "success",
         message: "ZIP de evidencias exportado com sucesso.",


### PR DESCRIPTION
## S6-05b-2 - API adapter placeholder para export de evidencias

### O que foi feito
- Adicionada funcao unica no adapter: exportJobEvidenceZip(jobId) em rontend/src/lib/api.ts.
- Mock Mode: reusa getJob + getAudits + buildJobEvidenceBundle + buildJobEvidenceZip + makeJobEvidenceZipFilename e retorna { filename, bytes }.
- API Mode (placeholder): tenta GET /api/v1/jobs/{jobId}/evidence.zip com auth headers e:
  - usa content-disposition para nome quando presente
  - fallback para naming local quando nao vier nome
  - erro claro para endpoint ausente (Export via API ainda nao disponivel.)
- UI do Job agora chama apenas exportJobEvidenceZip(job.id) e faz downloadZip(bytes, filename).

### Validacao
- 
pm test --silent (PASS)
- 
pm run build (PASS)

Closes #15
Refs #11