### PR TITLE
chore/feat(s19/s20/seo): debt técnico + ERP Export + SEO (#163 #223 #225 #226 #227 #173)

### DIFF
--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from hashlib import sha256
 from typing import Any, Optional
@@ -131,7 +132,7 @@ def create_audit_log(
             "action": entry.action,
             "entity_type": entry.entity_type,
             "entity_id": entry.entity_id,
-            "payload": __import__("json").dumps({**entry.payload, "_checksum": checksum}),
+            "payload": json.dumps({**entry.payload, "_checksum": checksum}),
         },
     )
     db.commit()

--- a/backend/app/routers/jobs.py
+++ b/backend/app/routers/jobs.py
@@ -1,20 +1,22 @@
 """Orchestration / Job Control Agent — manages async job lifecycle."""
 
+import json
 import logging
 from enum import Enum
 from typing import Any, Optional
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
-from sqlalchemy import text
+from sqlalchemy import func, text, update as sa_update
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.api.deps import get_current_user
 from app.api.plan_gate import require_plan, get_plan_slug
 from app.models.auth import User
+from app.models.jobs import Job
 from app.services.fiscal_justification import enrich_findings
 
 logger = logging.getLogger(__name__)
@@ -108,7 +110,6 @@ def create_job(
         if existing:
             return _row_to_response(existing)
 
-    import json
     job_id = str(uuid4())
     db.execute(
         text("""
@@ -177,33 +178,24 @@ def update_job(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Transition a job to a new status.
+    """Transition a job to a new status.
     Used by the worker or human-in-the-loop to mark progress.
     """
-
-    import json
-
-    updates = ["status = :status", "updated_at = now()"]
-    tenant_id = str(current_user.tenant_id)
-    params: dict[str, Any] = {"id": job_id, "tid": tenant_id, "status": req.status.value}
-
+    patch: dict[str, Any] = {"status": req.status.value, "updated_at": func.now()}
     if req.result is not None:
-        updates.append("result = CAST(:result AS jsonb)")
-        params["result"] = json.dumps(req.result)
+        patch["result"] = req.result
     if req.error_message is not None:
-        updates.append("error_message = :err")
-        params["err"] = req.error_message
-
-    set_clause = ", ".join(updates)
-    db.execute(text(f"UPDATE jobs SET {set_clause} WHERE id = :id AND tenant_id = :tid"), params)
-    db.commit()
+        patch["error_message"] = req.error_message
 
     row = db.execute(
-        text("SELECT * FROM jobs WHERE id = :id AND tenant_id = :tid"),
-        {"id": job_id, "tid": tenant_id},
+        sa_update(Job)
+        .where(Job.id == UUID(job_id), Job.tenant_id == current_user.tenant_id)
+        .values(**patch)
+        .returning(Job)
     ).fetchone()
-    if not row:
+    db.commit()
+
+    if row is None:
         raise HTTPException(404, "Job not found")
     return _row_to_response(row)
 

--- a/backend/app/routers/sped.py
+++ b/backend/app/routers/sped.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import json
 import uuid as _uuid
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
-from fastapi.responses import PlainTextResponse
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -236,3 +236,53 @@ def get_sped_csv(
         return buf.getvalue()
 
     return str(csv_data)
+
+
+@router.get(
+    "/{run_id}/export/erp",
+    summary="Exportar catálogo SPED para ERP (TOTVS, SAP, Omie, Linx, Genérico)",
+    description=(
+        "Gera arquivo de exportação no formato do ERP selecionado. "
+        "Disponível quando o processamento estiver em status SUCCESS."
+    ),
+)
+def export_sped_erp(
+    run_id: UUID,
+    format: Literal["totvs", "sap", "omie", "linx", "generic"] = Query(
+        default="generic",
+        description="Formato de exportação: totvs | sap | omie | linx | generic",
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    from app.services.erp_export import generate as erp_generate
+
+    row = db.execute(
+        text("""
+            SELECT j.result, sr.created_at
+            FROM sped_ingestion_runs sr
+            JOIN jobs j ON j.id = sr.job_id
+            WHERE sr.id = CAST(:id AS uuid) AND sr.tenant_id = CAST(:tid AS uuid)
+              AND sr.status = 'SUCCESS'
+        """),
+        {"id": str(run_id), "tid": str(current_user.tenant_id)},
+    ).fetchone()
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Resultado não disponível. Aguarde o processamento ou verifique o status.",
+        )
+
+    result = row[0] if isinstance(row[0], dict) else json.loads(row[0])
+    produtos = result.get("produtos", [])
+    data_validacao = row[1].date().isoformat() if row[1] else None
+
+    content, content_type, suffix = erp_generate(produtos, format, data_validacao)  # type: ignore[arg-type]
+    filename = f"tribultz_sped_{str(run_id)[:8]}_{suffix}"
+
+    return Response(
+        content=content,
+        media_type=content_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/app/services/erp_export.py
+++ b/backend/app/services/erp_export.py
@@ -1,0 +1,107 @@
+"""ERP Export Service — gera CSV/TXT por ERP a partir do catálogo SPED validado.
+
+Formatos suportados:
+  totvs   — CSV `;` latin-1  (TOTVS Protheus)
+  sap     — CSV `,` UTF-8   (SAP Business One)
+  omie    — CSV `,` UTF-8   (Omie)
+  linx    — TXT posicional  latin-1  (Linx)
+  generic — CSV `;` UTF-8   (genérico ERP)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date
+from typing import Literal
+
+ErpFormat = Literal["totvs", "sap", "omie", "linx", "generic"]
+
+_TOTVS_HEADERS = [
+    "CODIGOPROD", "DESCRICAO", "NCM", "CEST", "CLASSTRIB",
+    "CSTCBS", "CSTIBS", "ALIQCBS", "ALIQIBS",
+    "STATUS", "SEVERIDADE", "DTVALIDACAO",
+]
+_SAP_HEADERS = [
+    "ItemCode", "ItemName", "NCMCode", "CESTCode", "ClassTrib",
+    "CSTCBS", "CSTIBS", "CBSRate", "IBSRate",
+    "ValidationStatus", "FindingSeverity", "ValidationDate",
+]
+_OMIE_HEADERS = [
+    "codigo", "descricao", "ncm", "cest", "cClassTrib",
+    "cst_cbs", "cst_ibs", "aliquota_cbs", "aliquota_ibs",
+    "status_validacao", "severidade", "data_validacao",
+]
+
+# Widths for Linx positional format (total = 131 chars per line)
+_LINX_FIELDS: list[tuple[str, int]] = [
+    ("codigo_produto",   20),
+    ("descricao",        60),
+    ("ncm",               8),
+    ("cest",              7),
+    ("aliquota_cbs",      8),
+    ("aliquota_ibs",      8),
+    ("status_validacao", 10),
+    ("data_validacao",   10),
+]
+
+
+def _normalize(p: dict, today: str) -> dict:
+    flags = p.get("flags", [])
+    return {
+        "codigo_produto":    p.get("cod_item", ""),
+        "descricao":         p.get("descr", ""),
+        "ncm":               p.get("ncm", ""),
+        "cest":              p.get("cest", ""),
+        "cClassTrib":        p.get("cClassTrib", ""),
+        "cst_cbs":           p.get("cst_cbs", ""),
+        "cst_ibs":           p.get("cst_ibs", ""),
+        "aliquota_cbs":      p.get("cbs_rate", ""),
+        "aliquota_ibs":      p.get("ibs_rate", ""),
+        "status_validacao":  p.get("status", ""),
+        "finding_severity":  "ERROR" if flags else "OK",
+        "data_validacao":    today,
+    }
+
+
+def _csv_bytes(rows: list[dict], delimiter: str, headers: list[str], encoding: str) -> bytes:
+    keys = [
+        "codigo_produto", "descricao", "ncm", "cest", "cClassTrib",
+        "cst_cbs", "cst_ibs", "aliquota_cbs", "aliquota_ibs",
+        "status_validacao", "finding_severity", "data_validacao",
+    ]
+    buf = io.StringIO()
+    buf.write(delimiter.join(headers) + "\r\n")
+    writer = csv.DictWriter(buf, fieldnames=keys, delimiter=delimiter, extrasaction="ignore")
+    for row in rows:
+        writer.writerow(row)
+    return buf.getvalue().encode(encoding, errors="replace")
+
+
+def _linx_bytes(rows: list[dict], encoding: str) -> bytes:
+    lines: list[str] = []
+    for r in rows:
+        line = "".join(r.get(field, "").ljust(width)[:width] for field, width in _LINX_FIELDS)
+        lines.append(line)
+    return "\r\n".join(lines).encode(encoding, errors="replace")
+
+
+def generate(
+    produtos: list[dict],
+    fmt: ErpFormat,
+    data_validacao: str | None = None,
+) -> tuple[bytes, str, str]:
+    """Return ``(content_bytes, content_type, filename_suffix)``."""
+    today = data_validacao or date.today().isoformat()
+    rows = [_normalize(p, today) for p in produtos]
+
+    if fmt == "totvs":
+        return _csv_bytes(rows, ";", _TOTVS_HEADERS, "latin-1"), "text/csv; charset=iso-8859-1", "totvs.csv"
+    if fmt == "sap":
+        return _csv_bytes(rows, ",", _SAP_HEADERS, "utf-8"), "text/csv; charset=utf-8", "sap.csv"
+    if fmt == "omie":
+        return _csv_bytes(rows, ",", _OMIE_HEADERS, "utf-8"), "text/csv; charset=utf-8", "omie.csv"
+    if fmt == "linx":
+        return _linx_bytes(rows, "latin-1"), "text/plain; charset=iso-8859-1", "linx.txt"
+    # generic
+    return _csv_bytes(rows, ";", _TOTVS_HEADERS, "utf-8"), "text/csv; charset=utf-8", "generico.csv"

--- a/backend/app/tools/hubspot_tool.py
+++ b/backend/app/tools/hubspot_tool.py
@@ -1,6 +1,7 @@
 """HubSpotTool – CRM integration (MVP). All calls gated by HUBSPOT_ENABLED."""
 
 import logging
+import time
 from typing import Any, Optional
 
 import httpx
@@ -163,7 +164,7 @@ def log_note(
     payload = {
         "properties": {
             "hs_note_body": body,
-            "hs_timestamp": str(int(__import__("time").time() * 1000)),
+            "hs_timestamp": str(int(time.time() * 1000)),
         },
         "associations": [
             {

--- a/crews/tribultz_chatops/tools/GetJobStatusTool.py
+++ b/crews/tribultz_chatops/tools/GetJobStatusTool.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-# MVP tool skeleton. Must return a string.
+# Stub — chatops crew not active in production (chat feature deactivated post-S22).
+# Integrate with jobs table (app.models.jobs.Job) if crew is re-enabled.
 
 def run_get_job_status(*, tenant_id: str, user_id: str, job_id: str) -> str:
+    """Return job status/result string for a given job_id scoped to tenant.
+
+    Not implemented: chatops crew is inactive. Raises on all calls.
     """
-    TODO: integrate with your internal Jobs/Audit system.
-    Return status/result string.
-    """
-    raise NotImplementedError
+    raise NotImplementedError("Chatops crew inactive — query jobs table with tenant_id guard to enable.")

--- a/crews/tribultz_chatops/tools/TriggerTaskATool.py
+++ b/crews/tribultz_chatops/tools/TriggerTaskATool.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-# MVP tool skeleton. Must return a string.
-# In CrewAI, prefer using: from crewai_tools import tool
+# Stub — chatops crew not active in production (chat feature deactivated post-S22).
+# Integrate with Celery task_a_validate if crew is re-enabled.
 
 from uuid import uuid4
 
 def run_trigger_task_a(*, tenant_id: str, user_id: str, message: str, dry_run: bool = False) -> str:
-    """
-    TODO: integrate with your internal Task A trigger.
-    Return job_id as string.
+    """Trigger Task A validation job for a tenant.
+
+    Not implemented: chatops crew is inactive. Raises on non-dry-run calls.
     """
     if dry_run:
         return str(uuid4())
-    raise NotImplementedError("Integrate with real Task A trigger and return job_id.")
+    raise NotImplementedError("Chatops crew inactive — wire to task_a_validate Celery task to enable.")

--- a/frontend/src/app/validate-sped/page.tsx
+++ b/frontend/src/app/validate-sped/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
-import { getSpedCsv, getSpedRun, SpedRunResponse, uploadSped } from "@/lib/api";
+import { ErpFormat, getSpedCsv, getSpedErpExport, getSpedRun, SpedRunResponse, uploadSped } from "@/lib/api";
 
 type UploadState = "idle" | "uploading" | "polling" | "done" | "error";
 
@@ -36,8 +36,19 @@ export default function ValidateSpedPage() {
   const [run, setRun] = useState<SpedRunResponse | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [erpOpen, setErpOpen] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const erpRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!erpOpen) return;
+    function close(e: MouseEvent) {
+      if (erpRef.current && !erpRef.current.contains(e.target as Node)) setErpOpen(false);
+    }
+    document.addEventListener("mousedown", close);
+    return () => document.removeEventListener("mousedown", close);
+  }, [erpOpen]);
 
   const stopPolling = useCallback(() => {
     if (pollRef.current) {
@@ -110,6 +121,32 @@ export default function ValidateSpedPage() {
       URL.revokeObjectURL(url);
     } catch {
       setError("Não foi possível baixar o CSV.");
+    }
+  }
+
+  const ERP_OPTIONS: { value: ErpFormat; label: string }[] = [
+    { value: "totvs",   label: "TOTVS Protheus" },
+    { value: "sap",     label: "SAP Business One" },
+    { value: "omie",    label: "Omie" },
+    { value: "linx",    label: "Linx" },
+    { value: "generic", label: "Genérico (CSV)" },
+  ];
+
+  async function downloadErp(fmt: ErpFormat) {
+    if (!run) return;
+    setErpOpen(false);
+    try {
+      const blob = await getSpedErpExport(run.id, fmt);
+      const opt = ERP_OPTIONS.find((o) => o.value === fmt);
+      const ext = fmt === "linx" ? "txt" : "csv";
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `tribultz_sped_${run.id.slice(0, 8)}_${fmt}.${ext}`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError("Não foi possível exportar para o ERP selecionado.");
     }
   }
 
@@ -206,16 +243,45 @@ export default function ValidateSpedPage() {
             </div>
           )}
 
-          {/* CSV download */}
+          {/* Export buttons */}
           {state === "done" && run.status === "SUCCESS" && (
-            <div className="flex justify-end">
+            <div className="flex items-center justify-end gap-3">
               <button
                 type="button"
                 onClick={downloadCsv}
-                className="rounded-lg bg-tribultz-600 px-4 py-2 text-sm font-semibold text-white hover:bg-tribultz-700 transition-colors"
+                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 transition-colors"
               >
-                Baixar CSV ERP-ready
+                CSV Genérico
               </button>
+
+              {/* ERP dropdown */}
+              <div ref={erpRef} className="relative">
+                <button
+                  type="button"
+                  onClick={() => setErpOpen((o) => !o)}
+                  className="flex items-center gap-1.5 rounded-lg bg-tribultz-600 px-4 py-2 text-sm font-semibold text-white hover:bg-tribultz-700 transition-colors"
+                >
+                  Exportar para ERP
+                  <svg className={`h-4 w-4 transition-transform ${erpOpen ? "rotate-180" : ""}`} viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+                  </svg>
+                </button>
+
+                {erpOpen && (
+                  <div className="absolute right-0 z-10 mt-1 w-48 rounded-xl border border-slate-200 bg-white py-1 shadow-lg">
+                    {ERP_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => downloadErp(opt.value)}
+                        className="w-full px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 transition-colors"
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -506,6 +506,19 @@ export async function getSpedCsv(runId: string): Promise<string> {
   return res.text();
 }
 
+export type ErpFormat = "totvs" | "sap" | "omie" | "linx" | "generic";
+
+export async function getSpedErpExport(runId: string, format: ErpFormat): Promise<Blob> {
+  const token = getToken();
+  const tenant = getTenantId();
+  const res = await fetch(
+    `${API_BASE}/api/v1/sped/${encodeURIComponent(runId)}/export/erp?format=${format}`,
+    { headers: { Authorization: `Bearer ${token}`, "X-Tenant-Id": tenant }, cache: "no-store" },
+  );
+  if (!res.ok) throw new Error(`API ${res.status}`);
+  return res.blob();
+}
+
 // ── Compliance ─────────────────────────────────────────────────────────────────
 
 export type ComplianceScore = {


### PR DESCRIPTION
## Resumo

### S19 — Debt técnico

**#163 DMARC p=none → p=quarantine**
- `infra/cloudflare/main.tf`: política evoluída após 6 semanas de monitoramento sem falsos positivos
- ⚠️ Requer `cd infra/cloudflare && terraform apply` após merge

**#223 datetime.utcnow() deprecated**
- `app/crews/memory_system.py`: 2 ocorrências → `datetime.now(UTC)` (Python 3.12+)

**#225 jobs.py UPDATE via ORM**
- `update_job`: f-string SQL → `sa_update(Job).where().values().returning()`; imports movidos ao topo

**#226 __import__() inline removido**
- `audit.py` e `hubspot_tool.py`: `__import__()` → imports normais no topo

**#227 TODOs CrewAI chatops**
- `TriggerTaskATool` e `GetJobStatusTool`: TODOs → documentação de stub inativo

---

### S20 — Feature

**#173 ERP Export Formats**
- `erp_export.py`: serviço com 5 formatos (TOTVS latin-1, SAP UTF-8, Omie UTF-8, Linx posicional latin-1, Genérico UTF-8)
- `sped.py`: `GET /api/v1/sped/{run_id}/export/erp?format=...`
- `validate-sped/page.tsx`: dropdown "Exportar para ERP" com 5 opções

---

### SEO

- `page.tsx`: metadata explícito — title, description, keywords CBS/IBS/LC214, OG tags, canonical
- `layout.tsx`: JSON-LD schema.org (`Organization` + `SoftwareApplication`) para rich snippets
- `sitemap.ts`: `/validate-sped` (0.7) e `/compliance` (0.6) adicionados
- `changelog/page.tsx`: metadata com keywords fiscais e OG tag

## Checklist

- [x] Pyright: 0 erros
- [x] Frontend build: `✓ Compiled successfully`
- [x] JSON-LD validado no DOM (`Organization` + `SoftwareApplication`)
- [x] Homepage: title, description, keywords, canonical e ogTitle corretos
- [x] `__import__` e `utcnow()`: 0 ocorrências em `backend/app/`

## Closes

Closes #163, #223, #225, #226, #227, #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)