### PR TITLE
fix(validate-xml): adapter shape flat→aninhado (fix client crash)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "test:e2e": "tsx --test tests/calculadora.e2e.test.ts tests/auth.e2e.test.ts tests/validate-xml.e2e.test.ts"
   },

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { adaptValidationResult } from "./api";
+
+// Backend /api/v1/validate/xml retorna shape flat (job_id, audit_id).
+// Frontend consome ValidationResultV11 (job.{id,...}, audit.{id,...}).
+// adaptValidationResult faz a transformação — sem ela a página crasha
+// em result.job.id (issue: Application error após submit de XML em Trial).
+
+test("adapter: flat backend payload → nested ValidationResultV11", () => {
+  const raw = {
+    job_id: "job-abc",
+    audit_id: "aud-xyz",
+    document_type: "NFSE",
+    findings: [],
+    evidences: [],
+    fatals: 0,
+    alerts: 0,
+    created_at: "2026-04-19T16:00:00Z",
+  };
+  const out = adaptValidationResult(raw, "tenant-1", "txn-1");
+
+  assert.equal(out.job.id, "job-abc");
+  assert.equal(out.job.created_at, "2026-04-19T16:00:00Z");
+  assert.equal(out.job.tenant_id, "tenant-1");
+  assert.equal(out.job.transaction_id, "txn-1");
+  assert.equal(out.audit.id, "aud-xyz");
+  assert.equal(out.audit.job_id, "job-abc");
+  assert.deepEqual(out.audit.events, []);
+  assert.equal(out.transaction_id, "txn-1");
+});
+
+test("adapter: preserva findings e evidences", () => {
+  const findings = [
+    { id: "f1", rule_id: "CBS_RATE", severity: "ERROR" as const, title: "t", description: "d", evidence_ids: [] },
+  ];
+  const evidences = [{ id: "e1", type: "xml" as const, label: "Evidência" }];
+  const raw = {
+    job_id: "j",
+    audit_id: "a",
+    document_type: "NFE",
+    findings,
+    evidences,
+    fatals: 1,
+    alerts: 0,
+    created_at: "2026-01-01T00:00:00Z",
+  };
+  const out = adaptValidationResult(raw, "t", "x");
+  assert.equal(out.findings.length, 1);
+  assert.equal(out.findings[0].rule_id, "CBS_RATE");
+  assert.equal(out.evidences.length, 1);
+  assert.equal(out.evidences[0].id, "e1");
+});
+
+test("adapter: payload já aninhado passa através (forward-compat)", () => {
+  const raw = {
+    job: { id: "j2", created_at: "2026-02-02T00:00:00Z", tenant_id: "t9", transaction_id: "tx9" },
+    audit: { id: "a2", job_id: "j2", events: [] },
+    findings: [],
+    evidences: [],
+    transaction_id: "tx9",
+  };
+  const out = adaptValidationResult(raw, "t-default", "txn-default");
+  assert.equal(out.job.id, "j2");
+  assert.equal(out.job.tenant_id, "t9");
+  assert.equal(out.audit.id, "a2");
+  assert.equal(out.transaction_id, "tx9");
+});
+
+test("adapter: campos ausentes não quebram — defaults seguros", () => {
+  const out = adaptValidationResult({}, "tenant-z", "txn-z");
+  assert.equal(out.job.id, "");
+  assert.equal(out.job.tenant_id, "tenant-z");
+  assert.equal(out.job.transaction_id, "txn-z");
+  assert.equal(out.audit.id, "");
+  assert.equal(out.audit.job_id, "");
+  assert.deepEqual(out.audit.events, []);
+  assert.deepEqual(out.findings, []);
+  assert.deepEqual(out.evidences, []);
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -191,6 +191,46 @@ export async function registerWithApi(payload: RegisterRequest): Promise<Registe
   return (await res.json()) as RegisterResponse;
 }
 
+type ValidationResultApi = {
+  job_id?: string;
+  audit_id?: string;
+  document_type?: string;
+  findings?: ValidationResultV11["findings"];
+  evidences?: ValidationResultV11["evidences"];
+  fatals?: number;
+  alerts?: number;
+  created_at?: string;
+  job?: ValidationResultV11["job"];
+  audit?: ValidationResultV11["audit"];
+  transaction_id?: string;
+};
+
+export function adaptValidationResult(
+  raw: ValidationResultApi,
+  tenantId: string,
+  transactionId: string,
+): ValidationResultV11 {
+  const createdAt = raw.created_at ?? raw.job?.created_at ?? new Date().toISOString();
+  const jobId = raw.job?.id ?? raw.job_id ?? "";
+  const auditId = raw.audit?.id ?? raw.audit_id ?? "";
+  return {
+    job: {
+      id: jobId,
+      created_at: raw.job?.created_at ?? createdAt,
+      tenant_id: raw.job?.tenant_id ?? tenantId,
+      transaction_id: raw.job?.transaction_id ?? raw.transaction_id ?? transactionId,
+    },
+    audit: {
+      id: auditId,
+      job_id: raw.audit?.job_id ?? jobId,
+      events: raw.audit?.events ?? [],
+    },
+    findings: raw.findings ?? [],
+    evidences: raw.evidences ?? [],
+    transaction_id: raw.transaction_id ?? transactionId,
+  };
+}
+
 export async function validateXml(payload: ValidateXmlRequest): Promise<ValidationResultV11> {
   const tenantId = getTenantId();
   const transactionId = payload.transaction_id ?? createTransactionId();
@@ -213,15 +253,8 @@ export async function validateXml(payload: ValidateXmlRequest): Promise<Validati
     const detail = await res.text().catch(() => "Erro de API");
     throw new Error(`API ${res.status}: ${detail}`);
   }
-  const data = (await res.json()) as ValidationResultV11;
-  return {
-    ...data,
-    transaction_id: data.transaction_id ?? transactionId,
-    job: {
-      ...data.job,
-      transaction_id: data.job?.transaction_id ?? data.transaction_id ?? transactionId,
-    },
-  };
+  const raw = (await res.json()) as ValidationResultApi;
+  return adaptValidationResult(raw, tenantId, transactionId);
 }
 
 export async function getJobs(): Promise<Job[]> {


### PR DESCRIPTION
## Problema

Após [#232](https://github.com/mickbap/tribultz/pull/232) habilitar Trial em `/api/v1/validate/xml`, usuários passaram a atingir o caminho de sucesso pela primeira vez via UI. Crash imediato ao renderizar o resultado:

> Application error: a client-side exception has occurred while loading tribultz.com.br

## Root cause (não é regressão da #232)

Contrato desalinhado há muito tempo — só não era exercido pela UI porque o endpoint estava gated com 403 para Trial (e aparentemente ninguém em Starter+ passou por esse fluxo).

| Campo | Backend ([validate_xml.py:81-89](backend/app/routers/validate_xml.py:81)) | Frontend ([types.ts:74-80](frontend/src/lib/types.ts:74)) |
|---|---|---|
| Job | `job_id: str` (flat) | `job: { id, created_at, tenant_id, transaction_id? }` |
| Audit | `audit_id: str` (flat) | `audit: { id, job_id, events[] }` |

Crash em [page.tsx:302](frontend/src/app/validate-xml/page.tsx:302) → `result.job.id` → `result.job` é `undefined`.

## Solução

Adapter puro em [api.ts](frontend/src/lib/api.ts) que converte a resposta flat do backend em `ValidationResultV11`. Tolerante a payloads já aninhados (forward-compat — quando o backend migrar, o adapter vira no-op).

```ts
adaptValidationResult(raw, tenantId, transactionId) → ValidationResultV11
```

### Por que hotfix no frontend, não no backend?

- **Menor blast radius**: backend tem tests/CI/curl consumindo o shape flat.
- **Produção parada**: trial não consegue validar XML, com auto-deploy ativo no backend.
- **Follow-up**: issue separada para alinhar backend ao contrato (source of truth unificada).

## Gates

- `npm test` → **58/58 passed** (incluindo 4 novos testes de adapter)
- `npm run build` → **Compiled successfully**

## Test plan

- [ ] Trial faz login, submete XML em `/validate-xml`, vê o resultado renderizado (sem crash)
- [ ] Starter+ continuam funcionando (sem regressão)
- [ ] `job.id`, `audit.id`, findings e evidences aparecem no relatório
- [ ] Download de bundle/zip de evidências funciona

## Deploy

Auto-deploy via Vercel no merge (frontend é Vercel, não a VM Magalu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)