### PR TITLE
fix(frontend): auth guard on protected routes (#203)

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { FormEvent, useRef, useState } from "react";
+import { FormEvent, Suspense, useRef, useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { Toast } from "@/components/common/Toast";
 import { loginWithApi, resendVerificationEmail } from "@/lib/api";
@@ -11,7 +11,21 @@ import { setAccountType, setTenantId, setTenants, setToken } from "@/lib/storage
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
 export default function LoginPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-tribultz-600" />
+      </div>
+    }>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("redirect");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loadingApi, setLoadingApi] = useState(false);
@@ -60,7 +74,7 @@ export default function LoginPage() {
       if (login.role === "superadmin") {
         router.push("/select-mode");
       } else {
-        router.push("/dashboard");
+        router.push(redirectTo ?? "/dashboard");
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Falha ao autenticar.";

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,38 +1,69 @@
-﻿"use client";
+"use client";
 
-import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { AppLegalFooter } from "./AppLegalFooter";
 import { Sidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 import TrialBanner from "@/components/common/TrialBanner";
+import { getToken } from "@/lib/storage";
+
+const PUBLIC_ROUTES = [
+  "/",
+  "/calculadora",
+  "/changelog",
+  "/cookies",
+  "/diagnostico",
+  "/forgot-password",
+  "/lgpd",
+  "/login",
+  "/pricing",
+  "/privacy",
+  "/register",
+  "/reset-password",
+  "/select-mode",
+  "/terms",
+  "/verify-email",
+];
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [stateVersion, setStateVersion] = useState(0);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  const isPublic = useMemo(() => PUBLIC_ROUTES.includes(pathname), [pathname]);
 
   useEffect(() => {
     setMobileOpen(false);
   }, [pathname]);
 
-  const noShell = [
-    "/",
-    "/calculadora",
-    "/changelog",
-    "/cookies",
-    "/diagnostico",
-    "/forgot-password",
-    "/lgpd",
-    "/login",
-    "/pricing",
-    "/privacy",
-    "/register",
-    "/reset-password",
-    "/terms",
-    "/verify-email",
-  ];
-  if (noShell.includes(pathname)) return <>{children}</>;
+  // Auth guard: redirect to /login if no JWT token on protected routes
+  useEffect(() => {
+    if (isPublic) {
+      setAuthChecked(true);
+      return;
+    }
+    const token = getToken();
+    if (!token) {
+      router.replace(`/login?redirect=${encodeURIComponent(pathname)}`);
+    } else {
+      setAuthChecked(true);
+    }
+  }, [pathname, router, isPublic]);
+
+  // Public routes: render without shell
+  if (isPublic) return <>{children}</>;
+
+  // Protected route loading while checking auth
+  if (!authChecked) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-tribultz-600" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen md:flex">


### PR DESCRIPTION
## Summary
- Fixes #203: Protected frontend routes now redirect unauthenticated users to `/login` instead of rendering a broken AppShell with 401 API errors.
- `AppShell` checks `getToken()` from localStorage before rendering protected content.
- Login page accepts `?redirect=` param to return users to their intended page after authentication.
- Wrapped login page in `<Suspense>` for Next.js 16 `useSearchParams()` compatibility.

## Test plan
- [ ] Visit `/dashboard` without logging in → redirected to `/login?redirect=%2Fdashboard`
- [ ] Log in → redirected back to `/dashboard`
- [ ] Visit public routes (`/pricing`, `/changelog`) without auth → renders normally
- [ ] Visit `/select-mode` without auth → renders normally (intermediate auth page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)