### PR TITLE
feat(s9): Cloudflare Turnstile CAPTCHA on login/register (#56)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@marsidev/react-turnstile": "^1.4.2",
         "fflate": "^0.8.2",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -1466,6 +1467,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.4.2.tgz",
+      "integrity": "sha512-xs1qOuyeMOz6t9BXXCXWiukC0/0+48vR08B7uwNdG05wCMnbcNgxiFmdFKDOFbM76qFYFRYlGeRfhfq1U/iZmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts"
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.4.2",
     "fflate": "^0.8.2",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { Toast } from "@/components/common/Toast";
 import { loginWithApi, resendVerificationEmail } from "@/lib/api";
 import { DEFAULT_TENANT, setAccountType, setMockMode, setTenantId, setTenants, setToken } from "@/lib/storage";
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "1x00000000000000000000AA";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -14,6 +17,8 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [emailUnverified, setEmailUnverified] = useState(false);
   const [resending, setResending] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState("");
+  const turnstileRef = useRef<TurnstileInstance>(null);
 
   function enterDemo(): void {
     setMockMode(true);
@@ -30,6 +35,11 @@ export default function LoginPage() {
       return;
     }
 
+    if (!captchaToken) {
+      setError("Aguarde a verificacao de seguranca (CAPTCHA).");
+      return;
+    }
+
     setLoadingApi(true);
     setError(null);
     try {
@@ -37,6 +47,7 @@ export default function LoginPage() {
         email: email.trim(),
         password,
         tenant_slug: DEFAULT_TENANT,
+        captcha_token: captchaToken,
       });
       if (!login.access_token) {
         throw new Error("Resposta de login sem access_token.");
@@ -54,6 +65,8 @@ export default function LoginPage() {
         setEmailUnverified(true);
       }
       setError(msg);
+      setCaptchaToken("");
+      turnstileRef.current?.reset();
     } finally {
       setLoadingApi(false);
     }
@@ -108,9 +121,16 @@ export default function LoginPage() {
                     className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm"
                     autoComplete="current-password"
                   />
+                  <Turnstile
+                    ref={turnstileRef}
+                    siteKey={TURNSTILE_SITE_KEY}
+                    onSuccess={setCaptchaToken}
+                    onExpire={() => setCaptchaToken("")}
+                    options={{ theme: "light", size: "flexible" }}
+                  />
                   <button
                     type="submit"
-                    disabled={loadingApi}
+                    disabled={loadingApi || !captchaToken}
                     className="w-full rounded-lg border border-tribultz-400 bg-white px-4 py-2 text-sm font-semibold text-tribultz-700 hover:bg-tribultz-50 disabled:cursor-not-allowed disabled:opacity-70"
                   >
                     {loadingApi ? "Autenticando..." : "Entrar (API)"}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { FormEvent, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { Toast } from "@/components/common/Toast";
 import { registerWithApi } from "@/lib/api";
 import { DEFAULT_TENANT } from "@/lib/storage";
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "1x00000000000000000000AA";
 
 function formatCnpj(value: string): string {
   const digits = value.replace(/\D/g, "").slice(0, 14);
@@ -31,6 +34,8 @@ export default function RegisterPage() {
   const [loading, setLoading] = useState(false);
   const [registered, setRegistered] = useState(false);
   const [toast, setToast] = useState<{ tone: "success" | "error"; msg: string } | null>(null);
+  const [captchaToken, setCaptchaToken] = useState("");
+  const turnstileRef = useRef<TurnstileInstance>(null);
 
   async function onSubmit(event: FormEvent): Promise<void> {
     event.preventDefault();
@@ -61,6 +66,10 @@ export default function RegisterPage() {
       setToast({ tone: "error", msg: "Voce deve aceitar o termo de Responsabilidade Multi-Tenant para prosseguir." });
       return;
     }
+    if (!captchaToken) {
+      setToast({ tone: "error", msg: "Aguarde a verificacao de seguranca (CAPTCHA)." });
+      return;
+    }
 
     setLoading(true);
     try {
@@ -72,6 +81,7 @@ export default function RegisterPage() {
         account_type: accountType,
         lgpd_consent: true,
         tenant_slug: DEFAULT_TENANT,
+        captcha_token: captchaToken,
       });
 
       setRegistered(true);
@@ -80,6 +90,8 @@ export default function RegisterPage() {
         tone: "error",
         msg: err instanceof Error ? err.message : "Falha ao registrar.",
       });
+      setCaptchaToken("");
+      turnstileRef.current?.reset();
     } finally {
       setLoading(false);
     }
@@ -271,9 +283,17 @@ export default function RegisterPage() {
             </label>
           )}
 
+          <Turnstile
+            ref={turnstileRef}
+            siteKey={TURNSTILE_SITE_KEY}
+            onSuccess={setCaptchaToken}
+            onExpire={() => setCaptchaToken("")}
+            options={{ theme: "light", size: "flexible" }}
+          />
+
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || !captchaToken}
             className="w-full rounded-lg bg-tribultz-600 px-4 py-2.5 font-semibold text-white hover:bg-tribultz-700 disabled:opacity-70"
           >
             {loading ? "Registrando..." : "Criar conta"}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,6 +40,7 @@ type LoginRequest = {
   email: string;
   password: string;
   tenant_slug: string;
+  captcha_token?: string;
 };
 
 type TenantInfo = {
@@ -65,6 +66,7 @@ type RegisterRequest = {
   account_type: string;
   lgpd_consent: boolean;
   tenant_slug: string;
+  captcha_token?: string;
 };
 
 type RegisterResponse = {


### PR DESCRIPTION
## Summary
- Cloudflare Turnstile CAPTCHA widget integrated on **login** and **register** pages
- Submit buttons disabled until CAPTCHA verification completes
- `captcha_token` passed to backend API (already validates via `captcha_service.py`)
- Widget auto-resets on failed submissions
- Uses test key in dev (`1x00000000000000000000AA`), real key via `NEXT_PUBLIC_TURNSTILE_SITE_KEY` env var

## Closes
- #56

## Test plan
- [x] Frontend tests pass (41/41)
- [x] Frontend build succeeds
- [x] Turnstile widget renders on `/register` with "Sucesso!" (test key)
- [x] Turnstile widget renders on `/login` API form with "Sucesso!" (test key)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)