### PR TITLE
fix: remove boleto from all payment methods

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -33,7 +33,7 @@ class UserRegister(BaseModel):
     phone: str = ""
     account_type: str = "empresa"  # empresa | contador
     plan_slug: str = "trial"  # trial | starter | profissional | contador
-    billing_type: str = "PIX"  # PIX | CREDIT_CARD
+    billing_type: str = "PIX"  # PIX | CREDIT_CARD (boleto not supported)
     lgpd_consent: bool = False
     tenant_slug: str = "default"
     captcha_token: str = ""

--- a/backend/app/services/asaas_service.py
+++ b/backend/app/services/asaas_service.py
@@ -165,7 +165,7 @@ class AsaasService:
         description: str = "Assinatura Tribultz",
         next_due_date: str | None = None,
     ) -> dict[str, Any]:
-        """Create a monthly subscription. billing_type: CREDIT_CARD | PIX | BOLETO."""
+        """Create a monthly subscription. billing_type: CREDIT_CARD | PIX."""
         payload: dict[str, Any] = {
             "customer": customer_id,
             "billingType": billing_type,

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -95,7 +95,7 @@ def send_payment_confirmation_email(
     payment_method: str,
 ) -> bool:
     """Send the 'Payment confirmed / Premium activated' receipt email."""
-    method_labels = {"pix": "PIX", "credit_card": "Cartão de Crédito", "boleto": "Boleto"}
+    method_labels = {"pix": "PIX", "credit_card": "Cartão de Crédito"}
     method_display = method_labels.get(payment_method.lower(), payment_method.upper())
     amount_display = f"R$ {amount_cents / 100:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
 

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -129,7 +129,7 @@ class TestUploadUrl:
     def test_invalid_doc_type_returns_422(self, client_with_auth):
         resp = client_with_auth.post(
             self.ENDPOINT,
-            json={"doc_type": "boleto"},
+            json={"doc_type": "invalid_type"},
         )
         assert resp.status_code == 422
 

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -144,7 +144,7 @@ type UpgradeModalProps = {
 
 function UpgradeModal({ plan, onClose }: UpgradeModalProps) {
   const [loading, setLoading] = useState(false);
-  const [billingType, setBillingType] = useState<"PIX" | "CREDIT_CARD" | "BOLETO">("PIX");
+  const [billingType, setBillingType] = useState<"PIX" | "CREDIT_CARD">("PIX");
   const [result, setResult] = useState<{
     pixQrCode?: string;
     pixCopyPaste?: string;
@@ -194,8 +194,8 @@ function UpgradeModal({ plan, onClose }: UpgradeModalProps) {
             <p className="mb-4 text-sm text-slate-600">
               Escolha a forma de pagamento:
             </p>
-            <div className="mb-6 grid grid-cols-3 gap-2">
-              {(["PIX", "CREDIT_CARD", "BOLETO"] as const).map((type) => (
+            <div className="mb-6 grid grid-cols-2 gap-2">
+              {(["PIX", "CREDIT_CARD"] as const).map((type) => (
                 <button
                   key={type}
                   onClick={() => setBillingType(type)}
@@ -205,7 +205,7 @@ function UpgradeModal({ plan, onClose }: UpgradeModalProps) {
                       : "border-slate-200 text-slate-600 hover:border-slate-300"
                   }`}
                 >
-                  {type === "PIX" ? "PIX" : type === "CREDIT_CARD" ? "Cartão" : "Boleto"}
+                  {type === "PIX" ? "PIX" : "Cartão"}
                 </button>
               ))}
             </div>
@@ -500,7 +500,7 @@ export default function PricingPage() {
               },
               {
                 q: "Quais formas de pagamento são aceitas?",
-                a: "PIX (aprovação instantânea), cartão de crédito e boleto bancário.",
+                a: "PIX (aprovação instantânea) e cartão de crédito.",
               },
               {
                 q: "O que é a validação cruzada em lote?",


### PR DESCRIPTION
## Summary
- Remove "Boleto" como forma de pagamento em toda a plataforma
- Pricing page: grid passa de 3 para 2 colunas (PIX + Cartão), FAQ atualizado
- Email service: remove label "boleto" do mapeamento de métodos
- Asaas service: docstring atualizada
- Auth schema: comentário clarifica que boleto não é suportado

## Arquivos alterados
- `frontend/src/app/pricing/page.tsx` — UI e FAQ
- `backend/app/services/email_service.py` — labels
- `backend/app/services/asaas_service.py` — docstring
- `backend/app/schemas/auth.py` — comentário
- `backend/tests/test_documents.py` — test cleanup

## Test plan
- [ ] Pricing page mostra apenas PIX e Cartão
- [ ] FAQ não menciona boleto
- [ ] Registro com billing_type="PIX" funciona normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)