### PR TITLE
feat(s20): API pública pay-per-call — classify NCM + CBS/IBS via X-API-Key (#175)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -7,7 +7,7 @@ from alembic import context
 
 from app.database import Base
 from app.config import settings
-from app.models import auth, billing, documents, feedback, jobs, news, reports  # noqa: F401
+from app.models import api_key, auth, billing, documents, feedback, jobs, news, reports  # noqa: F401
 
 # Import models to register them with metadata
 

--- a/backend/app/alembic/versions/2026_05_17_0016_add_api_keys.py
+++ b/backend/app/alembic/versions/2026_05_17_0016_add_api_keys.py
@@ -1,0 +1,44 @@
+"""Add api_keys table.
+
+API Keys para acesso à API pública pay-per-call (issue #175).
+100 créditos grátis na criação. Compra adicional via Asaas (fase 2).
+
+Revision ID: 2026_05_17_0016
+Revises: 2026_05_01_0015
+Create Date: 2026-05-17
+"""
+
+from alembic import op
+
+revision = "2026_05_17_0016"
+down_revision = "2026_05_01_0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS api_keys (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id       UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            name            TEXT NOT NULL,
+            key_hash        TEXT NOT NULL UNIQUE,
+            key_prefix      TEXT NOT NULL,
+            credits_balance INTEGER NOT NULL DEFAULT 100,
+            is_active       BOOLEAN NOT NULL DEFAULT TRUE,
+            last_used_at    TIMESTAMPTZ,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_user    ON api_keys(user_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_tenant  ON api_keys(tenant_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_hash    ON api_keys(key_hash) WHERE is_active = TRUE")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_api_keys_hash")
+    op.execute("DROP INDEX IF EXISTS idx_api_keys_tenant")
+    op.execute("DROP INDEX IF EXISTS idx_api_keys_user")
+    op.execute("DROP TABLE IF EXISTS api_keys")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.core.logging import configure_logging
-from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, documents, exceptions, feedback, health, jobs, lgpd, news, public, reports, sped, support, tasks, validate, validate_xml, validation
+from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, documents, exceptions, feedback, health, jobs, lgpd, news, public, public_api, reports, sped, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry
 
 configure_logging()
@@ -63,7 +63,7 @@ app.add_middleware(
     allow_origin_regex=origin_regex,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-Tenant-Id", "X-Transaction-Id"],
+    allow_headers=["Authorization", "Content-Type", "X-Tenant-Id", "X-Transaction-Id", "X-API-Key"],
 )
 
 # ── Routers ───────────────────────────────────────────────────
@@ -81,6 +81,7 @@ app.include_router(lgpd.router)
 app.include_router(billing.router)
 app.include_router(validate_xml.router)
 app.include_router(public.router)
+app.include_router(public_api.router)
 app.include_router(calculadora.router)
 app.include_router(reports.router)
 app.include_router(news.router)

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -1,0 +1,23 @@
+"""ApiKey model — autenticação para a API pública pay-per-call (#175)."""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    name = Column(Text, nullable=False)
+    key_hash = Column(Text, nullable=False, unique=True)
+    key_prefix = Column(Text, nullable=False)
+    credits_balance = Column(Integer, nullable=False, default=100)
+    is_active = Column(Boolean, nullable=False, default=True)
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())

--- a/backend/app/routers/public_api.py
+++ b/backend/app/routers/public_api.py
@@ -11,7 +11,7 @@ import hashlib
 import secrets
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
-from typing import Optional
+from typing import Optional, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel, field_validator
@@ -132,7 +132,7 @@ def _resolve_api_key(x_api_key: str = Header(..., alias="X-API-Key"), db: Sessio
     ).scalar_one_or_none()
     if not api_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="X-API-Key inválida ou revogada.")
-    if api_key.credits_balance <= 0:
+    if cast(int, api_key.credits_balance) <= 0:
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
             detail="Créditos esgotados. Adquira mais em tribultz.com.br/settings/api.",
