### PR TITLE
feat(s12): freemium guardrails + data governance + frontend integration

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -1,6 +1,10 @@
 """Public endpoints — no authentication required.
 
 Rate-limited to prevent abuse. Used for the freemium diagnostic funnel.
+
+Data governance: XML content submitted to this endpoint is processed in-memory
+only, never persisted to disk or database. No PII extraction or storage occurs.
+See GET /api/v1/public/data-policy for the full commitment.
 """
 
 from __future__ import annotations
@@ -17,8 +21,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/public", tags=["public"])
 
-# Stricter rate limit for public endpoints: 10 req/min per IP
+# ── Rate limiting ────────────────────────────────────────────────────────────
+# Per-minute: burst protection (10 req/min)
 _rate_limiter = RateLimiter()
+
+# Per-day: freemium cap (20 validations/day per IP)
+_daily_limiter = RateLimiter()
+_daily_limiter.limit = 20
+_daily_limiter.ttl = 86400  # 24 hours
+
+# Freemium guardrail: max findings shown without login
+MAX_FREE_FINDINGS = 3
 
 
 def _client_ip(request: Request) -> str:
@@ -39,27 +52,38 @@ class PublicFindingSummary(BaseModel):
 class PublicValidationResult(BaseModel):
     """Simplified validation result for the freemium tier.
 
-    Shows rule names and severity but redacts detailed evidence,
-    xpath, snippets and recommendations (available in paid plans).
+    Shows up to 3 findings with rule names and severity.
+    Redacts detailed evidence, xpath, snippets and recommendations.
+    Full results available in paid plans.
     """
     document_type: str
     status: str  # PASS | FAIL
     total_findings: int
+    findings_shown: int
+    findings_hidden: int
     fatals: int
     alerts: int
     findings: list[PublicFindingSummary]
     rules_checked: int
     upgrade_cta: str
+    data_policy: str
 
 
-# Total rules the engine checks (for the "X rules checked" display)
+# Total rules the engine checks
 RULES_CHECKED = 14
+
+DATA_POLICY_SUMMARY = (
+    "Seu XML é processado em memória e descartado imediatamente após a validação. "
+    "Nenhum dado fiscal, CNPJ ou informação pessoal é armazenado, "
+    "compartilhado ou utilizado para qualquer outra finalidade. "
+    "Consulte /api/v1/public/data-policy para detalhes completos."
+)
 
 
 def _to_public_result(result: ValidationResult) -> PublicValidationResult:
     """Convert full ValidationResult to freemium-safe output."""
     status = "PASS" if result.fatals == 0 else "FAIL"
