### PR TITLE
feat(news): query param ?limit=N (default 10, max 50)

### DIFF
--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -41,10 +41,13 @@ class NewsCreateRequest(BaseModel):
     "",
     response_model=list[NewsResponse],
     summary="Listar novidades do sistema",
-    description="Retorna as 10 entradas mais recentes do changelog em ordem decrescente de data.",
+    description="Retorna as N entradas mais recentes do changelog em ordem decrescente de data (default 10, máximo 50).",
 )
-def list_news(db: Session = Depends(get_db)) -> list[News]:
-    stmt = select(News).order_by(News.created_at.desc()).limit(10)
+def list_news(
+    db: Session = Depends(get_db),
+    limit: int = Query(10, ge=1, le=50, description="Quantas entradas retornar (1-50)"),
+) -> list[News]:
+    stmt = select(News).order_by(News.created_at.desc()).limit(limit)
     return list(db.scalars(stmt).all())
 
 

--- a/backend/tests/test_news.py
+++ b/backend/tests/test_news.py
@@ -54,6 +54,34 @@ def test_list_news_returns_200(client):
     assert isinstance(resp.json(), list)
 
 
+def test_list_news_respects_limit_query_param(client, publish_token):
+    # Cria 12 entradas para validar que ?limit=N retorna até N e o default fica em 10
+    headers = {"Authorization": f"Bearer {publish_token}"}
+    for _ in range(12):
+        client.post(
+            "/api/v1/news",
+            json={
+                "title": f"Limit probe {uuid.uuid4().hex[:8]}",
+                "description": "probe",
+                "category": "Feature",
+            },
+            headers=headers,
+        )
+
+    default_resp = client.get("/api/v1/news")
+    assert default_resp.status_code == 200
+    assert len(default_resp.json()) <= 10
+
+    custom_resp = client.get("/api/v1/news?limit=12")
+    assert custom_resp.status_code == 200
+    assert len(custom_resp.json()) == 12
+
+
+def test_list_news_rejects_limit_out_of_range(client):
+    assert client.get("/api/v1/news?limit=0").status_code == 422
+    assert client.get("/api/v1/news?limit=51").status_code == 422
+
+
 # ── POST /api/v1/news ────────────────────────────────────────────────────
 
 

--- a/frontend/src/app/changelog/page.tsx
+++ b/frontend/src/app/changelog/page.tsx
@@ -31,7 +31,7 @@ export default function ChangelogPage() {
         </section>
 
         <section className="mx-auto max-w-5xl px-4 py-12 md:px-6">
-          <NewsFeed />
+          <NewsFeed limit={50} />
         </section>
       </main>
 

--- a/frontend/src/components/public/NewsFeed.tsx
+++ b/frontend/src/components/public/NewsFeed.tsx
@@ -34,7 +34,8 @@ export function NewsFeed({ limit, compact = false }: NewsFeedProps) {
     let intervalId: number | undefined;
 
     async function loadNews() {
-      const newsUrl = API_BASE ? `${API_BASE}/api/v1/news` : "/api/v1/news";
+      const base = API_BASE ? `${API_BASE}/api/v1/news` : "/api/v1/news";
+      const newsUrl = limit ? `${base}?limit=${limit}` : base;
 
       if (!API_BASE) {
         console.warn(
@@ -56,7 +57,7 @@ export function NewsFeed({ limit, compact = false }: NewsFeedProps) {
         const data = (await res.json()) as NewsItem[];
         if (!active) return;
 
-        setItems(limit ? data.slice(0, limit) : data);
+        setItems(data);
         setLastUpdated(new Date().toLocaleTimeString("pt-BR", {
           hour: "2-digit",
           minute: "2-digit",


### PR DESCRIPTION
## Summary
- `GET /api/v1/news` agora aceita `?limit=N` (1-50, default 10) — antes era hardcoded em 10
- `/changelog` passa `limit=50` para mostrar histórico amplo após backfill (23 entradas em prod)
- `NewsFeed` agora passa o limit para o backend ao invés de fatiar client-side
- Home continua com default 10 (componente sem prop `limit`)

## Contexto
Após o backfill executado hoje (PR #245 + correção do `NEWS_PUBLISH_TOKEN` no `.env` da VM), o banco passou de 1 → 23 entradas. A página `/changelog` continuava mostrando só 10 porque o endpoint tinha limit fixo. Este PR resolve isso sem quebrar a home (que continua mostrando 10).

## Test plan
- [ ] CI: backend pytest passa (3 testes novos: default, custom, bounds 0/51)
- [ ] CI: frontend `npm test` + `npm run build` passam
- [ ] Após merge + deploy: `curl https://api.tribultz.com.br/api/v1/news?limit=50` retorna mais que 10
- [ ] Após merge + deploy: https://tribultz.com.br/changelog mostra >10 cards

## Changelog público
Página de changelog do produto agora mostra histórico mais amplo (até 50 entradas) em vez das 10 mais recentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)