@@ -175,7 +175,7 @@ def classify(
     )
 
     # 3. Debitar 1 crédito e registrar last_used_at
-    new_balance = api_key.credits_balance - 1
+    new_balance = cast(int, api_key.credits_balance) - 1
     db.execute(
         update(ApiKey)
         .where(ApiKey.id == api_key.id)
@@ -217,18 +217,19 @@ def list_api_keys(
         .where(ApiKey.user_id == current_user.id)
         .order_by(ApiKey.created_at.desc())
     ).scalars().all()
-    return [
-        ApiKeyOut(
+    out: list[ApiKeyOut] = []
+    for k in rows:
+        lua = cast(Optional[datetime], k.last_used_at)
+        out.append(ApiKeyOut(
             id=str(k.id),
             name=str(k.name),
             key_prefix=str(k.key_prefix),
-            credits_balance=int(k.credits_balance),
-            is_active=bool(k.is_active),
-            last_used_at=k.last_used_at.isoformat() if k.last_used_at else None,
-            created_at=k.created_at.isoformat(),
-        )
-        for k in rows
-    ]
+            credits_balance=cast(int, k.credits_balance),
+            is_active=cast(bool, k.is_active),
+            last_used_at=lua.isoformat() if lua is not None else None,
+            created_at=cast(datetime, k.created_at).isoformat(),
+        ))
+    return out
 
 
 @router.post(

--- a/backend/app/routers/public_api.py
+++ b/backend/app/routers/public_api.py
@@ -1,0 +1,296 @@
+"""API Pública pay-per-call — classificação NCM + cálculo CBS/IBS (#175).
+
+Autenticação via header X-API-Key (não Bearer JWT).
+1 crédito por chamada a POST /classify.
+Gestão de keys em GET/POST/DELETE /api-keys (Bearer JWT).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from app.api.deps import get_current_user
+from app.data.ncm_codes import is_valid_ncm
+from app.data.uf_rates import VALID_UF_CODES
+from app.database import get_db
+from app.models.api_key import ApiKey
+from app.models.auth import User
+from app.services.tax_rate_resolver import calculate_full
+
+router = APIRouter(tags=["public-api"])
+
+_KEY_PREFIX = "tribultz_sk_"
+_FREE_CREDITS = 100
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+class ClassifyRequest(BaseModel):
+    ncm: str
+    uf_destino: str
+    base_value: str
+    cst: str = "000"
+
+    @field_validator("ncm")
+    @classmethod
+    def validate_ncm(cls, v: str) -> str:
+        v = v.strip().replace(".", "").replace("-", "")
+        if not is_valid_ncm(v):
+            raise ValueError(f"NCM inválido: {v}")
+        return v
+
+    @field_validator("uf_destino")
+    @classmethod
+    def validate_uf(cls, v: str) -> str:
+        v = v.upper().strip()
+        if v not in VALID_UF_CODES:
+            raise ValueError(f"UF inválida: {v}")
+        return v
+
+    @field_validator("base_value")
+    @classmethod
+    def validate_base_value(cls, v: str) -> str:
+        try:
+            val = Decimal(v.replace(",", "."))
+            if val <= 0:
+                raise ValueError
+        except (InvalidOperation, ValueError):
+            raise ValueError("base_value deve ser um número positivo (ex: '150.00')")
+        return v
+
+    @field_validator("cst")
+    @classmethod
+    def validate_cst(cls, v: str) -> str:
+        v = v.strip().zfill(3)
+        if len(v) != 3 or not v.isdigit():
+            raise ValueError("cst deve ter 3 dígitos (ex: '000')")
+        return v
+
+
+class ClassifyResponse(BaseModel):
+    ncm: str
+    cClassTrib: Optional[str]
+    cest: None = None
+    cst: str
+    vBC: str
+    vCBS: str
+    vIBS: str
+    total_tributos: str
+    aliquota_efetiva_pct: str
+    xml_snippet: str
+    credits_used: int
+    credits_remaining: int
+
+
+class ApiKeyOut(BaseModel):
+    id: str
+    name: str
+    key_prefix: str
+    credits_balance: int
+    is_active: bool
+    last_used_at: Optional[str]
+    created_at: str
+
+
+class ApiKeyCreateRequest(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v or len(v) > 80:
+            raise ValueError("name é obrigatório e deve ter até 80 caracteres")
+        return v
+
+
+class ApiKeyCreateResponse(BaseModel):
+    id: str
+    name: str
+    key: str
+    key_prefix: str
+    credits_balance: int
+    message: str
+
+
+# ── Auth por X-API-Key ────────────────────────────────────────────────────────
+
+def _resolve_api_key(x_api_key: str = Header(..., alias="X-API-Key"), db: Session = Depends(get_db)) -> ApiKey:
+    key_hash = hashlib.sha256(x_api_key.encode()).hexdigest()
+    api_key: ApiKey | None = db.execute(
+        select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.is_active.is_(True))
+    ).scalar_one_or_none()
+    if not api_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="X-API-Key inválida ou revogada.")
+    if api_key.credits_balance <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail="Créditos esgotados. Adquira mais em tribultz.com.br/settings/api.",
+            headers={"X-Credits-Remaining": "0"},
+        )
+    return api_key
+
+
+# ── Endpoints públicos (X-API-Key) ────────────────────────────────────────────
+
+@router.post(
+    "/api/v1/public-api/classify",
+    response_model=ClassifyResponse,
+    summary="Classificar NCM → cClassTrib + CBS/IBS (pay-per-call)",
+)
+def classify(
+    payload: ClassifyRequest,
+    api_key: ApiKey = Depends(_resolve_api_key),
+    db: Session = Depends(get_db),
+) -> ClassifyResponse:
+    # 1. Buscar cClassTrib pelo capítulo NCM (2 primeiros dígitos)
+    ncm_prefix = payload.ncm[:2]
+    row = db.execute(
+        text("""
+            SELECT codigo FROM cclass_trib_items
+            WHERE codigo LIKE :prefix AND is_active = TRUE
+            ORDER BY codigo
+            LIMIT 1
+        """),
+        {"prefix": f"{ncm_prefix}.%"},
+    ).mappings().fetchone()
+    classtrib_codigo: str | None = dict(row)["codigo"] if row else None
+
+    # 2. Calcular CBS/IBS
+    result = calculate_full(
+        vBC=Decimal(payload.base_value.replace(",", ".")),
+        ncm=payload.ncm,
+        uf=payload.uf_destino,
+        cst=payload.cst,
+    )
+
+    # 3. Debitar 1 crédito e registrar last_used_at
+    new_balance = api_key.credits_balance - 1
+    db.execute(
+        update(ApiKey)
+        .where(ApiKey.id == api_key.id)
+        .values(
+            credits_balance=new_balance,
+            last_used_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+
+    return ClassifyResponse(
+        ncm=payload.ncm,
+        cClassTrib=classtrib_codigo,
+        cst=result.cst,
+        vBC=str(result.vBC),
+        vCBS=str(result.vCBS),
+        vIBS=str(result.vIBS),
+        total_tributos=str(result.total_tributos),
+        aliquota_efetiva_pct=str((result.aliquota_efetiva * 100).quantize(Decimal("0.01"))),
+        xml_snippet=result.xml_snippet,
+        credits_used=1,
+        credits_remaining=new_balance,
+    )
+
+
+# ── Gestão de API Keys (Bearer JWT) ──────────────────────────────────────────
+
+@router.get(
+    "/api/v1/api-keys",
+    response_model=list[ApiKeyOut],
+    summary="Listar API Keys do usuário autenticado",
+)
+def list_api_keys(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[ApiKeyOut]:
+    rows = db.execute(
+        select(ApiKey)
+        .where(ApiKey.user_id == current_user.id)
+        .order_by(ApiKey.created_at.desc())
+    ).scalars().all()
+    return [
+        ApiKeyOut(
+            id=str(k.id),
+            name=str(k.name),
+            key_prefix=str(k.key_prefix),
+            credits_balance=int(k.credits_balance),
+            is_active=bool(k.is_active),
+            last_used_at=k.last_used_at.isoformat() if k.last_used_at else None,
+            created_at=k.created_at.isoformat(),
+        )
+        for k in rows
+    ]
+
+
+@router.post(
+    "/api/v1/api-keys",
+    response_model=ApiKeyCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Criar nova API Key (100 créditos grátis)",
+)
+def create_api_key(
+    payload: ApiKeyCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ApiKeyCreateResponse:
+    existing = db.execute(
+        select(ApiKey).where(ApiKey.user_id == current_user.id, ApiKey.is_active.is_(True))
+    ).scalars().all()
+    if len(existing) >= 5:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Limite de 5 API Keys ativas atingido. Revogue uma antes de criar outra.",
+        )
+
+    raw_key = _KEY_PREFIX + secrets.token_hex(24)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    key_prefix = raw_key[:20] + "..."
+
+    api_key = ApiKey(
+        tenant_id=current_user.tenant_id,
+        user_id=current_user.id,
+        name=payload.name,
+        key_hash=key_hash,
+        key_prefix=key_prefix,
+        credits_balance=_FREE_CREDITS,
+    )
+    db.add(api_key)
+    db.commit()
+    db.refresh(api_key)
+
+    return ApiKeyCreateResponse(
+        id=str(api_key.id),
+        name=str(api_key.name),
+        key=raw_key,
+        key_prefix=key_prefix,
+        credits_balance=_FREE_CREDITS,
+        message="Guarde esta chave agora — ela não será exibida novamente.",
+    )
+
+
+@router.delete(
+    "/api/v1/api-keys/{key_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revogar API Key",
+)
+def revoke_api_key(
+    key_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    api_key: ApiKey | None = db.execute(
+        select(ApiKey).where(ApiKey.id == key_id, ApiKey.user_id == current_user.id)
+    ).scalar_one_or_none()
+    if not api_key:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API Key não encontrada.")
+    db.execute(update(ApiKey).where(ApiKey.id == api_key.id).values(is_active=False))
+    db.commit()

--- a/frontend/src/app/settings/api/page.tsx
+++ b/frontend/src/app/settings/api/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Toast } from "@/components/common/Toast";
+import { API_BASE } from "@/lib/api";
+import { getToken, getTenantId } from "@/lib/storage";
+
+interface ApiKey {
+  id: string;
+  name: string;
+  key_prefix: string;
+  credits_balance: number;
+  is_active: boolean;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+function authHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${getToken()}`,
+    "X-Tenant-Id": getTenantId(),
+  };
+}
+
+export default function ApiSettingsPage() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [newName, setNewName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [revealedKey, setRevealedKey] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ tone: "success" | "error" | "info"; message: string } | null>(null);
+
+  const showToast = (tone: "success" | "error" | "info", message: string) => {
+    setToast({ tone, message });
+    setTimeout(() => setToast(null), 4000);
+  };
+
+  async function loadKeys() {
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/api-keys`, { headers: authHeaders() });
+      if (!res.ok) throw new Error(await res.text());
+      setKeys(await res.json());
+    } catch {
+      showToast("error", "Erro ao carregar API Keys.");
+    }
+  }
+
+  useEffect(() => { loadKeys(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function createKey() {
+    if (!newName.trim()) { showToast("error", "Informe um nome para a chave."); return; }
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/api-keys`, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ name: newName.trim() }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail ?? "Erro ao criar chave.");
+      }
+      const data = await res.json();
+      setRevealedKey(data.key);
+      setNewName("");
+      await loadKeys();
+      showToast("success", "API Key criada! Copie a chave agora — ela não será exibida novamente.");
+    } catch (e: unknown) {
+      showToast("error", e instanceof Error ? e.message : "Erro ao criar chave.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function revokeKey(id: string) {
+    if (!confirm("Revogar esta API Key? Integrações que a usam pararão de funcionar.")) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/api-keys/${id}`, {
+        method: "DELETE",
+        headers: authHeaders(),
+      });
+      if (!res.ok) throw new Error();
+      setRevealedKey(null);
+      await loadKeys();
+      showToast("success", "API Key revogada.");
+    } catch {
+      showToast("error", "Erro ao revogar chave.");
+    }
+  }
+
+  async function copyKey(text: string) {
+    await navigator.clipboard.writeText(text);
+    showToast("info", "Chave copiada para a área de transferência.");
+  }
+
+  return (
+    <section className="space-y-6">
+      {toast && <Toast tone={toast.tone} message={toast.message} onClose={() => setToast(null)} />}
+
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">API Keys</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          Autentique integrações ERP e sistemas externos com a API pay-per-call.
+          Cada chamada a <code className="bg-slate-100 px-1 rounded text-xs">/classify</code> consome 1 crédito.
+        </p>
+      </header>
+
+      {/* Nova key */}
+      <section className="rounded-xl border border-slate-200 bg-white p-5">
+        <h2 className="text-base font-semibold text-slate-800 mb-3">Criar nova API Key</h2>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && createKey()}
+            placeholder="Ex: ERP Producao, TOTVS Homologação"
+            className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            maxLength={80}
+          />
+          <button
+            type="button"
+            onClick={createKey}
+            disabled={loading}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? "Criando…" : "Criar Key"}
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-slate-400">
+          100 créditos grátis na criação. Limite de 5 keys ativas por conta.
+        </p>
+      </section>
+
+      {/* Chave recém-criada */}
+      {revealedKey && (
+        <section className="rounded-xl border border-amber-300 bg-amber-50 p-5">
+          <p className="text-sm font-semibold text-amber-800 mb-2">
+            ⚠️ Copie agora — esta chave não será exibida novamente.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 rounded bg-white border border-amber-200 px-3 py-2 text-xs font-mono break-all text-slate-700">
+              {revealedKey}
+            </code>
+            <button
+              type="button"
+              onClick={() => copyKey(revealedKey)}
+              className="shrink-0 rounded-lg border border-amber-300 bg-white px-3 py-2 text-xs font-medium text-amber-800 hover:bg-amber-100"
+            >
+              Copiar
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* Lista de keys */}
+      <section className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+        <div className="px-5 py-3 border-b border-slate-100">
+          <h2 className="text-base font-semibold text-slate-800">Suas API Keys</h2>
+        </div>
+        {keys.length === 0 ? (
+          <p className="px-5 py-8 text-center text-sm text-slate-400">
+            Nenhuma API Key criada ainda.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 text-xs text-slate-500 text-left">
+                <th className="px-5 py-3 font-medium">Nome</th>
+                <th className="px-5 py-3 font-medium">Prefixo</th>
+                <th className="px-5 py-3 font-medium">Créditos</th>
+                <th className="px-5 py-3 font-medium">Último uso</th>
+                <th className="px-5 py-3 font-medium">Status</th>
+                <th className="px-5 py-3 font-medium"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-50">
+              {keys.map((k) => (
+                <tr key={k.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-5 py-3 font-medium text-slate-800">{k.name}</td>
+                  <td className="px-5 py-3 font-mono text-xs text-slate-500">{k.key_prefix}</td>
+                  <td className="px-5 py-3">
+                    <span className={`font-semibold ${k.credits_balance === 0 ? "text-red-600" : k.credits_balance < 20 ? "text-amber-600" : "text-green-700"}`}>
+                      {k.credits_balance.toLocaleString("pt-BR")}
+                    </span>
+                  </td>
+                  <td className="px-5 py-3 text-xs text-slate-400">
+                    {k.last_used_at
+                      ? new Date(k.last_used_at).toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" })
+                      : "Nunca usado"}
+                  </td>
+                  <td className="px-5 py-3">
+                    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${k.is_active ? "bg-green-100 text-green-700" : "bg-slate-100 text-slate-500"}`}>
+                      {k.is_active ? "Ativa" : "Revogada"}
+                    </span>
+                  </td>
+                  <td className="px-5 py-3 text-right">
+                    {k.is_active && (
+                      <button
+                        type="button"
+                        onClick={() => revokeKey(k.id)}
+                        className="text-xs text-red-500 hover:text-red-700 font-medium"
+                      >
+                        Revogar
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {/* Documentação rápida */}
+      <section className="rounded-xl border border-slate-200 bg-white p-5 space-y-4">
+        <h2 className="text-base font-semibold text-slate-800">Como usar</h2>
+        <div>
+          <p className="text-xs font-medium text-slate-500 mb-1">POST /api/v1/public-api/classify</p>
+          <pre className="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto">{`curl -X POST https://api.tribultz.com.br/api/v1/public-api/classify \\
+  -H "X-API-Key: tribultz_sk_..." \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "ncm": "02013000",
+    "uf_destino": "SP",
+    "base_value": "150.00",
+    "cst": "000"
+  }'`}</pre>
+        </div>
+        <div>
+          <p className="text-xs font-medium text-slate-500 mb-1">Resposta</p>
+          <pre className="rounded-lg bg-slate-900 text-slate-100 text-xs p-4 overflow-x-auto">{`{
+  "ncm": "02013000",
+  "cClassTrib": "02.001.00",
+  "cst": "000",
+  "vBC": "150.00",
+  "vCBS": "13.20",
+  "vIBS": "26.55",
+  "total_tributos": "39.75",
+  "aliquota_efetiva_pct": "26.50",
+  "xml_snippet": "<IBSCBS>...</IBSCBS>",
+  "credits_used": 1,
+  "credits_remaining": 99
+}`}</pre>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -41,6 +41,21 @@ export default function SettingsPage() {
       </section>
 
       <section className="rounded-xl border border-slate-200 bg-white p-4">
+        <h2 className="text-lg font-semibold text-slate-900">API Keys</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Integre ERPs e sistemas externos via API pay-per-call.
+        </p>
+        <div className="mt-3">
+          <Link
+            href="/settings/api"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Gerenciar API Keys
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-slate-200 bg-white p-4">
         <h2 className="text-lg font-semibold text-slate-900">Meus Dados (LGPD)</h2>
         <p className="mt-1 text-sm text-slate-500">
           Seus direitos conforme a Lei Geral de Proteção de Dados (Lei 13.709/2018).


### PR DESCRIPTION
## Summary

- **`POST /api/v1/public-api/classify`** — recebe NCM + UF + valor, retorna cClassTrib + CBS + IBS + XML snippet, debita 1 crédito por call (auth via `X-API-Key`)
- **`GET/POST/DELETE /api/v1/api-keys`** — gestão de keys autenticada por JWT (até 5 ativas, 100 créditos grátis na criação)
- **Migration 0016** — tabela `api_keys` com key_hash, prefix, credits_balance, índices
- **`/settings/api`** — página frontend para criar, listar e revogar keys com docs curl inline

## Arquitetura

- Auth separada do JWT: `X-API-Key` → SHA-256 hash → lookup `api_keys.key_hash`
- Reutiliza `tax_rate_resolver.calculate_full()` e lookup cClassTrib existente
- `X-API-Key` adicionado ao CORS `allow_headers`
- Crédito debitado atomicamente via `UPDATE` antes do commit

## Fora do escopo desta PR (fase 2)
- Compra de créditos via Asaas
- Dashboard de consumo com gráfico diário
- Classificação por descrição de produto (depende de #170 — NCM Auto-classify IA)
- SDKs Python/Node

## Test plan

- [ ] Backend: `pytest tests/ -q` — 439 passed ✅
- [ ] Frontend: `npm test --silent` — 58 passed ✅
- [ ] Build: `npm run build` — `/settings/api` gerada ✅
- [ ] Lint: `ruff check` — sem issues ✅
- [ ] Migration: rodar `alembic upgrade head` em staging antes de merge
- [ ] Testar `POST /classify` com X-API-Key válida e inválida no Swagger `/docs`
- [ ] Verificar 402 ao esgotar créditos

Closes #175