### PR TITLE
fix(dashboard): 404s em audit/exceptions zeravam todos os KPIs do Painel

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.core.logging import configure_logging
-from app.routers import admin, auth, audit, billing, calculadora, documents, feedback, health, jobs, lgpd, news, public, reports, support, tasks, validate, validate_xml, validation
+from app.routers import admin, auth, audit, billing, calculadora, documents, exceptions, feedback, health, jobs, lgpd, news, public, reports, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry
 
 configure_logging()
@@ -72,6 +72,7 @@ app.include_router(health.router)
 app.include_router(validate.router)
 app.include_router(validation.router)
 app.include_router(audit.router)
+app.include_router(exceptions.router)
 app.include_router(jobs.router)
 app.include_router(tasks.router)
 # chat.router desativado — descontinuado por segurança (risco de prompt injection) e eficiência operacional

--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -3,7 +3,7 @@ from hashlib import sha256
 from typing import Any, Optional
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -49,7 +49,59 @@ def _compute_checksum(payload: dict) -> str:
     return sha256(raw).hexdigest()
 
 
+class AuditLogItem(BaseModel):
+    id: str
+    tenant_id: str
+    job_id: Optional[str]
+    action: str
+    created_at: str
+    payload: dict[str, Any]
+
+
 # ── Endpoints ─────────────────────────────────────────────────
+@router.get("", response_model=list[AuditLogItem])
+def list_audit_logs(
+    job_id: Optional[str] = Query(None),
+    limit: int = Query(default=50, le=200),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List audit log entries for the tenant, optionally filtered by job_id."""
+    tenant_id = str(current_user.tenant_id)
+
+    filters = ["al.tenant_id = CAST(:tid AS uuid)"]
+    bind: dict[str, Any] = {"tid": tenant_id, "limit": limit}
+
+    if job_id:
+        filters.append("al.entity_id = :job_id")
+        bind["job_id"] = job_id
+
+    where = " AND ".join(filters)
+    rows = db.execute(
+        text(f"""
+            SELECT al.id, al.tenant_id, al.entity_id, al.action,
+                   al.payload, al.created_at
+            FROM audit_log al
+            WHERE {where}
+            ORDER BY al.created_at DESC
+            LIMIT :limit
+        """),
+        bind,
+    ).fetchall()
+
+    return [
+        AuditLogItem(
+            id=str(r.id),
+            tenant_id=str(r.tenant_id),
+            job_id=str(r.entity_id) if r.entity_id else None,
+            action=r.action,
+            created_at=r.created_at.isoformat() if r.created_at else "",
+            payload=r.payload if isinstance(r.payload, dict) else {},
+        )
+        for r in rows
+    ]
+
+
 @router.post("/log", response_model=AuditRecord)
 def create_audit_log(
     entry: AuditEntry,

--- a/backend/app/routers/exceptions.py
+++ b/backend/app/routers/exceptions.py
@@ -1,0 +1,37 @@
+"""Exception requests router — stub (table not yet migrated)."""
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.models.auth import User
+
+router = APIRouter(prefix="/api/v1/exceptions", tags=["exceptions"])
+
+
+class ExceptionRequestResponse(BaseModel):
+    id: str
+    tenant_id: str
+    job_id: str
+    finding_id: str
+    rule_id: str
+    justification: str
+    status: str
+    created_by: str
+    created_at: str
+    decided_by: Optional[str] = None
+    decided_at: Optional[str] = None
+    decision_comment: Optional[str] = None
+
+
+@router.get("", response_model=list[ExceptionRequestResponse])
+def list_exception_requests(
+    db: Session = Depends(get_db),  # noqa: ARG001
+    current_user: User = Depends(get_current_user),  # noqa: ARG001
+) -> list[Any]:
+    """List exception requests for the tenant. Table migration pending — returns empty list."""
+    return []

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -113,13 +113,13 @@ export default function DashboardPage() {
     setTenantName(match?.name ?? tid);
 
     setLoading(true);
-    Promise.all([getJobs(), getAudits(), listExceptionRequests()])
-      .then(([jobsData, auditsData, exceptionsData]) => {
-        setJobs(jobsData);
-        setAudits(auditsData);
-        setExceptions(exceptionsData);
+    Promise.allSettled([getJobs(), getAudits(), listExceptionRequests()])
+      .then(([jobsResult, auditsResult, exceptionsResult]) => {
+        if (jobsResult.status === "fulfilled") setJobs(jobsResult.value);
+        else setError((jobsResult.reason as Error)?.message ?? "Erro ao carregar jobs");
+        if (auditsResult.status === "fulfilled") setAudits(auditsResult.value);
+        if (exceptionsResult.status === "fulfilled") setExceptions(exceptionsResult.value);
       })
-      .catch((err: Error) => setError(err.message))
       .finally(() => setLoading(false));
   }, []);
 


### PR DESCRIPTION
## Problema

Após o fix anterior (#235), o Painel continuava exibindo zero mesmo com jobs no DB.

Diagnóstico via DevTools revelou:
- `GET /api/v1/exceptions` → 404 (router inexistente)
- `GET /api/v1/audit` → 404 (router existia mas sem endpoint GET /)

Como o Dashboard usava `Promise.all`, qualquer 404 que o `apiFetch` lançasse derrubava o chain inteiro — `setJobs` nunca era chamado, deixando `jobs = []`.

## Mudanças

- **`dashboard/page.tsx`**: `Promise.all` → `Promise.allSettled`; jobs é exibido mesmo se audit ou exceptions falharem independentemente
- **`audit.py`**: adiciona `GET /api/v1/audit` com filtro opcional `?job_id=`
- **`exceptions.py`**: novo router `GET /api/v1/exceptions` (retorna `[]` enquanto tabela `exception_requests` não existe no DB)
- **`main.py`**: registra `exceptions.router`

## Test plan

- [ ] Backend: 419 testes passando
- [ ] Frontend: 54 testes passando
- [ ] Ruff: sem erros
- [ ] Após deploy: Painel deve exibir total de validações, taxa de conformidade e findings corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)