### PR TITLE
feat(jobs): dual-regime comparison — ICMS/PIS/COFINS vs CBS/IBS (#257)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -82,6 +82,20 @@ class Evidence(BaseModel):
     snippet: str | None = None
 
 
+class RegimeComparison(BaseModel):
+    """Side-by-side old-regime vs. new-regime totals extracted from the XML."""
+    base_old: str | None = None      # vBC (ICMS base, ICMSTot block)
+    base_new: str | None = None      # vBC (CBS/IBS base, IBSCBS block)
+    icms: str | None = None          # vICMS
+    pis: str | None = None           # vPIS
+    cofins: str | None = None        # vCOFINS
+    cbs: str | None = None           # vCBS
+    ibs: str | None = None           # vIBS (total)
+    total_old: str | None = None     # icms + pis + cofins
+    total_new: str | None = None     # cbs + ibs
+    delta: str | None = None         # total_new - total_old
+
+
 class ValidationResult(BaseModel):
     job_id: str
     audit_id: str
@@ -91,6 +105,7 @@ class ValidationResult(BaseModel):
     fatals: int
     alerts: int
     created_at: str
+    regime_comparison: RegimeComparison | None = None
 
 
 # ── XML helpers ─────────────────────────────────────────────────────────────
@@ -131,6 +146,62 @@ def _xpath(tag: str, doc_type: str) -> str:
 
 def _fingerprint(xml: str) -> str:
     return hashlib.md5(xml.encode()).hexdigest()[:12]
+
+
+def _extract_regime_comparison(xml: str, has_ibscbs: bool) -> RegimeComparison | None:
+    """Extract old-regime (ICMS/PIS/COFINS) and new-regime (CBS/IBS) monetary totals."""
+    from decimal import Decimal, InvalidOperation
+
+    def _val(tag_result: dict[str, Any] | None) -> Decimal | None:
+        if not tag_result:
+            return None
+        try:
+            return Decimal(tag_result["value"].replace(",", "."))
+        except (InvalidOperation, KeyError):
+            return None
+
+    # Old regime — prefer ICMSTot block so we don't grab CBS/IBS vBC by mistake
+    icms_tot = _first_tag(xml, ["ICMSTot"])
+    icms_block = icms_tot["snippet"] if icms_tot else xml
+
+    base_old = _val(_first_tag(icms_block, ["vBC"]))
+    v_icms = _val(_first_tag(icms_block, ["vICMS"]))
+    v_pis = _val(_first_tag(icms_block, ["vPIS"]))
+    v_cofins = _val(_first_tag(icms_block, ["vCOFINS"]))
+
+    # New regime — IBSCBS block
+    ibscbs = _first_tag(xml, ["IBSCBS"])
+    ibscbs_src = ibscbs["snippet"] if ibscbs else xml
+    base_new = _val(_first_tag(ibscbs_src, ["vBC"])) if has_ibscbs else None
+    v_cbs = _val(_first_tag(ibscbs_src, ["vCBS"])) if has_ibscbs else _val(_first_tag(xml, ["ValorCBS"]))
+    v_ibs = _val(_first_tag(ibscbs_src, ["vIBS"])) if has_ibscbs else _val(_first_tag(xml, ["ValorIBS"]))
+
+    # Skip if no useful data
+    has_old = any(x is not None for x in [v_icms, v_pis, v_cofins])
+    has_new = any(x is not None for x in [v_cbs, v_ibs])
+    if not has_old and not has_new:
+        return None
+
+    zero = Decimal("0")
+    total_old = (v_icms or zero) + (v_pis or zero) + (v_cofins or zero)
+    total_new = (v_cbs or zero) + (v_ibs or zero)
+    delta = total_new - total_old
+
+    def _fmt(d: Decimal | None) -> str | None:
+        return str(d.quantize(Decimal("0.01"))) if d is not None else None
+
+    return RegimeComparison(
+        base_old=_fmt(base_old),
+        base_new=_fmt(base_new),
+        icms=_fmt(v_icms),
+        pis=_fmt(v_pis),
+        cofins=_fmt(v_cofins),
+        cbs=_fmt(v_cbs),
+        ibs=_fmt(v_ibs),
+        total_old=_fmt(total_old),
+        total_new=_fmt(total_new),
+        delta=_fmt(delta),
+    )
 
 
 # ── Validation engine ───────────────────────────────────────────────────────
@@ -394,6 +465,7 @@ def validate_xml(
 
     fatals = sum(1 for f in findings if f.severity == "FATAL")
     alerts = sum(1 for f in findings if f.severity == "ALERT")
+    regime_comparison = _extract_regime_comparison(xml, has_ibscbs)
 
     return ValidationResult(
         job_id=job_id,
@@ -404,6 +476,7 @@ def validate_xml(
         fatals=fatals,
         alerts=alerts,
         created_at=datetime.now(timezone.utc).isoformat(),
+        regime_comparison=regime_comparison,
     )
 
 
@@ -456,13 +529,21 @@ async def validate_xml_endpoint(
     # Persist job record — id explícito garante que result.job_id == row.id no banco
     try:
         sp = db.begin_nested()
+        job_result: dict[str, Any] = {
+            "fatals": result.fatals,
+            "alerts": result.alerts,
+            "findings_count": len(result.findings),
+            "findings": [f.model_dump() for f in result.findings],
+        }
+        if result.regime_comparison:
+            job_result["regime_comparison"] = result.regime_comparison.model_dump()
         db.add(JobModel(
             id=UUID(result.job_id),
             tenant_id=current_user.tenant_id,
             job_type="validate_xml",
             status="SUCCESS",
             payload={"document_type": result.document_type, "audit_id": result.audit_id},
-            result={"fatals": result.fatals, "alerts": result.alerts, "findings_count": len(result.findings)},
+            result=job_result,
         ))
         sp.commit()
     except Exception:

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -9,6 +9,7 @@ import { MarkdownRenderer } from "@/components/common/MarkdownRenderer";
 import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
+import { RegimeComparison } from "@/components/jobs/RegimeComparison";
 import { getDocumentDownloadUrl, getJob, listDocuments } from "@/lib/api";
 import type { DocumentResponse } from "@/lib/api";
 import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
@@ -169,6 +170,10 @@ export default function JobDetailPage() {
               <p className="mt-1 text-slate-700">{new Date(job.updatedAt).toLocaleString()}</p>
             </div>
           </section>
+
+          {job.output?.regime_comparison ? (
+            <RegimeComparison data={job.output.regime_comparison as Record<string, string | null>} />
+          ) : null}
 
           <div className="grid gap-3 lg:grid-cols-2">
             <JsonViewer title="JSON de entrada" data={job.input} />

--- a/frontend/src/components/jobs/RegimeComparison.tsx
+++ b/frontend/src/components/jobs/RegimeComparison.tsx
@@ -1,0 +1,81 @@
+type RegimeData = {
+  base_old?: string | null;
+  base_new?: string | null;
+  icms?: string | null;
+  pis?: string | null;
+  cofins?: string | null;
+  cbs?: string | null;
+  ibs?: string | null;
+  total_old?: string | null;
+  total_new?: string | null;
+  delta?: string | null;
+};
+
+function fmt(v: string | null | undefined): string {
+  if (!v) return "—";
+  const n = parseFloat(v);
+  return isNaN(n) ? v : `R$ ${n.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function Row({ label, old: oldVal, next }: { label: string; old: string | null | undefined; next: string | null | undefined }) {
+  return (
+    <tr className="border-t border-slate-100">
+      <td className="py-2 pr-4 text-sm text-slate-600">{label}</td>
+      <td className="py-2 pr-4 text-right font-mono text-sm text-slate-700">{fmt(oldVal)}</td>
+      <td className="py-2 text-right font-mono text-sm text-slate-700">{fmt(next)}</td>
+    </tr>
+  );
+}
+
+export function RegimeComparison({ data }: { data: RegimeData }) {
+  const delta = data.delta ? parseFloat(data.delta) : null;
+  const deltaPositive = delta !== null && delta > 0;
+  const deltaNegative = delta !== null && delta < 0;
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4">
+      <h2 className="mb-1 text-sm font-semibold text-slate-700">Comparativo de Regimes</h2>
+      <p className="mb-4 text-xs text-slate-500">
+        Regime atual (ICMS/PIS/COFINS) × Reforma tributária (CBS/IBS) — dupla operação até 2033
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr>
+              <th className="pb-2 pr-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Campo</th>
+              <th className="pb-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Regime Atual</th>
+              <th className="pb-2 text-right text-xs font-semibold uppercase tracking-wide text-tribultz-600">Reforma (CBS/IBS)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data.base_old || data.base_new) && (
+              <Row label="Base de cálculo" old={data.base_old} next={data.base_new} />
+            )}
+            <Row label="ICMS" old={data.icms} next={null} />
+            <Row label="PIS" old={data.pis} next={null} />
+            <Row label="COFINS" old={data.cofins} next={null} />
+            <Row label="CBS" old={null} next={data.cbs} />
+            <Row label="IBS" old={null} next={data.ibs} />
+            <tr className="border-t-2 border-slate-200">
+              <td className="py-2 pr-4 text-sm font-semibold text-slate-800">Total tributado</td>
+              <td className="py-2 pr-4 text-right font-mono text-sm font-semibold text-slate-800">{fmt(data.total_old)}</td>
+              <td className="py-2 text-right font-mono text-sm font-semibold text-tribultz-700">{fmt(data.total_new)}</td>
+            </tr>
+            {delta !== null && (
+              <tr className="border-t border-slate-100">
+                <td className="py-2 pr-4 text-sm text-slate-600">Delta (impacto)</td>
+                <td className="py-2 pr-4" />
+                <td className={`py-2 text-right font-mono text-sm font-semibold ${deltaPositive ? "text-red-600" : deltaNegative ? "text-emerald-600" : "text-slate-600"}`}>
+                  {deltaPositive ? "+" : ""}{fmt(data.delta)}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-[11px] text-slate-400">
+        Extraído do XML da NF. Valores negativos (verde) indicam redução de carga; positivos (vermelho) indicam aumento.
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Extrai totais do regime atual (ICMS, PIS, COFINS) e da reforma (CBS, IBS) diretamente do XML da NF-e/NFS-e via `_extract_regime_comparison()`
- Persiste `regime_comparison` no JSONB `result` do job (disponível via `GET /api/v1/jobs/{id}`)
- Novo componente `RegimeComparison.tsx` exibe tabela lado a lado com delta de impacto financeiro no job detail
- Componente é renderizado condicionalmente — jobs sem dados monetários no XML não sofrem impacto

## Por que importa

Sovos é o único competidor com esse posicionamento. Contadores precisam mostrar ao cliente o impacto financeiro real da transição dupla (até 2033). Identificado na pesquisa competitiva de mai/2026.

## Test plan

- [ ] Backend: `pytest tests/ -q` (439 passando)
- [ ] Backend: `ruff check` + `pyright` — 0 erros
- [ ] Frontend: `npm test --silent` (58 passando) + `npm run build` — sucesso
- [ ] Job detail de job `validate_xml` com XML contendo ICMS + IBSCBS exibe tabela de comparativo
- [ ] Job detail de job sem dados monetários não exibe a seção (condicional por `regime_comparison`)

Closes #257