### PR TITLE
feat(news): auto-publicacao de novidades em merge para main

### DIFF
--- a/.github/scripts/publish_news.py
+++ b/.github/scripts/publish_news.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Publica uma entrada na tabela `news` a partir do último merge em `main`.
+
+Disparado pelo workflow `.github/workflows/publish-news.yml` em todo push para main.
+
+Lógica:
+1. Lê o commit em $COMMIT_SHA via `git show`
+2. Se for revert / merge sem mensagem útil → ignora
+3. Identifica o tipo (feat/fix/security) — só esses três viram news
+4. Tenta extrair o número do PR (#N) e busca o body do PR via `gh`
+5. Se o PR tem label `no-changelog` → pula
+6. Se o PR body tem seção `## Changelog público` → usa como description (override)
+7. Caso contrário, monta description automaticamente
+8. POST `/api/v1/news` com Bearer token
+
+Variáveis de ambiente:
+- COMMIT_SHA          (obrigatório)
+- BACKEND_URL         (ex.: https://api.tribultz.com.br)
+- NEWS_PUBLISH_TOKEN  (token do secret)
+- GH_TOKEN            (para `gh` CLI buscar PR body/labels)
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+import httpx
+
+
+CONVENTIONAL_PREFIX_RE = re.compile(
+    r"^(?P<type>feat|fix|chore|docs|refactor|test|ci|build|style|perf|security)"
+    r"(?:\((?P<scope>[^)]+)\))?:\s*(?P<subject>.+)$"
+)
+PR_NUMBER_RE = re.compile(r"#(\d+)")
+PUBLIC_CHANGELOG_RE = re.compile(
+    r"##\s*Changelog\s+p[úu]blico\s*\n+(.+?)(?=\n##|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+PUBLISHABLE_TYPES = {"feat", "fix", "security"}
+TYPE_TO_CATEGORY = {
+    "feat": "Feature",
+    "fix": "Fix",
+    "security": "Security",
+}
+
+
+def run(cmd: list[str], **kwargs) -> str:
+    """Roda comando e retorna stdout. Nunca levanta — retorna '' em erro."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+        if result.returncode != 0:
+            print(f"[warn] {' '.join(cmd)} -> exit {result.returncode}: {result.stderr.strip()}", file=sys.stderr)
+            return ""
+        return result.stdout.strip()
+    except FileNotFoundError as e:
+        print(f"[warn] command not found: {e}", file=sys.stderr)
+        return ""
+
+
+def get_commit_subject(sha: str) -> str:
+    return run(["git", "show", "-s", "--format=%s", sha])
+
+
+def get_commit_body(sha: str) -> str:
+    return run(["git", "show", "-s", "--format=%b", sha])
+
+
+def parse_subject(subject: str) -> Optional[dict]:
+    """Extrai type/scope/clean_subject do commit message."""
+    m = CONVENTIONAL_PREFIX_RE.match(subject.strip())
+    if not m:
+        return None
+    return {
+        "type": m.group("type").lower(),
+        "scope": m.group("scope"),
+        "subject_clean": m.group("subject").strip(),
+    }
+
+
+def fetch_pr_data(pr_number: str) -> dict:
+    """Busca body + labels do PR via `gh`. Retorna dict vazio em falha."""
+    raw = run(["gh", "pr", "view", pr_number, "--json", "body,labels,title"])
+    if not raw:
+        return {}
+    try:
+        import json
+        return json.loads(raw)
+    except Exception as e:
+        print(f"[warn] failed to parse PR data: {e}", file=sys.stderr)
+        return {}
+
+
+def has_no_changelog_label(pr_data: dict) -> bool:
+    labels = pr_data.get("labels") or []
+    return any(lbl.get("name") == "no-changelog" for lbl in labels)
+
+
+def extract_public_changelog(pr_body: str) -> Optional[str]:
+    """Se o PR body tem seção '## Changelog público', retorna o conteúdo."""
+    if not pr_body:
+        return None
+    m = PUBLIC_CHANGELOG_RE.search(pr_body)
+    if not m:
+        return None
+    text = m.group(1).strip()
+    return text or None
+
+
+def build_title(parsed: dict, scope_label: Optional[str]) -> str:
+    """Monta título amigável a partir do commit parseado."""
+    subject = parsed["subject_clean"]
+    # Capitaliza primeira letra
+    if subject and subject[0].islower():
+        subject = subject[0].upper() + subject[1:]
+    # Remove sufixos tipo (#244), (#241 #240), (#241, #240) — loop cobre múltiplos
+    while True:
+        new_subject = re.sub(r"\s*\(#\d+(?:[\s,]+#\d+)*\)\s*$", "", subject).strip()
+        if new_subject == subject:
+            break
+        subject = new_subject
+    # Trunca em 200 chars (limite da coluna)
+    if len(subject) > 200:
+        subject = subject[:197].rstrip() + "..."
+    return subject
+
+
+def build_description(parsed: dict, pr_body: str) -> str:
+    """Constrói descrição a partir do override do PR ou do body."""
+    override = extract_public_changelog(pr_body)
+    if override:
+        # Limpa markdown básico (mantém legível)
+        override = re.sub(r"^[-*]\s*", "• ", override, flags=re.MULTILINE)
+        return override[:2000]
+
+    # Fallback: pega o primeiro parágrafo significativo do PR body
+    if pr_body:
+        # Remove headers, pega o primeiro parágrafo real
+        for chunk in pr_body.split("\n\n"):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            if chunk.startswith("##") or chunk.startswith("Closes") or chunk.startswith("Fixes"):
+                continue
+            # Limpa marcações markdown comuns
+            chunk = re.sub(r"^#+\s*", "", chunk)
+            chunk = re.sub(r"`([^`]+)`", r"\1", chunk)
+            chunk = re.sub(r"\*\*([^*]+)\*\*", r"\1", chunk)
+            chunk = re.sub(r"^[-*]\s*", "• ", chunk, flags=re.MULTILINE)
+            return chunk[:2000]
+
+    # Último recurso: descrição genérica
+    type_label = {"feat": "Nova funcionalidade", "fix": "Correção", "security": "Atualização de segurança"}
+    return type_label.get(parsed["type"], "Atualização") + " disponível na plataforma."
+
+
+def main() -> int:
+    sha = os.environ.get("COMMIT_SHA", "").strip()
+    backend_url = os.environ.get("BACKEND_URL", "").strip().rstrip("/")
+    token = os.environ.get("NEWS_PUBLISH_TOKEN", "").strip()
+
+    if not sha:
+        print("[err] COMMIT_SHA not set", file=sys.stderr)
+        return 1
+    if not backend_url:
+        print("[skip] BACKEND_URL secret not configured — pulando publicação")
+        return 0
+    if not token:
+        print("[skip] NEWS_PUBLISH_TOKEN secret not configured — pulando publicação")
+        return 0
+
+    subject = get_commit_subject(sha)
+    if not subject:
+        print(f"[err] could not read commit {sha}", file=sys.stderr)
+        return 1
+
+    print(f"[info] commit subject: {subject}")
+
+    parsed = parse_subject(subject)
+    if not parsed:
+        print(f"[skip] subject não segue Conventional Commits — ignorando")
+        return 0
+
+    if parsed["type"] not in PUBLISHABLE_TYPES:
+        print(f"[skip] tipo '{parsed['type']}' não é publicado (só feat/fix/security)")
+        return 0
+
+    # Detecta PR via #N no subject ou body
+    body = get_commit_body(sha)
+    full_text = f"{subject}\n{body}"
+    pr_match = PR_NUMBER_RE.search(full_text)
+    pr_data = {}
+    if pr_match:
+        pr_number = pr_match.group(1)
+        print(f"[info] PR detectado: #{pr_number}")
+        pr_data = fetch_pr_data(pr_number)
+        if has_no_changelog_label(pr_data):
+            print(f"[skip] PR #{pr_number} tem label 'no-changelog'")
+            return 0
+
+    title = build_title(parsed, parsed.get("scope"))
+    description = build_description(parsed, pr_data.get("body", "") or "")
+    category = TYPE_TO_CATEGORY[parsed["type"]]
+
+    print(f"[info] vai publicar: category={category} title={title!r}")
+    print(f"[info] description (primeiros 200 chars): {description[:200]!r}")
+
+    payload = {"title": title, "description": description, "category": category}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        resp = httpx.post(
+            f"{backend_url}/api/v1/news",
+            json=payload,
+            headers=headers,
+            timeout=15.0,
+        )
+    except httpx.HTTPError as e:
+        print(f"[err] HTTP erro chamando backend: {e}", file=sys.stderr)
+        return 1
+
+    if resp.status_code in (200, 201):
+        kind = "criada" if resp.status_code == 201 else "deduplicada (já existia)"
+        print(f"[ok] news {kind} — id={resp.json().get('id')}")
+        return 0
+
+    print(f"[err] backend retornou {resp.status_code}: {resp.text}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/publish-news.yml
+++ b/.github/workflows/publish-news.yml
@@ -1,0 +1,49 @@
+name: Publish News on Merge
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to publish (defaults to HEAD of main)"
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  publish-news:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install httpx
+        run: pip install httpx==0.28.1
+
+      - name: Resolve commit SHA
+        id: sha
+        run: |
+          if [ -n "${{ inputs.sha }}" ]; then
+            echo "value=${{ inputs.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish news entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEWS_PUBLISH_TOKEN: ${{ secrets.NEWS_PUBLISH_TOKEN }}
+          BACKEND_URL: ${{ secrets.BACKEND_URL }}
+          COMMIT_SHA: ${{ steps.sha.outputs.value }}
+        run: python .github/scripts/publish_news.py

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -74,6 +74,9 @@ class Settings(BaseSettings):
     # ── GitHub Integration ────────────────────────────────────
     GITHUB_TOKEN: str = ""
 
+    # ── News Publishing (auto-publish via GitHub Actions on merge) ──
+    NEWS_PUBLISH_TOKEN: str = ""
+
     # ── External APIs ─────────────────────────────────────────
     CLASSTRIB_API_URL: str = "https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib"
     CNPJ_PRIMARY_URL: str = "https://brasilapi.com.br/api/cnpj/v1/{cnpj}"

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel, ConfigDict
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.database import get_db
 from app.models.news import News
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/v1/news", tags=["news"])
+
+NewsCategory = Literal["Feature", "Fix", "Security"]
 
 
 class NewsResponse(BaseModel):
@@ -21,8 +27,14 @@ class NewsResponse(BaseModel):
     id: UUID
     title: str
     description: str
-    category: Literal["Feature", "Fix", "Security"]
+    category: NewsCategory
     created_at: datetime
+
+
+class NewsCreateRequest(BaseModel):
+    title: str = Field(..., min_length=3, max_length=200)
+    description: str = Field(..., min_length=3, max_length=2000)
+    category: NewsCategory = "Feature"
 
 
 @router.get(
@@ -34,3 +46,71 @@ class NewsResponse(BaseModel):
 def list_news(db: Session = Depends(get_db)) -> list[News]:
     stmt = select(News).order_by(News.created_at.desc()).limit(10)
     return list(db.scalars(stmt).all())
+
+
+@router.post(
+    "",
+    response_model=NewsResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Publicar nova entrada de changelog (uso interno via GitHub Actions)",
+    description=(
+        "Endpoint protegido por token. Idempotente: se já existe uma entrada com o "
+        "mesmo título nos últimos 30 dias, retorna a existente (200) em vez de criar."
+    ),
+)
+def create_news(
+    payload: NewsCreateRequest,
+    response: Response,
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> News:
+    # ── Auth via token interno (Bearer) ──
+    expected_token = settings.NEWS_PUBLISH_TOKEN
+    if not expected_token:
+        # Em ambientes que não configuraram o token, recusa por default
+        # (evita que produção fique aberta caso o secret não tenha sido populado).
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="News publishing is not configured on this server.",
+        )
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or malformed Authorization header.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    provided_token = authorization.removeprefix("Bearer ").strip()
+    if provided_token != expected_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid news publish token.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # ── Idempotência: dedupe por título nos últimos 30 dias ──
+    from datetime import timedelta, timezone as _tz
+    cutoff = datetime.now(_tz.utc) - timedelta(days=30)
+    existing = db.scalar(
+        select(News)
+        .where(News.title == payload.title)
+        .where(News.created_at >= cutoff)
+        .order_by(News.created_at.desc())
+        .limit(1)
+    )
+    if existing is not None:
+        logger.info("create_news: duplicate title within 30d, returning existing %s", existing.id)
+        response.status_code = status.HTTP_200_OK
+        return existing
+
+    row = News(
+        title=payload.title,
+        description=payload.description,
+        category=payload.category,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    logger.info("create_news: published id=%s category=%s", row.id, payload.category)
+    return row

--- a/backend/scripts/backfill_news.py
+++ b/backend/scripts/backfill_news.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Backfill de notícias a partir do histórico recente de commits em main.
+
+Uso (na VM Magalu, dentro do container backend OU com .env carregado):
+
+    python -m backend.scripts.backfill_news --limit 30
+
+Lê os últimos N commits de `git log main`, parseia mensagens Conventional Commits,
+e insere entradas na tabela `news` para todo `feat:` / `fix:` / `security:`.
+
+Idempotente: se uma entrada com o mesmo título já existe (qualquer data), pula.
+
+Roda OFFLINE (acesso direto ao banco via SQLAlchemy) — não precisa do endpoint POST.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Permite rodar tanto como módulo (`python -m`) quanto direto (`python scripts/backfill_news.py`)
+THIS_DIR = Path(__file__).resolve().parent
+BACKEND_ROOT = THIS_DIR.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import select  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models.news import News  # noqa: E402
+
+
+CONVENTIONAL_RE = re.compile(
+    r"^(?P<type>feat|fix|security)"
+    r"(?:\([^)]+\))?:\s*(?P<subject>.+)$"
+)
+# Limpa sufixos como "(#243)", "(#241 #240)", "(#241, #240)" no final
+PR_SUFFIX_RE = re.compile(r"\s*\(#\d+(?:[\s,]+#\d+)*\)\s*$")
+TYPE_TO_CATEGORY = {
+    "feat": "Feature",
+    "fix": "Fix",
+    "security": "Security",
+}
+
+
+def get_recent_commits(limit: int) -> list[dict]:
+    """Retorna lista de {sha, subject} dos últimos N commits de origin/main.
+
+    Faz `git fetch origin main` antes de ler para garantir que estamos olhando
+    o estado canônico do servidor — independente de em qual branch o cwd está.
+    """
+    fetch_result = subprocess.run(
+        ["git", "fetch", "origin", "main"],
+        capture_output=True,
+        text=True,
+        cwd=BACKEND_ROOT.parent,
+    )
+    if fetch_result.returncode != 0:
+        print(f"[err] git fetch falhou: {fetch_result.stderr}", file=sys.stderr)
+        return []
+
+    result = subprocess.run(
+        ["git", "log", f"-{limit}", "--pretty=format:%H||%s", "origin/main"],
+        capture_output=True,
+        text=True,
+        cwd=BACKEND_ROOT.parent,  # repo root
+    )
+    if result.returncode != 0:
+        print(f"[err] git log falhou: {result.stderr}", file=sys.stderr)
+        return []
+
+    commits = []
+    for line in result.stdout.strip().splitlines():
+        if "||" not in line:
+            continue
+        sha, subject = line.split("||", 1)
+        commits.append({"sha": sha.strip(), "subject": subject.strip()})
+    return commits
+
+
+def parse_commit(subject: str) -> dict | None:
+    m = CONVENTIONAL_RE.match(subject)
+    if not m:
+        return None
+    clean = m.group("subject").strip()
+    # Aplica em loop pra cobrir "(#241 #240) (#243)" (dois grupos)
+    while True:
+        new_clean = PR_SUFFIX_RE.sub("", clean).strip()
+        if new_clean == clean:
+            break
+        clean = new_clean
+    if clean and clean[0].islower():
+        clean = clean[0].upper() + clean[1:]
+    if len(clean) > 200:
+        clean = clean[:197].rstrip() + "..."
+    return {
+        "type": m.group("type").lower(),
+        "title": clean,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Backfill news a partir do histórico recente de origin/main.",
+    )
+    ap.add_argument("--limit", type=int, default=30, help="Quantos commits varrer (default: 30)")
+    ap.add_argument("--dry-run", action="store_true", help="Não escreve no banco — só lista")
+    args = ap.parse_args()
+
+    commits = get_recent_commits(args.limit)
+    if not commits:
+        print("[skip] nenhum commit encontrado")
+        return 0
+
+    print(f"[info] varrendo {len(commits)} commits...")
+
+    inserted = 0
+    skipped_dup = 0
+    skipped_type = 0
+
+    with SessionLocal() as db:
+        for c in commits:
+            parsed = parse_commit(c["subject"])
+            if not parsed:
+                skipped_type += 1
+                continue
+
+            existing = db.scalar(select(News).where(News.title == parsed["title"]))
+            if existing is not None:
+                skipped_dup += 1
+                continue
+
+            category = TYPE_TO_CATEGORY[parsed["type"]]
+            description_label = {
+                "Feature": "Nova funcionalidade disponível na plataforma.",
+                "Fix": "Correção aplicada para garantir conformidade e estabilidade.",
+                "Security": "Atualização de segurança aplicada.",
+            }[category]
+
+            print(f"[+ {category:<7}] {parsed['title']}")
+            if not args.dry_run:
+                db.add(News(
+                    title=parsed["title"],
+                    description=description_label,
+                    category=category,
+                ))
+            inserted += 1
+
+        if not args.dry_run:
+            db.commit()
+
+    print(
+        f"\n[summary] inseridos={inserted} duplicados={skipped_dup} "
+        f"tipos_ignorados={skipped_type} dry_run={args.dry_run}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_news.py
+++ b/backend/tests/test_news.py
@@ -1,0 +1,163 @@
+"""Tests for /api/v1/news — list + auto-publish (token-protected)."""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings
+from app.database import get_db
+from app.main import app
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(name="publish_token")
+def publish_token_fixture(monkeypatch):
+    token = "test-news-token-" + uuid.uuid4().hex[:12]
+    monkeypatch.setattr(settings, "NEWS_PUBLISH_TOKEN", token)
+    return token
+
+
+# ── GET /api/v1/news ─────────────────────────────────────────────────────
+
+
+def test_list_news_returns_200(client):
+    resp = client.get("/api/v1/news")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+# ── POST /api/v1/news ────────────────────────────────────────────────────
+
+
+def test_post_news_without_token_setting_returns_503(client, monkeypatch):
+    """Se o servidor não configurou NEWS_PUBLISH_TOKEN, recusa (fail-closed)."""
+    monkeypatch.setattr(settings, "NEWS_PUBLISH_TOKEN", "")
+    resp = client.post(
+        "/api/v1/news",
+        json={"title": "x" * 5, "description": "d" * 5, "category": "Feature"},
+        headers={"Authorization": "Bearer anything"},
+    )
+    assert resp.status_code == 503
+
+
+def test_post_news_without_authorization_header_returns_401(client, publish_token):
+    resp = client.post(
+        "/api/v1/news",
+        json={"title": "Lançamento X", "description": "Detalhe Y", "category": "Feature"},
+    )
+    assert resp.status_code == 401
+
+
+def test_post_news_with_wrong_token_returns_401(client, publish_token):
+    resp = client.post(
+        "/api/v1/news",
+        json={"title": "Lançamento X", "description": "Detalhe Y", "category": "Feature"},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_post_news_with_valid_token_creates_entry(client, publish_token, session):
+    title = f"E2E test {uuid.uuid4().hex[:8]}"
+    resp = client.post(
+        "/api/v1/news",
+        json={
+            "title": title,
+            "description": "Implementação concluída via teste integrado.",
+            "category": "Feature",
+        },
+        headers={"Authorization": f"Bearer {publish_token}"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["title"] == title
+    assert body["category"] == "Feature"
+    assert "id" in body and "created_at" in body
+
+    # Persistido?
+    session.expire_all()
+    row = session.execute(
+        text("SELECT title, category FROM news WHERE id = :id"),
+        {"id": body["id"]},
+    ).fetchone()
+    assert row is not None
+    assert row.title == title
+
+
+def test_post_news_idempotent_returns_existing_within_30d(client, publish_token):
+    title = f"Dup test {uuid.uuid4().hex[:8]}"
+    payload = {"title": title, "description": "primeira", "category": "Fix"}
+    headers = {"Authorization": f"Bearer {publish_token}"}
+
+    first = client.post("/api/v1/news", json=payload, headers=headers)
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    # Segundo POST com mesmo título → retorna o existente
+    second = client.post(
+        "/api/v1/news",
+        json={"title": title, "description": "segunda tentativa", "category": "Feature"},
+        headers=headers,
+    )
+    assert second.status_code == 200
+    assert second.json()["id"] == first_id
+    # Description original preservada (não atualizou)
+    assert second.json()["description"] == "primeira"
+
+
+def test_post_news_validation_rejects_short_title(client, publish_token):
+    resp = client.post(
+        "/api/v1/news",
+        json={"title": "x", "description": "ok descrição", "category": "Feature"},
+        headers={"Authorization": f"Bearer {publish_token}"},
+    )
+    assert resp.status_code == 422
+
+
+def test_post_news_validation_rejects_invalid_category(client, publish_token):
+    resp = client.post(
+        "/api/v1/news",
+        json={"title": "Título OK", "description": "ok", "category": "Invalid"},
+        headers={"Authorization": f"Bearer {publish_token}"},
+    )
+    assert resp.status_code == 422
+
+
+def test_post_news_appears_in_list(client, publish_token):
+    title = f"List visibility {uuid.uuid4().hex[:8]}"
+    client.post(
+        "/api/v1/news",
+        json={"title": title, "description": "deve aparecer", "category": "Feature"},
+        headers={"Authorization": f"Bearer {publish_token}"},
+    )
+    resp = client.get("/api/v1/news")
+    titles = [item["title"] for item in resp.json()]
+    assert title in titles


### PR DESCRIPTION
## Resumo

Liga o auto-publish de novidades na home toda vez que algo entra em `main`. Resolve o problema da tabela `news` ter só 1 entrada velha (`Lançamento da Memória Fiscal Multi-tenant`, março/26) enquanto features novas eram entregues invisíveis aos prospects.

**Foco:** divulgação no LinkedIn semana que vem precisa de uma home viva, atualizada em tempo real.

## Como funciona — fluxo completo

```
PR mergeado em main
  → workflow publish-news.yml dispara
  → script lê o commit (`feat:` / `fix:` / `security:`)
  → POST /api/v1/news (Bearer token)
  → NewsFeed.tsx faz polling de 60s
  → home + /changelog mostram o card novo
```

## Filtros e overrides

- **Tipos publicados:** apenas `feat`, `fix`, `security`. `chore`, `docs`, `test`, `refactor`, `ci`, `build` são silenciosamente ignorados
- **Skip explícito:** label `no-changelog` no PR
- **Override de descrição:** seção `## Changelog público` no PR body
- **Limpeza automática:** sufixos como `(#243)`, `(#241 #240) (#243)` removidos do título

## Idempotência

`POST /api/v1/news` dedupe por título nos últimos 30 dias — retorna **200** com a entrada existente se duplicada (em vez de 201). Re-runs do workflow são seguros.

## Backfill do histórico

Pra popular as ~15 features já entregues que ainda não apareceram na home (incluindo as #243 e #244 de hoje):

```bash
# Na VM Magalu, dentro do diretório backend
python scripts/backfill_news.py --limit 30 --dry-run   # preview
python scripts/backfill_news.py --limit 30             # executa
```

Roda offline via SQLAlchemy (não precisa do endpoint POST). Faz `git fetch origin main` antes para garantir o estado canônico.

## ⚠️ Configuração one-time obrigatória

**1. GitHub Secrets** (em Settings → Secrets and variables → Actions):
- `NEWS_PUBLISH_TOKEN` — gerar com `openssl rand -hex 32`
- `BACKEND_URL` — URL do backend prod (ex.: `https://api.tribultz.com.br`)

**2. VM Magalu (.env do backend):**
- `NEWS_PUBLISH_TOKEN=<mesmo valor do secret>`

Sem esses dois, o `POST /api/v1/news` retorna **503** (fail-closed proposital).

## Arquivos

| Arquivo | Função |
|---------|--------|
| `backend/app/config.py` | setting `NEWS_PUBLISH_TOKEN` |
| `backend/app/routers/news.py` | POST endpoint com Bearer + dedup 30d |
| `backend/scripts/backfill_news.py` | backfill offline via SQLAlchemy |
| `backend/tests/test_news.py` | 9 testes (auth, dedup, validação) |
| `.github/workflows/publish-news.yml` | trigger em push pra main |
| `.github/scripts/publish_news.py` | parser de commit + chamada HTTP |

## Salvaguardas

- 🔒 **Tag de rollback** `pre-news-2026-04-25` no GitHub
- 🔒 **Fail-closed** se token não configurado (503)
- 🔒 **Não modifica** o GET /api/v1/news existente (é additivo)
- 🔒 **NewsFeed do frontend** já tinha auto-refresh de 60s — sem mudança no UI
- 🔒 **MERGE NÃO AUTOMÁTICO** — esperar revisão e configuração dos secrets

## Test plan

- [x] `pytest tests/ -q` → 437 passed
- [x] `pytest tests/test_news.py -v` → 9/9 passed
- [x] `ruff check app/ tests/ scripts/backfill_news.py` → All checks passed
- [x] `pyright@1.1.386 app/` → 0 errors
- [x] `npm test --silent` → 58 passed
- [x] `npm run build` → OK
- [x] Parsing testado em 5 casos (commits reais do repo, edge cases de sufixos múltiplos)

## Próximos passos pós-merge

1. Configurar os 2 secrets no GitHub
2. Adicionar `NEWS_PUBLISH_TOKEN` no `.env` da VM Magalu + restart do backend
3. SSH na VM e rodar `python scripts/backfill_news.py --limit 30 --dry-run` para preview
4. Se ok: `python scripts/backfill_news.py --limit 30` para popular a home
5. Conferir https://tribultz.com.br/ → seção de novidades deve mostrar os cards reais

🤖 Generated with [Claude Code](https://claude.com/claude-code)