### PR TITLE
feat: public changelog page with auto-sync from GitHub Issues

### DIFF
--- a/.github/scripts/update-changelog.py
+++ b/.github/scripts/update-changelog.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Auto-generate frontend/src/data/changelog.json from closed GitHub issues.
+
+Triggered by the changelog GitHub Action. Reads issues via `gh` CLI,
+groups by sprint tag [S<N>-*], and writes a structured JSON file.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OUTPUT = REPO_ROOT / "frontend" / "src" / "data" / "changelog.json"
+
+SPRINT_RE = re.compile(r"\[S(\d+)-(\d+)\]\s*(.+)")
+
+# Map issue labels to changelog entry type
+LABEL_TO_TYPE: dict[str, str] = {
+    "enhancement": "melhoria",
+    "bug": "correcao",
+}
+
+SPRINT_META: dict[str, dict[str, str]] = {
+    "6": {
+        "title": "Sprint 6 \u2014 Export & Evidencias",
+        "summary": "Exportacao de evidencias, pacotes ZIP e discovery com contabilidade.",
+    },
+    "7": {
+        "title": "Sprint 7 \u2014 Motor Deterministico",
+        "summary": "10 regras fiscais deterministicas com evidencias auditaveis.",
+    },
+    "8": {
+        "title": "Sprint 8 \u2014 API Mode & Integracao",
+        "summary": "Backend real conectado, CrewAI robusto e relatorios auditaveis.",
+    },
+    "9": {
+        "title": "Sprint 9 \u2014 Governanca & Seguranca",
+        "summary": "Multi-tenant, LGPD, autenticacao robusta e seguranca de producao.",
+    },
+    "10": {
+        "title": "Sprint 10 \u2014 Release Candidate",
+        "summary": "Polimento final, performance e preparacao para producao.",
+    },
+}
+
+
+def fetch_closed_issues() -> list[dict]:
+    """Fetch all closed issues from GitHub via gh CLI."""
+    result = subprocess.run(
+        [
+            "gh", "issue", "list",
+            "--state", "closed",
+            "--limit", "200",
+            "--json", "number,title,labels,closedAt",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"gh issue list failed: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+def classify_type(labels: list[dict]) -> str:
+    """Determine entry type from issue labels."""
+    names = {lbl["name"] for lbl in labels}
+    for label_name, entry_type in LABEL_TO_TYPE.items():
+        if label_name in names:
+            return entry_type
+    return "novo"
+
+
+def classify_scope(labels: list[dict]) -> list[str]:
+    """Determine scope (frontend/backend) from labels."""
+    names = {lbl["name"] for lbl in labels}
+    scope = []
+    if "frontend" in names:
+        scope.append("frontend")
+    if "backend" in names:
+        scope.append("backend")
+    return scope if scope else ["backend"]
+
+
+def build_changelog(issues: list[dict]) -> dict:
+    """Group issues by sprint and build the changelog structure."""
+    sprints: dict[str, list[dict]] = defaultdict(list)
+    sprint_dates: dict[str, str] = {}
+
+    for issue in issues:
+        m = SPRINT_RE.match(issue["title"])
+        if not m:
+            continue
+
+        sprint_num = m.group(1)
+        desc = m.group(3).strip()
+        closed_at = issue["closedAt"][:10] if issue.get("closedAt") else "2026-01-01"
+
+        entry = {
+            "type": classify_type(issue.get("labels", [])),
+            "text": desc,
+            "scope": classify_scope(issue.get("labels", [])),
+        }
+        sprints[sprint_num].append(entry)
+
+        # Keep most recent close date per sprint
+        if sprint_num not in sprint_dates or closed_at > sprint_dates[sprint_num]:
+            sprint_dates[sprint_num] = closed_at
+
+    # Build sorted output (newest sprint first)
+    result = []
+    for snum in sorted(sprints.keys(), key=int, reverse=True):
+        meta = SPRINT_META.get(snum, {
+            "title": f"Sprint {snum}",
+            "summary": "",
+        })
+        result.append({
+            "id": f"s{snum}",
+            "title": meta["title"],
+            "date": sprint_dates.get(snum, "2026-01-01"),
+            "summary": meta["summary"],
+            "entries": sprints[snum],
+        })
+
+    return {"sprints": result}
+
+
+def main():
+    issues = fetch_closed_issues()
+    changelog = build_changelog(issues)
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(changelog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {len(changelog['sprints'])} sprints to {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,42 @@
+name: Update Changelog
+
+on:
+  issues:
+    types: [closed]
+  workflow_dispatch: # manual trigger
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.issue.title, '[S')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/update-changelog.py
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add frontend/src/data/changelog.json
+          if git diff --cached --quiet; then
+            echo "No changelog changes to commit."
+          else
+            git commit -m "docs: auto-update changelog from closed issues"
+            git push
+          fi

--- a/frontend/src/app/changelog/page.tsx
+++ b/frontend/src/app/changelog/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import data from "@/data/changelog.json";
+
+const typeBadge: Record<string, { label: string; cls: string }> = {
+  novo: { label: "Novo", cls: "bg-emerald-100 text-emerald-800" },
+  melhoria: { label: "Melhoria", cls: "bg-blue-100 text-blue-800" },
+  correcao: { label: "Correcao", cls: "bg-amber-100 text-amber-800" },
+};
+
+const scopeBadge: Record<string, string> = {
+  frontend: "bg-violet-100 text-violet-700",
+  backend: "bg-slate-100 text-slate-700",
+};
+
+export default function ChangelogPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-5">
+          <div>
+            <Link href="/login" className="text-sm text-tribultz-600 hover:underline">
+              &larr; Voltar ao login
+            </Link>
+            <h1 className="mt-1 text-2xl font-bold text-slate-900">Changelog</h1>
+            <p className="text-sm text-slate-500">Acompanhe a evolucao da plataforma Tribultz.</p>
+          </div>
+          <span className="rounded-full bg-tribultz-100 px-3 py-1 text-xs font-semibold text-tribultz-700">
+            v0.{data.sprints.length + 5}.0
+          </span>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <div className="relative border-l-2 border-slate-200 pl-8">
+          {data.sprints.map((sprint) => (
+            <section key={sprint.id} className="relative mb-12 last:mb-0">
+              {/* Timeline dot */}
+              <div className="absolute -left-[41px] top-0 flex h-5 w-5 items-center justify-center rounded-full border-2 border-tribultz-500 bg-white">
+                <div className="h-2 w-2 rounded-full bg-tribultz-500" />
+              </div>
+
+              {/* Sprint header */}
+              <div className="mb-4">
+                <div className="flex items-center gap-3">
+                  <h2 className="text-lg font-bold text-slate-900">{sprint.title}</h2>
+                  <span className="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-500">
+                    {new Date(sprint.date + "T12:00:00").toLocaleDateString("pt-BR", {
+                      day: "2-digit",
+                      month: "short",
+                      year: "numeric",
+                    })}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-slate-600">{sprint.summary}</p>
+              </div>
+
+              {/* Entries */}
+              <ul className="space-y-3">
+                {sprint.entries.map((entry, i) => {
+                  const badge = typeBadge[entry.type] ?? typeBadge.novo;
+                  return (
+                    <li key={i} className="flex items-start gap-3 rounded-lg border border-slate-100 bg-white px-4 py-3 shadow-sm">
+                      <span className={`mt-0.5 inline-block shrink-0 rounded px-2 py-0.5 text-xs font-medium ${badge.cls}`}>
+                        {badge.label}
+                      </span>
+                      <div className="flex-1">
+                        <p className="text-sm text-slate-800">{entry.text}</p>
+                        <div className="mt-1.5 flex gap-1.5">
+                          {entry.scope.map((s) => (
+                            <span key={s} className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${scopeBadge[s] ?? "bg-slate-100 text-slate-600"}`}>
+                              {s}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-16 border-t border-slate-200 pt-6 text-center text-xs text-slate-400">
+          <p>Tribultz &mdash; Conformidade tributaria em tempo de execucao.</p>
+          <p className="mt-1">Atualizado automaticamente a cada release.</p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -162,6 +162,10 @@ export default function LoginPage() {
         <a href="/register" className="font-medium text-tribultz-700 hover:underline">
           Criar conta
         </a>
+        {" "}&middot;{" "}
+        <a href="/changelog" className="font-medium text-slate-500 hover:text-tribultz-700 hover:underline">
+          Novidades
+        </a>
       </p>
       {error ? <Toast message={error} tone="error" onClose={() => setError(null)} /> : null}
     </main>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -14,7 +14,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     setMobileOpen(false);
   }, [pathname]);
 
-  const noShell = ["/login", "/register", "/forgot-password", "/reset-password", "/verify-email"];
+  const noShell = ["/login", "/register", "/forgot-password", "/reset-password", "/verify-email", "/changelog"];
   if (noShell.includes(pathname)) return <>{children}</>;
 
   return (

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -63,6 +63,15 @@ export function Sidebar({ mobile = false, onNavigate }: { mobile?: boolean; onNa
         >
           Feedback
         </Link>
+        <Link
+          href="/changelog"
+          onClick={onNavigate}
+          className={`block rounded-lg px-3 py-2 text-sm ${
+            pathname === "/changelog" ? "bg-tribultz-100 text-tribultz-700" : "text-slate-600 hover:bg-slate-100"
+          }`}
+        >
+          Novidades
+        </Link>
         <button
           type="button"
           onClick={handleLogout}

--- a/frontend/src/data/changelog.json
+++ b/frontend/src/data/changelog.json
@@ -1,0 +1,65 @@
+{
+  "sprints": [
+    {
+      "id": "s9",
+      "title": "Sprint 9 — Governanca & Seguranca",
+      "date": "2026-03-22",
+      "summary": "Multi-tenant, LGPD, autenticacao robusta e seguranca de producao.",
+      "entries": [
+        { "type": "novo", "text": "Consentimento LGPD no cadastro + pagina de politica de privacidade", "scope": ["frontend", "backend"] },
+        { "type": "novo", "text": "Headers de seguranca (HSTS, X-Frame-Options, CSP) e CORS configuravel", "scope": ["backend"] },
+        { "type": "novo", "text": "Rate limiting em login, registro e recuperacao de senha", "scope": ["backend"] },
+        { "type": "novo", "text": "Campo CNPJ no cadastro com validacao via BrasilAPI e ReceitaWS", "scope": ["frontend", "backend"] },
+        { "type": "novo", "text": "Fluxo completo de verificacao de email com token de 24h", "scope": ["frontend", "backend"] },
+        { "type": "novo", "text": "Canal de feedback integrado (bug, sugestao, elogio)", "scope": ["frontend", "backend"] },
+        { "type": "novo", "text": "Direitos LGPD: exportar dados pessoais (JSON) e excluir conta com anonimizacao", "scope": ["frontend", "backend"] },
+        { "type": "melhoria", "text": "Revisao de sanitizacao de inputs com validators Pydantic", "scope": ["backend"] },
+        { "type": "novo", "text": "CrewAI Security Crews: SOC Analyst, CloudSec Engineer e SRE Lead", "scope": ["backend"] },
+        { "type": "novo", "text": "Fluxo de esqueci/redefinir senha com link por email", "scope": ["frontend", "backend"] },
+        { "type": "melhoria", "text": "Dashboard com contexto do tenant ativo (Empresa vs Contador)", "scope": ["frontend"] },
+        { "type": "melhoria", "text": "Governanca multi-tenant: checkbox de responsabilidade para Contadores", "scope": ["frontend"] }
+      ]
+    },
+    {
+      "id": "s8",
+      "title": "Sprint 8 — API Mode & Integracao",
+      "date": "2026-03-22",
+      "summary": "Backend real conectado, CrewAI robusto e relatorios auditaveis.",
+      "entries": [
+        { "type": "novo", "text": "Relatorio auditavel para contabilidade (CSV + PDF)", "scope": ["frontend", "backend"] },
+        { "type": "melhoria", "text": "Integracao Superpowers no workflow de desenvolvimento", "scope": ["backend"] },
+        { "type": "melhoria", "text": "CrewAI hardening: retry, logging estruturado e fallback de LLM", "scope": ["backend"] },
+        { "type": "novo", "text": "Wiring API Mode: validacao frontend conectada ao backend real", "scope": ["frontend", "backend"] },
+        { "type": "novo", "text": "Validacao em lote (batch upload) de notas fiscais", "scope": ["frontend"] },
+        { "type": "novo", "text": "Dashboard com KPIs reais vindos da API", "scope": ["frontend"] }
+      ]
+    },
+    {
+      "id": "s7",
+      "title": "Sprint 7 — Motor Deterministico",
+      "date": "2026-03-21",
+      "summary": "10 regras fiscais deterministicas com evidencias auditaveis.",
+      "entries": [
+        { "type": "novo", "text": "Pacote de 3 XMLs anonimizados com gabarito validado pela contabilidade", "scope": ["backend"] },
+        { "type": "novo", "text": "Top 10 regras fiscais deterministicas (CBS, IBS, CEST, ClassTrib)", "scope": ["frontend", "backend"] },
+        { "type": "melhoria", "text": "Cobertura de variacoes de paths NFS-e para diferentes municipios", "scope": ["backend"] },
+        { "type": "novo", "text": "Runbook S7 com criterios de aceite QA", "scope": ["backend"] }
+      ]
+    },
+    {
+      "id": "s6",
+      "title": "Sprint 6 — Export & Evidencias",
+      "date": "2026-02-26",
+      "summary": "Exportacao de evidencias, pacotes ZIP e discovery com contabilidade.",
+      "entries": [
+        { "type": "novo", "text": "Export de evidencias em ZIP unico por Job", "scope": ["frontend"] },
+        { "type": "novo", "text": "Gerador ZIP client-side para JobEvidenceBundle", "scope": ["frontend"] },
+        { "type": "novo", "text": "Adapter API Mode (placeholder) para export do Job", "scope": ["backend"] },
+        { "type": "correcao", "text": "Testes unitarios do ZIP e naming de arquivos", "scope": ["frontend"] },
+        { "type": "novo", "text": "Export de evidencias nas telas Jobs list e Auditoria", "scope": ["frontend"] },
+        { "type": "melhoria", "text": "Ajustes de UX (Toast, loading states) e testes leves", "scope": ["frontend"] },
+        { "type": "novo", "text": "Discovery formal com contabilidade: Top 10 validacoes + exemplos reais", "scope": ["backend"] }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New `/changelog` page with professional timeline UI (Novo/Melhoria/Correcao badges, scope tags, sprint grouping)
- GitHub Action that auto-generates `changelog.json` whenever a sprint issue is closed
- "Novidades" link added to login page and sidebar for easy access
- Page is public (no auth required) — clients see features, can't edit

## Files
- `frontend/src/app/changelog/page.tsx` — Timeline page
- `frontend/src/data/changelog.json` — Structured data (S6-S9, 29 entries)
- `.github/workflows/changelog.yml` — Auto-sync action on issue close
- `.github/scripts/update-changelog.py` — Generator script via gh CLI
- `frontend/src/components/layout/Sidebar.tsx` — "Novidades" nav link
- `frontend/src/app/login/page.tsx` — "Novidades" link on login
- `frontend/src/components/layout/AppShell.tsx` — Exclude /changelog from shell

## Test plan
- [x] Frontend tests pass (41/41)
- [x] Frontend build succeeds with /changelog route
- [ ] Verify changelog page renders correctly in browser
- [ ] Verify GitHub Action triggers on issue close

🤖 Generated with [Claude Code](https://claude.com/claude-code)