### PR TITLE
ci(publish-news): fetch-depth 0 para SHAs históricos via workflow_dispatch

### DIFF
--- a/.github/workflows/publish-news.yml
+++ b/.github/workflows/publish-news.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          # 0 = histórico completo. Necessário para workflow_dispatch poder
+          # re-publicar entradas a partir de SHAs antigos (caso contrário
+          # `git show <old-sha>` falha por falta de objeto local).
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- `fetch-depth: 2` → `fetch-depth: 0` em `.github/workflows/publish-news.yml`
- Permite que `workflow_dispatch` republique entradas a partir de SHAs antigos
- Trigger push (HEAD de main) continua funcionando igual

## Contexto
Hoje (2026-04-25), durante o backfill da tabela `news`, descobri que disparar `publish-news` via `workflow_dispatch` com um SHA fora dos 2 últimos commits falhava:

```
[err] could not read commit 704caf85df76624647495d1318b4fac67365f848
```

Causa: `actions/checkout@v4` com `fetch-depth: 2` só clona os 2 commits mais recentes. `git show <old-sha>` falha porque o objeto não está local. O workaround foi rodar `publish_news.py` localmente, onde o checkout está completo. PR resolve a raiz.

Custo extra de clonar full history em ubuntu-latest é desprezível para um repo desse tamanho (~30s a mais), e o workflow roda raramente (1x por merge em main).

## Test plan
- [ ] Após merge: disparar `gh workflow run publish-news.yml -f sha=<sha-antigo>` e confirmar que **não** falha mais com `could not read commit`
- [ ] Push normal em main continua publicando entrada via trigger `push`

## Changelog público
N/A — mudança interna de CI, sem impacto para usuário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)