-    findings = [
+    all_findings = [
         PublicFindingSummary(
             rule_id=f.rule_id,
             severity=f.severity,
@@ -67,15 +91,32 @@ def _to_public_result(result: ValidationResult) -> PublicValidationResult:
         )
         for f in result.findings
     ]
+    # Guardrail: show only first N findings, blur the rest
+    shown = all_findings[:MAX_FREE_FINDINGS]
+    hidden = len(all_findings) - len(shown)
+
+    cta = (
+        "Crie sua conta gratuita para ver o relatório completo com "
+        "evidências, recomendações e exportação PDF."
+    )
+    if hidden > 0:
+        cta = (
+            f"Mais {hidden} {'problema encontrado' if hidden == 1 else 'problemas encontrados'} — "
+            "crie sua conta para ver todos os detalhes, evidências e recomendações de correção."
+        )
+
     return PublicValidationResult(
         document_type=result.document_type,
         status=status,
-        total_findings=len(result.findings),
+        total_findings=len(all_findings),
+        findings_shown=len(shown),
+        findings_hidden=hidden,
         fatals=result.fatals,
         alerts=result.alerts,
-        findings=findings,
+        findings=shown,
         rules_checked=RULES_CHECKED,
-        upgrade_cta="Crie sua conta gratuita para ver o relatório completo com evidências, recomendações e exportação PDF.",
+        upgrade_cta=cta,
+        data_policy=DATA_POLICY_SUMMARY,
     )
 
 
@@ -90,10 +131,16 @@ async def public_validate(
     """Public XML validation — no login required, rate-limited.
 
     Upload an NF-e/NFC-e/NFS-e XML and get an instant conformity diagnostic.
-    Returns rule hits with severity but redacts detailed evidence (paid feature).
+    Returns up to 3 findings with severity. Detailed evidence requires a paid plan.
+
+    Rate limits: 10 req/min + 20 req/day per IP.
+
+    Data commitment: XML is processed in-memory only and immediately discarded.
+    No fiscal data, CNPJ, or PII is stored or shared.
     """
     ip = _client_ip(request)
     _rate_limiter.check_or_raise(f"public:{ip}")
+    _daily_limiter.check_or_raise(f"public_daily:{ip}")
 
     if file:
         raw = await file.read()
@@ -112,6 +159,82 @@ async def public_validate(
 
     result = validate_xml(xml)
     return _to_public_result(result)
+
+
+@router.get("/data-policy")
+def public_data_policy():
+    """Data governance policy for the public validation endpoint.
+
+    Transparent commitment to how submitted XML data is handled.
+    """
+    return {
+        "service": "Tribultz — Diagnóstico Gratuito de Conformidade Fiscal",
+        "version": "1.0",
+        "effective_date": "2026-03-24",
+        "commitments": [
+            {
+                "id": "NO_STORAGE",
+                "title": "Sem armazenamento",
+                "description": (
+                    "O XML enviado ao endpoint /api/v1/public/validate é processado "
+                    "exclusivamente em memória (RAM) durante a validação. Nenhum conteúdo "
+                    "do XML é gravado em disco, banco de dados, object storage (S3) ou "
+                    "qualquer outro meio persistente."
+                ),
+            },
+            {
+                "id": "NO_PII_EXTRACTION",
+                "title": "Sem extração de dados pessoais",
+                "description": (
+                    "O motor de validação analisa apenas a estrutura fiscal do XML "
+                    "(CST, cClassTrib, CEST, alíquotas IBS/CBS). Campos como CNPJ, "
+                    "razão social, endereço ou dados de produtos NÃO são extraídos, "
+                    "indexados ou armazenados."
+                ),
+            },
+            {
+                "id": "NO_SHARING",
+                "title": "Sem compartilhamento",
+                "description": (
+                    "Os dados do XML não são compartilhados com terceiros, "
+                    "parceiros comerciais, serviços de analytics ou modelos de IA. "
+                    "O processamento ocorre inteiramente nos servidores Tribultz."
+                ),
+            },
+            {
+                "id": "NO_LOGGING_CONTENT",
+                "title": "Sem log do conteúdo fiscal",
+                "description": (
+                    "Os logs do sistema registram apenas metadados operacionais "
+                    "(IP de origem, timestamp, tipo de documento, contagem de findings). "
+                    "O conteúdo do XML NUNCA é incluído em logs."
+                ),
+            },
+            {
+                "id": "IMMEDIATE_DISCARD",
+                "title": "Descarte imediato",
+                "description": (
+                    "Após a resposta HTTP ser enviada, a referência ao XML em memória "
+                    "é liberada e sujeita à coleta de lixo do runtime Python. "
+                    "Não há cache, fila ou reprocessamento posterior."
+                ),
+            },
+            {
+                "id": "LGPD_COMPLIANCE",
+                "title": "Conformidade LGPD",
+                "description": (
+                    "Este endpoint opera em conformidade com a Lei Geral de Proteção "
+                    "de Dados (Lei 13.709/2018). Como nenhum dado pessoal é armazenado, "
+                    "não há necessidade de base legal para tratamento. O titular pode "
+                    "exercer seus direitos via dpo@tribultz.com.br."
+                ),
+            },
+        ],
+        "contact": {
+            "dpo_email": "dpo@tribultz.com.br",
+            "privacy_page": "/privacy",
+        },
+    }
 
 
 @router.get("/health")

--- a/backend/tests/test_public_validate.py
+++ b/backend/tests/test_public_validate.py
@@ -6,23 +6,28 @@ from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.routers.public import _to_public_result, _client_ip, _rate_limiter
+from app.routers.public import (
+    _to_public_result, _client_ip, _rate_limiter, _daily_limiter,
+    MAX_FREE_FINDINGS,
+)
 from app.routers.validate_xml import validate_xml
 
 
 @pytest.fixture(autouse=True)
-def reset_public_rate_limiter():
-    """Clear rate limiter state between tests to avoid 429s in CI (double pytest run)."""
-    _rate_limiter._memory_store.clear()
-    if _rate_limiter.redis is not None:
-        try:
-            _rate_limiter.redis.delete("ratelimit:public:testclient")
-            _rate_limiter.redis.delete("ratelimit:public:127.0.0.1")
-            _rate_limiter.redis.delete("ratelimit:public:unknown")
-        except Exception:
-            pass
+def reset_public_rate_limiters():
+    """Clear rate limiter state between tests to avoid 429s in CI."""
+    for rl in (_rate_limiter, _daily_limiter):
+        rl._memory_store.clear()
+        if rl.redis is not None:
+            try:
+                for prefix in ("ratelimit:public:", "ratelimit:public_daily:"):
+                    for suffix in ("testclient", "127.0.0.1", "unknown"):
+                        rl.redis.delete(f"{prefix}{suffix}")
+            except Exception:
+                pass
     yield
-    _rate_limiter._memory_store.clear()
+    for rl in (_rate_limiter, _daily_limiter):
+        rl._memory_store.clear()
 
 # ── Sample XMLs ────────────────────────────────────────────────────────────────
 
@@ -103,10 +108,7 @@ MINIMAL_NFSE_XML = """<?xml version="1.0"?>
 """
 
 
-# ── Unit tests ─────────────────────────────────────────────────────────────────
-
-
-# ── Unit tests: validation engine (no HTTP) ────────────────────────────────────
+# ── Unit tests: conversion + guardrails ────────────────────────────────────────
 
 class TestPublicResultConversion:
     def test_valid_nfe_returns_pass(self):
@@ -116,7 +118,7 @@ class TestPublicResultConversion:
         assert public.status == "PASS"
         assert public.fatals == 0
         assert public.rules_checked == 14
-        assert "conta gratuita" in public.upgrade_cta
+        assert public.data_policy  # governance field present
 
     def test_invalid_nfe_returns_fail_with_findings(self):
         result = validate_xml(INVALID_NFE_XML_MISSING_CST)
@@ -124,11 +126,27 @@ class TestPublicResultConversion:
         assert public.status == "FAIL"
         assert public.fatals > 0
         assert public.total_findings > 0
-        # Findings should have rule_id but no detailed evidence
         for f in public.findings:
             assert f.rule_id
             assert f.severity in ("FATAL", "ALERT")
             assert f.title
+
+    def test_findings_capped_at_max_free(self):
+        """Guardrail: only MAX_FREE_FINDINGS shown, rest hidden."""
+        result = validate_xml(INVALID_NFE_XML_MISSING_CST)
+        public = _to_public_result(result)
+        if public.total_findings > MAX_FREE_FINDINGS:
+            assert len(public.findings) == MAX_FREE_FINDINGS
+            assert public.findings_hidden == public.total_findings - MAX_FREE_FINDINGS
+            assert public.findings_shown == MAX_FREE_FINDINGS
+            assert "problemas encontrados" in public.upgrade_cta or "problema encontrado" in public.upgrade_cta
+
+    def test_pass_result_shows_all_findings(self):
+        """When few findings, all are shown (no hiding needed)."""
+        result = validate_xml(VALID_NFE_XML)
+        public = _to_public_result(result)
+        assert public.findings_hidden == 0
+        assert public.findings_shown == public.total_findings
 
     def test_nfse_detection(self):
         result = validate_xml(MINIMAL_NFSE_XML)
@@ -151,6 +169,13 @@ class TestPublicResultConversion:
             assert "snippet" not in f
             assert "recommendation" not in f
             assert "evidence_ids" not in f
+
+    def test_data_policy_field_present(self):
+        """Governance: every response includes data policy summary."""
+        result = validate_xml(VALID_NFE_XML)
+        public = _to_public_result(result)
+        assert "LGPD" in public.data_policy or "descartado" in public.data_policy
+        assert "armazenado" in public.data_policy
 
 
 class TestClientIpExtraction:
@@ -189,7 +214,10 @@ class TestPublicValidateEndpoint:
         assert data["document_type"] == "NFE"
         assert data["status"] in ("PASS", "FAIL")
         assert "upgrade_cta" in data
+        assert "data_policy" in data
         assert data["rules_checked"] == 14
+        assert "findings_shown" in data
+        assert "findings_hidden" in data
 
     def test_post_file_upload(self):
         resp = client.post(
@@ -199,7 +227,7 @@ class TestPublicValidateEndpoint:
         assert resp.status_code == 200
         assert resp.json()["document_type"] == "NFE"
 
-    def test_post_invalid_xml_returns_findings(self):
+    def test_post_invalid_xml_returns_capped_findings(self):
         resp = client.post(
             "/api/v1/public/validate",
             data={"xml_content": INVALID_NFE_XML_MISSING_CST},
@@ -208,7 +236,9 @@ class TestPublicValidateEndpoint:
         data = resp.json()
         assert data["status"] == "FAIL"
         assert data["fatals"] > 0
-        assert len(data["findings"]) > 0
+        assert len(data["findings"]) <= MAX_FREE_FINDINGS
+        assert data["findings_shown"] <= MAX_FREE_FINDINGS
+        assert data["total_findings"] >= data["findings_shown"]
 
     def test_post_empty_body_returns_400(self):
         resp = client.post("/api/v1/public/validate")
@@ -233,6 +263,17 @@ class TestPublicValidateEndpoint:
         )
         assert resp.status_code == 200
         assert resp.json()["document_type"] == "NFSE"
+
+    def test_data_policy_endpoint(self):
+        resp = client.get("/api/v1/public/data-policy")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["commitments"]) >= 5
+        ids = {c["id"] for c in data["commitments"]}
+        assert "NO_STORAGE" in ids
+        assert "NO_PII_EXTRACTION" in ids
+        assert "NO_SHARING" in ids
+        assert "LGPD_COMPLIANCE" in ids
 
     @patch("app.routers.public._rate_limiter")
     def test_rate_limit_returns_429(self, mock_limiter):

--- a/frontend/src/app/diagnostico/page.tsx
+++ b/frontend/src/app/diagnostico/page.tsx
@@ -16,11 +16,14 @@ type DiagnosticResult = {
   document_type: string;
   status: string;
   total_findings: number;
+  findings_shown: number;
+  findings_hidden: number;
   fatals: number;
   alerts: number;
   findings: FindingSummary[];
   rules_checked: number;
   upgrade_cta: string;
+  data_policy: string;
 };
 
 type UploadState = "idle" | "uploading" | "done" | "error";
@@ -261,6 +264,24 @@ export default function DiagnosticoPage() {
               </div>
             )}
 
+            {/* Hidden findings indicator */}
+            {result.findings_hidden > 0 && (
+              <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+                <svg className="h-5 w-5 flex-shrink-0 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                </svg>
+                <p className="text-sm text-amber-800">
+                  Exibindo <strong>{result.findings_shown}</strong> de{" "}
+                  <strong>{result.total_findings}</strong> problemas encontrados.{" "}
+                  <strong>{result.findings_hidden}</strong>{" "}
+                  {result.findings_hidden === 1
+                    ? "problema adicional oculto"
+                    : "problemas adicionais ocultos"}{" "}
+                  no diagnóstico gratuito.
+                </p>
+              </div>
+            )}
+
             {/* Blurred CTA section */}
             <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-white">
               {/* Blurred fake content */}
@@ -307,6 +328,17 @@ export default function DiagnosticoPage() {
                     Já tenho conta
                   </Link>
                 </div>
+              </div>
+            </div>
+
+            {/* Data governance notice */}
+            <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
+              <svg className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+              </svg>
+              <div>
+                <p className="text-sm font-medium text-emerald-800">Seus dados estão seguros</p>
+                <p className="mt-0.5 text-xs text-emerald-700">{result.data_policy}</p>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- **Daily IP rate limit** (20 validations/day) to prevent freemium abuse
- **Findings cap** at 3 for unauthenticated users (blur rest behind upgrade CTA)
- **Data governance policy endpoint** (`/api/v1/public/data-policy`) with 6 LGPD-compliant commitments
- **Frontend**: findings hidden indicator + governance banner with shield icon
- **20 backend tests** covering guardrails, governance, rate limiting

## Test plan
- [x] Backend: `pytest tests/test_public_validate.py` — 20/20 passed
- [x] Backend: `ruff check` — all passed
- [x] Frontend: `npm test` — 54/54 passed
- [x] Frontend: `npm run build` — compiled successfully
- [x] Docker: endpoints verified live (`/public/health`, `/public/data-policy`)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)