### PR TITLE
feat(s11): NF-e/NFC-e validation engine + CrewAI IBSCBS crew

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,11 +3,10 @@
   "configurations": [
     {
       "name": "Frontend (Next.js)",
-      "runtimeExecutable": "C:/Program Files/nodejs/node.exe",
-      "runtimeArgs": ["node_modules/.bin/next", "dev"],
+      "runtimeExecutable": "npm.cmd",
+      "runtimeArgs": ["run", "dev"],
       "cwd": "frontend",
-      "port": 3000,
-      "autoPort": true
+      "port": 3000
     },
     {
       "name": "Infra (Docker Compose)",

--- a/backend/app/crews/chatops_crew.py
+++ b/backend/app/crews/chatops_crew.py
@@ -15,9 +15,11 @@ from app.crews.llm_config import (
     execute_with_fallback,
 )
 from app.crews.tools.get_job_status_tool import GetJobStatusTool
+from app.crews.tools.parse_nfe_xml_tool import ParseNFeXMLTool
 from app.crews.tools.parse_nfse_xml_tool import ParseNFSeXMLTool
 from app.crews.tools.trigger_task_a_tool import TriggerTaskATool
 from app.crews.tools.validate_fiscal_rules_tool import ValidateFiscalRulesTool
+from app.crews.tools.validate_ibscbs_rules_tool import ValidateIBSCBSRulesTool
 
 load_dotenv()
 
@@ -72,7 +74,9 @@ class TribultzChatOpsCrew:
         )
         status_tool = GetJobStatusTool(tenant_id=self._tenant_id)
         parse_nfse_tool = ParseNFSeXMLTool(tenant_id=self._tenant_id)
+        parse_nfe_tool = ParseNFeXMLTool(tenant_id=self._tenant_id)
         validate_rules_tool = ValidateFiscalRulesTool()
+        validate_ibscbs_tool = ValidateIBSCBSRulesTool()
 
         triage = Agent(
             role=agents_cfg["triage"]["role"],
@@ -85,7 +89,11 @@ class TribultzChatOpsCrew:
             role=agents_cfg["operator"]["role"],
             goal=agents_cfg["operator"]["goal"],
             backstory=agents_cfg["operator"]["backstory"],
-            tools=[trigger_tool, status_tool, parse_nfse_tool, validate_rules_tool],
+            tools=[
+                trigger_tool, status_tool,
+                parse_nfse_tool, validate_rules_tool,
+                parse_nfe_tool, validate_ibscbs_tool,
+            ],
             llm=llm,
             verbose=False,
         )

--- a/backend/app/crews/nfe_validation_crew.py
+++ b/backend/app/crews/nfe_validation_crew.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from crewai import Agent, Crew, LLM, Process, Task
+from dotenv import load_dotenv
+
+from app.crews.llm_config import (
+    LLMUnavailableError,
+    execute_with_fallback,
+)
+from app.crews.tools.parse_nfe_xml_tool import ParseNFeXMLTool
+from app.crews.tools.validate_ibscbs_rules_tool import ValidateIBSCBSRulesTool
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_DIR = (
+    Path(__file__).resolve().parents[3] / "crews" / "tribultz_nfe_validation" / "config"
+)
+
+
+def _load_yaml(name: str) -> dict[str, Any]:
+    with open(_CONFIG_DIR / name, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _parse_crew_output(raw: str) -> dict[str, Any]:
+    """Extract JSON dict from the reporter's raw output string."""
+    try:
+        return json.loads(raw.strip())
+    except json.JSONDecodeError:
+        pass
+    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            pass
+    return {"response_markdown": raw, "evidence": []}
+
+
+class NFeValidationCrew:
+    """
+    NF-e/NFC-e validation crew: parser → validator → reporter.
+
+    Pipeline:
+      1. nfe_parser — Extracts IBSCBS fields from XML (parse_nfe_xml tool)
+      2. ibscbs_validator — Applies 14 NT 2025.002-RTC rules (validate_ibscbs_rules tool)
+      3. nfe_reporter — Composes Markdown report with findings and recommendations
+
+    tenant_id is injected at construction and never passed through the LLM.
+    """
+
+    def __init__(self, tenant_id: str) -> None:
+        self._tenant_id = tenant_id
+
+    def _build_crew(self, llm: LLM, xml_content: str) -> Crew:
+        """Build the crew with a specific LLM instance."""
+        agents_cfg = _load_yaml("agents.yaml")
+        tasks_cfg = _load_yaml("tasks.yaml")
+
+        # Tool instantiation with tenant isolation
+        parse_tool = ParseNFeXMLTool(tenant_id=self._tenant_id)
+        validate_tool = ValidateIBSCBSRulesTool()
+
+        # Agent 1: NF-e Parser
+        parser_agent = Agent(
+            role=agents_cfg["nfe_parser"]["role"],
+            goal=agents_cfg["nfe_parser"]["goal"],
+            backstory=agents_cfg["nfe_parser"]["backstory"],
+            tools=[parse_tool],
+            llm=llm,
+            verbose=False,
+        )
+
+        # Agent 2: IBSCBS Validator
+        validator_agent = Agent(
+            role=agents_cfg["ibscbs_validator"]["role"],
+            goal=agents_cfg["ibscbs_validator"]["goal"],
+            backstory=agents_cfg["ibscbs_validator"]["backstory"],
+            tools=[validate_tool],
+            llm=llm,
+            verbose=False,
+        )
+
+        # Agent 3: Report Composer
+        reporter_agent = Agent(
+            role=agents_cfg["nfe_reporter"]["role"],
+            goal=agents_cfg["nfe_reporter"]["goal"],
+            backstory=agents_cfg["nfe_reporter"]["backstory"],
+            llm=llm,
+            verbose=False,
+        )
+
+        # Task 1: Parse XML
+        task_parse = Task(
+            description=tasks_cfg["parse_nfe_xml"]["description"].format(
+                xml_content=xml_content
+            ),
+            expected_output=tasks_cfg["parse_nfe_xml"]["expected_output"],
+            agent=parser_agent,
+        )
+
+        # Task 2: Validate (depends on parse)
+        task_validate = Task(
+            description=tasks_cfg["validate_ibscbs"]["description"],
+            expected_output=tasks_cfg["validate_ibscbs"]["expected_output"],
+            agent=validator_agent,
+            context=[task_parse],
+        )
+
+        # Task 3: Report (depends on parse + validate)
+        task_report = Task(
+            description=tasks_cfg["compose_nfe_report"]["description"],
+            expected_output=tasks_cfg["compose_nfe_report"]["expected_output"],
+            agent=reporter_agent,
+            context=[task_parse, task_validate],
+        )
+
+        return Crew(
+            agents=[parser_agent, validator_agent, reporter_agent],
+            tasks=[task_parse, task_validate, task_report],
+            process=Process.sequential,
+            verbose=False,
+        )
+
+    def run(self, xml_content: str) -> dict[str, Any]:
+        """Execute the NF-e validation crew with LLM fallback chain."""
+
+        def _kickoff(llm: LLM) -> str:
+            crew = self._build_crew(llm, xml_content)
+            result = crew.kickoff()
+            return str(result)
+
+        try:
+            raw_output, tier_used, elapsed = execute_with_fallback(_kickoff)
+        except LLMUnavailableError:
+            logger.error(
+                "All LLM tiers exhausted for NF-e validation tenant=%s",
+                self._tenant_id,
+            )
+            return {
+                "response_markdown": (
+                    "Todos os modelos de IA estao temporariamente indisponiveis. "
+                    "Tente novamente em alguns minutos."
+                ),
+                "evidence": [],
+            }
+
+        logger.info(
+            "nfe_validation_crew_complete tenant=%s tier=%s model=%s elapsed=%.2fs",
+            self._tenant_id,
+            tier_used.name,
+            tier_used.model_id,
+            elapsed,
+        )
+
+        return _parse_crew_output(raw_output)

--- a/backend/app/crews/tools/parse_nfe_xml_tool.py
+++ b/backend/app/crews/tools/parse_nfe_xml_tool.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+import xml.etree.ElementTree as ET
+from typing import Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from app.tools.s3_tool import put_object
+
+# CST table from NT 2025.002-RTC
+CST_TABLE: dict[str, dict[str, str | None]] = {
+    "000": {"group": "gIBSCBS", "description": "Tributacao normal (ad valorem)"},
+    "001": {"group": "gIBSCBS", "description": "Tributacao normal com reducao de base"},
+    "002": {"group": "gIBSCBSMono", "description": "Tributacao ad rem"},
+    "070": {"group": None, "description": "Imunidade / Isencao"},
+    "200": {"group": "gIBSCBS", "description": "Diferimento"},
+    "410": {"group": None, "description": "Suspensao"},
+    "510": {"group": "gIBSCBS", "description": "Credito presumido"},
+    "515": {"group": "gIBSCBS", "description": "Credito presumido especial"},
+    "550": {"group": "gIBSCBS", "description": "Regime especifico"},
+    "620": {"group": "gIBSCBSMono", "description": "Monofasico"},
+    "800": {"group": "gTransfCred", "description": "Transferencia de credito"},
+    "810": {"group": None, "description": "Ressarcimento"},
+    "811": {"group": "gAjusteCompet", "description": "Ajuste de competencia"},
+    "830": {"group": "gEstornoCred", "description": "Estorno de credito"},
+}
+
+
+class ParseNFeInput(BaseModel):
+    xml_content: str = Field(
+        description="NF-e or NFC-e XML string to parse. Paste the full XML content."
+    )
+
+
+class ParseNFeXMLTool(BaseTool):
+    """
+    Parse a NF-e/NFC-e XML string (NT 2025.002-RTC), store raw XML in S3,
+    and extract IBSCBS fiscal fields including IBS UF/Municipal split.
+    tenant_id is injected at construction and never exposed to the LLM.
+    """
+
+    name: str = "parse_nfe_xml"
+    description: str = (
+        "Parse a NF-e or NFC-e XML string with IBSCBS group (NT 2025.002-RTC). "
+        "Extracts: CST, cClassTrib, NCM, CEST, vBC, pCBS, vCBS, pIBSUF, vIBSUF, "
+        "pIBSMun, vIBSMun, vIBS, IBSCBSTot totals, and document type (mod 55/65). "
+        "Stores original XML in S3. "
+        "Returns JSON with {invoice_id, s3_key, doc_type, parse_error, fields, items[]}."
+    )
+    args_schema: Type[BaseModel] = ParseNFeInput
+    tenant_id: str  # injected at construction — never exposed to LLM
+
+    def _run(self, xml_content: str) -> str:
+        invoice_id = str(uuid.uuid4())
+        s3_key = f"invoices/{self.tenant_id}/{invoice_id}.xml"
+
+        # Store raw XML — soft-fail if S3 unavailable (local dev)
+        try:
+            put_object(
+                key=s3_key,
+                data=xml_content.encode("utf-8"),
+                content_type="application/xml",
+                metadata={"tenant_id": self.tenant_id, "invoice_id": invoice_id},
+            )
+        except Exception as exc:
+            s3_key = f"(s3-unavailable: {exc})"
+
+        # Detect document type from mod tag
+        doc_type = "NFE"
+        mod_match = re.search(r"<mod>\s*(\d+)\s*</mod>", xml_content, re.IGNORECASE)
+        if mod_match:
+            if mod_match.group(1) == "65":
+                doc_type = "NFCE"
+
+        # Global fields
+        fields: dict[str, str] = {
+            "cst": "",
+            "cclasstrib": "",
+            "ncm": "",
+            "cest": "",
+            "vbc": "",
+            "pcbs": "",
+            "vcbs": "",
+            "pibsuf": "",
+            "vibsuf": "",
+            "pibsmun": "",
+            "vibsmun": "",
+            "vibs": "",
+            # Totals from IBSCBSTot
+            "tot_vcbs": "",
+            "tot_vibs": "",
+        }
+        parse_error: str | None = None
+
+        # Per-item extraction (NF-e can have multiple <det> items)
+        items: list[dict[str, str]] = []
+
+        # Track NF-e layout tags
+        layout_tags: dict[str, bool] = {
+            "emit": False,
+            "det": False,
+            "total": False,
+            "IBSCBS": False,
+            "IBSCBSTot": False,
+        }
+
+        try:
+            root = ET.fromstring(xml_content.strip())
+
+            # Find parent context for IBSCBS CST extraction
+            ibscbs_cst_found = False
+
+            for elem in root.iter():
+                tag = elem.tag.split("}")[-1]
+                text = (elem.text or "").strip()
+
+                if tag in layout_tags:
+                    layout_tags[tag] = True
+
+                # Extract per-item fields from inside IBSCBS groups
+                if tag == "IBSCBS":
+                    item: dict[str, str] = {}
+                    for child in elem.iter():
+                        ctag = child.tag.split("}")[-1]
+                        ctext = (child.text or "").strip()
+                        if ctag == "CST":
+                            item["cst"] = ctext
+                            if not ibscbs_cst_found:
+                                fields["cst"] = ctext
+                                ibscbs_cst_found = True
+                        elif ctag == "cClassTrib":
+                            item["cclasstrib"] = ctext
+                            if not fields["cclasstrib"]:
+                                fields["cclasstrib"] = ctext
+                        elif ctag == "vBC":
+                            item["vbc"] = ctext
+                            if not fields["vbc"]:
+                                fields["vbc"] = ctext
+                        elif ctag == "pCBS":
+                            item["pcbs"] = ctext
+                            if not fields["pcbs"]:
+                                fields["pcbs"] = ctext
+                        elif ctag == "vCBS":
+                            item["vcbs"] = ctext
+                            if not fields["vcbs"]:
+                                fields["vcbs"] = ctext
+                        elif ctag == "pIBSUF":
+                            item["pibsuf"] = ctext
+                            if not fields["pibsuf"]:
+                                fields["pibsuf"] = ctext
+                        elif ctag == "vIBSUF":
+                            item["vibsuf"] = ctext
+                            if not fields["vibsuf"]:
+                                fields["vibsuf"] = ctext
+                        elif ctag == "pIBSMun":
+                            item["pibsmun"] = ctext
+                            if not fields["pibsmun"]:
+                                fields["pibsmun"] = ctext
+                        elif ctag == "vIBSMun":
+                            item["vibsmun"] = ctext
+                            if not fields["vibsmun"]:
+                                fields["vibsmun"] = ctext
+                        elif ctag == "vIBS":
+                            item["vibs"] = ctext
+                            if not fields["vibs"]:
+                                fields["vibs"] = ctext
+                    if item:
+                        items.append(item)
+
+                # Extract IBSCBSTot totals
+                if tag == "IBSCBSTot":
+                    for child in elem.iter():
+                        ctag = child.tag.split("}")[-1]
+                        ctext = (child.text or "").strip()
+                        if ctag == "vCBS" and not fields["tot_vcbs"]:
+                            fields["tot_vcbs"] = ctext
+                        elif ctag == "vIBS" and not fields["tot_vibs"]:
+                            fields["tot_vibs"] = ctext
+
+                # Top-level fields (outside IBSCBS)
+                if tag == "NCM" and not fields["ncm"]:
+                    fields["ncm"] = text
+                elif tag == "CEST" and not fields["cest"]:
+                    fields["cest"] = text
+
+        except ET.ParseError as exc:
+            parse_error = str(exc)
+
+        fields["layout_tags"] = ",".join(
+            t for t, present in layout_tags.items() if present
+        )
+
+        return json.dumps({
+            "invoice_id": invoice_id,
+            "s3_key": s3_key,
+            "doc_type": doc_type,
+            "parse_error": parse_error,
+            "fields": fields,
+            "items": items,
+        })

--- a/backend/app/crews/tools/validate_ibscbs_rules_tool.py
+++ b/backend/app/crews/tools/validate_ibscbs_rules_tool.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from app.crews.tools.parse_nfe_xml_tool import CST_TABLE
+
+VALID_CST_CODES = set(CST_TABLE.keys())
+
+
+class ValidateIBSCBSInput(BaseModel):
+    invoice_id: str = Field(description="Invoice ID returned by parse_nfe_xml")
+    fields_json: str = Field(
+        description=(
+            "JSON string with extracted fields from parse_nfe_xml. "
+            "Must include: doc_type, fields (cst, cclasstrib, ncm, cest, vbc, "
+            "pcbs, vcbs, pibsuf, vibsuf, pibsmun, vibsmun, vibs, "
+            "tot_vcbs, tot_vibs, layout_tags), items[]."
+        )
+    )
+
+
+class ValidateIBSCBSRulesTool(BaseTool):
+    """
+    Apply NF-e/NFC-e IBSCBS validation rules (NT 2025.002-RTC) to extracted fields.
+    Validates: CST codes, CST-group coherence, IBS UF/Municipal split, CBS/IBS
+    calculations, IBSCBS totals, CEST, and NF-e layout structure.
+    Returns findings with severity FATAL or ALERT and actionable recommendations.
+    """
+
+    name: str = "validate_ibscbs_rules"
+    description: str = (
+        "Apply NF-e/NFC-e IBSCBS validation rules (NT 2025.002-RTC). "
+        "Validates 14 rules: CST validity, CST-group coherence, CST semantics, "
+        "CBS calculation, IBS UF calculation, IBS Municipal calculation, "
+        "IBS split (UF+Mun=total), IBSCBS totals, CEST, and NF-e layout. "
+        "Requires invoice_id and fields_json from parse_nfe_xml. "
+        "Returns JSON with {invoice_id, doc_type, findings[], summary}."
+    )
+    args_schema: Type[BaseModel] = ValidateIBSCBSInput
+
+    def _run(self, invoice_id: str, fields_json: str) -> str:
+        try:
+            data = json.loads(fields_json)
+        except json.JSONDecodeError:
+            data = {}
+
+        fields = data.get("fields", data)
+        items = data.get("items", [])
+        doc_type = data.get("doc_type", "NFE")
+        parse_error: str | None = data.get("parse_error")
+
+        cst = (fields.get("cst") or "").strip()
+        cclasstrib = (fields.get("cclasstrib") or "").strip()
+        ncm = (fields.get("ncm") or "").strip()
+        cest = (fields.get("cest") or "").strip()
+        vbc = (fields.get("vbc") or "").strip()
+        pcbs = (fields.get("pcbs") or "").strip()
+        vcbs = (fields.get("vcbs") or "").strip()
+        pibsuf = (fields.get("pibsuf") or "").strip()
+        vibsuf = (fields.get("vibsuf") or "").strip()
+        pibsmun = (fields.get("pibsmun") or "").strip()
+        vibsmun = (fields.get("vibsmun") or "").strip()
+        vibs = (fields.get("vibs") or "").strip()
+        tot_vcbs = (fields.get("tot_vcbs") or "").strip()
+        tot_vibs = (fields.get("tot_vibs") or "").strip()
+        layout_tags = (fields.get("layout_tags") or "").strip()
+
+        findings: list[dict[str, str]] = []
+        xpath_base = "/nfeProc/NFe/infNFe"
+
+        # Rule 1: XML_PARSE
+        if parse_error:
+            findings.append({
+                "rule_id": "XML_PARSE",
+                "severity": "FATAL",
+                "field": "documento",
+                "xpath": "/",
+                "snippet": parse_error,
+                "recommendation": "XML invalido. Verificar arquivo ou colar o XML correto.",
+            })
+
+        # Rule 2: CST_3_DIGITS
+        if not re.fullmatch(r"\d{3}", cst):
+            findings.append({
+                "rule_id": "CST_3_DIGITS",
+                "severity": "FATAL",
+                "field": "CST",
+                "xpath": f"{xpath_base}//IBSCBS/CST",
+                "snippet": f"<CST>{cst}</CST>" if cst else "(nao encontrado)",
+                "recommendation": "CST deve ter exatamente 3 digitos. Corrigir no ERP e reemitir.",
+            })
+
+        # Rule 3: CCLASSTRIB_6_DIGITS
+        if not re.fullmatch(r"\d{6}", cclasstrib):
+            findings.append({
+                "rule_id": "CCLASSTRIB_6_DIGITS",
+                "severity": "FATAL",
+                "field": "cClassTrib",
+                "xpath": f"{xpath_base}//IBSCBS/cClassTrib",
+                "snippet": f"<cClassTrib>{cclasstrib}</cClassTrib>" if cclasstrib else "(nao encontrado)",
+                "recommendation": "ClassTrib incorreto. Verificar codigo conforme categoria do negocio.",
+            })
+
+        # Rule 4: CST_VALID — must be a known CST code
+        if re.fullmatch(r"\d{3}", cst) and cst not in VALID_CST_CODES:
+            findings.append({
+                "rule_id": "CST_VALID",
+                "severity": "FATAL",
+                "field": "CST",
+                "xpath": f"{xpath_base}//IBSCBS/CST",
+                "snippet": f"<CST>{cst}</CST>",
+                "recommendation": (
+                    f"CST '{cst}' nao e codigo valido conforme NT 2025.002-RTC. "
+                    f"CSTs validos: {', '.join(sorted(VALID_CST_CODES))}."
+                ),
+            })
+
+        # Rule 5: CST_GROUP_MATCH — CST ↔ XML group coherence
+        if cst in VALID_CST_CODES:
+            expected_group = CST_TABLE[cst].get("group")
+            if expected_group:
+                present_tags = set(layout_tags.split(",")) if layout_tags else set()
+                # Check if the expected group tag is present
+                # gIBSCBS maps to IBSCBS presence, etc.
+                group_tag_map = {
+                    "gIBSCBS": "IBSCBS",
+                    "gIBSCBSMono": "IBSCBS",
+                    "gTransfCred": "IBSCBS",
+                    "gAjusteCompet": "IBSCBS",
+                    "gEstornoCred": "IBSCBS",
+                }
+                check_tag = group_tag_map.get(str(expected_group), str(expected_group))
+                if check_tag not in present_tags:
+                    findings.append({
+                        "rule_id": "CST_GROUP_MATCH",
+                        "severity": "FATAL",
+                        "field": "IBSCBS",
+                        "xpath": f"{xpath_base}//IBSCBS",
+                        "snippet": f"<CST>{cst}</CST>",
+                        "recommendation": (
+                            f"CST {cst} ({CST_TABLE[cst].get('description')}) "
+                            f"requer grupo XML <{expected_group}>. Preencher conforme NT 2025.002."
+                        ),
+                    })
+
+        # Rule 5b: CST_SEMANTIC — 070/410 should not have tax > 0
+        if cst in ("070", "410"):
+            tax_val = _safe_float(vcbs)
+            ibs_tax_val = _safe_float(vibs)
+            if tax_val > 0 or ibs_tax_val > 0:
+                findings.append({
+                    "rule_id": "CST_SEMANTIC",
+                    "severity": "FATAL",
+                    "field": "IBS/CBS",
+                    "xpath": f"{xpath_base}//IBSCBS",
+                    "snippet": f"<CST>{cst}</CST> vCBS={vcbs} vIBS={vibs}",
+                    "recommendation": (
+                        f"CST {cst} ({CST_TABLE[cst].get('description')}) "
+                        "nao deve ter valores tributarios > 0."
+                    ),
+                })
+
+        # Rule 6: IBSCBS_MISSING
+        has_ibscbs = "IBSCBS" in (layout_tags.split(",") if layout_tags else [])
+        if not has_ibscbs:
+            findings.append({
+                "rule_id": "IBSCBS_MISSING",
+                "severity": "FATAL",
+                "field": "IBSCBS",
+                "xpath": f"{xpath_base}//imposto",
+                "snippet": "(Grupo <IBSCBS> nao encontrado em <imposto>)",
+                "recommendation": "Informar grupo IBSCBS com CST, cClassTrib e campos de calculo conforme NT 2025.002.",
+            })
+
+        # Rule 7: IBSCBS_CALC — CBS calculation (vCBS == vBC x pCBS)
+        if vbc and pcbs and vcbs:
+            base = _safe_float(vbc)
+            rate = _safe_float(pcbs)
+            declared = _safe_float(vcbs)
+            if base > 0 and rate >= 0:
+                expected = base * rate
+                if abs(declared - expected) > 0.01:
+                    findings.append({
+                        "rule_id": "IBSCBS_CALC",
+                        "severity": "FATAL",
+                        "field": "vCBS",
+                        "xpath": f"{xpath_base}//gCBS/vCBS",
+                        "snippet": f"<vCBS>{vcbs}</vCBS>",
+                        "recommendation": (
+                            f"vCBS deve ser vBC ({base:.2f}) x pCBS ({rate}) "
+                            f"= R$ {expected:.2f}. Informado: R$ {declared:.2f}."
+                        ),
+                    })
+
+        # Rule 11: IBSCBS_UF_CALC — vIBSUF == vBC x pIBSUF
+        if vbc and pibsuf and vibsuf:
+            base = _safe_float(vbc)
+            rate = _safe_float(pibsuf)
+            declared = _safe_float(vibsuf)
+            if base > 0 and rate >= 0:
+                expected = base * rate
+                if abs(declared - expected) > 0.01:
+                    findings.append({
+                        "rule_id": "IBSCBS_UF_CALC",
+                        "severity": "FATAL",
+                        "field": "vIBSUF",
+                        "xpath": f"{xpath_base}//gIBSUF/vIBSUF",
+                        "snippet": f"<vIBSUF>{vibsuf}</vIBSUF>",
+                        "recommendation": (
+                            f"vIBSUF deve ser vBC ({base:.2f}) x pIBSUF ({rate}) "
+                            f"= R$ {expected:.2f}. Informado: R$ {declared:.2f}."
+                        ),
+                    })
+
+        # Rule 12: IBSCBS_MUN_CALC — vIBSMun == vBC x pIBSMun
+        if vbc and pibsmun and vibsmun:
+            base = _safe_float(vbc)
+            rate = _safe_float(pibsmun)
+            declared = _safe_float(vibsmun)
+            if base > 0 and rate >= 0:
+                expected = base * rate
+                if abs(declared - expected) > 0.01:
+                    findings.append({
+                        "rule_id": "IBSCBS_MUN_CALC",
+                        "severity": "FATAL",
+                        "field": "vIBSMun",
+                        "xpath": f"{xpath_base}//gIBSMun/vIBSMun",
+                        "snippet": f"<vIBSMun>{vibsmun}</vIBSMun>",
+                        "recommendation": (
+                            f"vIBSMun deve ser vBC ({base:.2f}) x pIBSMun ({rate}) "
+                            f"= R$ {expected:.2f}. Informado: R$ {declared:.2f}."
+                        ),
+                    })
+
+        # Rule 13: IBSCBS_SPLIT — vIBS == vIBSUF + vIBSMun
+        if vibs and vibsuf and vibsmun:
+            total = _safe_float(vibs)
+            uf = _safe_float(vibsuf)
+            mun = _safe_float(vibsmun)
+            expected = uf + mun
+            if abs(total - expected) > 0.01:
+                findings.append({
+                    "rule_id": "IBSCBS_SPLIT",
+                    "severity": "FATAL",
+                    "field": "vIBS",
+                    "xpath": f"{xpath_base}//gIBSCBS/vIBS",
+                    "snippet": f"vIBS={vibs} vIBSUF={vibsuf} vIBSMun={vibsmun}",
+                    "recommendation": (
+                        f"Split IBS incorreto: vIBS ({total:.2f}) != "
+                        f"vIBSUF ({uf:.2f}) + vIBSMun ({mun:.2f}) = R$ {expected:.2f}."
+                    ),
+                })
+
+        # Rule 14: IBSCBS_TOTAL — totals vs sum of items
+        if len(items) > 0 and tot_vcbs:
+            sum_vcbs = sum(_safe_float(it.get("vcbs", "0")) for it in items)
+            declared_tot = _safe_float(tot_vcbs)
+            if abs(declared_tot - sum_vcbs) > 0.01:
+                findings.append({
+                    "rule_id": "IBSCBS_TOTAL",
+                    "severity": "FATAL",
+                    "field": "IBSCBSTot/vCBS",
+                    "xpath": f"{xpath_base}//total/IBSCBSTot/vCBS",
+                    "snippet": f"<vCBS>{tot_vcbs}</vCBS> (total) vs soma itens={sum_vcbs:.2f}",
+                    "recommendation": (
+                        f"Total CBS ({declared_tot:.2f}) != soma dos itens ({sum_vcbs:.2f})."
+                    ),
+                })
+
+        if len(items) > 0 and tot_vibs:
+            sum_vibs = sum(_safe_float(it.get("vibs", "0")) for it in items)
+            declared_tot = _safe_float(tot_vibs)
+            if abs(declared_tot - sum_vibs) > 0.01:
+                findings.append({
+                    "rule_id": "IBSCBS_TOTAL",
+                    "severity": "FATAL",
+                    "field": "IBSCBSTot/vIBS",
+                    "xpath": f"{xpath_base}//total/IBSCBSTot/vIBS",
+                    "snippet": f"<vIBS>{tot_vibs}</vIBS> (total) vs soma itens={sum_vibs:.2f}",
+                    "recommendation": (
+                        f"Total IBS ({declared_tot:.2f}) != soma dos itens ({sum_vibs:.2f})."
+                    ),
+                })
+
+        # Rule 8: CEST_MISSING
+        if not cest:
+            findings.append({
+                "rule_id": "CEST_MISSING",
+                "severity": "FATAL",
+                "field": "CEST",
+                "xpath": f"{xpath_base}//prod/CEST",
+                "snippet": "(nao encontrado)",
+                "recommendation": "Informar codigo CEST conforme nova classificacao tributaria.",
+            })
+
+        # Rule 9: CEST_FORMAT
+        if cest and not re.fullmatch(r"\d{7}", cest):
+            findings.append({
+                "rule_id": "CEST_FORMAT",
+                "severity": "FATAL",
+                "field": "CEST",
+                "xpath": f"{xpath_base}//prod/CEST",
+                "snippet": f"<CEST>{cest}</CEST>",
+                "recommendation": "CEST deve ter exatamente 7 digitos.",
+            })
+
+        # Rule 10b: LAYOUT_NFE — required NF-e structure
+        required = ["emit", "det", "total"]
+        present = set(layout_tags.split(",")) if layout_tags else set()
+        missing = [t for t in required if t not in present]
+        if missing:
+            findings.append({
+                "rule_id": "LAYOUT_NFE",
+                "severity": "FATAL",
+                "field": "Estrutura XML",
+                "xpath": xpath_base,
+                "snippet": f"(Tags obrigatorias ausentes: {', '.join(missing)})",
+                "recommendation": "NF-e deve conter emit, det e total conforme layout padrao.",
+            })
+
+        # Rule: NCM advisory
+        if not ncm:
+            findings.append({
+                "rule_id": "NCM_PLACEHOLDER",
+                "severity": "ALERT",
+                "field": "NCM",
+                "xpath": f"{xpath_base}//prod/NCM",
+                "snippet": "(nao encontrado)",
+                "recommendation": "Revisar NCM conforme classificacao fiscal vigente.",
+            })
+
+        fatals = sum(1 for f in findings if f["severity"] == "FATAL")
+        alerts = sum(1 for f in findings if f["severity"] == "ALERT")
+
+        return json.dumps({
+            "invoice_id": invoice_id,
+            "doc_type": doc_type,
+            "findings": findings,
+            "summary": {
+                "total": len(findings),
+                "fatals": fatals,
+                "alerts": alerts,
+                "status": "FAIL" if fatals > 0 else "PASS",
+                "items_parsed": len(items),
+            },
+        })
+
+
+def _safe_float(value: str) -> float:
+    """Parse a string to float, returning 0.0 on failure."""
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return 0.0

--- a/backend/tests/test_crewai_nfe_tools.py
+++ b/backend/tests/test_crewai_nfe_tools.py
@@ -1,0 +1,396 @@
+"""Tests for CrewAI NF-e/NFC-e tools (ParseNFeXMLTool + ValidateIBSCBSRulesTool).
+
+These tests validate the tools directly (no LLM needed), following the same
+pattern as existing tool tests: call _run() and assert JSON output.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from app.crews.tools.parse_nfe_xml_tool import CST_TABLE, ParseNFeXMLTool
+from app.crews.tools.validate_ibscbs_rules_tool import ValidateIBSCBSRulesTool
+
+# ── Test fixtures ──────────────────────────────────────────────
+
+NFE_OK_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc xmlns="http://www.portalfiscal.inf.br/nfe" versao="4.00">
+  <NFe>
+    <infNFe versao="4.00" Id="NFe35260312345678000195550010000001231234567890">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod>
+          <NCM>84713012</NCM>
+          <CEST>2104900</CEST>
+        </prod>
+        <imposto>
+          <ICMS><ICMS00><CST>00</CST></ICMS00></ICMS>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>654321</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.00</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>9.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total>
+        <IBSCBSTot>
+          <vCBS>9.00</vCBS>
+          <vIBS>1.00</vIBS>
+        </IBSCBSTot>
+      </total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+
+NFCE_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>65</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>22021000</NCM><CEST>0300100</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>123456</cClassTrib>
+            <gIBSCBS>
+              <vBC>50.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.03</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.03</vIBSMun></gIBSMun>
+              <vIBS>0.05</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>0.45</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total>
+        <IBSCBSTot><vCBS>0.45</vCBS><vIBS>0.05</vIBS></IBSCBSTot>
+      </total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+
+NFE_SPLIT_ERROR_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>654321</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.50</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>9.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total>
+        <IBSCBSTot><vCBS>9.00</vCBS><vIBS>1.50</vIBS></IBSCBSTot>
+      </total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+
+NFE_INVALID_CST_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>999</CST>
+            <cClassTrib>654321</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.00</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>9.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total>
+        <IBSCBSTot><vCBS>9.00</vCBS><vIBS>1.00</vIBS></IBSCBSTot>
+      </total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+
+
+# ── CST_TABLE tests ────────────────────────────────────────────
+
+
+def test_cst_table_has_14_entries():
+    assert len(CST_TABLE) == 14
+
+
+def test_cst_table_keys_are_3_digit_strings():
+    for code in CST_TABLE:
+        assert len(code) == 3
+        assert code.isdigit()
+
+
+# ── ParseNFeXMLTool tests ─────────────────────────────────────
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfe_ok(mock_s3):
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run(NFE_OK_XML))
+
+    assert result["parse_error"] is None
+    assert result["doc_type"] == "NFE"
+    assert result["fields"]["cst"] == "000"
+    assert result["fields"]["cclasstrib"] == "654321"
+    assert result["fields"]["vbc"] == "1000.00"
+    assert result["fields"]["pcbs"] == "0.0090"
+    assert result["fields"]["vcbs"] == "9.00"
+    assert result["fields"]["pibsuf"] == "0.0005"
+    assert result["fields"]["vibsuf"] == "0.50"
+    assert result["fields"]["pibsmun"] == "0.0005"
+    assert result["fields"]["vibsmun"] == "0.50"
+    assert result["fields"]["vibs"] == "1.00"
+    assert len(result["items"]) == 1
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfce_detects_mod_65(mock_s3):
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run(NFCE_XML))
+    assert result["doc_type"] == "NFCE"
+    assert result["fields"]["cst"] == "000"
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfe_extracts_ibscbs_cst_not_icms(mock_s3):
+    """CST must come from IBSCBS (3 digits), not ICMS (2 digits)."""
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run(NFE_OK_XML))
+    assert result["fields"]["cst"] == "000"  # not "00" from ICMS
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfe_totals(mock_s3):
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run(NFE_OK_XML))
+    assert result["fields"]["tot_vcbs"] == "9.00"
+    assert result["fields"]["tot_vibs"] == "1.00"
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfe_layout_tags(mock_s3):
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run(NFE_OK_XML))
+    tags = result["fields"]["layout_tags"]
+    assert "emit" in tags
+    assert "det" in tags
+    assert "total" in tags
+    assert "IBSCBS" in tags
+    assert "IBSCBSTot" in tags
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfe_s3_soft_fail(mock_s3):
+    """S3 failure should not break parsing."""
+    mock_s3.side_effect = ConnectionError("minio down")
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run(NFE_OK_XML))
+    assert result["parse_error"] is None
+    assert "s3-unavailable" in result["s3_key"]
+
+
+@patch("app.crews.tools.parse_nfe_xml_tool.put_object")
+def test_parse_nfe_invalid_xml(mock_s3):
+    tool = ParseNFeXMLTool(tenant_id="t-test-001")
+    result = json.loads(tool._run("<broken>xml"))
+    assert result["parse_error"] is not None
+
+
+# ── ValidateIBSCBSRulesTool tests ─────────────────────────────
+
+
+def _parse_and_validate(xml: str) -> dict:
+    """Helper: parse XML then validate — returns validation result."""
+    with patch("app.crews.tools.parse_nfe_xml_tool.put_object"):
+        parser = ParseNFeXMLTool(tenant_id="t-test-001")
+        parsed = json.loads(parser._run(xml))
+
+    validator = ValidateIBSCBSRulesTool()
+    return json.loads(validator._run(
+        invoice_id=parsed["invoice_id"],
+        fields_json=json.dumps(parsed),
+    ))
+
+
+def test_validate_nfe_ok_no_fatals():
+    result = _parse_and_validate(NFE_OK_XML)
+    fatals = [f for f in result["findings"] if f["severity"] == "FATAL"]
+    assert len(fatals) == 0
+    assert result["summary"]["status"] == "PASS"
+
+
+def test_validate_nfce_ok():
+    result = _parse_and_validate(NFCE_XML)
+    fatals = [f for f in result["findings"] if f["severity"] == "FATAL"]
+    assert len(fatals) == 0
+
+
+def test_validate_ibs_split_error():
+    result = _parse_and_validate(NFE_SPLIT_ERROR_XML)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "IBSCBS_SPLIT" in rule_ids
+    assert result["summary"]["status"] == "FAIL"
+
+
+def test_validate_invalid_cst():
+    result = _parse_and_validate(NFE_INVALID_CST_XML)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "CST_VALID" in rule_ids
+
+
+def test_validate_missing_ibscbs():
+    """XML without IBSCBS group should trigger IBSCBS_MISSING."""
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto></imposto>
+      </det>
+      <total></total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+    result = _parse_and_validate(xml)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "IBSCBS_MISSING" in rule_ids
+
+
+def test_validate_cst_semantic_070():
+    """CST 070 (imunidade) with vCBS > 0 should trigger CST_SEMANTIC."""
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>070</CST>
+            <cClassTrib>654321</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.00</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>9.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total><IBSCBSTot><vCBS>9.00</vCBS><vIBS>1.00</vIBS></IBSCBSTot></total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+    result = _parse_and_validate(xml)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "CST_SEMANTIC" in rule_ids
+
+
+def test_validate_cbs_calc_error():
+    """vCBS wrong calculation should trigger IBSCBS_CALC."""
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>654321</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.00</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>99.99</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total><IBSCBSTot><vCBS>99.99</vCBS><vIBS>1.00</vIBS></IBSCBSTot></total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+    result = _parse_and_validate(xml)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "IBSCBS_CALC" in rule_ids
+
+
+def test_validate_layout_nfe_missing_emit():
+    """Missing emit tag should trigger LAYOUT_NFE."""
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>654321</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.00</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>9.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total><IBSCBSTot><vCBS>9.00</vCBS><vIBS>1.00</vIBS></IBSCBSTot></total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+    result = _parse_and_validate(xml)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "LAYOUT_NFE" in rule_ids

--- a/crews/tribultz_chatops/config/agents.yaml
+++ b/crews/tribultz_chatops/config/agents.yaml
@@ -14,10 +14,14 @@ operator:
     Execute the operation indicated by the triage agent using the available tools.
     For CBS/IBS validation: use trigger_task_a and return the job_id.
     For NFS-e XML validation: use parse_nfse_xml then validate_fiscal_rules and return findings.
+    For NF-e/NFC-e XML validation: use parse_nfe_xml then validate_ibscbs_rules and return findings.
   backstory: >
     You execute operations precisely based on the intent classified by triage.
     You never accept tenant_id from user text; it is injected by the service.
     You always call the correct tool sequence and return structured JSON output.
+    For NF-e (mod 55) and NFC-e (mod 65) documents, you use parse_nfe_xml followed
+    by validate_ibscbs_rules to apply NT 2025.002-RTC validation rules.
+    For NFS-e documents, you use parse_nfse_xml followed by validate_fiscal_rules.
 
 narrator:
   role: >

--- a/crews/tribultz_nfe_validation/config/agents.yaml
+++ b/crews/tribultz_nfe_validation/config/agents.yaml
@@ -1,0 +1,50 @@
+nfe_parser:
+  role: >
+    Analista de XML Fiscal — NF-e/NFC-e
+  goal: >
+    Parsear XML de NF-e (mod 55) e NFC-e (mod 65) extraindo todos os campos
+    do grupo IBSCBS conforme NT 2025.002-RTC: CST, cClassTrib, vBC, pCBS, vCBS,
+    pIBSUF, vIBSUF, pIBSMun, vIBSMun, vIBS, e totais IBSCBSTot.
+  backstory: >
+    Voce e o especialista em parsing de documentos fiscais eletronicos do Tribultz.
+    Domina a estrutura XML da NF-e conforme NT 2025.002-RTC e sabe extrair campos
+    do grupo IBSCBS, diferenciando CST do ICMS (2 digitos) do CST do IBSCBS (3 digitos).
+    Voce detecta automaticamente se o documento e NF-e (mod 55) ou NFC-e (mod 65).
+    Nunca aceita tenant_id do usuario — ele e injetado pelo sistema.
+  allow_delegation: false
+  verbose: false
+
+ibscbs_validator:
+  role: >
+    Auditor Fiscal IBSCBS — Motor Deterministico
+  goal: >
+    Aplicar as 14 regras de validacao IBSCBS (NT 2025.002-RTC) aos campos extraidos:
+    CST_3_DIGITS, CCLASSTRIB_6_DIGITS, CST_VALID, CST_GROUP_MATCH, CST_SEMANTIC,
+    IBSCBS_MISSING, IBSCBS_CALC, IBSCBS_UF_CALC, IBSCBS_MUN_CALC, IBSCBS_SPLIT,
+    IBSCBS_TOTAL, CEST_MISSING, CEST_FORMAT, LAYOUT_NFE.
+    Retornar findings com severidade FATAL/ALERT e recomendacoes acionaveis.
+  backstory: >
+    Voce e o auditor fiscal deterministico do Tribultz. Aplica regras de validacao
+    sem ambiguidade: cada regra produz finding com rule_id, severidade, campo, xpath,
+    snippet e recomendacao. Voce entende CBS (0.90%, federal), IBS (0.10%, UF+Municipal),
+    split IBS (vIBS = vIBSUF + vIBSMun), e os 14 CSTs da reforma tributaria.
+    Tolerancia de calculo: R$ 0.01. Voce nunca inventa regras — aplica somente
+    as 14 regras do motor e retorna JSON estruturado.
+  allow_delegation: false
+  verbose: false
+
+nfe_reporter:
+  role: >
+    Relator de Conformidade Fiscal
+  goal: >
+    Compor relatorio de validacao em Markdown com resumo executivo, lista de
+    findings por severidade, e recomendacoes de correcao. Incluir informacoes
+    do CST_TABLE (descricao do CST encontrado) e status PASS/FAIL.
+  backstory: >
+    Voce e o narrador de conformidade do Tribultz. Transforma findings tecnicos
+    em linguagem clara para operadores fiscais e contadores. Seus relatorios
+    seguem o padrao: (1) Resumo executivo com status, (2) Tabela de findings,
+    (3) Recomendacoes priorizadas por severidade. Voce escreve em portugues
+    brasileiro e nunca omite findings FATAL.
+  allow_delegation: false
+  verbose: false

--- a/crews/tribultz_nfe_validation/config/tasks.yaml
+++ b/crews/tribultz_nfe_validation/config/tasks.yaml
@@ -1,0 +1,57 @@
+parse_nfe_xml:
+  description: >
+    Receber o XML fiscal do usuario e executar o parse completo usando a ferramenta
+    parse_nfe_xml. O XML pode ser NF-e (mod 55) ou NFC-e (mod 65).
+    Extrair todos os campos IBSCBS e armazenar o XML original no S3.
+
+    XML recebido:
+    {xml_content}
+  expected_output: >
+    JSON string com: invoice_id, s3_key, doc_type (NFE ou NFCE),
+    parse_error (null se ok), fields (cst, cclasstrib, ncm, cest,
+    vbc, pcbs, vcbs, pibsuf, vibsuf, pibsmun, vibsmun, vibs,
+    tot_vcbs, tot_vibs, layout_tags), items[] (campos por item det).
+
+validate_ibscbs:
+  description: >
+    Aplicar as 14 regras de validacao IBSCBS aos campos extraidos pelo parser.
+    Usar a ferramenta validate_ibscbs_rules com o invoice_id e fields_json
+    retornados pela task anterior.
+
+    Regras a validar:
+    1. XML_PARSE — XML bem formado
+    2. CST_3_DIGITS — CST com 3 digitos
+    3. CCLASSTRIB_6_DIGITS — ClassTrib com 6 digitos
+    4. CST_VALID — CST conhecido (NT 2025.002)
+    5. CST_GROUP_MATCH — CST coerente com grupo XML
+    5b. CST_SEMANTIC — CST 070/410 sem valores > 0
+    6. IBSCBS_MISSING — Grupo IBSCBS presente
+    7. IBSCBS_CALC — vCBS = vBC x pCBS
+    11. IBSCBS_UF_CALC — vIBSUF = vBC x pIBSUF
+    12. IBSCBS_MUN_CALC — vIBSMun = vBC x pIBSMun
+    13. IBSCBS_SPLIT — vIBS = vIBSUF + vIBSMun
+    14. IBSCBS_TOTAL — IBSCBSTot = soma itens
+    8-9. CEST presente e formato 7 digitos
+    10b. LAYOUT_NFE — emit, det, total presentes
+  expected_output: >
+    JSON string com: invoice_id, doc_type, findings[] (cada um com rule_id,
+    severity, field, xpath, snippet, recommendation), summary (total, fatals,
+    alerts, status PASS/FAIL, items_parsed).
+
+compose_nfe_report:
+  description: >
+    Com base nos resultados do parser e do validador, compor um relatorio
+    de conformidade em Markdown. O relatorio deve incluir:
+
+    1. Resumo executivo: tipo documento, status (PASS/FAIL), total findings
+    2. Informacoes do CST encontrado (codigo + descricao da CST_TABLE)
+    3. Tabela de findings ordenados por severidade (FATAL primeiro)
+    4. Recomendacoes priorizadas
+    5. Referencia a base legal: NT 2025.002-RTC, LC 214, LC 227
+
+    Retornar como JSON com response_markdown e evidence[].
+  expected_output: >
+    JSON com campos:
+    - response_markdown: string Markdown do relatorio
+    - evidence: array com objetos {type, label, snippet}
+    - summary: {status, fatals, alerts, doc_type}


### PR DESCRIPTION
## Summary

Sprint 11 — Motor de validação NF-e/NFC-e com regras IBSCBS (NT 2025.002-RTC) e CrewAI agents.

### Commits incluídos
- `601ea72` feat(s11): NF-e/NFC-e validation engine, IBSCBS rules, ClassTrib API (#78-#80, #82-#87)
- `5c11a5d` fix(s11): correct alembic revision ID in migration 0005
- `eb1a73c` feat(s11): CrewAI NF-e/NFC-e validation crew with IBSCBS tools

### Entregas

**Frontend (xmlRules.ts + page.tsx)**
- Auto-detect NFS-e/NF-e/NFC-e (mod 55/65)
- 14 CST codes (NT 2025.002-RTC) com CST_TABLE e descrições
- CST extraction scoped ao bloco IBSCBS (evita colisão com ICMS CST)
- Regras: CST_VALID, CST_GROUP_MATCH, CST_SEMANTIC, IBSCBS_CALC, IBSCBS_UF_CALC, IBSCBS_MUN_CALC, IBSCBS_SPLIT, IBSCBS_TOTAL, LAYOUT_NFE
- Página validate-xml com seletor NFS-e/NF-e/NFC-e e painel IBSCBS
- 54 frontend tests passing

**Backend (validate_xml.py)**
- Endpoint unificado `POST /api/v1/validate/xml` — dual-stack NFS-e + NF-e/NFC-e
- ClassTrib service + endpoint (`GET /api/v1/validation/classtrib/{code}`)
- Migration 0005: correção alíquotas CBS 0.90%, IBS 0.10%
- 128 backend tests passing (excl. 4 test_auth que requerem Docker DB)

**CrewAI (novo)**
- `ParseNFeXMLTool` — Parser NF-e/NFC-e com extração IBSCBS, IBS split UF/Mun, per-item, S3
- `ValidateIBSCBSRulesTool` — 14 regras determinísticas com findings + recommendations
- `NFeValidationCrew` — Crew 3 agentes: parser → validator → reporter
- YAML configs em `crews/tribultz_nfe_validation/config/`
- ChatOps operator atualizado com tools NF-e
- 17 novos testes CrewAI tools

**Issues fechadas**: #78, #79, #80, #82, #83, #84, #85, #86, #87

## Test plan

- [x] Frontend: `cd frontend && npm test --silent` — 54/54 pass
- [x] Backend: `cd backend && python -m pytest tests/ -q --ignore=tests/test_auth.py` — 128/128 pass
- [x] Ruff lint: All checks passed
- [x] Frontend build: `npm run build` — success
- [x] NF-e ok fixture: no FATALs
- [x] NFC-e ok fixture: no FATALs
- [x] IBS split error: IBSCBS_SPLIT detected
- [x] Invalid CST 999: CST_VALID detected
- [x] CST 070 with values: CST_SEMANTIC detected
- [x] CBS calc error: IBSCBS_CALC detected
- [x] Missing IBSCBS group: IBSCBS_MISSING detected
- [x] Missing emit tag: LAYOUT_NFE detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)