### PR TITLE
chore(backend): migrate jobs table to Alembic (#205)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -7,7 +7,7 @@ from alembic import context
 
 from app.database import Base
 from app.config import settings
-from app.models import auth, billing, documents, feedback, news, reports  # noqa: F401
+from app.models import auth, billing, documents, feedback, jobs, news, reports  # noqa: F401
 
 # Import models to register them with metadata
 

--- a/backend/app/alembic/versions/2026_04_15_0011_add_jobs_table.py
+++ b/backend/app/alembic/versions/2026_04_15_0011_add_jobs_table.py
@@ -1,0 +1,43 @@
+"""Add jobs table managed by Alembic.
+
+Replaces the runtime DDL (CREATE TABLE IF NOT EXISTS) that ran on every
+request in app/routers/jobs.py. The table may already exist in production,
+so all operations use IF NOT EXISTS / IF EXISTS for idempotency.
+
+Revision ID: 2026_04_15_0011
+Revises: 2026_04_11_0010
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+
+revision = "2026_04_15_0011"
+down_revision = "2026_04_11_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS jobs (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id       UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            job_type        VARCHAR(100) NOT NULL,
+            status          VARCHAR(30)  NOT NULL DEFAULT 'QUEUED',
+            idempotency_key VARCHAR(200),
+            payload         JSONB NOT NULL DEFAULT '{}',
+            result          JSONB,
+            error_message   TEXT,
+            created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+            CONSTRAINT uq_jobs_tenant_idempotency UNIQUE (tenant_id, idempotency_key)
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_jobs_tenant ON jobs(tenant_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(tenant_id, status)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_jobs_status")
+    op.execute("DROP INDEX IF EXISTS idx_jobs_tenant")
+    op.execute("DROP TABLE IF EXISTS jobs")

--- a/backend/app/models/jobs.py
+++ b/backend/app/models/jobs.py
@@ -1,0 +1,53 @@
+"""SQLAlchemy model for the jobs table.
+
+Replaces the runtime DDL that was previously in app/routers/jobs.py.
+"""
+
+from sqlalchemy import (
+    Column,
+    String,
+    Text,
+    ForeignKey,
+    DateTime,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    tenant_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    job_type = Column(String(100), nullable=False)
+    status = Column(String(30), nullable=False, server_default="QUEUED")
+    idempotency_key = Column(String(200), nullable=True)
+    payload = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    result = Column(JSONB, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "idempotency_key", name="uq_jobs_tenant_idempotency"),
+    )

--- a/backend/app/routers/jobs.py
+++ b/backend/app/routers/jobs.py
@@ -59,30 +59,6 @@ class JobResponse(BaseModel):
     findings: Optional[list[dict[str, Any]]] = None
 
 
-# ── Bootstrap (ensure jobs table exists) ─────────────────────────────────────
-_JOBS_DDL = """
-CREATE TABLE IF NOT EXISTS jobs (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    tenant_id       UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-    job_type        VARCHAR(100) NOT NULL,
-    status          VARCHAR(30)  NOT NULL DEFAULT 'QUEUED',
-    idempotency_key VARCHAR(200),
-    payload         JSONB NOT NULL DEFAULT '{}',
-    result          JSONB,
-    error_message   TEXT,
-    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    UNIQUE (tenant_id, idempotency_key)
-);
-CREATE INDEX IF NOT EXISTS idx_jobs_tenant ON jobs(tenant_id);
-CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(tenant_id, status);
-"""
-
-
-def _ensure_table(db: Session):
-    db.execute(text(_JOBS_DDL))
-    db.commit()
-
 
 def _row_to_response(r) -> JobResponse:
     return JobResponse(
@@ -110,7 +86,7 @@ def create_job(
     Enqueue a new job.  If an idempotency_key is provided and already
     exists for this tenant, the existing job is returned (safe retry).
     """
-    _ensure_table(db)
+
     tenant_id = str(current_user.tenant_id)
 
     # Idempotent check
@@ -163,7 +139,7 @@ def get_job(
       - profissional / empresarial / contador → justification included
       - trial / starter → justification_gated=True (frontend shows upgrade CTA)
     """
-    _ensure_table(db)
+
     tenant_id = str(current_user.tenant_id)
     row = db.execute(
         text("SELECT * FROM jobs WHERE id = :id AND tenant_id = :tid"),
@@ -195,7 +171,7 @@ def update_job(
     Transition a job to a new status.
     Used by the worker or human-in-the-loop to mark progress.
     """
-    _ensure_table(db)
+
     import json
 
     updates = ["status = :status", "updated_at = now()"]
@@ -230,7 +206,7 @@ def list_jobs(
     current_user: User = Depends(get_current_user),
 ):
     """List jobs for the authenticated user's tenant, optionally filtered by status."""
-    _ensure_table(db)
+
     tenant_id = str(current_user.tenant_id)
 
     filters = ["j.tenant_id = :tid"]
@@ -263,7 +239,7 @@ def reprocess_job(
     """
     Reset a FAILED or NEEDS_HUMAN job back to QUEUED for idempotent retry.
     """
-    _ensure_table(db)
+
     tenant_id = str(current_user.tenant_id)
     row = db.execute(
         text("SELECT * FROM jobs WHERE id = :id AND tenant_id = :tid"),
@@ -300,7 +276,7 @@ def get_job_report_pdf(
 
     Gated to Profissional and Contador plans.
     """
-    _ensure_table(db)
+
     tenant_id = str(current_user.tenant_id)
 
     row = db.execute(


### PR DESCRIPTION
## Summary
- Fixes #205: Jobs table is now managed by Alembic instead of runtime DDL
- New `app/models/jobs.py` SQLAlchemy model with proper types, FK, and constraints
- New migration `0011_add_jobs_table` using `IF NOT EXISTS` for safe runs on existing DBs
- Removed `_ensure_table()` and `_JOBS_DDL` from `jobs.py` router (7 call sites)
- Registered jobs model in `alembic/env.py`

## Test plan
- [ ] Run `alembic upgrade head` on fresh DB → jobs table created
- [ ] Run `alembic upgrade head` on existing DB (table already exists) → no error
- [ ] CRUD operations on `/api/v1/jobs` work as before
- [ ] `alembic downgrade -1` → jobs table dropped cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)