### PR TITLE
fix(billing): Trial em /validate/xml com cota 5/mês — fixes #231

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -24,7 +24,7 @@ from app.models.auth import User
 from app.models.documents import Document
 from app.tools import s3_tool, postgres_tool
 from app.services.xml_correction_service import correct_xml
-from app.api.plan_gate import require_plan
+from app.api.plan_gate import require_plan, check_usage_limit, increment_usage
 from app.data.ncm_codes import VALID_NCM_CODES
 from uuid import uuid4
 
@@ -408,13 +408,17 @@ def validate_xml(
 @router.post(
     "/validate/xml",
     response_model=ValidationResult,
-    dependencies=[Depends(require_plan("starter", "profissional", "contador"))],
+    dependencies=[
+        Depends(require_plan("trial", "starter", "profissional", "contador")),
+        Depends(check_usage_limit("validations")),
+    ],
 )
 async def validate_xml_endpoint(
     file: UploadFile = File(None),
     xml_content: str = Form(None),
     document_type: str | None = Form(None),
     current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> ValidationResult:
     """Validate an XML document (NFS-e, NF-e, or NFC-e) against fiscal rules.
 
@@ -441,11 +445,16 @@ async def validate_xml_endpoint(
     classtrib_data = await _enrich_classtrib(xml)
     cnpj_data = await _enrich_cnpj(xml)
 
-    return validate_xml(
+    result = validate_xml(
         xml, doc_type,
         classtrib_results=classtrib_data,
         cnpj_result=cnpj_data,
     )
+
+    increment_usage(db, current_user.id, current_user.tenant_id, "validations")
+    db.commit()
+
+    return result
 
 
 # ── XML Correction (MVP) ───────────────────────────────────────────────────
@@ -462,7 +471,10 @@ class CorrectionResponse(BaseModel):
 @router.post(
     "/validate/xml/correct",
     response_model=CorrectionResponse,
-    dependencies=[Depends(require_plan("starter", "profissional", "contador"))],
+    dependencies=[
+        Depends(require_plan("trial", "starter", "profissional", "contador")),
+        Depends(check_usage_limit("validations")),
+    ],
 )
 async def correct_xml_endpoint(
     file: UploadFile = File(None),
@@ -541,6 +553,7 @@ async def correct_xml_endpoint(
         },
     )
     db.add(doc)
+    increment_usage(db, current_user.id, current_user.tenant_id, "validations")
     db.commit()
     db.refresh(doc)
 

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -338,6 +338,99 @@ class TestPlanGate:
         assert callable(increment_usage)
 
 
+# ── Trial plan access to XML validation (issue #231) ──────────────────────
+
+
+class TestValidateXmlTrialAccess:
+    """Trial plan must reach /validate/xml and be bounded by max_validations quota."""
+
+    def _routes(self):
+        from app.routers.validate_xml import router
+        return {getattr(r, "path", ""): r for r in router.routes}
+
+    def _allowed_slugs(self, route):
+        # require_plan closure captures allowed_slugs; inspect free vars
+        for dep in route.dependant.dependencies:
+            fn = dep.call
+            cells = getattr(fn, "__closure__", None) or ()
+            for cell in cells:
+                val = cell.cell_contents
+                if isinstance(val, tuple) and val and all(isinstance(s, str) for s in val):
+                    if "starter" in val or "profissional" in val or "trial" in val:
+                        return val
+        return None
+
+    def _has_usage_check(self, route):
+        for dep in route.dependant.dependencies:
+            fn = dep.call
+            cells = getattr(fn, "__closure__", None) or ()
+            for cell in cells:
+                if cell.cell_contents == "validations":
+                    return True
+        return False
+
+    def test_validate_xml_allows_trial(self):
+        route = self._routes().get("/api/v1/validate/xml")
+        assert route is not None
+        slugs = self._allowed_slugs(route)
+        assert slugs is not None and "trial" in slugs
+
+    def test_validate_xml_has_usage_limit(self):
+        route = self._routes().get("/api/v1/validate/xml")
+        assert self._has_usage_check(route) is True
+
+    def test_correct_xml_allows_trial(self):
+        route = self._routes().get("/api/v1/validate/xml/correct")
+        assert route is not None
+        slugs = self._allowed_slugs(route)
+        assert slugs is not None and "trial" in slugs
+
+    def test_correct_xml_has_usage_limit(self):
+        route = self._routes().get("/api/v1/validate/xml/correct")
+        assert self._has_usage_check(route) is True
+
+    def test_batch_cross_check_still_blocks_trial(self):
+        # Batch is not advertised for Trial — must stay Profissional+
+        route = self._routes().get("/api/v1/validate/batch-cross-check")
+        assert route is not None
+        slugs = self._allowed_slugs(route)
+        assert slugs is not None and "trial" not in slugs
+
+    def test_check_usage_limit_blocks_trial_at_quota(self):
+        # At 5/5, Trial user must be rejected with 403
+        from fastapi import HTTPException
+        from app.api.plan_gate import check_usage_limit
+
+        mock_plan = MagicMock(max_validations=5)
+        mock_user = MagicMock(id="u1", tenant_id="t1")
+        mock_usage = MagicMock(validations_used=5)
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_usage
+
+        with patch("app.api.plan_gate._get_active_subscription", return_value=(MagicMock(), mock_plan)):
+            dep = check_usage_limit("validations")
+            with pytest.raises(HTTPException) as exc:
+                dep(current_user=mock_user, db=mock_db)
+            assert exc.value.status_code == 403
+            assert "Limite mensal" in exc.value.detail
+
+    def test_check_usage_limit_allows_trial_under_quota(self):
+        from app.api.plan_gate import check_usage_limit
+
+        mock_plan = MagicMock(max_validations=5)
+        mock_user = MagicMock(id="u1", tenant_id="t1")
+        mock_usage = MagicMock(validations_used=3)
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.scalar_one_or_none.return_value = mock_usage
+
+        with patch("app.api.plan_gate._get_active_subscription", return_value=(MagicMock(), mock_plan)):
+            dep = check_usage_limit("validations")
+            result = dep(current_user=mock_user, db=mock_db)
+            assert result is mock_user
+
+
 # ── PDF service tests ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #231.

## Problema

Trial recebia **403** em `/validate/xml`, apesar da pricing anunciar "5 validações/mês" e o DB atribuir `max_validations = 5` ao Trial. Mesmo padrão de propaganda enganosa do #221.

## Solução — opção 1 (honrar a promessa)

| Endpoint | Antes | Depois |
|---|---|---|
| `POST /api/v1/validate/xml` | `require_plan("starter","profissional","contador")` | `require_plan("trial", …)` + `check_usage_limit("validations")` |
| `POST /api/v1/validate/xml/correct` | idem | idem |
| `POST /api/v1/validate/batch-cross-check` | `require_plan("profissional","contador")` | **sem mudança** (não anunciado para Trial) |

`increment_usage()` é chamado após validação bem-sucedida nos dois endpoints liberados. O mecanismo já existia em [plan_gate.py](backend/app/api/plan_gate.py) — só não havia sido plugado.

## Cobertura

7 testes novos em `TestValidateXmlTrialAccess` ([test_billing.py](backend/tests/test_billing.py)):

- Trial presente em `require_plan` nos 2 endpoints liberados
- `check_usage_limit("validations")` presente nos 2 endpoints
- batch-cross-check **não** libera Trial (guarda contra regressão)
- `check_usage_limit` rejeita Trial com 5/5 usados (403 "Limite mensal…")
- `check_usage_limit` libera Trial com 3/5 usados

## Gates

- `python -m pytest tests/ -q` → **396 passed**, 23 errors (pré-existentes: `OperationalError`, tests que precisam de Postgres live — não relacionados a este PR, endereçados em #224)
- `ruff check app/ tests/` → **All checks passed**

## Test plan

- [x] Trial consegue submeter XML em `/validate/xml` e receber resultado
- [x] Após 5 validações no mês, Trial recebe 403 com mensagem de limite
- [x] Starter/Profissional/Contador continuam funcionando (sem regressão)
- [x] `batch-cross-check` continua bloqueado para Trial

🤖 Generated with [Claude Code](https://claude.com/claude-code)