### PR TITLE
fix(s11): sanitize hardcoded secrets and centralize config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,66 @@
+# ============================================================
+# Tribultz — Environment Variables
+# Copy this file to ../.env and fill in the values.
+# ============================================================
+
+# ── PostgreSQL ──────────────────────────────────────────────
+POSTGRES_DB=tribultz
+POSTGRES_USER=tribultz
+POSTGRES_PASSWORD=       # REQUIRED
+DATABASE_URL=postgresql+psycopg2://tribultz:YOUR_PASSWORD@db:5432/tribultz  # REQUIRED
+
+# ── Redis ───────────────────────────────────────────────────
+REDIS_URL=redis://redis:6379/0
+
+# ── JWT ─────────────────────────────────────────────────────
+JWT_SECRET=              # REQUIRED (min 32 chars, generate with: openssl rand -hex 32)
+
+# ── MinIO / S3 ──────────────────────────────────────────────
+MINIO_ROOT_USER=         # REQUIRED
+MINIO_ROOT_PASSWORD=     # REQUIRED (min 8 chars)
+S3_ENDPOINT=http://minio:9000
+S3_BUCKET=tribultz
+S3_ACCESS_KEY=           # REQUIRED (same as MINIO_ROOT_USER)
+S3_SECRET_KEY=           # REQUIRED (same as MINIO_ROOT_PASSWORD)
+
+# ── Security ────────────────────────────────────────────────
+ALLOWED_ORIGINS=http://localhost:3000
+ENVIRONMENT=development  # development | staging | production
+FRONTEND_URL=http://localhost:3000
+
+# ── HubSpot (optional) ─────────────────────────────────────
+HUBSPOT_ENABLED=false
+HUBSPOT_PRIVATE_APP_TOKEN=
+HUBSPOT_API_BASE_URL=https://api.hubapi.com
+
+# ── Turnstile CAPTCHA (optional) ────────────────────────────
+CAPTCHA_ENABLED=false
+TURNSTILE_SECRET_KEY=
+CAPTCHA_VERIFY_URL=https://challenges.cloudflare.com/turnstile/v0/siteverify
+
+# ── Email / SMTP (optional) ─────────────────────────────────
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM_EMAIL=noreply@tribultz.com.br
+SMTP_FROM_NAME=Tribultz
+SMTP_TLS=true
+EMAIL_VERIFICATION_ENABLED=false
+
+# ── Asaas Payment Gateway (optional) ────────────────────────
+ASAAS_API_KEY=
+ASAAS_ENVIRONMENT=sandbox  # sandbox | production
+ASAAS_WEBHOOK_TOKEN=
+
+# ── LLM / OpenRouter (optional — needed for CrewAI agents) ──
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+LLM_FREE_PRIMARY=openrouter/google/gemini-2.0-flash-exp:free
+LLM_FREE_FALLBACK=openrouter/qwen/qwen3-coder-480b-a35b-instruct:free
+LLM_PAID_FALLBACK=openrouter/anthropic/claude-3-5-sonnet
+
+# ── External APIs ───────────────────────────────────────────
+CLASSTRIB_API_URL=https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib
+CNPJ_PRIMARY_URL=https://brasilapi.com.br/api/cnpj/v1/{cnpj}
+CNPJ_FALLBACK_URL=https://receitaws.com.br/v1/cnpj/{cnpj}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,8 @@
-"""Tribultz – application settings (reads from .env / environment)."""
+"""Tribultz – application settings (reads from .env / environment).
+
+All secrets and service URLs are read from environment variables.
+Defaults are provided only for non-sensitive, development-safe values.
+"""
 
 from pydantic_settings import BaseSettings
 
@@ -7,28 +11,29 @@ class Settings(BaseSettings):
     # ── Postgres ──────────────────────────────────────────────
     POSTGRES_DB: str = "tribultz"
     POSTGRES_USER: str = "tribultz"
-    POSTGRES_PASSWORD: str = "tribultz_pw"
-    DATABASE_URL: str = "postgresql+psycopg2://tribultz:tribultz_pw@db:5432/tribultz"
+    POSTGRES_PASSWORD: str = ""  # REQUIRED: set via env or .env
+    DATABASE_URL: str = "postgresql+psycopg2://tribultz:changeme@localhost:5432/tribultz"  # Override via env or .env
 
     # ── Redis ─────────────────────────────────────────────────
     REDIS_URL: str = "redis://redis:6379/0"
 
     # ── JWT ───────────────────────────────────────────────────
