### PR TITLE
fix(auth): reject invalid CNPJ in add_cnpj (#197)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -514,7 +514,9 @@ async def add_cnpj(
 
     # Validate CNPJ
     cnpj_result = await validate_cnpj(cnpj_digits)
-    company_name = cnpj_result.company_name if cnpj_result.valid else ""
+    if not cnpj_result.valid:
+        raise HTTPException(status_code=400, detail="CNPJ inválido ou não encontrado na Receita Federal.")
+    company_name = cnpj_result.company_name
 
     # Get or create tenant
     tenant = _get_or_create_tenant_for_cnpj(db, cnpj_digits, company_name)


### PR DESCRIPTION
## Summary
- Fixes #197: `add_cnpj` endpoint now returns HTTP 400 when the CNPJ fails validation against Receita Federal, instead of silently creating a tenant with an empty company name.
- Production already has this fix via hotfix; this PR aligns the codebase.

## Test plan
- [ ] Call `POST /api/v1/auth/add-cnpj` with an invalid CNPJ → expect 400
- [ ] Call with a valid CNPJ → expect tenant creation as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)