### PR TITLE
chore(ci): migrate GitHub Actions Node.js 20 → 22 (#162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Node (pin) # needed for pyright via npx
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.1"
+          node-version: "22.12.0"
 
       - name: Install backend deps
         working-directory: backend
@@ -168,7 +168,7 @@ jobs:
       - name: Setup Node (pin)
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.1"
+          node-version: "22.12.0"
           cache: "npm"
           cache-dependency-path: |
             package-lock.json

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.20",
@@ -1775,9 +1775,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: pin `node-version` **20.11.1 → 22.12.0** nos 2 jobs (backend gates + frontend build)
- `frontend/package.json`: `@types/node` **^20 → ^22**
- `package-lock.json` atualizado via `npm install`

## Contexto

Node 20 atinge EOL em **2026-06-02** (~6.5 semanas). Após EOL, security patches param e o setup-node pode falhar ao resolver o pin. Subindo agora para Node 22 LTS (\"Jod\", LTS até abril 2027).

Closes #162

## Test plan

- [x] `npm test` → **54/54** passing no Node 22.15.1 local
- [x] `npm run build` → sucesso (todas rotas compiladas)
- [x] Lockfile atualizado (apenas @types/node — 8 linhas)
- [ ] CI passa no PR (backend gates + frontend build)

## Rollback

Reverter o commit — o pin anterior (20.11.1) continua suportado até 2026-06-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)