### PR TITLE
test(backend): isolated DB fixture via testcontainers (#224)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,22 +1,74 @@
-"""Root conftest — injects minimal env vars before any app module is imported.
+"""Root conftest — prepares env + optional Postgres testcontainer.
 
-pytest_configure runs before collection, so Settings() never sees a missing variable.
-All values are deterministic test doubles — never connect to real infrastructure.
+pytest_configure runs before collection, so Settings() never sees a missing
+variable and tests that create engines at import time see a reachable DB.
+
+Postgres strategy:
+  - CI (env var CI=true) or USE_EXTERNAL_DB=1: respect existing DATABASE_URL
+  - Otherwise: spin up a fresh Postgres 16 container via testcontainers and
+    run alembic upgrade head against it. Container is torn down at session end.
+
+All non-DB values are deterministic test doubles — never connect to real infra.
 """
 
+from __future__ import annotations
+
 import os
+from pathlib import Path
+
+
+_postgres_container = None
+
+
+def _use_external_db() -> bool:
+    return os.getenv("USE_EXTERNAL_DB") == "1" or os.getenv("CI") == "true"
+
+
+def _run_alembic_upgrade(url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config(str(Path(__file__).parent / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "head")
+
+
+def _start_postgres_container() -> str | None:
+    """Start a Postgres testcontainer and return the connection URL.
+
+    Returns None if testcontainers is not installed or Docker is unavailable —
+    callers then fall back to whatever DATABASE_URL is already in env.
+    """
+    global _postgres_container
+
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        return None
+
+    try:
+        _postgres_container = PostgresContainer(
+            "postgres:16-alpine",
+            username="tribultz",
+            password="tribultz",
+            dbname="tribultz",
+        )
+        _postgres_container.start()
+    except Exception:
+        _postgres_container = None
+        return None
+
+    return _postgres_container.get_connection_url()
 
 
 def pytest_configure(config):  # noqa: ARG001
+    global _postgres_container
+
     defaults = {
-        # Postgres
         "POSTGRES_PASSWORD": "test-password",
         "DATABASE_URL": "postgresql+psycopg2://tribultz:test-password@localhost:5432/tribultz_test",
-        # Redis
         "REDIS_URL": "redis://localhost:6379/15",
-        # JWT
         "JWT_SECRET": "test-jwt-secret-minimum-32-characters-long",
-        # MinIO / S3
         "MINIO_ROOT_USER": "test-minio-user",
         "MINIO_ROOT_PASSWORD": "test-minio-password",
         "S3_ENDPOINT": "http://localhost:9000",
@@ -26,3 +78,22 @@ def pytest_configure(config):  # noqa: ARG001
     }
     for key, value in defaults.items():
         os.environ.setdefault(key, value)
+
+    if not _use_external_db():
+        url = _start_postgres_container()
+        if url is not None:
+            os.environ["DATABASE_URL"] = url
+            try:
+                _run_alembic_upgrade(url)
+            except Exception:
+                if _postgres_container is not None:
+                    _postgres_container.stop()
+                    _postgres_container = None
+                raise
+
+
+def pytest_unconfigure(config):  # noqa: ARG001
+    global _postgres_container
+    if _postgres_container is not None:
+        _postgres_container.stop()
+        _postgres_container = None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ weasyprint==63.1
 jinja2==3.1.6
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
+testcontainers[postgres]>=4.8.2
 crewai==1.10.1
 litellm==1.82.0
 fakeredis==2.26.2


### PR DESCRIPTION
## Summary

Rodar `pytest tests/` local exigia `docker compose up db` antes — 23 tests de auth/billing/email falhavam com `connection refused` se Postgres não estivesse rodando.

Agora `pytest_configure` sobe um **Postgres 16 testcontainer** session-scoped, roda `alembic upgrade head` no container, e exporta `DATABASE_URL` antes da coleta. Container é descartado automaticamente no `pytest_unconfigure`.

Closes #224

## Resultado

| | Antes | Depois |
|---|---|---|
| Tests | 389 pass + 23 errors | **412 pass / 0 errors** |
| Tempo | 157s | **18.5s** |
| Setup | `docker compose up db` + aguardar | só Docker daemon rodando |

## Comportamento em CI

CI continua usando o service container existente — o testcontainer **não** sobe quando:
- `CI=true` (GitHub Actions seta automaticamente)
- `USE_EXTERNAL_DB=1` (opt-out manual para dev que já tem Postgres rodando)

Nesses casos, `DATABASE_URL` do env é respeitado. Verificado programaticamente.

## Mudanças

- [backend/conftest.py](backend/conftest.py): adicionada lógica `_start_postgres_container()` + `_run_alembic_upgrade()` em `pytest_configure`, teardown em `pytest_unconfigure`. Fallback silencioso se testcontainers/Docker indisponível.
- [backend/requirements.txt](backend/requirements.txt): `+ testcontainers[postgres]>=4.8.2`

## Test plan

- [x] `unset CI DATABASE_URL && pytest tests/` → **412/412 pass** em 18.5s
- [x] `ruff check .` → All checks passed
- [x] CI-path (`CI=true` + `DATABASE_URL` setado) → bypass do container confirmado
- [x] Container é limpo no session end (`pytest_unconfigure`)
- [x] CI green (service container permanece sendo usado)

## Requisitos para dev local

- Docker daemon rodando (já era implícito via docker compose)
- Primeira execução: ~5-10s extra para pull da imagem `postgres:16-alpine` (cache depois)

## Rollback

Reverter commit — comportamento anterior preserva os 389 tests que passam sem Postgres; os 23 voltam a exigir `docker compose up db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)