### PR TITLE
feat(split-payment): rastreabilidade de crédito CBS/IBS por NF (#169)

### DIFF
--- a/backend/app/alembic/versions/2026_05_17_0017_add_split_payment_status.py
+++ b/backend/app/alembic/versions/2026_05_17_0017_add_split_payment_status.py
@@ -1,0 +1,46 @@
+"""Add split_payment_status to documents.
+
+Revision ID: 2026_05_17_0017
+Revises: 2026_05_17_0016
+Create Date: 2026-05-17
+
+Split Payment (LC 214 art. 22): o crédito IBS/CBS só é liberado após confirmação
+do pagamento do imposto destacado na NF. Este campo rastreia o status por documento.
+
+NULL    = documento não é NF-e com CBS/IBS (não aplicável)
+pending = aguardando confirmação do pagamento (Split Payment não processado)
+confirmed = imposto pago e confirmado, crédito liberado para uso
+credit_released = crédito já apropriado/compensado
+failed  = falha ou prazo expirado (crédito em risco)
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_05_17_0017"
+down_revision = "2026_05_17_0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column(
+            "split_payment_status",
+            sa.String(30),
+            nullable=True,
+            comment="pending | confirmed | credit_released | failed | NULL=não aplicável",
+        ),
+    )
+    op.create_index(
+        "ix_documents_split_payment_status",
+        "documents",
+        ["split_payment_status"],
+        postgresql_where=sa.text("split_payment_status IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_documents_split_payment_status", table_name="documents")
+    op.drop_column("documents", "split_payment_status")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.core.logging import configure_logging
-from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, documents, exceptions, feedback, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, sped, support, tasks, validate, validate_xml, validation
+from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, documents, exceptions, feedback, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, sped, split_payment, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry
 
 configure_logging()
@@ -92,6 +92,7 @@ app.include_router(admin.router)
 app.include_router(sped.router)
 app.include_router(classtrib.router)
 app.include_router(compliance.router)
+app.include_router(split_payment.router)
 
 
 @app.get("/", tags=["root"])

--- a/backend/app/models/documents.py
+++ b/backend/app/models/documents.py
@@ -56,4 +56,9 @@ class Document(Base):
 
     # Flexible fiscal metadata extracted from XML
     # Keys: chave_acesso, cnpj_emitente, cnpj_destinatario, valor_total, ncm, etc.
+    # Split Payment: credit_value (CBS+IBS), credit_due_date
     fiscal_metadata = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+    # Split Payment status (LC 214 art. 22)
+    # NULL = não aplicável; pending | confirmed | credit_released | failed
+    split_payment_status = Column(String(30), nullable=True)

--- a/backend/app/routers/split_payment.py
+++ b/backend/app/routers/split_payment.py
@@ -1,0 +1,282 @@
+"""Split Payment Dashboard — rastreabilidade de crédito CBS/IBS por NF (LC 214 art. 22).
+
+GET  /api/v1/split-payment/summary          → totais por status (gated: profissional+)
+GET  /api/v1/split-payment/status/{doc_id}  → status + crédito de um documento
+PATCH /api/v1/split-payment/status/{doc_id} → atualizar status manualmente (fase 1)
+
+Fase 2 (não implementada aqui): Celery beat task que consulta Nota Nacional
+(NT 2025.002) para atualizar status automaticamente.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from app.api.deps import get_current_user
+from app.api.plan_gate import require_plan
+from app.database import get_db
+from app.models.auth import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/split-payment", tags=["split-payment"])
+
+VALID_STATUSES = {"pending", "confirmed", "credit_released", "failed"}
+
+# ── Schemas ─────────────────────────────────────────────────────────────────
+
+
+class SplitPaymentDoc(BaseModel):
+    document_id: str
+    original_filename: Optional[str]
+    doc_type: str
+    split_payment_status: str
+    credit_value: Optional[str]       # CBS + IBS (R$), from fiscal_metadata
+    credit_due_date: Optional[str]    # ISO date, from fiscal_metadata
+    created_at: str
+    days_pending: Optional[int]       # days since created_at if still pending
+
+
+class SplitPaymentStatusUpdate(BaseModel):
+    status: str
+    credit_value: Optional[str] = None    # R$ total CBS+IBS
+    credit_due_date: Optional[str] = None  # ISO date (expected confirmation)
+
+
+class SplitPaymentSummary(BaseModel):
+    pending_count: int
+    pending_total: str        # R$ sum
+    confirmed_count: int
+    confirmed_total: str
+    credit_released_count: int
+    credit_released_total: str
+    failed_count: int
+    failed_total: str         # crédito em risco
+    at_risk_count: int        # pending > 5 dias
+    at_risk_total: str
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _to_doc(row: Any) -> SplitPaymentDoc:
+    fm = row.fiscal_metadata if isinstance(row.fiscal_metadata, dict) else {}
+    created_at_str = row.created_at.isoformat() if row.created_at else ""
+    days_pending = None
+    if row.split_payment_status == "pending" and row.created_at:
+        delta = datetime.now(timezone.utc) - row.created_at.replace(tzinfo=timezone.utc)
+        days_pending = delta.days
+    return SplitPaymentDoc(
+        document_id=str(row.id),
+        original_filename=row.original_filename,
+        doc_type=row.doc_type,
+        split_payment_status=row.split_payment_status,
+        credit_value=fm.get("credit_value"),
+        credit_due_date=fm.get("credit_due_date"),
+        created_at=created_at_str,
+        days_pending=days_pending,
+    )
+
+
+def _sum_credit(rows: list[Any]) -> str:
+    total = 0.0
+    for r in rows:
+        fm = r.fiscal_metadata if isinstance(r.fiscal_metadata, dict) else {}
+        try:
+            total += float(fm.get("credit_value") or 0)
+        except (ValueError, TypeError):
+            pass
+    return f"{total:.2f}"
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/summary",
+    response_model=SplitPaymentSummary,
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def split_payment_summary(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SplitPaymentSummary:
+    """Aggregate Split Payment credit totals by status for the authenticated tenant."""
+    rows = db.execute(
+        text("""
+            SELECT id, fiscal_metadata, split_payment_status, created_at
+            FROM documents
+            WHERE tenant_id = :tid
+              AND split_payment_status IS NOT NULL
+            ORDER BY created_at DESC
+        """),
+        {"tid": str(current_user.tenant_id)},
+    ).fetchall()
+
+    by_status: dict[str, list[Any]] = {s: [] for s in VALID_STATUSES}
+    at_risk: list[Any] = []
+
+    for r in rows:
+        st = r.split_payment_status
+        if st in by_status:
+            by_status[st].append(r)
+        if st == "pending":
+            delta = datetime.now(timezone.utc) - r.created_at.replace(tzinfo=timezone.utc)
+            if delta.days > 5:
+                at_risk.append(r)
+
+    return SplitPaymentSummary(
+        pending_count=len(by_status["pending"]),
+        pending_total=_sum_credit(by_status["pending"]),
+        confirmed_count=len(by_status["confirmed"]),
+        confirmed_total=_sum_credit(by_status["confirmed"]),
+        credit_released_count=len(by_status["credit_released"]),
+        credit_released_total=_sum_credit(by_status["credit_released"]),
+        failed_count=len(by_status["failed"]),
+        failed_total=_sum_credit(by_status["failed"]),
+        at_risk_count=len(at_risk),
+        at_risk_total=_sum_credit(at_risk),
+    )
+
+
+@router.get(
+    "/documents",
+    response_model=list[SplitPaymentDoc],
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def list_split_payment_documents(
+    status: Optional[str] = Query(None, pattern="^(pending|confirmed|credit_released|failed)$"),
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[SplitPaymentDoc]:
+    """List documents tracked for Split Payment, optionally filtered by status."""
+    filters = ["tenant_id = :tid", "split_payment_status IS NOT NULL"]
+    params: dict[str, Any] = {"tid": str(current_user.tenant_id), "limit": limit}
+
+    if status:
+        filters.append("split_payment_status = :status")
+        params["status"] = status
+
+    where = " AND ".join(filters)
+    rows = db.execute(
+        text(f"""
+            SELECT id, original_filename, doc_type, fiscal_metadata,
+                   split_payment_status, created_at
+            FROM documents
+            WHERE {where}
+            ORDER BY created_at DESC
+            LIMIT :limit
+        """),
+        params,
+    ).fetchall()
+
+    return [_to_doc(r) for r in rows]
+
+
+@router.get(
+    "/status/{document_id}",
+    response_model=SplitPaymentDoc,
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def get_split_payment_status(
+    document_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SplitPaymentDoc:
+    """Get Split Payment status for a single document."""
+    try:
+        row = db.execute(
+            text("""
+                SELECT id, original_filename, doc_type, fiscal_metadata,
+                       split_payment_status, created_at
+                FROM documents
+                WHERE id = CAST(:id AS uuid) AND tenant_id = :tid
+            """),
+            {"id": document_id, "tid": str(current_user.tenant_id)},
+        ).fetchone()
+    except Exception:
+        raise HTTPException(404, "Documento não encontrado")
+    if not row:
+        raise HTTPException(404, "Documento não encontrado")
+    if not row.split_payment_status:
+        raise HTTPException(400, "Este documento não está rastreado no Split Payment")
+    return _to_doc(row)
+
+
+@router.patch(
+    "/status/{document_id}",
+    response_model=SplitPaymentDoc,
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def update_split_payment_status(
+    document_id: str,
+    body: SplitPaymentStatusUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SplitPaymentDoc:
+    """Manually update Split Payment status for a document.
+
+    Phase 1: manual updates. Phase 2: automated via Celery + Nota Nacional API.
+    """
+    if body.status not in VALID_STATUSES:
+        raise HTTPException(400, f"Status inválido. Use: {', '.join(sorted(VALID_STATUSES))}")
+
+    try:
+        row = db.execute(
+            text("""
+                SELECT id, original_filename, doc_type, fiscal_metadata,
+                       split_payment_status, created_at
+                FROM documents
+                WHERE id = CAST(:id AS uuid) AND tenant_id = :tid
+            """),
+            {"id": document_id, "tid": str(current_user.tenant_id)},
+        ).fetchone()
+    except Exception:
+        raise HTTPException(404, "Documento não encontrado")
+    if not row:
+        raise HTTPException(404, "Documento não encontrado")
+
+    # Merge fiscal_metadata updates
+    fm: dict[str, Any] = dict(row.fiscal_metadata) if isinstance(row.fiscal_metadata, dict) else {}
+    if body.credit_value is not None:
+        fm["credit_value"] = body.credit_value
+    if body.credit_due_date is not None:
+        fm["credit_due_date"] = body.credit_due_date
+
+    import json
+    db.execute(
+        text("""
+            UPDATE documents
+            SET split_payment_status = :status,
+                fiscal_metadata = CAST(:fm AS jsonb),
+                updated_at = now()
+            WHERE id = CAST(:id AS uuid) AND tenant_id = :tid
+        """),
+        {
+            "status": body.status,
+            "fm": json.dumps(fm),
+            "id": document_id,
+            "tid": str(current_user.tenant_id)
+        },
+    )
+    db.commit()
+
+    updated = db.execute(
+        text("""
+            SELECT id, original_filename, doc_type, fiscal_metadata,
+                   split_payment_status, created_at
+            FROM documents
+            WHERE id = CAST(:id AS uuid) AND tenant_id = :tid
+        """),
+        {"id": document_id, "tid": str(current_user.tenant_id)},
+    ).fetchone()
+
+    if not updated:
+        raise HTTPException(500, "Erro ao recarregar documento")
+    return _to_doc(updated)

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,7 +5,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
-import { ComplianceScore, getAudits, getComplianceScore, getJobs, listExceptionRequests } from "@/lib/api";
+import { ComplianceScore, getAudits, getComplianceScore, getJobs, getSplitPaymentSummary, listExceptionRequests } from "@/lib/api";
+import type { SplitPaymentSummary } from "@/lib/api";
 import { AuditLog, ExceptionRequest, Finding, Job } from "@/lib/types";
 import { getAccountType, getTenantId, getTenants, type StoredTenant } from "@/lib/storage";
 
@@ -96,6 +97,7 @@ export default function DashboardPage() {
   const [audits, setAudits] = useState<AuditLog[]>([]);
   const [exceptions, setExceptions] = useState<ExceptionRequest[]>([]);
   const [complianceScore, setComplianceScore] = useState<ComplianceScore | null>(null);
+  const [splitSummary, setSplitSummary] = useState<SplitPaymentSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tenantId, setTenantIdState] = useState("");
@@ -114,13 +116,14 @@ export default function DashboardPage() {
     setTenantName(match?.name ?? tid);
 
     setLoading(true);
-    Promise.allSettled([getJobs(), getAudits(), listExceptionRequests(), getComplianceScore()])
-      .then(([jobsResult, auditsResult, exceptionsResult, complianceResult]) => {
+    Promise.allSettled([getJobs(), getAudits(), listExceptionRequests(), getComplianceScore(), getSplitPaymentSummary()])
+      .then(([jobsResult, auditsResult, exceptionsResult, complianceResult, splitResult]) => {
         if (jobsResult.status === "fulfilled") setJobs(jobsResult.value);
         else setError((jobsResult.reason as Error)?.message ?? "Erro ao carregar jobs");
         if (auditsResult.status === "fulfilled") setAudits(auditsResult.value);
         if (exceptionsResult.status === "fulfilled") setExceptions(exceptionsResult.value);
         if (complianceResult.status === "fulfilled") setComplianceScore(complianceResult.value);
+        if (splitResult.status === "fulfilled") setSplitSummary(splitResult.value);
       })
       .finally(() => setLoading(false));
   }, []);
@@ -212,6 +215,52 @@ export default function DashboardPage() {
           <p className="mt-2 text-3xl font-bold text-red-600">{loading ? "..." : metrics.fatalFindings}</p>
         </article>
       </div>
+
+      {/* Split Payment widget */}
+      {(splitSummary || loading) && (
+        <div className={`rounded-xl border p-4 ${
+          splitSummary && splitSummary.at_risk_count > 0
+            ? "border-red-200 bg-red-50"
+            : "border-amber-200 bg-amber-50"
+        }`}>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-slate-700">Split Payment — Crédito CBS/IBS</h2>
+            <Link href="/split-payment" className="text-xs text-tribultz-600 hover:underline">Ver painel →</Link>
+          </div>
+          {loading ? (
+            <div className="flex gap-4">
+              <Skeleton className="h-8 w-32" />
+              <Skeleton className="h-8 w-32" />
+            </div>
+          ) : splitSummary ? (
+            <div className="flex flex-wrap gap-6 text-sm">
+              <div>
+                <p className="text-xs text-slate-500">Pendente</p>
+                <p className="mt-0.5 text-xl font-bold text-amber-700">
+                  R$ {parseFloat(splitSummary.pending_total).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                </p>
+                <p className="text-xs text-slate-500">{splitSummary.pending_count} NF(s)</p>
+              </div>
+              {splitSummary.at_risk_count > 0 && (
+                <div>
+                  <p className="text-xs font-semibold text-red-600">Em Risco ({">"}5 dias)</p>
+                  <p className="mt-0.5 text-xl font-bold text-red-700">
+                    R$ {parseFloat(splitSummary.at_risk_total).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                  </p>
+                  <p className="text-xs text-red-500">{splitSummary.at_risk_count} NF(s)</p>
+                </div>
+              )}
+              <div>
+                <p className="text-xs text-slate-500">Liberado</p>
+                <p className="mt-0.5 text-xl font-bold text-emerald-700">
+                  R$ {parseFloat(splitSummary.credit_released_total).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                </p>
+                <p className="text-xs text-slate-500">{splitSummary.credit_released_count} NF(s)</p>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
 
       {/* Compliance Score widget */}
       <div className="rounded-xl border border-slate-200 bg-white p-4">

--- a/frontend/src/app/split-payment/page.tsx
+++ b/frontend/src/app/split-payment/page.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Skeleton } from "@/components/common/Skeleton";
+import { Toast } from "@/components/common/Toast";
+import { listSplitPaymentDocs, getSplitPaymentSummary, updateSplitPaymentStatus } from "@/lib/api";
+import type { SplitPaymentDoc, SplitPaymentSummary } from "@/lib/api";
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: "Pendente",
+  confirmed: "Confirmado",
+  credit_released: "Crédito Liberado",
+  failed: "Em Risco",
+};
+
+const STATUS_CLASSES: Record<string, string> = {
+  pending: "bg-amber-100 text-amber-700 border-amber-200",
+  confirmed: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  credit_released: "bg-tribultz-100 text-tribultz-700 border-tribultz-200",
+  failed: "bg-red-100 text-red-700 border-red-200",
+};
+
+function fmtBrl(v: string | null | undefined): string {
+  if (!v) return "—";
+  const n = parseFloat(v);
+  return isNaN(n) ? v : `R$ ${n.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function SummaryCard({ label, count, total, className }: { label: string; count: number; total: string; className: string }) {
+  return (
+    <article className={`rounded-xl border p-4 ${className}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide opacity-70">{label}</p>
+      <p className="mt-2 text-2xl font-bold">{count}</p>
+      <p className="mt-0.5 text-sm font-medium">{fmtBrl(total)}</p>
+    </article>
+  );
+}
+
+export default function SplitPaymentPage() {
+  const [docs, setDocs] = useState<SplitPaymentDoc[]>([]);
+  const [summary, setSummary] = useState<SplitPaymentSummary | null>(null);
+  const [filter, setFilter] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [toast, setToast] = useState<{ tone: "success" | "error"; message: string } | null>(null);
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  function load(status: string) {
+    setLoading(true);
+    Promise.allSettled([
+      listSplitPaymentDocs(status || undefined),
+      getSplitPaymentSummary(),
+    ]).then(([docsResult, summaryResult]) => {
+      if (docsResult.status === "fulfilled") setDocs(docsResult.value);
+      if (summaryResult.status === "fulfilled") setSummary(summaryResult.value);
+    }).finally(() => setLoading(false));
+  }
+
+  useEffect(() => { load(filter); }, [filter]);
+
+  async function handleStatusChange(doc: SplitPaymentDoc, newStatus: string): Promise<void> {
+    setUpdating(doc.document_id);
+    try {
+      const updated = await updateSplitPaymentStatus(doc.document_id, { status: newStatus });
+      setDocs((prev) => prev.map((d) => d.document_id === doc.document_id ? updated : d));
+      setToast({ tone: "success", message: `Status atualizado para ${STATUS_LABELS[newStatus] ?? newStatus}` });
+      // Refresh summary
+      getSplitPaymentSummary().then(setSummary).catch(() => {});
+    } catch {
+      setToast({ tone: "error", message: "Erro ao atualizar status" });
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  return (
+    <section className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">Split Payment</h1>
+        <p className="text-sm text-slate-500">
+          Rastreabilidade de crédito CBS/IBS por NF — LC 214 art. 22. O crédito só é liberado após confirmação do pagamento do imposto.
+        </p>
+      </header>
+
+      {summary ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <SummaryCard
+            label="Pendente"
+            count={summary.pending_count}
+            total={summary.pending_total}
+            className="border-amber-200 bg-amber-50"
+          />
+          <SummaryCard
+            label="Confirmado"
+            count={summary.confirmed_count}
+            total={summary.confirmed_total}
+            className="border-emerald-200 bg-emerald-50"
+          />
+          <SummaryCard
+            label="Crédito Liberado"
+            count={summary.credit_released_count}
+            total={summary.credit_released_total}
+            className="border-tribultz-200 bg-tribultz-50"
+          />
+          <SummaryCard
+            label="Em Risco"
+            count={summary.failed_count}
+            total={summary.failed_total}
+            className="border-red-200 bg-red-50"
+          />
+        </div>
+      ) : loading ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => <Skeleton key={i} className="h-24 w-full" />)}
+        </div>
+      ) : null}
+
+      {summary && summary.at_risk_count > 0 && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          <span className="font-semibold">{summary.at_risk_count} NF(s) com crédito em risco</span>
+          {" "}— aguardando confirmação há mais de 5 dias.{" "}
+          <span className="font-semibold">{fmtBrl(summary.at_risk_total)}</span> em crédito potencialmente perdido.
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {["", "pending", "confirmed", "credit_released", "failed"].map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setFilter(s)}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              filter === s
+                ? "border-tribultz-500 bg-tribultz-600 text-white"
+                : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+            }`}
+          >
+            {s ? STATUS_LABELS[s] : "Todos"}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-16 w-full" />)}
+        </div>
+      ) : docs.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white px-6 py-10 text-center text-sm text-slate-500">
+          Nenhum documento rastreado no Split Payment ainda.
+          <br />
+          <span className="text-xs text-slate-400">
+            Os documentos aparecem aqui quando o status Split Payment é atribuído via API ou automaticamente pela validação de XML.
+          </span>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50">
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Documento</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Data</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Status</th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Crédito CBS+IBS</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Ação</th>
+              </tr>
+            </thead>
+            <tbody>
+              {docs.map((doc) => {
+                const isAtRisk = doc.split_payment_status === "pending" && (doc.days_pending ?? 0) > 5;
+                return (
+                  <tr key={doc.document_id} className={`border-t border-slate-100 ${isAtRisk ? "bg-red-50" : ""}`}>
+                    <td className="px-4 py-3">
+                      <p className="font-medium text-slate-800 truncate max-w-[200px]">
+                        {doc.original_filename ?? doc.doc_type}
+                      </p>
+                      <p className="text-xs text-slate-400 font-mono">{doc.document_id.slice(0, 8)}…</p>
+                      {isAtRisk && (
+                        <span className="mt-0.5 inline-block rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold text-red-600">
+                          {doc.days_pending}d sem confirmação
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600 text-xs">
+                      {new Date(doc.created_at).toLocaleDateString("pt-BR")}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-block rounded-full border px-2.5 py-0.5 text-[11px] font-semibold ${STATUS_CLASSES[doc.split_payment_status] ?? ""}`}>
+                        {STATUS_LABELS[doc.split_payment_status] ?? doc.split_payment_status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono font-medium text-slate-700">
+                      {fmtBrl(doc.credit_value)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <select
+                        disabled={updating === doc.document_id}
+                        value={doc.split_payment_status}
+                        onChange={(e) => void handleStatusChange(doc, e.target.value)}
+                        className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 disabled:opacity-50"
+                      >
+                        <option value="pending">Pendente</option>
+                        <option value="confirmed">Confirmado</option>
+                        <option value="credit_released">Crédito Liberado</option>
+                        <option value="failed">Em Risco</option>
+                      </select>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {toast ? <Toast message={toast.message} tone={toast.tone} onClose={() => setToast(null)} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ const links = [
   { href: "/jobs", label: "Jobs" },
   { href: "/audit", label: "Auditoria" },
   { href: "/exceptions", label: "Exceções" },
+  { href: "/split-payment", label: "Split Payment" },
   { href: "/billing", label: "Faturamento" },
   { href: "/settings", label: "Configurações" },
   { href: "/support", label: "Suporte" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -550,3 +550,49 @@ export async function getComplianceScore(period?: string): Promise<ComplianceSco
 export async function getComplianceHistory(): Promise<ComplianceHistory[]> {
   return apiFetch("/api/v1/compliance/score/history");
 }
+
+// ── Split Payment ────────────────────────────────────────────────────────────
+
+export type SplitPaymentDoc = {
+  document_id: string;
+  original_filename: string | null;
+  doc_type: string;
+  split_payment_status: "pending" | "confirmed" | "credit_released" | "failed";
+  credit_value: string | null;
+  credit_due_date: string | null;
+  created_at: string;
+  days_pending: number | null;
+};
+
+export type SplitPaymentSummary = {
+  pending_count: number;
+  pending_total: string;
+  confirmed_count: number;
+  confirmed_total: string;
+  credit_released_count: number;
+  credit_released_total: string;
+  failed_count: number;
+  failed_total: string;
+  at_risk_count: number;
+  at_risk_total: string;
+};
+
+export async function getSplitPaymentSummary(): Promise<SplitPaymentSummary> {
+  return apiFetch("/api/v1/split-payment/summary");
+}
+
+export async function listSplitPaymentDocs(status?: string): Promise<SplitPaymentDoc[]> {
+  const qs = status ? `?status=${encodeURIComponent(status)}` : "";
+  return apiFetch(`/api/v1/split-payment/documents${qs}`);
+}
+
+export async function updateSplitPaymentStatus(
+  documentId: string,
+  payload: { status: string; credit_value?: string; credit_due_date?: string },
+): Promise<SplitPaymentDoc> {
+  return apiFetch(`/api/v1/split-payment/status/${encodeURIComponent(documentId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION
## Summary

Implementa o Split Payment Dashboard (LC 214 art. 22) — fase 1 com controle manual de status; fase 2 (Celery + Nota Nacional API) fica para próximo sprint.

- **Migration 0017**: coluna `split_payment_status` em `documents` (nullable, indexed) com estados `pending | confirmed | credit_released | failed`
- **Backend** `split_payment.py`: 4 endpoints gated para Profissional+:
  - `GET /summary` — totais por status + crédito em risco (pendente > 5 dias)
  - `GET /documents` — lista filtrada por status
  - `GET /status/{doc_id}` — status de um documento específico
  - `PATCH /status/{doc_id}` — atualização manual (fase 1)
- **Frontend** `/split-payment`: tabela de NFs com badges de status coloridos, alerta de crédito em risco, atualização de status inline
- **Dashboard widget**: card Split Payment mostrando R$ pendente + R$ em risco + link para o painel
- **Sidebar**: novo item "Split Payment" após "Exceções"

## Test plan

- [ ] `pytest tests/ -q` (439 passando), `ruff check`, `pyright` — 0 erros
- [ ] `npm test --silent` (58 passando) + `npm run build` — `/split-payment` no build
- [ ] Migration 0017 executa sem erros em produção
- [ ] Sem documentos com split_payment_status: painel mostra empty state, widget do dashboard não aparece
- [ ] Com documentos: summary cards corretos, badge "Xd sem confirmação" para pending > 5 dias
- [ ] PATCH status atualiza badge inline sem reload

Closes #169