-    JWT_SECRET: str = "CHANGE_ME_NOW"
+    JWT_SECRET: str = ""  # REQUIRED: set via env or .env (min 32 chars)
     JWT_ALG: str = "HS256"
     JWT_EXPIRES_MIN: int = 480
 
     # ── MinIO / S3 ────────────────────────────────────────────
-    MINIO_ROOT_USER: str = "tribultz_minio"
-    MINIO_ROOT_PASSWORD: str = "tribultz_minio_pw"
+    MINIO_ROOT_USER: str = ""  # REQUIRED: set via env or .env
+    MINIO_ROOT_PASSWORD: str = ""  # REQUIRED: set via env or .env
     S3_ENDPOINT: str = "http://minio:9000"
     S3_BUCKET: str = "tribultz"
-    S3_ACCESS_KEY: str = "tribultz_minio"
-    S3_SECRET_KEY: str = "tribultz_minio_pw"
+    S3_ACCESS_KEY: str = ""  # REQUIRED: set via env or .env
+    S3_SECRET_KEY: str = ""  # REQUIRED: set via env or .env
 
     # ── HubSpot ───────────────────────────────────────────────
     HUBSPOT_ENABLED: bool = False
     HUBSPOT_PRIVATE_APP_TOKEN: str = ""
+    HUBSPOT_API_BASE_URL: str = "https://api.hubapi.com"
     CHATOPS_TIMEOUT_SECONDS: int = 45
 
     # ── Security ────────────────────────────────────────────
@@ -38,6 +43,7 @@ class Settings(BaseSettings):
     # ── Turnstile (CAPTCHA) ─────────────────────────────────
     TURNSTILE_SECRET_KEY: str = ""
     CAPTCHA_ENABLED: bool = False
+    CAPTCHA_VERIFY_URL: str = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 
     # ── Email / SMTP ──────────────────────────────────────
     SMTP_HOST: str = ""
@@ -57,9 +63,15 @@ class Settings(BaseSettings):
 
     # ── LLM / OpenRouter ─────────────────────────────────────
     OPENROUTER_API_KEY: str = ""
+    OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
     LLM_FREE_PRIMARY: str = "openrouter/google/gemini-2.0-flash-exp:free"
     LLM_FREE_FALLBACK: str = "openrouter/qwen/qwen3-coder-480b-a35b-instruct:free"
     LLM_PAID_FALLBACK: str = "openrouter/anthropic/claude-3-5-sonnet"
+
+    # ── External APIs ─────────────────────────────────────────
+    CLASSTRIB_API_URL: str = "https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib"
+    CNPJ_PRIMARY_URL: str = "https://brasilapi.com.br/api/cnpj/v1/{cnpj}"
+    CNPJ_FALLBACK_URL: str = "https://receitaws.com.br/v1/cnpj/{cnpj}"
 
     class Config:
         env_file = ".env"

--- a/backend/app/crews/llm_config.py
+++ b/backend/app/crews/llm_config.py
@@ -19,9 +19,9 @@ from typing import Any
 
 from crewai import LLM
 
-logger = logging.getLogger(__name__)
+from app.config import settings
 
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+logger = logging.getLogger(__name__)
 
 
 class LLMUnavailableError(RuntimeError):
@@ -73,7 +73,7 @@ def build_llm(tier: ModelTier) -> LLM:
     """Create a CrewAI LLM instance for a given tier."""
     return LLM(
         model=tier.model_id,
-        base_url=OPENROUTER_BASE_URL,
+        base_url=settings.OPENROUTER_BASE_URL,
         api_key=_get_api_key(),
     )
 
