### PR TITLE
fix(frontend): SEO — sitemap, robots, meta tags (#209)

### DIFF
--- a/frontend/src/app/changelog/page.tsx
+++ b/frontend/src/app/changelog/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { PublicFooter } from "@/components/public/PublicFooter";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { NewsFeed } from "@/components/public/NewsFeed";
+
+export const metadata: Metadata = {
+  title: "Changelog",
+  description: "Novidades e atualizações da plataforma Tribultz de conformidade fiscal.",
+};
 
 export default function ChangelogPage() {
   return (

--- a/frontend/src/app/cookies/page.tsx
+++ b/frontend/src/app/cookies/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Cookies",
+  description: "Política de cookies da plataforma Tribultz.",
+};
 
 export default function CookiesPage() {
   return (

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,9 +13,35 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_URL = "https://tribultz.com.br";
+const SITE_NAME = "Tribultz";
+const DEFAULT_DESCRIPTION =
+  "Plataforma de inteligência fiscal para a reforma tributária brasileira. Validação determinística CBS/IBS, memória de precedentes e trilha auditável.";
+
 export const metadata: Metadata = {
-  title: "Tribultz | Inteligência Fiscal para a Reforma Tributária",
-  description: "Plataforma de inteligência fiscal para a reforma tributária com validação determinística, memória de precedentes e trilha auditável.",
+  title: {
+    default: "Tribultz | Inteligência Fiscal para a Reforma Tributária",
+    template: "%s | Tribultz",
+  },
+  description: DEFAULT_DESCRIPTION,
+  metadataBase: new URL(SITE_URL),
+  openGraph: {
+    type: "website",
+    locale: "pt_BR",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: "Tribultz | Inteligência Fiscal para a Reforma Tributária",
+    description: DEFAULT_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Tribultz | Inteligência Fiscal para a Reforma Tributária",
+    description: DEFAULT_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/frontend/src/app/lgpd/page.tsx
+++ b/frontend/src/app/lgpd/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "LGPD",
+  description: "Como a Tribultz trata seus dados pessoais de acordo com a LGPD.",
+};
 
 export default function LGPDPage() {
   return (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { PublicFooter } from "@/components/public/PublicFooter";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { NewsFeed } from "@/components/public/NewsFeed";
+
+export const metadata: Metadata = {
+  title: "Tribultz | Inteligência Fiscal para a Reforma Tributária",
+  description:
+    "Valide notas fiscais contra CBS/IBS, classifique produtos com cClassTrib e garanta conformidade com a LC 214. Motor determinístico com trilha auditável.",
+};
 
 // ── Dados estáticos ────────────────────────────────────────────────────────────
 

--- a/frontend/src/app/pricing/layout.tsx
+++ b/frontend/src/app/pricing/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Planos e Preços",
+  description:
+    "Conheça os planos Tribultz: Trial, Starter, Profissional, Empresarial e Contador. " +
+    "Validação fiscal CBS/IBS a partir de R$49,90/mês.",
+  openGraph: {
+    title: "Planos e Preços — Tribultz",
+    description:
+      "Escolha o plano ideal para sua empresa. Validação fiscal CBS/IBS com trilha auditável.",
+    type: "website",
+  },
+};
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Privacidade",
+  description: "Política de privacidade da plataforma Tribultz.",
+};
 
 export default function PrivacyPage() {
   return (

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/dashboard",
+          "/validate-xml",
+          "/validate-batch",
+          "/jobs",
+          "/audit",
+          "/billing",
+          "/settings",
+          "/support",
+          "/admin",
+          "/closing",
+          "/exceptions",
+          "/documents",
+          "/feedback",
+          "/report",
+          "/select-mode",
+          "/cerebro",
+        ],
+      },
+    ],
+    sitemap: "https://tribultz.com.br/sitemap.xml",
+  };
+}

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://tribultz.com.br";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date().toISOString();
+
+  return [
+    { url: SITE_URL, lastModified: now, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${SITE_URL}/pricing`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${SITE_URL}/calculadora`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${SITE_URL}/diagnostico`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${SITE_URL}/changelog`, lastModified: now, changeFrequency: "weekly", priority: 0.6 },
+    { url: `${SITE_URL}/login`, lastModified: now, changeFrequency: "yearly", priority: 0.5 },
+    { url: `${SITE_URL}/register`, lastModified: now, changeFrequency: "yearly", priority: 0.5 },
+    { url: `${SITE_URL}/privacy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${SITE_URL}/lgpd`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${SITE_URL}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${SITE_URL}/cookies`, lastModified: now, changeFrequency: "yearly", priority: 0.2 },
+  ];
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Termos de Uso",
+  description: "Termos de uso da plataforma Tribultz de conformidade fiscal.",
+};
 
 export default function TermsPage() {
   return (


### PR DESCRIPTION
## Summary
- Fixes #209: Adds `sitemap.xml` and `robots.txt` via Next.js dynamic routes
- Root layout now has OG, Twitter Card, and title template (`%s | Tribultz`)
- Per-page metadata on all public server-component pages (home, changelog, privacy, lgpd, terms, cookies)
- New `pricing/layout.tsx` with metadata for the client component pricing page
- `robots.txt` disallows all protected routes (dashboard, billing, admin, etc.)

## Test plan
- [ ] Visit `/sitemap.xml` → returns XML with 11 public URLs
- [ ] Visit `/robots.txt` → returns rules disallowing protected routes
- [ ] Check `<head>` on `/pricing` → has OG title/description
- [ ] Check `<title>` on `/changelog` → shows "Changelog | Tribultz"

🤖 Generated with [Claude Code](https://claude.com/claude-code)