### PR TITLE
fix(security): CAPTCHA fail-closed on network error (#196)

### DIFF
--- a/backend/app/services/captcha_service.py
+++ b/backend/app/services/captcha_service.py
@@ -26,8 +26,8 @@ async def verify_captcha(token: str, remote_ip: str | None = None) -> bool:
         return True
 
     if not settings.TURNSTILE_SECRET_KEY:
-        logger.warning("captcha_no_secret_key: CAPTCHA_ENABLED but no TURNSTILE_SECRET_KEY set")
-        return True
+        logger.error("captcha_no_secret_key: CAPTCHA_ENABLED but no TURNSTILE_SECRET_KEY set")
+        return False
 
     if not token:
         return False
@@ -50,5 +50,6 @@ async def verify_captcha(token: str, remote_ip: str | None = None) -> bool:
             return success
     except Exception as exc:
         logger.error("captcha_verify_error", extra={"error": str(exc)})
-        # Fail open: don't block users if Cloudflare is unreachable
-        return True
+        # Fail closed: reject request when Cloudflare is unreachable.
+        # Attacker could block Cloudflare connectivity to bypass CAPTCHA.
+        return False


### PR DESCRIPTION
## Summary
- Fixes #196: CAPTCHA validation now returns `False` (fail-closed) when Cloudflare Turnstile is unreachable, instead of `True` (fail-open).
- Also fails closed when `TURNSTILE_SECRET_KEY` is not configured but `CAPTCHA_ENABLED=true`.
- Prevents attackers from bypassing CAPTCHA by blocking Cloudflare connectivity.

## Test plan
- [ ] With CAPTCHA enabled and valid key: normal verification works
- [ ] With CAPTCHA enabled but Cloudflare unreachable: login/register returns CAPTCHA error
- [ ] With CAPTCHA enabled but no secret key: login/register returns CAPTCHA error

🤖 Generated with [Claude Code](https://claude.com/claude-code)