### PR TITLE
fix(frontend): remove JSX return type in documents page

### DIFF
--- a/frontend/src/app/documents/page.tsx
+++ b/frontend/src/app/documents/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { listDocuments, getDocumentDownloadUrl, type DocumentResponse } from "@/lib/api";
 
-export default function DocumentsPage(): JSX.Element {
+export default function DocumentsPage() {
   const [docs, setDocs] = useState<DocumentResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [onlyCorrected, setOnlyCorrected] = useState(true);


### PR DESCRIPTION
Remove  return type que causa erro de build (requires explicit React import).