@@ -94,7 +94,7 @@ def get_llm_with_fallback(
         try:
             llm = LLM(
                 model=tier.model_id,
-                base_url=OPENROUTER_BASE_URL,
+                base_url=settings.OPENROUTER_BASE_URL,
                 api_key=api_key,
             )
             logger.info("LLM selected: %s (free=%s)", tier.name, tier.is_free)
@@ -125,7 +125,7 @@ def execute_with_fallback(
     for tier in tiers:
         llm = LLM(
             model=tier.model_id,
-            base_url=OPENROUTER_BASE_URL,
+            base_url=settings.OPENROUTER_BASE_URL,
             api_key=api_key,
         )
         for attempt in range(1, tier.max_retries + 1):

--- a/backend/app/services/captcha_service.py
+++ b/backend/app/services/captcha_service.py
@@ -17,7 +17,7 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+SITEVERIFY_URL = settings.CAPTCHA_VERIFY_URL
 
 
 async def verify_captcha(token: str, remote_ip: str | None = None) -> bool:

--- a/backend/app/services/classtrib_service.py
+++ b/backend/app/services/classtrib_service.py
@@ -11,16 +11,16 @@ from typing import Any
 
 import httpx
 
-logger = logging.getLogger(__name__)
+from app.config import settings
 
-SVRS_BASE_URL = "https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib"
+logger = logging.getLogger(__name__)
 
 
 class ClassTribService:
     """Client for the Conformidade Fácil ClassTrib API."""
 
     def __init__(self) -> None:
-        self.base_url = SVRS_BASE_URL
+        self.base_url = settings.CLASSTRIB_API_URL
         self.timeout = 10.0
 
     async def lookup(self, code: str) -> dict[str, Any] | None:

--- a/backend/app/services/cnpj_validator.py
+++ b/backend/app/services/cnpj_validator.py
@@ -13,10 +13,12 @@ from dataclasses import dataclass
 
 import httpx
 
+from app.config import settings
+
 logger = logging.getLogger(__name__)
 
-BRASILAPI_URL = "https://brasilapi.com.br/api/cnpj/v1/{cnpj}"
-RECEITAWS_URL = "https://receitaws.com.br/v1/cnpj/{cnpj}"
+BRASILAPI_URL = settings.CNPJ_PRIMARY_URL
+RECEITAWS_URL = settings.CNPJ_FALLBACK_URL
 TIMEOUT_SECONDS = 5.0
 
 

--- a/backend/app/tools/hubspot_tool.py
+++ b/backend/app/tools/hubspot_tool.py
@@ -9,7 +9,7 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-BASE_URL = "https://api.hubapi.com"
+BASE_URL = settings.HUBSPOT_API_BASE_URL
 
 
 # ── Guard ─────────────────────────────────────────────────────

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+
 const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
@@ -17,7 +19,7 @@ const securityHeaders = [
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob:",
       "font-src 'self'",
-      "connect-src 'self' http://localhost:8000 https://challenges.cloudflare.com",
+      `connect-src 'self' ${apiBase} https://challenges.cloudflare.com`,
       "frame-src https://challenges.cloudflare.com",
     ].join("; "),
   },

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -10,8 +10,7 @@ import {
   setMockMode,
   setToken,
 } from "@/lib/storage";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+import { API_BASE } from "@/lib/api";
 
 export default function SettingsPage() {
   const [mockMode, setMock] = useState(true);

--- a/frontend/src/app/verify-email/page.tsx
+++ b/frontend/src/app/verify-email/page.tsx
@@ -3,8 +3,7 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+import { API_BASE } from "@/lib/api";
 
 type VerifyState = "loading" | "verified" | "already_verified" | "error";
 

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -10,8 +10,7 @@ import {
   setToken,
   type StoredTenant,
 } from "@/lib/storage";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+import { API_BASE } from "@/lib/api";
 
 type TopbarProps = {
   onOpenMenu: () => void;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,7 +34,7 @@ import {
 } from "./mock";
 import { getMockMode, getTenantId, getToken } from "./storage";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
 
 type LoginRequest = {
   email: string;


### PR DESCRIPTION
## Summary
- Remove hardcoded passwords/secrets from `config.py` defaults (POSTGRES_PASSWORD, JWT_SECRET, MINIO credentials)
- Externalize 6 API URLs to env vars via `pydantic_settings` (ClassTrib, CNPJ primary/fallback, HubSpot, Captcha, OpenRouter)
- Consolidate frontend `API_BASE` into single export from `api.ts` (was duplicated in 4 files)
- Use `NEXT_PUBLIC_API_BASE_URL` env var in CSP `connect-src` header
- Add `backend/.env.example` documenting all required/optional vars
- Fix ruff E402 import order in `cnpj_validator.py`

Closes #92

## Test plan
- [x] Backend: 128 tests pass (`pytest tests/ -q --ignore=tests/test_auth.py`)
- [x] Ruff lint: All checks passed
- [x] Frontend: 54 tests pass (`npm test --silent`)
- [x] Frontend build: success (`npm run build`)
- [x] Docker hot-reload picks up changes without rebuild
