### PR TITLE
feat(s16): plano Empresarial + correção de descrições na /pricing

### DIFF
--- a/backend/app/alembic/versions/2026_03_26_0006_add_empresarial_plan.py
+++ b/backend/app/alembic/versions/2026_03_26_0006_add_empresarial_plan.py
@@ -1,0 +1,39 @@
+"""add empresarial plan between profissional and contador
+
+Revision ID: 2026_03_26_0006
+Revises: 2026_03_23_0005
+Create Date: 2026-03-26
+"""
+
+from alembic import op
+
+revision = "2026_03_26_0006"
+down_revision = "2026_03_23_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── Add plano Empresarial ────────────────────────────────────
+    # Positioned between Profissional (R$149) and Contador (R$349)
+    # Profissional + controle de filiais (até 10 CNPJs)
+    op.execute("""
+        INSERT INTO plans (slug, name, price_cents, max_validations, max_ai_messages,
+                           has_pdf_reports, has_batch, has_dashboard, has_api_access,
+                           has_multi_cnpj, trial_days)
+        VALUES
+            ('empresarial', 'Empresarial', 24900, 2000, NULL, TRUE, TRUE, TRUE, TRUE, TRUE, NULL)
+        ON CONFLICT (slug) DO UPDATE
+            SET name          = EXCLUDED.name,
+                price_cents   = EXCLUDED.price_cents,
+                max_validations = EXCLUDED.max_validations,
+                has_pdf_reports = EXCLUDED.has_pdf_reports,
+                has_batch       = EXCLUDED.has_batch,
+                has_dashboard   = EXCLUDED.has_dashboard,
+                has_api_access  = EXCLUDED.has_api_access,
+                has_multi_cnpj  = EXCLUDED.has_multi_cnpj;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM plans WHERE slug = 'empresarial'")

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -313,7 +313,8 @@ INSERT INTO plans (slug, name, price_cents, max_validations, max_ai_messages,
 VALUES
     ('trial',        'Trial',        0,     5,    25,   FALSE, FALSE, FALSE, FALSE, FALSE, 3),
     ('starter',      'Starter',      4990,  10,   50,   FALSE, FALSE, TRUE,  FALSE, FALSE, NULL),
-    ('profissional', 'Profissional', 14900, 500,  NULL, TRUE,  TRUE,  TRUE,  FALSE, FALSE, NULL),
+    ('profissional', 'Profissional', 14900, 500,  NULL, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, NULL),
+    ('empresarial',  'Empresarial',  24900, 2000, NULL, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  NULL),
     ('contador',     'Contador',     34900, NULL, NULL, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  NULL)
 ON CONFLICT (slug) DO NOTHING;
 

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -69,9 +69,27 @@ const PLANS: Plan[] = [
       "Acesso à API REST",
       "Dashboard completo",
     ],
-    limits: "1 CNPJ • Suporte prioritário",
+    limits: "1 CNPJ • Sem controle de filiais",
     cta: "Assinar Profissional",
     highlighted: true,
+  },
+  {
+    slug: "empresarial",
+    name: "Empresarial",
+    priceCents: 24900,
+    badge: "Filiais",
+    tagline: "Para empresas com filiais",
+    features: [
+      "2.000 validações XML por mês",
+      "IA fiscal ilimitada",
+      "Relatórios PDF auditáveis",
+      "Validação cruzada em lote",
+      "Acesso à API REST",
+      "Controle de até 10 CNPJs de filiais",
+    ],
+    limits: "Até 10 CNPJs (matriz + filiais)",
+    cta: "Assinar Empresarial",
+    highlighted: false,
   },
   {
     slug: "contador",
@@ -82,12 +100,12 @@ const PLANS: Plan[] = [
     features: [
       "Validações ilimitadas",
       "IA fiscal ilimitada",
-      "Relatórios PDF auditáveis",
-      "Validação cruzada em lote",
-      "Acesso à API REST",
-      "Múltiplos CNPJs",
+      "Relatórios PDF e evidências auditáveis",
+      "Validação cruzada em lote ilimitada",
+      "API REST com webhooks",
+      "Gestão de até 50 CNPJs de clientes",
     ],
-    limits: "Até 50 CNPJs • SLA garantido",
+    limits: "Até 50 CNPJs • SLA 99,9% • Suporte prioritário",
     cta: "Assinar Contador",
     highlighted: false,
   },
@@ -363,7 +381,7 @@ export default function PricingPage() {
 
         {/* Plan cards */}
         <section className="mx-auto max-w-6xl px-4 pb-16 md:px-6">
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
             {PLANS.map((plan) => (
               <PlanCard
                 key={plan.slug}
@@ -401,35 +419,40 @@ export default function PricingPage() {
                 {[
                   {
                     label: "Validações XML/mês",
-                    values: ["5", "10", "500", "Ilimitadas"],
+                    // Trial | Starter | Profissional | Empresarial | Contador
+                    values: ["5", "10", "500", "2.000", "Ilimitadas"],
                   },
                   {
                     label: "Mensagens IA fiscal",
-                    values: ["25", "50", "Ilimitadas", "Ilimitadas"],
+                    values: ["25", "50", "Ilimitadas", "Ilimitadas", "Ilimitadas"],
                   },
                   {
                     label: "18 regras CBS/IBS",
-                    values: [true, true, true, true],
+                    values: [true, true, true, true, true],
                   },
                   {
                     label: "Dashboard de conformidade",
-                    values: [false, true, true, true],
+                    values: [false, true, true, true, true],
                   },
                   {
                     label: "Relatório PDF auditável",
-                    values: [false, false, true, true],
+                    values: [false, false, true, true, true],
                   },
                   {
                     label: "Validação cruzada em lote",
-                    values: [false, false, true, true],
+                    values: [false, false, true, true, true],
                   },
                   {
                     label: "Acesso à API REST",
-                    values: [false, false, true, true],
+                    values: [false, false, true, true, true],
                   },
                   {
-                    label: "Múltiplos CNPJs",
-                    values: [false, false, false, true],
+                    label: "Controle de filiais (CNPJ)",
+                    values: ["—", "—", "—", "Até 10", "Até 50"],
+                  },
+                  {
+                    label: "Suporte prioritário",
+                    values: [false, false, false, true, true],
                   },
                 ].map((row) => (
                   <tr key={row.label} className="hover:bg-slate-50">

--- a/frontend/src/lib/plan.ts
+++ b/frontend/src/lib/plan.ts
@@ -19,7 +19,7 @@ function safeLocalStorage(): Storage | null {
 
 // ── Plan feature matrix ─────────────────────────────────────────
 
-export type PlanSlug = "trial" | "starter" | "profissional" | "contador";
+export type PlanSlug = "trial" | "starter" | "profissional" | "empresarial" | "contador";
 
 export type PlanFeatures = {
   name: string;
@@ -71,6 +71,18 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasMultiCnpj: false,
     trialDays: null,
   },
+  empresarial: {
+    name: "Empresarial",
+    priceCents: 24900,
+    maxValidations: 2000,
+    maxAiMessages: null,
+    hasPdfReports: true,
+    hasBatch: true,
+    hasDashboard: true,
+    hasApiAccess: true,
+    hasMultiCnpj: true, // filiais — até 10 CNPJs
+    trialDays: null,
+  },
   contador: {
     name: "Contador",
     priceCents: 34900,
@@ -87,7 +99,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
 
 // ── Plan hierarchy (for upgrade comparisons) ────────────────────
 
-const PLAN_ORDER: PlanSlug[] = ["trial", "starter", "profissional", "contador"];
+const PLAN_ORDER: PlanSlug[] = ["trial", "starter", "profissional", "empresarial", "contador"];
 
 // ── Storage getters/setters ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **fix**: Profissional e Contador tinham features idênticas — corrigidas com textos distintos e posicionamento correto
- **fix**: Profissional exibia texto de responsabilidade multi-tenant — removido, agora exibe \"1 CNPJ • Sem controle de filiais\"
- **feat**: Novo plano **Empresarial** (R\$ 249/mês) entre Profissional e Contador
  - 2.000 validações/mês, IA ilimitada, PDF auditável, batch, API REST, até 10 CNPJs de filiais
- Tabela comparativa atualizada para 5 colunas + linha \"Controle de filiais (CNPJ)\"
- `plan.ts`: slug \`empresarial\` adicionado ao tipo, PLAN_FEATURES e PLAN_ORDER
- Migration Alembic \`2026_03_26_0006\`: INSERT empresarial com ON CONFLICT DO UPDATE
- `schema.sql` seed atualizado com 5 planos
- **DB confirmado**: 5 planos (trial → starter → profissional → empresarial → contador)
- **Docker**: todos os 6 serviços healthy

## Test plan

- [x] 54 testes frontend passando
- [x] Build Next.js limpo (sem erros TypeScript)
- [x] Ruff lint OK
- [x] Migration aplicada: `alembic upgrade head` → `2026_03_26_0006`
- [x] DB: `SELECT slug, name, price_cents FROM plans` → 5 linhas corretas
- [x] Docker: db, redis, api, worker, beat, minio — todos healthy

Closes #117 #118 #119 #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)