### PR TITLE
S6-05c-3: polish export UX copy and error handling

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts"
   },
   "dependencies": {

--- a/frontend/src/app/audit/page.tsx
+++ b/frontend/src/app/audit/page.tsx
@@ -5,8 +5,8 @@ import { useSearchParams } from "next/navigation";
 import { JsonViewer } from "@/components/common/JsonViewer";
 import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
-import { exportJobEvidenceZip, getAudits } from "@/lib/api";
-import { downloadZip } from "@/lib/export/jobEvidenceZip";
+import { getAudits } from "@/lib/api";
+import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
 import { AuditLog } from "@/lib/types";
 
 function AuditContent() {
@@ -54,18 +54,9 @@ function AuditContent() {
 
   async function handleExport(jobId: string): Promise<void> {
     setExportingByJobId((prev) => ({ ...prev, [jobId]: true }));
-    try {
-      const result = await exportJobEvidenceZip(jobId);
-      downloadZip(result.bytes, result.filename);
-      setToast({ tone: "success", message: `ZIP exportado para ${jobId}.` });
-    } catch (err) {
-      setToast({
-        tone: "error",
-        message: err instanceof Error ? err.message : "Falha ao exportar evidencias.",
-      });
-    } finally {
-      setExportingByJobId((prev) => ({ ...prev, [jobId]: false }));
-    }
+    const feedback = await exportEvidenceZipAndDownload(jobId);
+    setToast(feedback);
+    setExportingByJobId((prev) => ({ ...prev, [jobId]: false }));
   }
 
   return (
@@ -138,7 +129,7 @@ function AuditContent() {
                             onClick={() => void handleExport(item.jobId as string)}
                             className="rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                           >
-                            {exportingByJobId[item.jobId] ? "Exportando..." : "Exportar evidencias"}
+                            {exportingByJobId[item.jobId] ? "Exportando…" : "Exportar evidências"}
                           </button>
                         ) : null}
                       </div>

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -9,8 +9,8 @@ import { MarkdownRenderer } from "@/components/common/MarkdownRenderer";
 import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
-import { exportJobEvidenceZip, getJob } from "@/lib/api";
-import { downloadZip } from "@/lib/export/jobEvidenceZip";
+import { getJob } from "@/lib/api";
+import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
 import { Job } from "@/lib/types";
 
 export default function JobDetailPage() {
@@ -33,21 +33,9 @@ export default function JobDetailPage() {
   async function exportEvidenceBundle(): Promise<void> {
     if (!job || exporting) return;
     setExporting(true);
-    try {
-      const zip = await exportJobEvidenceZip(job.id);
-      downloadZip(zip.bytes, zip.filename);
-      setToast({
-        tone: "success",
-        message: "ZIP de evidencias exportado com sucesso.",
-      });
-    } catch (err) {
-      setToast({
-        tone: "error",
-        message: err instanceof Error ? err.message : "Falha ao exportar evidencias.",
-      });
-    } finally {
-      setExporting(false);
-    }
+    const feedback = await exportEvidenceZipAndDownload(job.id);
+    setToast(feedback);
+    setExporting(false);
   }
 
   return (
@@ -64,7 +52,7 @@ export default function JobDetailPage() {
             onClick={() => void exportEvidenceBundle()}
             className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {exporting ? "Exportando..." : "Exportar evidencias"}
+            {exporting ? "Exportando…" : "Exportar evidências"}
           </button>
           {job ? <StatusBadge status={job.status} /> : null}
         </div>

--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -5,8 +5,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
-import { exportJobEvidenceZip, getJobs } from "@/lib/api";
-import { downloadZip } from "@/lib/export/jobEvidenceZip";
+import { getJobs } from "@/lib/api";
+import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
 import { Job, JobStatus } from "@/lib/types";
 
 type PeriodFilter = "24h" | "7d" | "30d" | "all";
@@ -50,18 +50,9 @@ export default function JobsPage() {
 
   async function handleExport(jobId: string): Promise<void> {
     setExportingByJobId((prev) => ({ ...prev, [jobId]: true }));
-    try {
-      const result = await exportJobEvidenceZip(jobId);
-      downloadZip(result.bytes, result.filename);
-      setToast({ tone: "success", message: `ZIP exportado para ${jobId}.` });
-    } catch (err) {
-      setToast({
-        tone: "error",
-        message: err instanceof Error ? err.message : "Falha ao exportar evidencias.",
-      });
-    } finally {
-      setExportingByJobId((prev) => ({ ...prev, [jobId]: false }));
-    }
+    const feedback = await exportEvidenceZipAndDownload(jobId);
+    setToast(feedback);
+    setExportingByJobId((prev) => ({ ...prev, [jobId]: false }));
   }
 
   return (
@@ -153,7 +144,7 @@ export default function JobsPage() {
                           onClick={() => void handleExport(job.id)}
                           className="rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                         >
-                          {exportingByJobId[job.id] ? "Exportando..." : "Exportar evidencias"}
+                          {exportingByJobId[job.id] ? "Exportando…" : "Exportar evidências"}
                         </button>
                       </div>
                     </td>

--- a/frontend/src/lib/export/evidenceExportUi.test.ts
+++ b/frontend/src/lib/export/evidenceExportUi.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toastFromExportError } from "./evidenceExportUi";
+
+test("toastFromExportError retorna info para placeholder de API indisponivel", () => {
+  const feedback = toastFromExportError(new Error("Export via API ainda nao disponivel."));
+  assert.equal(feedback.tone, "info");
+  assert.equal(feedback.message, "Export via API ainda não disponível. Use Mock Mode ou tente novamente mais tarde.");
+});
+
+test("toastFromExportError retorna erro padrao para falha generica", () => {
+  const feedback = toastFromExportError(new Error("API 500: boom"));
+  assert.equal(feedback.tone, "error");
+  assert.equal(feedback.message, "Falha ao exportar evidências: API 500: boom");
+});

--- a/frontend/src/lib/export/evidenceExportUi.ts
+++ b/frontend/src/lib/export/evidenceExportUi.ts
@@ -1,0 +1,37 @@
+import { exportJobEvidenceZip } from "../api";
+import { downloadZip } from "./jobEvidenceZip";
+
+export type ExportToastFeedback = {
+  tone: "success" | "error" | "info";
+  message: string;
+};
+
+export function toastFromExportError(err: unknown): ExportToastFeedback {
+  const rawMessage = err instanceof Error ? err.message : String(err ?? "");
+  const message = rawMessage.trim() || "erro desconhecido";
+
+  if (/Export via API ainda n[aã]o dispon[ií]vel\.?/i.test(message)) {
+    return {
+      tone: "info",
+      message: "Export via API ainda não disponível. Use Mock Mode ou tente novamente mais tarde.",
+    };
+  }
+
+  return {
+    tone: "error",
+    message: `Falha ao exportar evidências: ${message}`,
+  };
+}
+
+export async function exportEvidenceZipAndDownload(jobId: string): Promise<ExportToastFeedback> {
+  try {
+    const result = await exportJobEvidenceZip(jobId);
+    downloadZip(result.bytes, result.filename);
+    return {
+      tone: "success",
+      message: "ZIP de evidências exportado com sucesso.",
+    };
+  } catch (err) {
+    return toastFromExportError(err);
+  }
+}


### PR DESCRIPTION
## S6-05c-3 - UX polish de export nas superficies /jobs, /audit e /jobs/[id]

### O que foi feito
- Padronizada copy em todas as telas:
  - Botao: Exportar evidências
  - Loading: Exportando…
  - Sucesso: ZIP de evidências exportado com sucesso.
- Criado helper unico evidenceExportUi para evitar duplicacao:
  - exportEvidenceZipAndDownload(jobId)
  - 	oastFromExportError(err)
- Padronizado erro:
  - Genérico: Falha ao exportar evidências: <mensagem>
  - API placeholder: toast info com instrução:
    Export via API ainda não disponível. Use Mock Mode ou tente novamente mais tarde.
- /jobs e /audit mantem loading isolado por jobId.

### Testes leves
- Novo teste unitario: evidenceExportUi.test.ts
  - placeholder de API -> 	one=info
  - erro genérico -> 	one=error com mensagem formatada

### Validacao
- 
pm test --silent (PASS)
- 
pm run build (PASS)

Closes #19
Refs #12