### PR TITLE
feat(s20): ERP export por job — TOTVS, SAP, Omie, Linx, Genérico (#173)

### DIFF
--- a/backend/app/routers/jobs.py
+++ b/backend/app/routers/jobs.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from sqlalchemy import func, text, update as sa_update
@@ -324,3 +324,41 @@ def get_job_report_pdf(
         },
     )
 
+
+@router.get(
+    "/{job_id}/export/erp",
+    summary="Exportar catálogo de produtos do job em formato ERP (TOTVS, SAP, Omie, Linx, Genérico)",
+)
+def export_job_erp(
+    job_id: str,
+    format: str = Query("generic", pattern="^(totvs|sap|omie|linx|generic)$"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _plan: User = Depends(require_plan("profissional", "empresarial", "contador")),
+) -> Response:
+    tenant_id = str(current_user.tenant_id)
+    row = db.execute(
+        text("SELECT * FROM jobs WHERE id = :id AND tenant_id = :tid"),
+        {"id": job_id, "tid": tenant_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Job não encontrado.")
+    if row.status != "SUCCESS":
+        raise HTTPException(status_code=400, detail=f"Job não concluído (status: {row.status}).")
+
+    result = row.result if isinstance(row.result, dict) else {}
+    produtos = result.get("produtos", [])
+    if not produtos:
+        raise HTTPException(
+            status_code=400,
+            detail="Este job não possui catálogo de produtos exportável. Apenas jobs SPED suportam export ERP.",
+        )
+
+    from app.services.erp_export import generate as erp_generate
+
+    content, content_type, suffix = erp_generate(produtos, format, result.get("periodo", {}).get("ini"))  # type: ignore[arg-type]
+    return Response(
+        content=content,
+        media_type=content_type,
+        headers={"Content-Disposition": f'attachment; filename="tribultz_erp_{job_id[:8]}_{suffix}"'},
+    )

--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -25,6 +25,7 @@ export default function JobsPage() {
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<{ tone: "success" | "error" | "info"; message: string } | null>(null);
   const [exportingByJobId, setExportingByJobId] = useState<Record<string, boolean>>({});
+  const [erpDropdownJobId, setErpDropdownJobId] = useState<string | null>(null);
 
   const [status, setStatus] = useState<JobStatus | "ALL">("ALL");
   const [period, setPeriod] = useState<PeriodFilter>("all");
@@ -53,6 +54,32 @@ export default function JobsPage() {
     const feedback = await exportEvidenceZipAndDownload(jobId);
     setToast(feedback);
     setExportingByJobId((prev) => ({ ...prev, [jobId]: false }));
+  }
+
+  async function handleErpExport(jobId: string, format: string): Promise<void> {
+    setErpDropdownJobId(null);
+    try {
+      const { getToken, getTenantId } = await import("@/lib/storage");
+      const { API_BASE } = await import("@/lib/api");
+      const res = await fetch(`${API_BASE}/api/v1/jobs/${jobId}/export/erp?format=${format}`, {
+        headers: { Authorization: `Bearer ${getToken()}`, "X-Tenant-Id": getTenantId() },
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: "Erro ao exportar." }));
+        setToast({ tone: "error", message: err.detail ?? "Erro ao exportar." });
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `tribultz_erp_${jobId.slice(0, 8)}_${format}.${format === "linx" ? "txt" : "csv"}`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setToast({ tone: "success", message: `Export ${format.toUpperCase()} iniciado.` });
+    } catch {
+      setToast({ tone: "error", message: "Erro ao gerar export ERP." });
+    }
   }
 
   return (
@@ -146,6 +173,34 @@ export default function JobsPage() {
                         >
                           {exportingByJobId[job.id] ? "Exportando…" : "Exportar evidências"}
                         </button>
+                        {job.status === "SUCCESS" && job.jobType === "sped_validation" && (
+                          <div className="relative">
+                            <button
+                              type="button"
+                              onClick={() => setErpDropdownJobId(erpDropdownJobId === job.id ? null : job.id)}
+                              className="rounded border border-blue-300 bg-blue-50 px-2 py-1 text-xs text-blue-700 hover:bg-blue-100"
+                            >
+                              Exportar ERP ▾
+                            </button>
+                            {erpDropdownJobId === job.id && (
+                              <div className="absolute left-0 top-full z-10 mt-1 w-36 rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+                                {(["totvs", "sap", "omie", "linx", "generic"] as const).map((fmt) => (
+                                  <button
+                                    key={fmt}
+                                    type="button"
+                                    onClick={() => void handleErpExport(job.id, fmt)}
+                                    className="block w-full px-4 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-50"
+                                  >
+                                    {fmt === "totvs" ? "TOTVS Protheus" :
+                                     fmt === "sap" ? "SAP Business One" :
+                                     fmt === "omie" ? "Omie" :
+                                     fmt === "linx" ? "Linx" : "Genérico CSV"}
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

- **`GET /api/v1/jobs/{job_id}/export/erp?format=totvs|sap|omie|linx|generic`** — export do catálogo de produtos de jobs SPED nos 5 formatos ERP (gated: Profissional+)
- **Frontend**: dropdown \"Exportar ERP ▾\" na tabela de Jobs — aparece apenas para jobs `sped_validation` com status `SUCCESS`; download direto no browser

## O que já existia (não alterado)
- `erp_export.py` — serviço completo com todos os 5 formatos
- `GET /api/v1/sped/{run_id}/export/erp` — export via SPED run ID

## O que esta PR adiciona
- Endpoint no jobs router para consumir `result.produtos` de qualquer job
- Botão dropdown no frontend com os 5 opções de formato

## Test plan

- [ ] Backend: `pytest tests/ -q` — 439 passed ✅
- [ ] Frontend: `npm test --silent` — 58 passed ✅  
- [ ] Build: `npm run build` — verde ✅
- [ ] Lint: `ruff check` — sem issues ✅
- [ ] Testar download TOTVS (`;` latin-1) e SAP (`,` UTF-8) em job SPED real
- [ ] Confirmar 400 para job sem `produtos` (ex: validate_xml job)
- [ ] Confirmar 403 para plano Trial/Starter

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)