### PR TITLE
feat: admin dashboard — rich metrics Phase 1 (#211)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -41,14 +41,14 @@ def _registrations_last_30_days(db: Session) -> list[dict[str, Any]]:
     try:
         rows = db.execute(
             text("""
-                SELECT DATE(created_at) AS day, COUNT(*) AS count
+                SELECT DATE(created_at) AS day, COUNT(*) AS cnt
                 FROM users
                 WHERE created_at >= CURRENT_DATE - INTERVAL '30 days'
                 GROUP BY DATE(created_at)
                 ORDER BY day
             """)
         ).fetchall()
-        return [{"day": str(r.day), "count": r.count} for r in rows]
+        return [{"day": str(r.day), "count": r.cnt} for r in rows]
     except Exception:
         return []
 
@@ -57,12 +57,12 @@ def _plan_distribution(db: Session) -> list[dict[str, Any]]:
     """Count subscriptions per plan slug."""
     try:
         rows = db.execute(
-            select(Plan.slug, func.count(Subscription.id).label("count"))
+            select(Plan.slug, func.count(Subscription.id).label("cnt"))
             .select_from(Subscription)
             .join(Plan, Subscription.plan_id == Plan.id)
             .group_by(Plan.slug)
         ).fetchall()
-        return [{"plan": r.slug, "count": r.count} for r in rows]
+        return [{"plan": r.slug, "count": r.cnt} for r in rows]
     except Exception:
         return []
 
@@ -72,7 +72,7 @@ def _revenue_by_plan(db: Session, month_start: datetime) -> list[dict[str, Any]]
     try:
         rows = db.execute(
             text("""
-                SELECT p.slug, COUNT(pay.id) AS count,
+                SELECT p.slug, COUNT(pay.id) AS cnt,
                        COALESCE(SUM(pay.amount_cents), 0) AS total_cents
                 FROM payments pay
                 JOIN subscriptions s ON pay.subscription_id = s.id
@@ -85,7 +85,7 @@ def _revenue_by_plan(db: Session, month_start: datetime) -> list[dict[str, Any]]
             {"start": month_start},
         ).fetchall()
         return [
-            {"plan": r.slug, "count": r.count, "total_cents": r.total_cents}
+            {"plan": r.slug, "count": r.cnt, "total_cents": r.total_cents}
             for r in rows
         ]
     except Exception:
@@ -97,14 +97,14 @@ def _validations_last_7_days(db: Session) -> list[dict[str, Any]]:
     try:
         rows = db.execute(
             text("""
-                SELECT DATE(created_at) AS day, COUNT(*) AS count
+                SELECT DATE(created_at) AS day, COUNT(*) AS cnt
                 FROM jobs
                 WHERE created_at >= CURRENT_DATE - INTERVAL '7 days'
                 GROUP BY DATE(created_at)
                 ORDER BY day
             """)
         ).fetchall()
-        return [{"day": str(r.day), "count": r.count} for r in rows]
+        return [{"day": str(r.day), "count": r.cnt} for r in rows]
     except Exception:
         return []
 
@@ -114,14 +114,14 @@ def _support_stats(db: Session) -> dict[str, int]:
     try:
         rows = db.execute(
             text("""
-                SELECT status, COUNT(*) AS count
+                SELECT status, COUNT(*) AS cnt
                 FROM support_tickets
                 GROUP BY status
             """)
         ).fetchall()
         result: dict[str, int] = {"open": 0, "in_progress": 0, "resolved": 0, "closed": 0}
         for r in rows:
-            result[str(r.status)] = int(r.count)
+            result[str(r.status)] = int(r.cnt)
         return result
     except Exception:
         return {"open": 0, "in_progress": 0, "resolved": 0, "closed": 0}
@@ -132,7 +132,7 @@ def _feedback_stats(db: Session, month_start: datetime) -> dict[str, int]:
     try:
         rows = db.execute(
             text("""
-                SELECT category, COUNT(*) AS count
+                SELECT category, COUNT(*) AS cnt
                 FROM feedback
                 WHERE created_at >= :start
                 GROUP BY category
@@ -142,8 +142,8 @@ def _feedback_stats(db: Session, month_start: datetime) -> dict[str, int]:
         result: dict[str, int] = {}
         total = 0
         for r in rows:
-            result[str(r.category)] = int(r.count)
-            total += int(r.count)
+            result[str(r.category)] = int(r.cnt)
+            total += int(r.cnt)
         result["total"] = total
         return result
     except Exception:

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -121,7 +121,7 @@ def _support_stats(db: Session) -> dict[str, int]:
         ).fetchall()
         result: dict[str, int] = {"open": 0, "in_progress": 0, "resolved": 0, "closed": 0}
         for r in rows:
-            result[r.status] = r.count
+            result[str(r.status)] = int(r.count)
         return result
     except Exception:
         return {"open": 0, "in_progress": 0, "resolved": 0, "closed": 0}
@@ -142,8 +142,8 @@ def _feedback_stats(db: Session, month_start: datetime) -> dict[str, int]:
         result: dict[str, int] = {}
         total = 0
         for r in rows:
-            result[r.category] = r.count
-            total += r.count
+            result[str(r.category)] = int(r.count)
+            total += int(r.count)
         result["total"] = total
         return result
     except Exception:
@@ -156,13 +156,14 @@ def _redis_info(redis_url: str) -> dict[str, Any]:
         import redis as redis_lib
         r = redis_lib.from_url(redis_url, socket_connect_timeout=2)
         r.ping()
-        info = r.info(section="memory")
-        clients = r.info(section="clients")
+        info: dict[str, Any] = r.info(section="memory")  # type: ignore[assignment]
+        clients: dict[str, Any] = r.info(section="clients")  # type: ignore[assignment]
+        server: dict[str, Any] = r.info(section="server")  # type: ignore[assignment]
         return {
             "status": "healthy",
             "used_memory_human": info.get("used_memory_human", "?"),
             "connected_clients": clients.get("connected_clients", 0),
-            "uptime_days": r.info(section="server").get("uptime_in_days", 0),
+            "uptime_days": server.get("uptime_in_days", 0),
         }
     except Exception:
         return {"status": "unhealthy", "used_memory_human": "?", "connected_clients": 0, "uptime_days": 0}

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import Annotated, cast
+from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func, select, text
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.database import get_db
-from app.models.auth import User
+from app.models.auth import User, Tenant
 from app.models.billing import Payment, Plan, Subscription
 
 logger = logging.getLogger(__name__)
@@ -26,79 +26,232 @@ def _require_superadmin(current_user: User = Depends(get_current_user)) -> User:
     return current_user
 
 
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _safe_count(db: Session, query: Any) -> int:
+    try:
+        return db.scalar(query) or 0
+    except Exception:
+        return 0
+
+
+def _registrations_last_30_days(db: Session) -> list[dict[str, Any]]:
+    """Daily registration counts for the last 30 days."""
+    try:
+        rows = db.execute(
+            text("""
+                SELECT DATE(created_at) AS day, COUNT(*) AS count
+                FROM users
+                WHERE created_at >= CURRENT_DATE - INTERVAL '30 days'
+                GROUP BY DATE(created_at)
+                ORDER BY day
+            """)
+        ).fetchall()
+        return [{"day": str(r.day), "count": r.count} for r in rows]
+    except Exception:
+        return []
+
+
+def _plan_distribution(db: Session) -> list[dict[str, Any]]:
+    """Count subscriptions per plan slug."""
+    try:
+        rows = db.execute(
+            select(Plan.slug, func.count(Subscription.id).label("count"))
+            .select_from(Subscription)
+            .join(Plan, Subscription.plan_id == Plan.id)
+            .group_by(Plan.slug)
+        ).fetchall()
+        return [{"plan": r.slug, "count": r.count} for r in rows]
+    except Exception:
+        return []
+
+
+def _revenue_by_plan(db: Session, month_start: datetime) -> list[dict[str, Any]]:
+    """Revenue per plan this month (from confirmed payments)."""
+    try:
+        rows = db.execute(
+            text("""
+                SELECT p.slug, COUNT(pay.id) AS count,
+                       COALESCE(SUM(pay.amount_cents), 0) AS total_cents
+                FROM payments pay
+                JOIN subscriptions s ON pay.subscription_id = s.id
+                JOIN plans p ON s.plan_id = p.id
+                WHERE pay.status = 'confirmed'
+                  AND pay.created_at >= :start
+                GROUP BY p.slug
+                ORDER BY total_cents DESC
+            """),
+            {"start": month_start},
+        ).fetchall()
+        return [
+            {"plan": r.slug, "count": r.count, "total_cents": r.total_cents}
+            for r in rows
+        ]
+    except Exception:
+        return []
+
+
+def _validations_last_7_days(db: Session) -> list[dict[str, Any]]:
+    """Daily validation counts for the last 7 days."""
+    try:
+        rows = db.execute(
+            text("""
+                SELECT DATE(created_at) AS day, COUNT(*) AS count
+                FROM jobs
+                WHERE created_at >= CURRENT_DATE - INTERVAL '7 days'
+                GROUP BY DATE(created_at)
+                ORDER BY day
+            """)
+        ).fetchall()
+        return [{"day": str(r.day), "count": r.count} for r in rows]
+    except Exception:
+        return []
+
+
+def _support_stats(db: Session) -> dict[str, int]:
+    """Support ticket counts by status."""
+    try:
+        rows = db.execute(
+            text("""
+                SELECT status, COUNT(*) AS count
+                FROM support_tickets
+                GROUP BY status
+            """)
+        ).fetchall()
+        result: dict[str, int] = {"open": 0, "in_progress": 0, "resolved": 0, "closed": 0}
+        for r in rows:
+            result[r.status] = r.count
+        return result
+    except Exception:
+        return {"open": 0, "in_progress": 0, "resolved": 0, "closed": 0}
+
+
+def _feedback_stats(db: Session, month_start: datetime) -> dict[str, int]:
+    """Feedback counts by category this month."""
+    try:
+        rows = db.execute(
+            text("""
+                SELECT category, COUNT(*) AS count
+                FROM feedback
+                WHERE created_at >= :start
+                GROUP BY category
+            """),
+            {"start": month_start},
+        ).fetchall()
+        result: dict[str, int] = {}
+        total = 0
+        for r in rows:
+            result[r.category] = r.count
+            total += r.count
+        result["total"] = total
+        return result
+    except Exception:
+        return {"total": 0}
+
+
+def _redis_info(redis_url: str) -> dict[str, Any]:
+    """Get Redis memory and connection info."""
+    try:
+        import redis as redis_lib
+        r = redis_lib.from_url(redis_url, socket_connect_timeout=2)
+        r.ping()
+        info = r.info(section="memory")
+        clients = r.info(section="clients")
+        return {
+            "status": "healthy",
+            "used_memory_human": info.get("used_memory_human", "?"),
+            "connected_clients": clients.get("connected_clients", 0),
+            "uptime_days": r.info(section="server").get("uptime_in_days", 0),
+        }
+    except Exception:
+        return {"status": "unhealthy", "used_memory_human": "?", "connected_clients": 0, "uptime_days": 0}
+
+
+# ── Main endpoint ────────────────────────────────────────────────────
+
+
 @router.get("/dashboard")
 def admin_dashboard(
     db: Annotated[Session, Depends(get_db)],
     _admin: Annotated[User, Depends(_require_superadmin)],
 ):
-    """Aggregated platform metrics for the admin dashboard."""
+    """Aggregated platform metrics for the admin dashboard (Phase 1 MVP)."""
 
     now = datetime.now(timezone.utc)
     month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
     # ── Users ────────────────────────────────────────────────
-    total_users = db.scalar(select(func.count(User.id))) or 0
-    active_users = db.scalar(
-        select(func.count(User.id)).where(User.is_active == True)  # noqa: E712
-    ) or 0
+    total_users = _safe_count(db, select(func.count(User.id)))
+    active_users = _safe_count(
+        db, select(func.count(User.id)).where(User.is_active == True)  # noqa: E712
+    )
+    trial_count = _safe_count(
+        db, select(func.count(Subscription.id)).where(Subscription.status == "trial")
+    )
+    paid_count = _safe_count(
+        db, select(func.count(Subscription.id)).where(Subscription.status == "active")
+    )
+    cancelled_count = _safe_count(
+        db, select(func.count(Subscription.id)).where(Subscription.status == "cancelled")
+    )
+    total_tenants = _safe_count(db, select(func.count(Tenant.id)))
 
-    # Trial = subscription.status == 'trial'
-    trial_count = db.scalar(
-        select(func.count(Subscription.id)).where(Subscription.status == "trial")
-    ) or 0
-
-    paid_count_users = db.scalar(
-        select(func.count(Subscription.id)).where(
-            Subscription.status == "active",
-        )
-    ) or 0
+    registrations_today = _safe_count(
+        db, select(func.count(User.id)).where(User.created_at >= today_start)
+    )
 
     # ── Revenue ──────────────────────────────────────────────
-    # MRR: sum of price_cents for all active subscriptions
-    mrr_result = db.execute(
+    mrr_cents = db.execute(
         select(func.coalesce(func.sum(Plan.price_cents), 0))
         .select_from(Subscription)
         .join(Plan, Subscription.plan_id == Plan.id)
         .where(Subscription.status == "active")
     ).scalar() or 0
 
-    # Payments this month
-    paid_payments = db.scalar(
+    total_revenue_cents = _safe_count(
+        db,
+        select(func.coalesce(func.sum(Payment.amount_cents), 0)).where(
+            Payment.status == "confirmed"
+        ),
+    )
+    revenue_month_cents = _safe_count(
+        db,
+        select(func.coalesce(func.sum(Payment.amount_cents), 0)).where(
+            Payment.status == "confirmed",
+            Payment.created_at >= month_start,
+        ),
+    )
+
+    paid_payments_month = _safe_count(
+        db,
         select(func.count(Payment.id)).where(
             Payment.status == "confirmed",
             Payment.created_at >= month_start,
-        )
-    ) or 0
+        ),
+    )
+    pending_payments = _safe_count(
+        db, select(func.count(Payment.id)).where(Payment.status == "pending")
+    )
+    overdue_payments = _safe_count(
+        db, select(func.count(Payment.id)).where(Payment.status == "overdue")
+    )
 
-    pending_payments = db.scalar(
-        select(func.count(Payment.id)).where(
-            Payment.status.in_(("pending", "overdue")),
-        )
-    ) or 0
+    # ── Infra ────────────────────────────────────────────────
+    from app.config import settings
+    redis_data = _redis_info(settings.REDIS_URL)
 
-    # ── Infra (lightweight health check) ─────────────────────
+    db_status = "healthy"
     try:
         db.execute(text("SELECT 1"))
     except Exception:
-        pass  # DB connectivity checked implicitly by queries above
-
-    try:
-        from app.config import settings
-        import redis as redis_lib
-        r = redis_lib.from_url(settings.REDIS_URL, socket_connect_timeout=2)
-        r.ping()
-        redis_status = "healthy"
-    except Exception:
-        redis_status = "unhealthy"
+        db_status = "unhealthy"
 
     # ── Validations ──────────────────────────────────────────
-    # Count from jobs table (if it exists)
     try:
         validations_today = db.scalar(
-            text(
-                "SELECT COUNT(*) FROM jobs WHERE created_at >= :start"
-            ),
+            text("SELECT COUNT(*) FROM jobs WHERE created_at >= :start"),
             {"start": today_start},
         ) or 0
     except Exception:
@@ -106,33 +259,51 @@ def admin_dashboard(
 
     try:
         validations_month = db.scalar(
-            text(
-                "SELECT COUNT(*) FROM jobs WHERE created_at >= :start"
-            ),
+            text("SELECT COUNT(*) FROM jobs WHERE created_at >= :start"),
             {"start": month_start},
         ) or 0
     except Exception:
         validations_month = 0
 
+    try:
+        validations_total = db.scalar(text("SELECT COUNT(*) FROM jobs")) or 0
+    except Exception:
+        validations_total = 0
+
+    # ── Aggregated response ──────────────────────────────────
     return {
+        "generated_at": now.isoformat(),
         "users": {
             "total": total_users,
             "active": active_users,
             "trial": trial_count,
-            "paid": paid_count_users,
+            "paid": paid_count,
+            "cancelled": cancelled_count,
+            "tenants": total_tenants,
+            "registrations_today": registrations_today,
+            "registrations_30d": _registrations_last_30_days(db),
+            "plan_distribution": _plan_distribution(db),
         },
         "revenue": {
-            "mrr_cents": mrr_result,
-            "paid_count": paid_payments,
+            "mrr_cents": mrr_cents,
+            "total_revenue_cents": total_revenue_cents,
+            "revenue_month_cents": revenue_month_cents,
+            "paid_count_month": paid_payments_month,
             "pending_count": pending_payments,
+            "overdue_count": overdue_payments,
+            "by_plan": _revenue_by_plan(db, month_start),
         },
         "infra": {
             "api_status": "healthy",
-            "worker_status": "running",
-            "redis_status": redis_status,
+            "db_status": db_status,
+            "redis": redis_data,
         },
         "validations": {
             "today": validations_today,
             "month": validations_month,
+            "total": validations_total,
+            "last_7_days": _validations_last_7_days(db),
         },
+        "support": _support_stats(db),
+        "feedback": _feedback_stats(db, month_start),
     }

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,21 +1,96 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { API_BASE } from "@/lib/api";
 import { getToken } from "@/lib/storage";
 import { getPlanSlug } from "@/lib/plan";
 
+// ── Types ───────────────────────────────────────────────────────────
+
+type DayStat = { day: string; count: number };
+type PlanDist = { plan: string; count: number };
+type RevByPlan = { plan: string; count: number; total_cents: number };
+
 type AdminStats = {
-  users: { total: number; active: number; trial: number; paid: number };
-  revenue: { mrr_cents: number; pending_count: number; paid_count: number };
-  infra: { api_status: string; worker_status: string; redis_status: string };
-  validations: { today: number; month: number };
+  generated_at: string;
+  users: {
+    total: number;
+    active: number;
+    trial: number;
+    paid: number;
+    cancelled: number;
+    tenants: number;
+    registrations_today: number;
+    registrations_30d: DayStat[];
+    plan_distribution: PlanDist[];
+  };
+  revenue: {
+    mrr_cents: number;
+    total_revenue_cents: number;
+    revenue_month_cents: number;
+    paid_count_month: number;
+    pending_count: number;
+    overdue_count: number;
+    by_plan: RevByPlan[];
+  };
+  infra: {
+    api_status: string;
+    db_status: string;
+    redis: {
+      status: string;
+      used_memory_human: string;
+      connected_clients: number;
+      uptime_days: number;
+    };
+  };
+  validations: {
+    today: number;
+    month: number;
+    total: number;
+    last_7_days: DayStat[];
+  };
+  support: {
+    open: number;
+    in_progress: number;
+    resolved: number;
+    closed: number;
+  };
+  feedback: Record<string, number>;
 };
 
-function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function fmtBRL(cents: number): string {
+  return `R$ ${(cents / 100).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
+}
+
+function StatusDot({ ok }: { ok: boolean }) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+    <span
+      className={`inline-block h-2.5 w-2.5 rounded-full ${ok ? "bg-emerald-500" : "bg-red-500"}`}
+    />
+  );
+}
+
+// ── Reusable cards ──────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  accent?: "green" | "red" | "blue" | "amber";
+}) {
+  const accentBorder = accent
+    ? { green: "border-l-emerald-500", red: "border-l-red-500", blue: "border-l-blue-500", amber: "border-l-amber-500" }[accent]
+    : "";
+  return (
+    <div className={`rounded-xl border border-slate-200 bg-white p-5 shadow-sm ${accent ? `border-l-4 ${accentBorder}` : ""}`}>
       <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
       <p className="mt-1 text-2xl font-bold text-slate-900">{value}</p>
       {sub && <p className="mt-1 text-xs text-slate-400">{sub}</p>}
@@ -23,11 +98,103 @@ function StatCard({ label, value, sub }: { label: string; value: string | number
   );
 }
 
+function MiniBar({ data, label }: { data: DayStat[]; label: string }) {
+  if (data.length === 0) return null;
+  const max = Math.max(...data.map((d) => d.count), 1);
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <div className="flex items-end gap-1" style={{ height: 80 }}>
+        {data.map((d) => (
+          <div key={d.day} className="group relative flex-1">
+            <div
+              className="w-full rounded-t bg-tribultz-500 transition-all hover:bg-tribultz-600"
+              style={{ height: `${Math.max((d.count / max) * 100, 4)}%` }}
+            />
+            <div className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-[10px] text-white opacity-0 shadow group-hover:opacity-100">
+              {d.day.slice(5)}: {d.count}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-1 flex justify-between text-[10px] text-slate-400">
+        <span>{data[0]?.day.slice(5)}</span>
+        <span>{data[data.length - 1]?.day.slice(5)}</span>
+      </div>
+    </div>
+  );
+}
+
+function PlanDistributionTable({ data }: { data: PlanDist[] }) {
+  const total = data.reduce((s, d) => s + d.count, 0) || 1;
+  const colors: Record<string, string> = {
+    trial: "bg-slate-400",
+    starter: "bg-blue-400",
+    profissional: "bg-tribultz-500",
+    empresarial: "bg-purple-500",
+    contador: "bg-amber-500",
+  };
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">
+        Distribuicao por plano
+      </p>
+      {/* Bar */}
+      <div className="mb-3 flex h-4 overflow-hidden rounded-full bg-slate-100">
+        {data.map((d) => (
+          <div
+            key={d.plan}
+            className={`${colors[d.plan] ?? "bg-slate-300"}`}
+            style={{ width: `${(d.count / total) * 100}%` }}
+            title={`${d.plan}: ${d.count}`}
+          />
+        ))}
+      </div>
+      {/* Legend */}
+      <div className="flex flex-wrap gap-3 text-xs text-slate-600">
+        {data.map((d) => (
+          <span key={d.plan} className="flex items-center gap-1">
+            <span className={`inline-block h-2.5 w-2.5 rounded-full ${colors[d.plan] ?? "bg-slate-300"}`} />
+            {d.plan} ({d.count})
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ───────────────────────────────────────────────────────
+
 export default function AdminPage() {
   const router = useRouter();
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+
+  const loadStats = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/admin/dashboard`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.status === 403) {
+        router.replace("/dashboard");
+        return;
+      }
+      if (!res.ok) throw new Error(`Erro ${res.status}`);
+      setStats(await res.json());
+      setLastRefresh(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erro ao carregar dashboard admin.");
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
 
   useEffect(() => {
     const plan = getPlanSlug();
@@ -35,52 +202,36 @@ export default function AdminPage() {
       router.replace("/dashboard");
       return;
     }
-
-    async function loadStats() {
-      const token = getToken();
-      if (!token) {
-        router.replace("/login");
-        return;
-      }
-
-      try {
-        const res = await fetch(`${API_BASE}/api/v1/admin/dashboard`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-
-        if (res.status === 403) {
-          router.replace("/dashboard");
-          return;
-        }
-
-        if (!res.ok) throw new Error(`Erro ${res.status}`);
-        setStats(await res.json());
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Erro ao carregar dashboard admin.");
-      } finally {
-        setLoading(false);
-      }
-    }
-
     loadStats();
-  }, [router]);
+
+    // Auto-refresh every 60s
+    const interval = setInterval(loadStats, 60_000);
+    return () => clearInterval(interval);
+  }, [router, loadStats]);
 
   if (loading) {
     return (
-      <main className="grid min-h-screen place-items-center">
-        <p className="text-sm text-slate-500">Carregando painel administrativo...</p>
+      <main className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-center">
+          <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-tribultz-600" />
+          <p className="text-sm text-slate-500">Carregando painel administrativo...</p>
+        </div>
       </main>
     );
   }
 
   if (error) {
     return (
-      <main className="grid min-h-screen place-items-center">
+      <main className="flex min-h-[60vh] items-center justify-center">
         <div className="text-center">
           <p className="text-sm text-red-600">{error}</p>
           <button
             type="button"
-            onClick={() => window.location.reload()}
+            onClick={() => {
+              setError(null);
+              setLoading(true);
+              loadStats();
+            }}
             className="mt-3 text-sm text-tribultz-600 underline"
           >
             Tentar novamente
@@ -93,70 +244,182 @@ export default function AdminPage() {
   const s = stats!;
 
   return (
-    <main className="min-h-screen bg-slate-50 p-6">
-      <div className="mx-auto max-w-6xl">
-        <div className="mb-8 flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-slate-900">Painel Administrativo</h1>
-            <p className="text-sm text-slate-500">Dados em tempo real do ecossistema Tribultz</p>
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              localStorage.clear();
-              window.dispatchEvent(new Event("tribultz-settings-updated"));
-              router.push("/login");
-            }}
-            className="rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100"
-          >
-            Sair
-          </button>
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Painel Administrativo</h1>
+          <p className="text-sm text-slate-500">
+            Dados em tempo real do ecossistema Tribultz
+            {lastRefresh && (
+              <span className="ml-2 text-xs text-slate-400">
+                (atualizado {lastRefresh.toLocaleTimeString("pt-BR")})
+              </span>
+            )}
+          </p>
         </div>
-
-        {/* Usuarios */}
-        <section className="mb-8">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">Usuarios</h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard label="Total" value={s.users.total} />
-            <StatCard label="Ativos" value={s.users.active} />
-            <StatCard label="Trial" value={s.users.trial} />
-            <StatCard label="Pagantes" value={s.users.paid} />
-          </div>
-        </section>
-
-        {/* Financeiro */}
-        <section className="mb-8">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">Financeiro</h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <StatCard
-              label="MRR"
-              value={`R$ ${(s.revenue.mrr_cents / 100).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`}
-              sub="Receita mensal recorrente"
-            />
-            <StatCard label="Pagos (mes)" value={s.revenue.paid_count} />
-            <StatCard label="Pendentes" value={s.revenue.pending_count} />
-          </div>
-        </section>
-
-        {/* Infra */}
-        <section className="mb-8">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">Infraestrutura</h2>
-          <div className="grid gap-4 sm:grid-cols-3">
-            <StatCard label="API" value={s.infra.api_status} />
-            <StatCard label="Worker" value={s.infra.worker_status} />
-            <StatCard label="Redis" value={s.infra.redis_status} />
-          </div>
-        </section>
-
-        {/* Validacoes */}
-        <section className="mb-8">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">Validacoes</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <StatCard label="Hoje" value={s.validations.today} />
-            <StatCard label="Este mes" value={s.validations.month} />
-          </div>
-        </section>
+        <button
+          type="button"
+          onClick={() => {
+            setLoading(true);
+            loadStats();
+          }}
+          className="rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100"
+        >
+          Atualizar
+        </button>
       </div>
-    </main>
+
+      {/* ── Usuarios ─────────────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Usuarios
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard label="Total" value={s.users.total} accent="blue" />
+          <StatCard label="Ativos" value={s.users.active} accent="green" />
+          <StatCard label="Trial" value={s.users.trial} accent="amber" />
+          <StatCard label="Pagantes" value={s.users.paid} accent="green" />
+        </div>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <StatCard label="Cancelados" value={s.users.cancelled} accent="red" />
+          <StatCard label="Tenants" value={s.users.tenants} />
+          <StatCard label="Cadastros hoje" value={s.users.registrations_today} />
+        </div>
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          <MiniBar data={s.users.registrations_30d} label="Cadastros (ultimos 30 dias)" />
+          <PlanDistributionTable data={s.users.plan_distribution} />
+        </div>
+      </section>
+
+      {/* ── Financeiro ────────────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Financeiro
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            label="MRR"
+            value={fmtBRL(s.revenue.mrr_cents)}
+            sub="Receita mensal recorrente"
+            accent="green"
+          />
+          <StatCard
+            label="Receita total"
+            value={fmtBRL(s.revenue.total_revenue_cents)}
+            sub="Todos os pagamentos confirmados"
+          />
+          <StatCard
+            label="Receita do mes"
+            value={fmtBRL(s.revenue.revenue_month_cents)}
+            sub={`${s.revenue.paid_count_month} pagamento(s)`}
+            accent="blue"
+          />
+          <StatCard
+            label="Pendentes / Atrasados"
+            value={`${s.revenue.pending_count} / ${s.revenue.overdue_count}`}
+            accent={s.revenue.overdue_count > 0 ? "red" : undefined}
+          />
+        </div>
+        {s.revenue.by_plan.length > 0 && (
+          <div className="mt-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">
+              Receita por plano (mes atual)
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs text-slate-500">
+                    <th className="pb-2">Plano</th>
+                    <th className="pb-2 text-right">Pagamentos</th>
+                    <th className="pb-2 text-right">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {s.revenue.by_plan.map((r) => (
+                    <tr key={r.plan} className="border-b last:border-0">
+                      <td className="py-2 font-medium capitalize text-slate-800">{r.plan}</td>
+                      <td className="py-2 text-right text-slate-600">{r.count}</td>
+                      <td className="py-2 text-right font-semibold text-slate-900">
+                        {fmtBRL(r.total_cents)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* ── Infraestrutura ────────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Infraestrutura
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">API</p>
+            <p className="mt-1 flex items-center gap-2 text-lg font-bold text-slate-900">
+              <StatusDot ok={s.infra.api_status === "healthy"} />
+              {s.infra.api_status === "healthy" ? "Online" : "Offline"}
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Banco de dados</p>
+            <p className="mt-1 flex items-center gap-2 text-lg font-bold text-slate-900">
+              <StatusDot ok={s.infra.db_status === "healthy"} />
+              {s.infra.db_status === "healthy" ? "Online" : "Offline"}
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Redis</p>
+            <p className="mt-1 flex items-center gap-2 text-lg font-bold text-slate-900">
+              <StatusDot ok={s.infra.redis.status === "healthy"} />
+              {s.infra.redis.status === "healthy" ? "Online" : "Offline"}
+            </p>
+            <p className="mt-1 text-xs text-slate-400">
+              Memoria: {s.infra.redis.used_memory_human} · {s.infra.redis.connected_clients} conexoes · {s.infra.redis.uptime_days}d uptime
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Validacoes ────────────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Validacoes
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <StatCard label="Hoje" value={s.validations.today} accent="blue" />
+          <StatCard label="Este mes" value={s.validations.month} />
+          <StatCard label="Total" value={s.validations.total} />
+        </div>
+        <div className="mt-4">
+          <MiniBar data={s.validations.last_7_days} label="Validacoes (ultimos 7 dias)" />
+        </div>
+      </section>
+
+      {/* ── Suporte & Feedback ────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Suporte & Feedback
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+          <StatCard label="Tickets abertos" value={s.support.open} accent={s.support.open > 0 ? "red" : "green"} />
+          <StatCard label="Em andamento" value={s.support.in_progress} accent="amber" />
+          <StatCard label="Resolvidos" value={s.support.resolved} accent="green" />
+          <StatCard label="Fechados" value={s.support.closed} />
+          <StatCard
+            label="Feedback (mes)"
+            value={s.feedback.total ?? 0}
+            sub={Object.entries(s.feedback)
+              .filter(([k]) => k !== "total")
+              .map(([k, v]) => `${k}: ${v}`)
+              .join(" · ") || "Nenhum"}
+          />
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Expande o dashboard administrativo (superadmin only) com métricas detalhadas do ecossistema Tribultz.

### Backend — `GET /api/v1/admin/dashboard`
- **Usuarios**: total, ativos, trial, pagantes, cancelados, tenants, cadastros hoje, cadastros 30d (por dia), distribuição por plano
- **Financeiro**: MRR, receita total, receita do mês, pagamentos pendentes/atrasados, receita por plano
- **Infra**: status API, DB, Redis (memória, conexões, uptime)
- **Validações**: hoje, mês, total, últimos 7 dias (por dia)
- **Suporte**: tickets por status (open/in_progress/resolved/closed)
- **Feedback**: por categoria no mês

### Frontend — `/admin`
- StatCards com acentos coloridos por contexto (verde=ok, vermelho=alerta, azul=info)
- Mini gráfico de barras para cadastros (30d) e validações (7d)
- Barra de distribuição por plano com legenda
- Tabela de receita por plano
- Status dots para infraestrutura com detalhes de Redis
- Seção de suporte e feedback
- Auto-refresh a cada 60s

## Test plan
- [ ] Login como superadmin → select-mode → Administrador → /admin
- [ ] Verificar todas as seções carregam dados
- [ ] Auto-refresh funciona (observar timestamp)
- [ ] Usuário não-admin redireciona para /dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)