### PR TITLE
feat(exceptions): tabela exception_requests + CRUD + notificacao por e-mail (#242)

### DIFF
--- a/backend/app/alembic/versions/2026_04_25_0012_add_exception_requests_table.py
+++ b/backend/app/alembic/versions/2026_04_25_0012_add_exception_requests_table.py
@@ -1,0 +1,51 @@
+"""Add exception_requests table.
+
+Tabela de exceções fiscais — operador abre exceção em um finding,
+informa nome/e-mail de um "admin" responsável, e o sistema notifica esse
+admin por e-mail (informativo). Decisão (APPROVED/REJECTED) ocorre dentro
+do app, autenticada — sem role-based formal por enquanto.
+
+Revision ID: 2026_04_25_0012
+Revises: 2026_04_15_0011
+Create Date: 2026-04-25
+"""
+
+from alembic import op
+
+
+revision = "2026_04_25_0012"
+down_revision = "2026_04_15_0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS exception_requests (
+            id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id        UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            job_id           UUID REFERENCES jobs(id) ON DELETE SET NULL,
+            finding_id       TEXT NOT NULL,
+            rule_id          TEXT NOT NULL,
+            justification    TEXT NOT NULL,
+            status           TEXT NOT NULL DEFAULT 'OPEN'
+                             CHECK (status IN ('OPEN', 'APPROVED', 'REJECTED')),
+            admin_name       TEXT NOT NULL,
+            admin_email      TEXT NOT NULL,
+            created_by       TEXT NOT NULL,
+            created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+            decided_by       TEXT,
+            decided_at       TIMESTAMPTZ,
+            decision_comment TEXT
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_exception_requests_tenant ON exception_requests(tenant_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_exception_requests_status ON exception_requests(tenant_id, status)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_exception_requests_job ON exception_requests(job_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_exception_requests_job")
+    op.execute("DROP INDEX IF EXISTS idx_exception_requests_status")
+    op.execute("DROP INDEX IF EXISTS idx_exception_requests_tenant")
+    op.execute("DROP TABLE IF EXISTS exception_requests")

--- a/backend/app/models/exception_requests.py
+++ b/backend/app/models/exception_requests.py
@@ -1,0 +1,61 @@
+"""SQLAlchemy model for exception_requests table."""
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class ExceptionRequest(Base):
+    __tablename__ = "exception_requests"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    tenant_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    job_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("jobs.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    finding_id = Column(Text, nullable=False)
+    rule_id = Column(Text, nullable=False)
+    justification = Column(Text, nullable=False)
+    status = Column(
+        String(20),
+        nullable=False,
+        server_default="OPEN",
+    )
+    admin_name = Column(Text, nullable=False)
+    admin_email = Column(Text, nullable=False)
+    created_by = Column(Text, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    decided_by = Column(Text, nullable=True)
+    decided_at = Column(DateTime(timezone=True), nullable=True)
+    decision_comment = Column(Text, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('OPEN', 'APPROVED', 'REJECTED')",
+            name="ck_exception_requests_status",
+        ),
+    )

--- a/backend/app/routers/exceptions.py
+++ b/backend/app/routers/exceptions.py
@@ -1,26 +1,66 @@
-"""Exception requests router — stub (table not yet migrated)."""
+"""Exception requests router — CRUD + notificação por e-mail.
 
-from typing import Any, Optional
+Fluxo:
+1. Operador abre exceção em um finding informando justificativa + admin (nome + e-mail)
+2. Sistema registra no banco e envia e-mail informativo para o admin
+3. Operador (ou outro user do tenant) decide (APPROVED/REJECTED) dentro do app
+4. Auditoria via audit_log: exception_created e exception_decided
+"""
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.database import get_db
 from app.models.auth import User
+from app.models.exception_requests import ExceptionRequest
+from app.services.email_service import send_exception_notification_email
+from app.tools import postgres_tool
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/exceptions", tags=["exceptions"])
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────
+
+
+class ExceptionCreateRequest(BaseModel):
+    job_id: Optional[str] = None
+    finding_id: str = Field(..., min_length=1)
+    rule_id: str = Field(..., min_length=1)
+    justification: str = Field(..., min_length=1)
+    admin_name: str = Field(..., min_length=1)
+    admin_email: EmailStr
+    # Mantido por compat com payload legado do frontend; ignorado se enviado.
+    created_by: Optional[str] = None
+
+
+class ExceptionDecisionRequest(BaseModel):
+    status: str = Field(..., pattern="^(APPROVED|REJECTED)$")
+    decision_comment: Optional[str] = None
+    # Compat com payload legado; ignorado — usamos current_user.email.
+    decided_by: Optional[str] = None
 
 
 class ExceptionRequestResponse(BaseModel):
     id: str
     tenant_id: str
-    job_id: str
+    job_id: Optional[str] = None
     finding_id: str
     rule_id: str
     justification: str
     status: str
+    admin_name: str
+    admin_email: str
     created_by: str
     created_at: str
     decided_by: Optional[str] = None
@@ -28,10 +68,160 @@ class ExceptionRequestResponse(BaseModel):
     decision_comment: Optional[str] = None
 
 
+def _to_response(row: ExceptionRequest) -> ExceptionRequestResponse:
+    return ExceptionRequestResponse(
+        id=str(row.id),
+        tenant_id=str(row.tenant_id),
+        job_id=str(row.job_id) if row.job_id else None,
+        finding_id=row.finding_id,
+        rule_id=row.rule_id,
+        justification=row.justification,
+        status=row.status,
+        admin_name=row.admin_name,
+        admin_email=row.admin_email,
+        created_by=row.created_by,
+        created_at=row.created_at.isoformat() if row.created_at else "",
+        decided_by=row.decided_by,
+        decided_at=row.decided_at.isoformat() if row.decided_at else None,
+        decision_comment=row.decision_comment,
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────
+
+
+@router.post("", response_model=ExceptionRequestResponse, status_code=201)
+def create_exception_request(
+    req: ExceptionCreateRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ExceptionRequestResponse:
+    """Cria uma exceção e dispara e-mail informativo para o admin indicado."""
+    job_uuid: Optional[UUID] = None
+    if req.job_id:
+        try:
+            job_uuid = UUID(req.job_id)
+        except ValueError:
+            # job_id inválido (ex: fingerprint legado) — registra exceção sem vincular
+            logger.warning("create_exception: invalid job_id %r — saving without link", req.job_id)
+            job_uuid = None
+
+    operator_email = current_user.email
+    operator_name = current_user.full_name or operator_email
+    operator_phone = current_user.phone
+
+    row = ExceptionRequest(
+        id=uuid4(),
+        tenant_id=current_user.tenant_id,
+        job_id=job_uuid,
+        finding_id=req.finding_id,
+        rule_id=req.rule_id,
+        justification=req.justification,
+        status="OPEN",
+        admin_name=req.admin_name,
+        admin_email=str(req.admin_email),
+        created_by=operator_email,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    # Audit log (não-bloqueante via try/except)
+    try:
+        postgres_tool.insert_audit_log(
+            tenant_id=str(current_user.tenant_id),
+            user_id=str(current_user.id),
+            action="exception_created",
+            entity_type="exception_request",
+            entity_id=str(row.id),
+            payload={
+                "rule_id": row.rule_id,
+                "finding_id": row.finding_id,
+                "admin_email": row.admin_email,
+            },
+        )
+    except Exception:
+        logger.warning("create_exception: audit_log failed", exc_info=True)
+
+    # Envio de e-mail em background — não bloqueia o response
+    background_tasks.add_task(
+        send_exception_notification_email,
+        to_email=str(req.admin_email),
+        admin_name=req.admin_name,
+        operator_name=operator_name,
+        operator_email=operator_email,
+        operator_phone=operator_phone,
+    )
+
+    return _to_response(row)
+
+
 @router.get("", response_model=list[ExceptionRequestResponse])
 def list_exception_requests(
-    db: Session = Depends(get_db),  # noqa: ARG001
-    current_user: User = Depends(get_current_user),  # noqa: ARG001
-) -> list[Any]:
-    """List exception requests for the tenant. Table migration pending — returns empty list."""
-    return []
+    status: Optional[str] = Query(default=None, pattern="^(OPEN|APPROVED|REJECTED)$"),
+    limit: int = Query(default=100, ge=1, le=500),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[ExceptionRequestResponse]:
+    """Lista exceções do tenant, com filtro opcional por status."""
+    q = (
+        db.query(ExceptionRequest)
+        .filter(ExceptionRequest.tenant_id == current_user.tenant_id)
+    )
+    if status:
+        q = q.filter(ExceptionRequest.status == status)
+    rows = q.order_by(ExceptionRequest.created_at.desc()).limit(limit).all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("/{exception_id}/decision", response_model=ExceptionRequestResponse)
+def decide_exception_request(
+    exception_id: str,
+    req: ExceptionDecisionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ExceptionRequestResponse:
+    """Aprova ou rejeita uma exceção. Qualquer user do tenant pode decidir."""
+    try:
+        ex_uuid = UUID(exception_id)
+    except ValueError:
+        raise HTTPException(404, "Exception not found")
+
+    row = (
+        db.query(ExceptionRequest)
+        .filter(
+            ExceptionRequest.id == ex_uuid,
+            ExceptionRequest.tenant_id == current_user.tenant_id,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(404, "Exception not found")
+    if row.status != "OPEN":
+        raise HTTPException(409, f"Exception already {row.status}")
+
+    row.status = req.status
+    row.decided_by = current_user.email
+    row.decided_at = datetime.now(timezone.utc)
+    row.decision_comment = req.decision_comment
+    db.commit()
+    db.refresh(row)
+
+    try:
+        postgres_tool.insert_audit_log(
+            tenant_id=str(current_user.tenant_id),
+            user_id=str(current_user.id),
+            action="exception_decided",
+            entity_type="exception_request",
+            entity_id=str(row.id),
+            payload={
+                "status": row.status,
+                "rule_id": row.rule_id,
+                "finding_id": row.finding_id,
+            },
+        )
+    except Exception:
+        logger.warning("decide_exception: audit_log failed", exc_info=True)
+
+    return _to_response(row)

--- a/backend/app/routers/exceptions.py
+++ b/backend/app/routers/exceptions.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, cast
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
@@ -69,21 +69,24 @@ class ExceptionRequestResponse(BaseModel):
 
 
 def _to_response(row: ExceptionRequest) -> ExceptionRequestResponse:
+    job_uuid = row.job_id
+    created_at = row.created_at
+    decided_at = row.decided_at
     return ExceptionRequestResponse(
         id=str(row.id),
         tenant_id=str(row.tenant_id),
-        job_id=str(row.job_id) if row.job_id else None,
-        finding_id=row.finding_id,
-        rule_id=row.rule_id,
-        justification=row.justification,
-        status=row.status,
-        admin_name=row.admin_name,
-        admin_email=row.admin_email,
-        created_by=row.created_by,
-        created_at=row.created_at.isoformat() if row.created_at else "",
-        decided_by=row.decided_by,
-        decided_at=row.decided_at.isoformat() if row.decided_at else None,
-        decision_comment=row.decision_comment,
+        job_id=str(job_uuid) if job_uuid is not None else None,
+        finding_id=cast(str, row.finding_id),
+        rule_id=cast(str, row.rule_id),
+        justification=cast(str, row.justification),
+        status=cast(str, row.status),
+        admin_name=cast(str, row.admin_name),
+        admin_email=cast(str, row.admin_email),
+        created_by=cast(str, row.created_by),
+        created_at=cast(datetime, created_at).isoformat() if created_at is not None else "",
+        decided_by=cast(Optional[str], row.decided_by),
+        decided_at=cast(datetime, decided_at).isoformat() if decided_at is not None else None,
+        decision_comment=cast(Optional[str], row.decision_comment),
     )
 
 
@@ -107,9 +110,9 @@ def create_exception_request(
             logger.warning("create_exception: invalid job_id %r — saving without link", req.job_id)
             job_uuid = None
 
-    operator_email = current_user.email
-    operator_name = current_user.full_name or operator_email
-    operator_phone = current_user.phone
+    operator_email = cast(str, current_user.email)
+    operator_name = cast(str, current_user.full_name) or operator_email
+    operator_phone = cast(Optional[str], current_user.phone)
 
     row = ExceptionRequest(
         id=uuid4(),
@@ -198,13 +201,14 @@ def decide_exception_request(
     )
     if not row:
         raise HTTPException(404, "Exception not found")
-    if row.status != "OPEN":
-        raise HTTPException(409, f"Exception already {row.status}")
+    current_status = cast(str, row.status)
+    if current_status != "OPEN":
+        raise HTTPException(409, f"Exception already {current_status}")
 
-    row.status = req.status
-    row.decided_by = current_user.email
-    row.decided_at = datetime.now(timezone.utc)
-    row.decision_comment = req.decision_comment
+    row.status = req.status  # type: ignore[assignment]
+    row.decided_by = cast(str, current_user.email)  # type: ignore[assignment]
+    row.decided_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+    row.decision_comment = req.decision_comment  # type: ignore[assignment]
     db.commit()
     db.refresh(row)
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -227,6 +227,48 @@ def send_feedback_received_email(to_email: str, user_name: str) -> bool:
     )
 
 
+def send_exception_notification_email(
+    to_email: str,
+    admin_name: str,
+    operator_name: str,
+    operator_email: str,
+    operator_phone: str | None,
+) -> bool:
+    """Notifica o admin indicado pelo operador sobre uma exceção aberta.
+
+    Notificação puramente informativa — a decisão é registrada no app
+    pelo operador após alinhamento off-line com o admin.
+    """
+    html_body = _render(
+        "exception_notification.html",
+        admin_name=admin_name,
+        operator_name=operator_name,
+        operator_email=operator_email,
+        operator_phone=operator_phone,
+        frontend_url=settings.FRONTEND_URL,
+    )
+    phone_line = operator_phone or "Não informado"
+    text_body = (
+        f"Prezado(a) {admin_name},\n\n"
+        f"{operator_name} cadastrou você como responsável por aprovar ou rejeitar "
+        "uma exceção no Tribultz.\n\n"
+        f"Localize o operador pelo e-mail {operator_email} ou telefone "
+        f"{phone_line} para prosseguir com o processo.\n\n"
+        "Qualquer dúvida, pode entrar em contato conosco pelo e-mail "
+        "suporte@tribultz.com.br\n\n"
+        "Cordialmente,\n"
+        "TRIbultz Admin.\n"
+        "Sem improviso, sem risco silencioso."
+    )
+    return _send_email(
+        to_email=to_email,
+        subject="Tribultz — Solicitação de exceção fiscal",
+        html_body=html_body,
+        text_body=text_body,
+        log_url=f"{settings.FRONTEND_URL}/exceptions",
+    )
+
+
 def send_staff_ticket_notification(ticket_title: str, user_email: str, priority: str) -> bool:
     """Notify contato@tribultz.com.br when a new ticket is opened."""
     priority_labels = {"low": "Baixa", "medium": "Média", "high": "Alta", "critical": "Crítica"}

--- a/backend/app/templates/emails/exception_notification.html
+++ b/backend/app/templates/emails/exception_notification.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Solicitação de exceção fiscal — Tribultz</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:16px;border:1px solid #e2e8f0;overflow:hidden;max-width:560px;">
+
+        <!-- Header -->
+        <tr>
+          <td style="background:#0f172a;padding:28px 40px;">
+            <span style="color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.3px;">Tribultz</span>
+            <span style="color:#64748b;font-size:12px;margin-left:10px;letter-spacing:0.08em;text-transform:uppercase;">Exceção</span>
+          </td>
+        </tr>
+
+        <!-- Body -->
+        <tr>
+          <td style="padding:40px 40px 32px;">
+            <p style="margin:0 0 8px;font-size:13px;color:#64748b;text-transform:uppercase;letter-spacing:0.12em;font-weight:600;">Conformidade Tributária</p>
+            <h1 style="margin:0 0 20px;font-size:24px;font-weight:800;color:#0f172a;line-height:1.2;">
+              Solicitação de exceção fiscal
+            </h1>
+
+            <p style="margin:0 0 16px;font-size:15px;color:#334155;line-height:1.7;">
+              Prezado(a) <strong>{{ admin_name }}</strong>,
+            </p>
+            <p style="margin:0 0 16px;font-size:15px;color:#334155;line-height:1.7;">
+              <strong>{{ operator_name }}</strong> cadastrou você como responsável por aprovar
+              ou rejeitar uma exceção no Tribultz.
+            </p>
+            <p style="margin:0 0 28px;font-size:15px;color:#334155;line-height:1.7;">
+              Localize o operador pelos contatos abaixo para prosseguir com o processo:
+            </p>
+
+            <table cellpadding="0" cellspacing="0" style="margin:0 0 28px;width:100%;">
+              <tr>
+                <td style="background:#f1f5f9;border:1px solid #e2e8f0;border-radius:10px;padding:16px 20px;">
+                  <p style="margin:0 0 6px;font-size:12px;color:#64748b;text-transform:uppercase;letter-spacing:0.08em;font-weight:600;">E-mail do operador</p>
+                  <p style="margin:0 0 14px;font-size:15px;color:#0f172a;">
+                    <a href="mailto:{{ operator_email }}" style="color:#2563eb;text-decoration:none;">{{ operator_email }}</a>
+                  </p>
+                  <p style="margin:0 0 6px;font-size:12px;color:#64748b;text-transform:uppercase;letter-spacing:0.08em;font-weight:600;">Telefone do operador</p>
+                  <p style="margin:0;font-size:15px;color:#0f172a;">
+                    {{ operator_phone or "Não informado" }}
+                  </p>
+                </td>
+              </tr>
+            </table>
+
+            <div style="background:#fff7ed;border:1px solid #fed7aa;border-radius:10px;padding:16px 20px;margin-bottom:28px;">
+              <p style="margin:0;font-size:13px;color:#9a3412;line-height:1.6;">
+                Esta é uma <strong>notificação informativa</strong>. A decisão (aprovar ou rejeitar)
+                deve ser registrada no Tribultz pelo operador, após o seu alinhamento.
+              </p>
+            </div>
+
+            <p style="margin:0;font-size:13px;color:#64748b;line-height:1.6;">
+              Qualquer dúvida, pode entrar em contato conosco pelo e-mail
+              <a href="mailto:suporte@tribultz.com.br" style="color:#2563eb;">suporte@tribultz.com.br</a>.
+            </p>
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="border-top:1px solid #e2e8f0;padding:20px 40px;">
+            <p style="margin:0 0 4px;font-size:13px;color:#334155;font-weight:600;">Cordialmente,</p>
+            <p style="margin:0 0 12px;font-size:13px;color:#334155;">TRIbultz Admin.</p>
+            <p style="margin:0 0 12px;font-size:12px;color:#64748b;font-style:italic;">
+              Sem improviso, sem risco silencioso.
+            </p>
+            <p style="margin:0;font-size:11px;color:#94a3b8;line-height:1.6;">
+              Tribultz Tecnologia Ltda. — Motor determinístico de conformidade tributária (CBS/IBS · LC 214).<br/>
+              Dúvidas: <a href="mailto:suporte@tribultz.com.br" style="color:#64748b;">suporte@tribultz.com.br</a>
+              &nbsp;·&nbsp; DPO: <a href="mailto:dpo@tribultz.com.br" style="color:#64748b;">dpo@tribultz.com.br</a>
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/backend/tests/test_exceptions.py
+++ b/backend/tests/test_exceptions.py
@@ -1,0 +1,238 @@
+"""Integration tests for /api/v1/exceptions — CRUD + decision flow.
+
+Padrão de auth: override de get_current_user (idêntico a tests/api/test_tasks_async.py).
+DB real (Postgres do testcontainer) com transaction rollback por teste.
+"""
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="auth_user")
+def auth_user_fixture(session):
+    """Cria tenant + user real no banco de teste."""
+    slug = f"tenant-{uuid.uuid4()}"
+    tenant = Tenant(name="Tribultz Test", slug=slug)
+    session.add(tenant)
+    session.commit()
+    session.refresh(tenant)
+
+    email = f"op-{uuid.uuid4()}@tribultz.com"
+    user = User(
+        email=email,
+        full_name="Operador Teste",
+        password_hash="hashed",
+        tenant_id=tenant.id,
+        role="admin",
+        email_verified=True,
+        phone="11 99999-0000",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@pytest.fixture(name="client")
+def client_fixture(session, auth_user):
+    def override_get_db():
+        yield session
+
+    def override_get_current_user():
+        return auth_user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+def test_create_exception_persists_and_dispatches_email(client, auth_user, session):
+    payload = {
+        "finding_id": "F_CST_LEN",
+        "rule_id": "CST_3_DIGITS",
+        "justification": "Item em regime monofásico — CST não se aplica.",
+        "admin_name": "Roberta Admin",
+        "admin_email": "roberta@cliente.com",
+    }
+    with patch("app.routers.exceptions.send_exception_notification_email") as mock_send:
+        mock_send.return_value = True
+        resp = client.post("/api/v1/exceptions", json=payload)
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "OPEN"
+    assert body["admin_name"] == "Roberta Admin"
+    assert body["admin_email"] == "roberta@cliente.com"
+    assert body["created_by"] == auth_user.email
+    assert body["finding_id"] == "F_CST_LEN"
+    # E-mail dispatched via BackgroundTasks — TestClient runs them after response
+    assert mock_send.called
+    args = mock_send.call_args.kwargs
+    assert args["to_email"] == "roberta@cliente.com"
+    assert args["operator_email"] == auth_user.email
+    assert args["operator_phone"] == "11 99999-0000"
+
+    # Confirma persistência no banco
+    session.expire_all()
+    row = session.execute(
+        text("SELECT status, admin_email FROM exception_requests WHERE id = :id"),
+        {"id": body["id"]},
+    ).fetchone()
+    assert row is not None
+    assert row.status == "OPEN"
+    assert row.admin_email == "roberta@cliente.com"
+
+
+def test_create_exception_with_invalid_email_returns_422(client):
+    resp = client.post(
+        "/api/v1/exceptions",
+        json={
+            "finding_id": "F1",
+            "rule_id": "R1",
+            "justification": "x",
+            "admin_name": "X",
+            "admin_email": "not-an-email",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_create_exception_with_invalid_job_id_still_succeeds(client):
+    """job_id no formato fingerprint legado não deve quebrar — registra sem vínculo."""
+    with patch("app.routers.exceptions.send_exception_notification_email"):
+        resp = client.post(
+            "/api/v1/exceptions",
+            json={
+                "job_id": "job_xml_legacy_fingerprint",
+                "finding_id": "F1",
+                "rule_id": "R1",
+                "justification": "x",
+                "admin_name": "X",
+                "admin_email": "admin@x.com",
+            },
+        )
+    assert resp.status_code == 201
+    assert resp.json()["job_id"] is None
+
+
+def test_list_exceptions_returns_only_tenant_data(client):
+    with patch("app.routers.exceptions.send_exception_notification_email"):
+        client.post(
+            "/api/v1/exceptions",
+            json={
+                "finding_id": "F1",
+                "rule_id": "R1",
+                "justification": "x",
+                "admin_name": "Admin",
+                "admin_email": "a@x.com",
+            },
+        )
+    resp = client.get("/api/v1/exceptions")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) >= 1
+    assert rows[0]["status"] == "OPEN"
+
+
+def test_list_exceptions_filter_by_status_approved_returns_empty(client):
+    """Sem nada APPROVED, filtro retorna lista vazia."""
+    resp = client.get("/api/v1/exceptions?status=APPROVED")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_decide_exception_approves_and_records_decided_by(client, auth_user):
+    with patch("app.routers.exceptions.send_exception_notification_email"):
+        create_resp = client.post(
+            "/api/v1/exceptions",
+            json={
+                "finding_id": "F1",
+                "rule_id": "R1",
+                "justification": "x",
+                "admin_name": "Admin",
+                "admin_email": "a@x.com",
+            },
+        )
+    ex_id = create_resp.json()["id"]
+
+    resp = client.post(
+        f"/api/v1/exceptions/{ex_id}/decision",
+        json={"status": "APPROVED", "decision_comment": "OK"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "APPROVED"
+    assert body["decided_by"] == auth_user.email
+    assert body["decision_comment"] == "OK"
+    assert body["decided_at"] is not None
+
+
+def test_decide_exception_rejects_invalid_status(client):
+    resp = client.post(
+        f"/api/v1/exceptions/{uuid.uuid4()}/decision",
+        json={"status": "MAYBE"},
+    )
+    assert resp.status_code == 422
+
+
+def test_decide_exception_404_for_nonexistent(client):
+    resp = client.post(
+        f"/api/v1/exceptions/{uuid.uuid4()}/decision",
+        json={"status": "APPROVED"},
+    )
+    assert resp.status_code == 404
+
+
+def test_decide_exception_409_when_already_decided(client):
+    with patch("app.routers.exceptions.send_exception_notification_email"):
+        create_resp = client.post(
+            "/api/v1/exceptions",
+            json={
+                "finding_id": "F1",
+                "rule_id": "R1",
+                "justification": "x",
+                "admin_name": "Admin",
+                "admin_email": "a@x.com",
+            },
+        )
+    ex_id = create_resp.json()["id"]
+    client.post(
+        f"/api/v1/exceptions/{ex_id}/decision",
+        json={"status": "APPROVED"},
+    )
+    # Segunda tentativa deve falhar com 409
+    resp = client.post(
+        f"/api/v1/exceptions/{ex_id}/decision",
+        json={"status": "REJECTED"},
+    )
+    assert resp.status_code == 409

--- a/frontend/src/app/validate-xml/page.tsx
+++ b/frontend/src/app/validate-xml/page.tsx
@@ -41,6 +41,8 @@ export default function ValidateXmlPage() {
   const [loading, setLoading] = useState(false);
   const [openingExceptionFor, setOpeningExceptionFor] = useState<Finding | null>(null);
   const [justification, setJustification] = useState("");
+  const [adminName, setAdminName] = useState("");
+  const [adminEmail, setAdminEmail] = useState("");
   const [toast, setToast] = useState<{ tone: "success" | "error" | "info"; msg: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [correcting, setCorrecting] = useState(false);
@@ -143,17 +145,29 @@ export default function ValidateXmlPage() {
       setToast({ tone: "error", msg: "Justificativa obrigatória para abrir exceção." });
       return;
     }
+    if (!adminName.trim()) {
+      setToast({ tone: "error", msg: "Nome do admin obrigatório." });
+      return;
+    }
+    const emailTrimmed = adminEmail.trim();
+    if (!emailTrimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailTrimmed)) {
+      setToast({ tone: "error", msg: "E-mail do admin inválido." });
+      return;
+    }
     try {
       await openExceptionRequest({
         job_id: result.job.id,
         finding_id: openingExceptionFor.id,
         rule_id: openingExceptionFor.rule_id,
         justification: justification.trim(),
-        created_by: "operador.demo",
+        admin_name: adminName.trim(),
+        admin_email: emailTrimmed,
       });
       setOpeningExceptionFor(null);
       setJustification("");
-      setToast({ tone: "success", msg: "Exceção aberta e enviada para fila do coordenador." });
+      setAdminName("");
+      setAdminEmail("");
+      setToast({ tone: "success", msg: "Exceção aberta. Admin foi notificado por e-mail." });
       await refreshJob(result.job.id);
     } catch (err) {
       setToast({ tone: "error", msg: err instanceof Error ? err.message : "Falha ao abrir exceção." });
@@ -462,12 +476,37 @@ export default function ValidateXmlPage() {
                 placeholder="Descreva motivo, base legal e plano de correção."
               />
             </label>
+            <label className="mt-3 block text-sm">
+              <span className="mb-1 block text-slate-600">Nome do admin (obrigatório)</span>
+              <input
+                type="text"
+                value={adminName}
+                onChange={(e) => setAdminName(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 p-2 text-sm"
+                placeholder="Ex.: Roberta Silva"
+              />
+            </label>
+            <label className="mt-3 block text-sm">
+              <span className="mb-1 block text-slate-600">E-mail do admin (obrigatório)</span>
+              <input
+                type="email"
+                value={adminEmail}
+                onChange={(e) => setAdminEmail(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 p-2 text-sm"
+                placeholder="admin@empresa.com.br"
+              />
+            </label>
+            <p className="mt-2 text-xs text-slate-500">
+              O admin receberá um e-mail informando seu contato (e-mail e telefone do operador) para coordenar a decisão.
+            </p>
             <div className="mt-3 flex justify-end gap-2">
               <button
                 type="button"
                 onClick={() => {
                   setOpeningExceptionFor(null);
                   setJustification("");
+                  setAdminName("");
+                  setAdminEmail("");
                 }}
                 className="rounded border border-slate-300 px-3 py-1.5 text-sm"
               >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -324,7 +324,8 @@ export async function openExceptionRequest(payload: {
   finding_id: string;
   rule_id: string;
   justification: string;
-  created_by: string;
+  admin_name: string;
+  admin_email: string;
 }): Promise<ExceptionRequest> {
   const tenantId = getTenantId();
   const row = await apiFetch<ApiExceptionRequest>("/api/v1/exceptions", {

--- a/frontend/src/lib/closing/aggregate.test.ts
+++ b/frontend/src/lib/closing/aggregate.test.ts
@@ -47,6 +47,8 @@ function makeException(id: string, createdAt: string, status: ExceptionRequest["
     rule_id: "RULE_X",
     justification: "Need exception",
     status,
+    admin_name: "Admin Test",
+    admin_email: "admin@example.com",
     created_by: "operator.demo",
     created_at: createdAt,
   };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -89,6 +89,8 @@ export type ExceptionRequest = {
   rule_id: string;
   justification: string;
   status: ExceptionRequestStatus;
+  admin_name: string;
+  admin_email: string;
   created_by: string;
   created_at: string;
   decided_by?: string;
@@ -177,6 +179,8 @@ export type ApiExceptionRequest = {
   rule_id: string;
   justification: string;
   status: ExceptionRequestStatus;
+  admin_name?: string;
+  admin_email?: string;
   created_by: string;
   created_at: string;
   decided_by?: string;
@@ -263,6 +267,8 @@ export function normalizeException(raw: ApiExceptionRequest, fallbackTenant: str
     rule_id: raw.rule_id,
     justification: raw.justification,
     status: raw.status,
+    admin_name: raw.admin_name ?? "",
+    admin_email: raw.admin_email ?? "",
     created_by: raw.created_by,
     created_at: raw.created_at,
     decided_by: raw.decided_by,


### PR DESCRIPTION
## Closes
Closes #242

## Resumo

Substitui o stub de `routers/exceptions.py` (que retornava `[]` porque a tabela não existia) por implementação completa de CRUD + notificação por e-mail.

## Schema da tabela (conforme definido na issue)

```sql
CREATE TABLE exception_requests (
  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  tenant_id        UUID NOT NULL REFERENCES tenants(id),
  job_id           UUID REFERENCES jobs(id),
  finding_id       TEXT NOT NULL,
  rule_id          TEXT NOT NULL,
  justification    TEXT NOT NULL,
  status           TEXT NOT NULL DEFAULT 'OPEN'
                   CHECK (status IN ('OPEN','APPROVED','REJECTED')),
  admin_name       TEXT NOT NULL,
  admin_email      TEXT NOT NULL,
  created_by       TEXT NOT NULL,
  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
  decided_by       TEXT,
  decided_at       TIMESTAMPTZ,
  decision_comment TEXT
);
```

## Fluxo

1. Operador clica "Abrir exceção" em um finding → modal pede justificativa + nome + e-mail do admin
2. Backend persiste a exceção e dispara e-mail informativo (BackgroundTask) para o admin com:
   - E-mail e telefone do operador (do perfil do user autenticado)
   - Mensagem: "Localize o operador para prosseguir com o processo"
3. Admin contata operador off-line e decide
4. Operador (ou outro user do tenant) clica APPROVED/REJECTED dentro do app
5. Audit log: `exception_created` e `exception_decided`

## Arquivos novos

- `backend/app/alembic/versions/2026_04_25_0012_add_exception_requests_table.py`
- `backend/app/models/exception_requests.py`
- `backend/app/templates/emails/exception_notification.html`
- `backend/tests/test_exceptions.py` (9 testes)

## Arquivos modificados

- `backend/app/routers/exceptions.py` — stub virou implementação completa
- `backend/app/services/email_service.py` — adiciona `send_exception_notification_email()`
- `frontend/src/app/validate-xml/page.tsx` — modal ganha 2 campos novos
- `frontend/src/lib/types.ts`, `lib/api.ts`, `lib/closing/aggregate.test.ts`

## Tradeoff aceito

Decisão APROVAR/REJEITAR é **"honor system"** (qualquer user autenticado do tenant pode decidir). Não há role-based admin formal. **O audit log + e-mail de notificação são a evidência defensável.** Magic-link foi descartado para reduzir superfície de ataque e complexidade.

## Cuidado em produção

- **Tag de rollback criada:** `pre-exceptions-2026-04-25` — em caso de problema, `git reset --hard pre-exceptions-2026-04-25` na VM Magalu + redeploy
- **Migração idempotente** (`CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`)
- **Não modifica endpoints existentes** — apenas substitui o stub e adiciona POST/decision
- **E-mail em BackgroundTask** — falhas no SMTP não derrubam a criação da exceção
- **MERGE NÃO AUTOMÁTICO** — aguardar revisão antes de mergear

## Test plan

- [x] `pytest tests/ -q` → 428 passed (era 389; subiu 39 porque migration destravou tests de billing/email)
- [x] `pytest tests/test_exceptions.py -v` → 9/9 passed
- [x] `ruff check app/ tests/` → All checks passed
- [x] `npm test --silent` → 58 passed
- [x] `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)