### PR TITLE
feat(s8): batch upload + dashboard KPIs (#45 #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Plataforma de compliance e simulação CBS/IBS para a reforma tributária brasil
 
 ```
 frontend/            Next.js app (app router)
-  src/app/           Páginas: dashboard, validate-xml, audit, chat, closing, jobs,
-                     report, settings, login, register, exceptions
-  src/lib/           Validação (xmlRules), export (CSV/PDF auditável, zip), closing
+  src/app/           Páginas: dashboard, validate-xml, validate-batch, audit, chat,
+                     closing, jobs, report, settings, login, register, exceptions
+  src/lib/           Validação (xmlRules), export (CSV/PDF auditável, batch, zip), closing
   src/components/    UI: AppShell, Sidebar, EvidenceList, JsonViewer, Toast
 
 backend/             FastAPI
@@ -61,7 +61,7 @@ uvicorn app.main:app --reload   # porta 8000
 cd frontend
 npm ci
 npm run dev    # porta 3000
-npm test       # 23 testes
+npm test       # 41 testes
 npm run build  # produção
 ```
 
@@ -78,12 +78,13 @@ npm run build  # produção
 
 1. **Login** — Demo (mock, sem backend) ou API (autenticação real)
 2. **Registro** — `/register` com auto-login após cadastro
-3. **Dashboard** — KPIs: jobs 24h, validações aprovadas, exceções abertas
+3. **Dashboard** — KPIs: jobs 24h, total validações, taxa conformidade, exceções abertas, total findings, FATAL count, top 3 regras violadas, trend 7 dias
 4. **Validar XML** — Upload NFS-e/NF-e → validação CBS/IBS → download CSV/PDF auditável
-5. **Chat** — Assistente fiscal com CrewAI (3 agentes: triage → operator → narrator)
-6. **Jobs** — Histórico de execuções com export de evidências (.zip)
-7. **Auditoria** — Trilha auditável com SHA-256 checksums
-8. **Exceções** — Workflow OPEN → APPROVED/REJECTED com eventos no audit
+5. **Lote** — Upload múltiplos XMLs → validação sequencial com progress bar → relatório consolidado CSV/PDF
+6. **Chat** — Assistente fiscal com CrewAI (3 agentes: triage → operator → narrator)
+7. **Jobs** — Histórico de execuções com export de evidências (.zip)
+8. **Auditoria** — Trilha auditável com SHA-256 checksums
+9. **Exceções** — Workflow OPEN → APPROVED/REJECTED com eventos no audit
 
 ## Regras de domínio
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts"
   },
   "dependencies": {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
@@ -6,11 +6,88 @@ import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
 import { getAudits, getJobs, listExceptionRequests } from "@/lib/api";
-import { AuditLog, ExceptionRequest, Job } from "@/lib/types";
+import { AuditLog, ExceptionRequest, Finding, Job } from "@/lib/types";
 
 function percent(success: number, total: number): string {
   if (!total) return "0%";
   return `${Math.round((success / total) * 100)}%`;
+}
+
+type RuleViolation = { rule_id: string; count: number };
+
+function topRules(jobs: Job[], limit: number): RuleViolation[] {
+  const counts = new Map<string, number>();
+  for (const job of jobs) {
+    if (!job.findings) continue;
+    for (const f of job.findings) {
+      counts.set(f.rule_id, (counts.get(f.rule_id) ?? 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([rule_id, count]) => ({ rule_id, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+type TrendDay = { label: string; count: number; pass: number; fail: number };
+
+function trendLast7Days(jobs: Job[]): TrendDay[] {
+  const days: TrendDay[] = [];
+  const now = new Date();
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    const label = `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}`;
+    const dayJobs = jobs.filter((j) => j.createdAt.slice(0, 10) === key);
+    const pass = dayJobs.filter((j) => j.status === "SUCCESS").length;
+    days.push({ label, count: dayJobs.length, pass, fail: dayJobs.length - pass });
+  }
+
+  return days;
+}
+
+function TrendChart({ data }: { data: TrendDay[] }) {
+  const maxCount = Math.max(...data.map((d) => d.count), 1);
+
+  return (
+    <div className="flex items-end gap-2" style={{ height: 120 }}>
+      {data.map((day) => {
+        const totalH = Math.max((day.count / maxCount) * 100, 2);
+        const passH = day.count > 0 ? (day.pass / day.count) * totalH : 0;
+        const failH = totalH - passH;
+        return (
+          <div key={day.label} className="flex flex-1 flex-col items-center gap-1">
+            <div className="flex w-full flex-col items-center" style={{ height: 100 }}>
+              <div className="flex-1" />
+              <div className="w-full max-w-8 flex flex-col">
+                {failH > 0 && (
+                  <div
+                    className="w-full rounded-t bg-red-400"
+                    style={{ height: `${failH}px` }}
+                    title={`FAIL: ${day.fail}`}
+                  />
+                )}
+                {passH > 0 && (
+                  <div
+                    className={`w-full bg-emerald-500 ${failH > 0 ? "" : "rounded-t"} rounded-b`}
+                    style={{ height: `${passH}px` }}
+                    title={`PASS: ${day.pass}`}
+                  />
+                )}
+                {day.count === 0 && (
+                  <div className="w-full rounded bg-slate-200" style={{ height: "2px" }} />
+                )}
+              </div>
+            </div>
+            <span className="text-[10px] text-slate-500">{day.label}</span>
+            <span className="text-[10px] font-medium text-slate-700">{day.count}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export default function DashboardPage() {
@@ -36,12 +113,23 @@ export default function DashboardPage() {
     const jobs24h = jobs.filter((job) => Date.now() - new Date(job.createdAt).getTime() <= 24 * 60 * 60 * 1000);
     const successCount = jobs.filter((job) => job.status === "SUCCESS").length;
     const openExceptions = exceptions.filter((row) => row.status === "OPEN").length;
+    const totalFindings = jobs.reduce((sum, j) => sum + (j.findings?.length ?? 0), 0);
+    const fatalFindings = jobs.reduce(
+      (sum, j) => sum + (j.findings?.filter((f) => f.severity === "FATAL").length ?? 0),
+      0,
+    );
     return {
       total24h: jobs24h.length,
+      totalJobs: jobs.length,
       successRate: percent(successCount, jobs.length),
       exceptionsOpen: openExceptions,
+      totalFindings,
+      fatalFindings,
     };
   }, [jobs, exceptions]);
+
+  const top3Rules = useMemo(() => topRules(jobs, 3), [jobs]);
+  const trend = useMemo(() => trendLast7Days(jobs), [jobs]);
 
   return (
     <section className="space-y-5">
@@ -50,19 +138,75 @@ export default function DashboardPage() {
         <p className="text-sm text-slate-500">Visão executiva da operação tributária.</p>
       </header>
 
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-3 lg:grid-cols-6">
         <article className="rounded-xl border border-slate-200 bg-white p-4">
           <p className="text-xs uppercase text-slate-500">Jobs 24h</p>
           <p className="mt-2 text-3xl font-bold">{loading ? "..." : metrics.total24h}</p>
         </article>
         <article className="rounded-xl border border-slate-200 bg-white p-4">
-          <p className="text-xs uppercase text-slate-500">Validações aprovadas %</p>
-          <p className="mt-2 text-3xl font-bold">{loading ? "..." : metrics.successRate}</p>
+          <p className="text-xs uppercase text-slate-500">Total Validações</p>
+          <p className="mt-2 text-3xl font-bold">{loading ? "..." : metrics.totalJobs}</p>
         </article>
         <article className="rounded-xl border border-slate-200 bg-white p-4">
-          <p className="text-xs uppercase text-slate-500">Exceções abertas</p>
+          <p className="text-xs uppercase text-slate-500">Taxa Conformidade</p>
+          <p className="mt-2 text-3xl font-bold text-emerald-600">{loading ? "..." : metrics.successRate}</p>
+        </article>
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">Exceções Abertas</p>
           <p className="mt-2 text-3xl font-bold">{loading ? "..." : metrics.exceptionsOpen}</p>
         </article>
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">Total Findings</p>
+          <p className="mt-2 text-3xl font-bold">{loading ? "..." : metrics.totalFindings}</p>
+        </article>
+        <article className="rounded-xl border border-slate-200 bg-white p-4">
+          <p className="text-xs uppercase text-slate-500">FATAL</p>
+          <p className="mt-2 text-3xl font-bold text-red-600">{loading ? "..." : metrics.fatalFindings}</p>
+        </article>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <section className="rounded-xl border border-slate-200 bg-white p-4 lg:col-span-2">
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Trend (7 dias)</h2>
+          {loading ? (
+            <Skeleton className="h-32 w-full" />
+          ) : (
+            <>
+              <TrendChart data={trend} />
+              <div className="mt-2 flex items-center gap-4 text-xs text-slate-500">
+                <span className="flex items-center gap-1">
+                  <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" /> PASS
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block h-2 w-2 rounded-full bg-red-400" /> FAIL
+                </span>
+              </div>
+            </>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-4">
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Top 3 Regras Violadas</h2>
+          {loading ? (
+            <Skeleton className="h-20 w-full" />
+          ) : top3Rules.length === 0 ? (
+            <p className="text-sm text-slate-500">Sem violações registradas.</p>
+          ) : (
+            <ul className="space-y-2">
+              {top3Rules.map((rule, idx) => (
+                <li key={rule.rule_id} className="flex items-center justify-between rounded border border-slate-100 p-2">
+                  <div className="flex items-center gap-2">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-full bg-slate-100 text-xs font-bold text-slate-600">
+                      {idx + 1}
+                    </span>
+                    <span className="font-mono text-sm">{rule.rule_id}</span>
+                  </div>
+                  <span className="text-sm font-semibold text-red-600">{rule.count}x</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-2">

--- a/frontend/src/app/validate-batch/page.tsx
+++ b/frontend/src/app/validate-batch/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import Link from "next/link";
+import { ChangeEvent, useCallback, useMemo, useRef, useState } from "react";
+import { Toast } from "@/components/common/Toast";
+import { validateXml } from "@/lib/api";
+import { buildBatchReportCsv, buildBatchReportHtml, downloadBatchCsv, downloadBatchPdf } from "@/lib/export/batchReport";
+import { ValidateXmlRequest, ValidationResultV11, XmlDocumentType } from "@/lib/types";
+
+type BatchItem = {
+  filename: string;
+  xml: string;
+  status: "pending" | "validating" | "done" | "error";
+  result?: ValidationResultV11;
+  error?: string;
+};
+
+function statusLabel(status: BatchItem["status"]): string {
+  switch (status) {
+    case "pending":
+      return "Aguardando";
+    case "validating":
+      return "Validando...";
+    case "done":
+      return "Concluído";
+    case "error":
+      return "Erro";
+  }
+}
+
+function statusColor(status: BatchItem["status"]): string {
+  switch (status) {
+    case "pending":
+      return "text-slate-500";
+    case "validating":
+      return "text-blue-600";
+    case "done":
+      return "text-emerald-600";
+    case "error":
+      return "text-red-600";
+  }
+}
+
+function resultBadge(item: BatchItem): string {
+  if (!item.result) return "-";
+  const fatals = item.result.findings.filter((f) => f.severity === "FATAL").length;
+  return fatals > 0 ? `FAIL (${fatals})` : "PASS";
+}
+
+function resultBadgeColor(item: BatchItem): string {
+  if (!item.result) return "text-slate-400";
+  const fatals = item.result.findings.filter((f) => f.severity === "FATAL").length;
+  return fatals > 0 ? "text-red-600 font-semibold" : "text-emerald-600 font-semibold";
+}
+
+export default function ValidateBatchPage() {
+  const [documentType, setDocumentType] = useState<XmlDocumentType>("NFSE");
+  const [items, setItems] = useState<BatchItem[]>([]);
+  const [running, setRunning] = useState(false);
+  const [toast, setToast] = useState<{ tone: "success" | "error" | "info"; msg: string } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const completedResults = useMemo(() => {
+    return items.filter((i) => i.status === "done" && i.result).map((i) => ({
+      filename: i.filename,
+      result: i.result!,
+    }));
+  }, [items]);
+
+  const summary = useMemo(() => {
+    const done = items.filter((i) => i.status === "done" && i.result);
+    const pass = done.filter((i) => i.result!.findings.every((f) => f.severity !== "FATAL")).length;
+    const fail = done.length - pass;
+    const totalFindings = done.reduce((sum, i) => sum + i.result!.findings.length, 0);
+    const totalFatal = done.reduce((sum, i) => sum + i.result!.findings.filter((f) => f.severity === "FATAL").length, 0);
+    return { total: done.length, pass, fail, totalFindings, totalFatal };
+  }, [items]);
+
+  const progress = useMemo(() => {
+    if (items.length === 0) return 0;
+    const done = items.filter((i) => i.status === "done" || i.status === "error").length;
+    return Math.round((done / items.length) * 100);
+  }, [items]);
+
+  function onFileChange(event: ChangeEvent<HTMLInputElement>): void {
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
+
+    const newItems: BatchItem[] = [];
+    const readPromises: Promise<void>[] = [];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const idx = newItems.length;
+      newItems.push({ filename: file.name, xml: "", status: "pending" });
+      readPromises.push(
+        file.text().then((text) => {
+          newItems[idx].xml = text;
+        }),
+      );
+    }
+
+    void Promise.all(readPromises).then(() => {
+      setItems((prev) => [...prev, ...newItems]);
+    });
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  function onDrop(event: React.DragEvent): void {
+    event.preventDefault();
+    const files = event.dataTransfer.files;
+    if (!files || files.length === 0) return;
+
+    const newItems: BatchItem[] = [];
+    const readPromises: Promise<void>[] = [];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      if (!file.name.toLowerCase().endsWith(".xml")) continue;
+      const idx = newItems.length;
+      newItems.push({ filename: file.name, xml: "", status: "pending" });
+      readPromises.push(
+        file.text().then((text) => {
+          newItems[idx].xml = text;
+        }),
+      );
+    }
+
+    void Promise.all(readPromises).then(() => {
+      if (newItems.length === 0) {
+        setToast({ tone: "error", msg: "Nenhum arquivo .xml encontrado." });
+        return;
+      }
+      setItems((prev) => [...prev, ...newItems]);
+    });
+  }
+
+  function removeItem(index: number): void {
+    setItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function clearAll(): void {
+    setItems([]);
+  }
+
+  const runBatch = useCallback(async () => {
+    const pendingItems = items.filter((i) => i.status === "pending");
+    if (pendingItems.length === 0) {
+      setToast({ tone: "info", msg: "Nenhum arquivo pendente para validar." });
+      return;
+    }
+
+    setRunning(true);
+
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].status !== "pending") continue;
+
+      setItems((prev) =>
+        prev.map((item, idx) => (idx === i ? { ...item, status: "validating" } : item)),
+      );
+
+      try {
+        const payload: ValidateXmlRequest = {
+          document_type: documentType,
+          xml: items[i].xml,
+          source: "upload",
+        };
+        const result = await validateXml(payload);
+        setItems((prev) =>
+          prev.map((item, idx) => (idx === i ? { ...item, status: "done", result } : item)),
+        );
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : "Falha ao validar";
+        setItems((prev) =>
+          prev.map((item, idx) => (idx === i ? { ...item, status: "error", error: errorMsg } : item)),
+        );
+      }
+    }
+
+    setRunning(false);
+    setToast({ tone: "success", msg: "Lote concluído." });
+  }, [items, documentType]);
+
+  return (
+    <section className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">Validar em Lote</h1>
+        <p className="text-sm text-slate-500">
+          Upload de múltiplos XMLs para validação sequencial com relatório consolidado.
+        </p>
+      </header>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 space-y-4">
+        <div className="flex flex-wrap items-end gap-4">
+          <label className="text-sm">
+            <span className="mb-1 block text-slate-500">Tipo do documento</span>
+            <select
+              value={documentType}
+              onChange={(e) => setDocumentType(e.target.value as XmlDocumentType)}
+              className="w-48 rounded-lg border border-slate-300 px-3 py-2"
+            >
+              <option value="NFSE">NFS-e</option>
+              <option value="NFE">NF-e</option>
+            </select>
+          </label>
+
+          <label className="text-sm">
+            <span className="mb-1 block text-slate-500">Selecionar XMLs</span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".xml,text/xml"
+              multiple
+              onChange={onFileChange}
+              className="rounded-lg border border-slate-300 px-3 py-2"
+            />
+          </label>
+        </div>
+
+        <div
+          onDrop={onDrop}
+          onDragOver={(e) => e.preventDefault()}
+          className="flex min-h-24 items-center justify-center rounded-xl border-2 border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500"
+        >
+          Arraste arquivos .xml aqui ou use o seletor acima
+        </div>
+
+        {items.length > 0 && (
+          <>
+            {running && (
+              <div className="space-y-1">
+                <div className="flex justify-between text-xs text-slate-600">
+                  <span>Progresso</span>
+                  <span>{progress}%</span>
+                </div>
+                <div className="h-2 w-full rounded-full bg-slate-200">
+                  <div
+                    className="h-2 rounded-full bg-tribultz-600 transition-all"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-left text-xs uppercase text-slate-500">
+                    <th className="px-3 py-2">#</th>
+                    <th className="px-3 py-2">Arquivo</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2">Resultado</th>
+                    <th className="px-3 py-2">Findings</th>
+                    <th className="px-3 py-2">Ações</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item, idx) => (
+                    <tr key={idx} className="border-b border-slate-100">
+                      <td className="px-3 py-2 text-slate-400">{idx + 1}</td>
+                      <td className="px-3 py-2 font-mono text-xs">{item.filename}</td>
+                      <td className={`px-3 py-2 text-xs ${statusColor(item.status)}`}>
+                        {statusLabel(item.status)}
+                      </td>
+                      <td className={`px-3 py-2 text-xs ${resultBadgeColor(item)}`}>
+                        {resultBadge(item)}
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        {item.result ? item.result.findings.length : item.error ? item.error : "-"}
+                      </td>
+                      <td className="px-3 py-2">
+                        {item.result && (
+                          <Link
+                            href={`/jobs/${item.result.job.id}`}
+                            className="text-xs text-tribultz-700 hover:underline"
+                          >
+                            Ver Job
+                          </Link>
+                        )}
+                        {!running && item.status === "pending" && (
+                          <button
+                            type="button"
+                            onClick={() => removeItem(idx)}
+                            className="text-xs text-red-500 hover:underline"
+                          >
+                            Remover
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {summary.total > 0 && (
+              <div className="grid gap-3 md:grid-cols-4">
+                <div className="rounded-lg border border-slate-200 p-3 text-center">
+                  <p className="text-xs uppercase text-slate-500">Total</p>
+                  <p className="text-xl font-bold">{summary.total}</p>
+                </div>
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-center">
+                  <p className="text-xs uppercase text-emerald-600">PASS</p>
+                  <p className="text-xl font-bold text-emerald-700">{summary.pass}</p>
+                </div>
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-center">
+                  <p className="text-xs uppercase text-red-600">FAIL</p>
+                  <p className="text-xl font-bold text-red-700">{summary.fail}</p>
+                </div>
+                <div className="rounded-lg border border-slate-200 p-3 text-center">
+                  <p className="text-xs uppercase text-slate-500">Findings</p>
+                  <p className="text-xl font-bold">{summary.totalFindings}</p>
+                </div>
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => void runBatch()}
+                disabled={running || items.every((i) => i.status !== "pending")}
+                className="rounded-lg bg-tribultz-600 px-4 py-2 text-sm font-semibold text-white hover:bg-tribultz-700 disabled:opacity-70"
+              >
+                {running ? "Processando..." : "Validar Lote"}
+              </button>
+
+              {completedResults.length > 0 && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => downloadBatchCsv(buildBatchReportCsv(completedResults, documentType), "lote")}
+                    className="rounded border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100"
+                  >
+                    Exportar CSV
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => downloadBatchPdf(buildBatchReportHtml(completedResults, documentType), "lote")}
+                    className="rounded border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-100"
+                  >
+                    Exportar PDF
+                  </button>
+                </>
+              )}
+
+              <button
+                type="button"
+                onClick={clearAll}
+                disabled={running}
+                className="rounded border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-500 hover:bg-slate-100 disabled:opacity-50"
+              >
+                Limpar
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {toast ? <Toast message={toast.msg} tone={toast.tone} onClose={() => setToast(null)} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ const links = [
   { href: "/dashboard", label: "Painel" },
   { href: "/closing", label: "Fechamento" },
   { href: "/validate-xml", label: "Validar XML" },
+  { href: "/validate-batch", label: "Lote" },
   { href: "/chat", label: "Chat" },
   { href: "/jobs", label: "Jobs" },
   { href: "/audit", label: "Auditoria" },

--- a/frontend/src/lib/export/batchReport.test.ts
+++ b/frontend/src/lib/export/batchReport.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildBatchReportCsv, buildBatchReportHtml, type BatchEntry } from "./batchReport";
+
+function makeFinding(id: string, severity: "FATAL" | "ALERT", ruleId: string) {
+  return {
+    id,
+    severity,
+    rule_id: ruleId,
+    title: `Finding ${id}`,
+    where: { field: "tag", xpath: "/root/tag" },
+    recommendation: "Fix it",
+    evidence_ids: [`ev-${id}`],
+  };
+}
+
+function makeResult(jobId: string, findings: ReturnType<typeof makeFinding>[]) {
+  return {
+    job: { id: jobId, created_at: "2026-03-22T00:00:00Z", tenant_id: "tenant-a" },
+    audit: { id: `aud-${jobId}`, job_id: jobId, events: [] },
+    findings,
+    evidences: [],
+  };
+}
+
+const FIXED_DATE = new Date("2026-03-22T12:00:00Z");
+
+const entries: BatchEntry[] = [
+  {
+    filename: "nota1.xml",
+    result: makeResult("job-1", [makeFinding("f1", "FATAL", "R01")]),
+  },
+  {
+    filename: "nota2.xml",
+    result: makeResult("job-2", [makeFinding("f2", "ALERT", "R05")]),
+  },
+  {
+    filename: "nota3.xml",
+    result: makeResult("job-3", []),
+  },
+];
+
+describe("batchReport CSV", () => {
+  it("should include meta header comments", () => {
+    const csv = buildBatchReportCsv(entries, "NFSE", FIXED_DATE);
+    assert.ok(csv.includes("# Tribultz"));
+    assert.ok(csv.includes("# total_files: 3"));
+    assert.ok(csv.includes("# pass: 2"));
+    assert.ok(csv.includes("# fail: 1"));
+  });
+
+  it("should include summary rows for each file", () => {
+    const csv = buildBatchReportCsv(entries, "NFSE", FIXED_DATE);
+    assert.ok(csv.includes("nota1.xml"));
+    assert.ok(csv.includes("nota2.xml"));
+    assert.ok(csv.includes("nota3.xml"));
+    assert.ok(csv.includes("FAIL"));
+    assert.ok(csv.includes("PASS"));
+  });
+
+  it("should include finding detail rows", () => {
+    const csv = buildBatchReportCsv(entries, "NFSE", FIXED_DATE);
+    assert.ok(csv.includes("# Detalhes dos Findings"));
+    assert.ok(csv.includes("f1"));
+    assert.ok(csv.includes("R01"));
+    assert.ok(csv.includes("f2"));
+  });
+
+  it("should be deterministic", () => {
+    const a = buildBatchReportCsv(entries, "NFSE", FIXED_DATE);
+    const b = buildBatchReportCsv(entries, "NFSE", FIXED_DATE);
+    assert.equal(a, b);
+  });
+});
+
+describe("batchReport HTML", () => {
+  it("should include doctype and lang", () => {
+    const html = buildBatchReportHtml(entries, "NFSE", FIXED_DATE);
+    assert.ok(html.startsWith("<!DOCTYPE html>"));
+    assert.ok(html.includes('lang="pt-BR"'));
+  });
+
+  it("should show summary stats", () => {
+    const html = buildBatchReportHtml(entries, "NFSE", FIXED_DATE);
+    assert.ok(html.includes("2 PASS"));
+    assert.ok(html.includes("1 FAIL"));
+  });
+
+  it("should show per-file rows", () => {
+    const html = buildBatchReportHtml(entries, "NFSE", FIXED_DATE);
+    assert.ok(html.includes("nota1.xml"));
+    assert.ok(html.includes("nota2.xml"));
+    assert.ok(html.includes("nota3.xml"));
+  });
+
+  it("should include legal base reference", () => {
+    const html = buildBatchReportHtml(entries, "NFSE", FIXED_DATE);
+    assert.ok(html.includes("LC 214"));
+    assert.ok(html.includes("LC 227"));
+  });
+
+  it("should be deterministic", () => {
+    const a = buildBatchReportHtml(entries, "NFSE", FIXED_DATE);
+    const b = buildBatchReportHtml(entries, "NFSE", FIXED_DATE);
+    assert.equal(a, b);
+  });
+});

--- a/frontend/src/lib/export/batchReport.ts
+++ b/frontend/src/lib/export/batchReport.ts
@@ -1,0 +1,254 @@
+/**
+ * Batch report generator — CSV + PDF (printable HTML).
+ *
+ * Consolidates multiple validation results into a single report
+ * with per-file PASS/FAIL status and aggregate findings.
+ */
+
+import type { Finding, ValidationEvidence, ValidationResultV11 } from "../types";
+
+export type BatchEntry = {
+  filename: string;
+  result: ValidationResultV11;
+};
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function escapeCsv(value: string): string {
+  if (value.includes('"') || value.includes(",") || value.includes("\n") || value.includes("\r")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 3)}...`;
+}
+
+function fatalCount(result: ValidationResultV11): number {
+  return result.findings.filter((f) => f.severity === "FATAL").length;
+}
+
+function passOrFail(result: ValidationResultV11): string {
+  return fatalCount(result) > 0 ? "FAIL" : "PASS";
+}
+
+// ── CSV ────────────────────────────────────────────────────────
+
+export function buildBatchReportCsv(
+  entries: BatchEntry[],
+  documentType: string,
+  now: Date = new Date(),
+): string {
+  const lines: string[] = [];
+  const pass = entries.filter((e) => passOrFail(e.result) === "PASS").length;
+  const fail = entries.length - pass;
+  const totalFindings = entries.reduce((s, e) => s + e.result.findings.length, 0);
+
+  lines.push(`# Tribultz – Relatorio de Lote`);
+  lines.push(`# generated_at: ${now.toISOString()}`);
+  lines.push(`# document_type: ${documentType}`);
+  lines.push(`# total_files: ${entries.length}`);
+  lines.push(`# pass: ${pass}`);
+  lines.push(`# fail: ${fail}`);
+  lines.push(`# total_findings: ${totalFindings}`);
+  lines.push("");
+
+  // Summary table
+  lines.push("arquivo,job_id,resultado,findings,fatal,alert");
+  for (const entry of entries) {
+    const fatals = fatalCount(entry.result);
+    const alerts = entry.result.findings.length - fatals;
+    lines.push(
+      [
+        escapeCsv(entry.filename),
+        escapeCsv(entry.result.job.id),
+        passOrFail(entry.result),
+        String(entry.result.findings.length),
+        String(fatals),
+        String(alerts),
+      ].join(","),
+    );
+  }
+
+  lines.push("");
+  lines.push("# Detalhes dos Findings");
+  lines.push("arquivo,finding_id,severity,rule_id,title,field,xpath,recommendation");
+
+  for (const entry of entries) {
+    for (const f of entry.result.findings) {
+      lines.push(
+        [
+          escapeCsv(entry.filename),
+          escapeCsv(f.id),
+          escapeCsv(f.severity),
+          escapeCsv(f.rule_id),
+          escapeCsv(f.title),
+          escapeCsv(f.where.field ?? ""),
+          escapeCsv(f.where.xpath ?? ""),
+          escapeCsv(f.recommendation),
+        ].join(","),
+      );
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+// ── PDF (printable HTML) ───────────────────────────────────────
+
+export function buildBatchReportHtml(
+  entries: BatchEntry[],
+  documentType: string,
+  now: Date = new Date(),
+): string {
+  const pass = entries.filter((e) => passOrFail(e.result) === "PASS").length;
+  const fail = entries.length - pass;
+  const totalFindings = entries.reduce((s, e) => s + e.result.findings.length, 0);
+
+  const summaryRows = entries
+    .map((entry) => {
+      const fatals = fatalCount(entry.result);
+      const alerts = entry.result.findings.length - fatals;
+      const status = passOrFail(entry.result);
+      const statusColor = status === "PASS" ? "#16a34a" : "#dc2626";
+      return `<tr>
+        <td style="padding:6px 8px;border:1px solid #e2e8f0">${escapeHtml(entry.filename)}</td>
+        <td style="padding:6px 8px;border:1px solid #e2e8f0;font-family:monospace;font-size:11px">${escapeHtml(entry.result.job.id)}</td>
+        <td style="padding:6px 8px;border:1px solid #e2e8f0;font-weight:700;color:${statusColor}">${status}</td>
+        <td style="padding:6px 8px;border:1px solid #e2e8f0;text-align:center">${entry.result.findings.length}</td>
+        <td style="padding:6px 8px;border:1px solid #e2e8f0;text-align:center;color:#dc2626">${fatals}</td>
+        <td style="padding:6px 8px;border:1px solid #e2e8f0;text-align:center;color:#d97706">${alerts}</td>
+      </tr>`;
+    })
+    .join("\n");
+
+  const findingRows = entries
+    .flatMap((entry) =>
+      entry.result.findings.map(
+        (f) =>
+          `<tr>
+        <td style="padding:4px 8px;border:1px solid #e2e8f0;font-size:11px">${escapeHtml(entry.filename)}</td>
+        <td style="padding:4px 8px;border:1px solid #e2e8f0;font-weight:600;color:${f.severity === "FATAL" ? "#dc2626" : "#d97706"}">${escapeHtml(f.severity)}</td>
+        <td style="padding:4px 8px;border:1px solid #e2e8f0;font-family:monospace;font-size:11px">${escapeHtml(f.rule_id)}</td>
+        <td style="padding:4px 8px;border:1px solid #e2e8f0">${escapeHtml(f.title)}</td>
+        <td style="padding:4px 8px;border:1px solid #e2e8f0">${escapeHtml(f.where.field ?? "")}</td>
+        <td style="padding:4px 8px;border:1px solid #e2e8f0">${escapeHtml(f.recommendation)}</td>
+      </tr>`,
+      ),
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<title>Tribultz - Relatorio de Lote</title>
+<style>
+  @media print {
+    body { font-size: 11px; }
+    .no-print { display: none; }
+  }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: #1e293b; margin: 24px; }
+  h1 { font-size: 20px; margin-bottom: 4px; }
+  table { border-collapse: collapse; width: 100%; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<h1>Tribultz - Relatorio de Lote</h1>
+<p style="color:#64748b;font-size:13px;margin-top:0">
+  Base legal: LC 214 + LC 227 | CBS 0,10% | IBS 0,90%
+</p>
+
+<table style="width:auto;font-size:13px;margin-top:12px">
+  <tr><td style="padding:2px 12px 2px 0;font-weight:600">Gerado em</td><td>${escapeHtml(now.toISOString())}</td></tr>
+  <tr><td style="padding:2px 12px 2px 0;font-weight:600">Tipo documento</td><td>${escapeHtml(documentType)}</td></tr>
+  <tr><td style="padding:2px 12px 2px 0;font-weight:600">Total arquivos</td><td>${entries.length}</td></tr>
+  <tr><td style="padding:2px 12px 2px 0;font-weight:600">PASS / FAIL</td><td style="color:#16a34a">${pass} PASS</td></tr>
+  <tr><td></td><td style="color:#dc2626">${fail} FAIL</td></tr>
+  <tr><td style="padding:2px 12px 2px 0;font-weight:600">Total findings</td><td>${totalFindings}</td></tr>
+</table>
+
+<h2 style="margin-top:24px;font-size:16px;color:#1e293b">Resumo por Arquivo</h2>
+<table style="font-size:12px">
+  <thead>
+    <tr style="background:#f1f5f9">
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Arquivo</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Job ID</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Resultado</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:center">Findings</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:center">FATAL</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:center">ALERT</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${summaryRows}
+  </tbody>
+</table>
+
+<h2 style="margin-top:24px;font-size:16px;color:#1e293b">Findings Detalhados</h2>
+<table style="font-size:12px">
+  <thead>
+    <tr style="background:#f1f5f9">
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Arquivo</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Severidade</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Regra</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Titulo</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Campo</th>
+      <th style="padding:6px 8px;border:1px solid #e2e8f0;text-align:left">Recomendacao</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${findingRows}
+  </tbody>
+</table>
+
+<hr style="margin-top:32px;border:none;border-top:1px solid #e2e8f0">
+<p style="font-size:11px;color:#94a3b8;margin-top:8px">
+  Documento gerado automaticamente pelo Tribultz. Nao possui valor fiscal.
+  Conferir com documentos oficiais do portal nacional.
+</p>
+
+</body>
+</html>
+`;
+}
+
+// ── Download helpers (browser) ─────────────────────────────────
+
+export function downloadBatchCsv(csv: string, batchId: string): void {
+  if (typeof window === "undefined") return;
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `tribultz_batch_${batchId}_${Date.now()}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadBatchPdf(html: string, batchId: string): void {
+  if (typeof window === "undefined") return;
+  const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const w = window.open(url, "_blank");
+  if (w) {
+    w.addEventListener("load", () => {
+      w.document.title = `Tribultz Batch Report ${batchId}`;
+      w.print();
+    });
+  }
+  setTimeout(() => URL.revokeObjectURL(url), 30000);
+}


### PR DESCRIPTION
## Summary

- **#45 Batch Upload**: `/validate-batch` page with multi-XML upload (drag & drop + file picker), sequential validation with progress bar, consolidated PASS/FAIL results table, batch CSV/PDF export
- **#46 Dashboard KPIs reais**: 6 metric cards (jobs 24h, total validações, taxa conformidade, exceções abertas, total findings, FATAL count), top 3 regras violadas ranking, 7-day trend bar chart (PASS/FAIL stacked)

## Test plan

- [x] 41/41 frontend tests pass (`npm test`)
- [x] 47/47 backend tests pass (`pytest tests/ -q`)
- [x] Ruff clean (`ruff check app/ tests/`)
- [x] Frontend build succeeds with `/validate-batch` route
- [x] 9 new batch report tests (CSV meta, summary, details, determinism; HTML doctype, stats, rows, legal refs, determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)