### PR TITLE
feat(#258): credits dashboard fase 1 — saldo IBS/CBS por período

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.core.logging import configure_logging
-from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, documents, exceptions, feedback, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, sped, split_payment, support, tasks, validate, validate_xml, validation
+from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, sped, split_payment, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry
 
 configure_logging()
@@ -93,6 +93,7 @@ app.include_router(sped.router)
 app.include_router(classtrib.router)
 app.include_router(compliance.router)
 app.include_router(split_payment.router)
+app.include_router(credits.router)
 
 
 @app.get("/", tags=["root"])

--- a/backend/app/routers/credits.py
+++ b/backend/app/routers/credits.py
@@ -1,0 +1,191 @@
+"""Credit Dashboard — saldo e fluxo de crédito IBS/CBS por período (LC 214).
+
+Fase 1 (#258): visão agregada por período (mês/trimestre) derivada da tabela
+`documents` + `split_payment_status` (introduzido pelo #169). Sem tabela nova.
+
+GET /api/v1/credits/balance?period=month|quarter — série temporal de saldo
+GET /api/v1/credits/export.csv?period=...        — mesmo dado em CSV auditável
+
+Fluxo (LC 214 art. 22, não-cumulatividade plena):
+  gerado      = confirmed + credit_released  (crédito efetivamente formalizado)
+  apropriado  = credit_released              (crédito já utilizado/compensado)
+  disponível  = confirmed                    (crédito formalizado e não utilizado)
+  em_risco    = failed                       (crédito potencialmente perdido)
+
+Fase 2 (futuro): drill-down por NF, PDF, IBS/CBS separados por NCM,
+breakdown automático a partir de fiscal_metadata enriquecido.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_user
+from app.api.plan_gate import require_plan
+from app.database import get_db
+from app.models.auth import User
+
+router = APIRouter(prefix="/api/v1/credits", tags=["credits"])
+
+PeriodGranularity = Literal["month", "quarter"]
+
+
+class CreditPeriodRow(BaseModel):
+    period: str                # "2026-05" ou "2026-Q2"
+    generated_count: int
+    generated_total: str       # R$ (string p/ evitar perda de precisão)
+    apropriated_count: int
+    apropriated_total: str
+    available_count: int
+    available_total: str
+    at_risk_count: int
+    at_risk_total: str
+
+
+class CreditBalanceResponse(BaseModel):
+    period_type: PeriodGranularity
+    periods: list[CreditPeriodRow]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _period_label(period_type: PeriodGranularity, bucket_iso: str) -> str:
+    """bucket_iso vem do date_trunc — formata para 'YYYY-MM' ou 'YYYY-Qn'."""
+    # bucket_iso ex: '2026-05-01' (month) ou '2026-04-01' (quarter start)
+    year, month, _ = bucket_iso.split("-")[:3]
+    if period_type == "month":
+        return f"{year}-{month}"
+    # quarter: month 1→Q1, 4→Q2, 7→Q3, 10→Q4
+    q = (int(month) - 1) // 3 + 1
+    return f"{year}-Q{q}"
+
+
+def _compute_balance(
+    db: Session,
+    tenant_id: str,
+    period_type: PeriodGranularity,
+    months_back: int,
+) -> list[CreditPeriodRow]:
+    """Agrega documents.split_payment_status por bucket de tempo.
+
+    Usa date_trunc + COALESCE para extrair credit_value de fiscal_metadata.
+    """
+    trunc_unit = "month" if period_type == "month" else "quarter"
+    rows = db.execute(
+        text(f"""
+            SELECT
+                date_trunc('{trunc_unit}', created_at)::date AS bucket,
+                split_payment_status AS status,
+                COUNT(*) AS cnt,
+                COALESCE(SUM(
+                    NULLIF(fiscal_metadata->>'credit_value', '')::numeric
+                ), 0) AS total
+            FROM documents
+            WHERE tenant_id = CAST(:tid AS uuid)
+              AND split_payment_status IS NOT NULL
+              AND created_at >= (now() - (:months_back || ' months')::interval)
+            GROUP BY bucket, split_payment_status
+            ORDER BY bucket DESC
+        """),
+        {"tid": tenant_id, "months_back": months_back},
+    ).mappings().all()
+
+    # Agrupa por bucket
+    buckets: dict[str, dict[str, dict[str, float]]] = {}
+    for r in rows:
+        bucket_iso = r["bucket"].isoformat()
+        status = r["status"]
+        buckets.setdefault(bucket_iso, {})[status] = {
+            "count": int(r["cnt"] or 0),
+            "total": float(r["total"] or 0),
+        }
+
+    out: list[CreditPeriodRow] = []
+    for bucket_iso in sorted(buckets.keys(), reverse=True):
+        by_status = buckets[bucket_iso]
+        confirmed = by_status.get("confirmed", {"count": 0, "total": 0.0})
+        released = by_status.get("credit_released", {"count": 0, "total": 0.0})
+        failed = by_status.get("failed", {"count": 0, "total": 0.0})
+
+        gen_count = int(confirmed["count"] + released["count"])
+        gen_total = float(confirmed["total"] + released["total"])
+
+        out.append(CreditPeriodRow(
+            period=_period_label(period_type, bucket_iso),
+            generated_count=gen_count,
+            generated_total=f"{gen_total:.2f}",
+            apropriated_count=int(released["count"]),
+            apropriated_total=f"{float(released['total']):.2f}",
+            available_count=int(confirmed["count"]),
+            available_total=f"{float(confirmed['total']):.2f}",
+            at_risk_count=int(failed["count"]),
+            at_risk_total=f"{float(failed['total']):.2f}",
+        ))
+
+    return out
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/balance",
+    response_model=CreditBalanceResponse,
+    summary="Saldo de crédito IBS/CBS por período",
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def get_credit_balance(
+    period: PeriodGranularity = Query("month", description="Granularidade: month | quarter"),
+    months_back: int = Query(12, ge=1, le=36, description="Janela em meses"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CreditBalanceResponse:
+    periods = _compute_balance(db, str(current_user.tenant_id), period, months_back)
+    return CreditBalanceResponse(period_type=period, periods=periods)
+
+
+@router.get(
+    "/export.csv",
+    summary="Exporta saldo de crédito em CSV auditável",
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def export_credit_balance_csv(
+    period: PeriodGranularity = Query("month"),
+    months_back: int = Query(12, ge=1, le=36),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> StreamingResponse:
+    rows = _compute_balance(db, str(current_user.tenant_id), period, months_back)
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, delimiter=";")  # ; para compatibilidade Excel pt-BR
+    writer.writerow([
+        "PERIODO",
+        "GERADO_QTD", "GERADO_TOTAL_BRL",
+        "APROPRIADO_QTD", "APROPRIADO_TOTAL_BRL",
+        "DISPONIVEL_QTD", "DISPONIVEL_TOTAL_BRL",
+        "EM_RISCO_QTD", "EM_RISCO_TOTAL_BRL",
+    ])
+    for r in rows:
+        writer.writerow([
+            r.period,
+            r.generated_count, r.generated_total,
+            r.apropriated_count, r.apropriated_total,
+            r.available_count, r.available_total,
+            r.at_risk_count, r.at_risk_total,
+        ])
+
+    buf.seek(0)
+    filename = f"credito-ibs-cbs-{period}.csv"
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/tests/test_credits.py
+++ b/backend/tests/test_credits.py
@@ -1,0 +1,184 @@
+"""Tests for /api/v1/credits endpoints (#258 Phase 1).
+
+Mocks DB Session and plan-gate (profissional) via dependency_overrides.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.main import app
+from app.models.auth import User
+
+TENANT_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+_mock_user = User(
+    id=USER_ID,
+    email="techlead@tribultz.com",
+    tenant_id=TENANT_ID,
+    full_name="Tech Lead",
+    is_active=True,
+    role="admin",
+    password_hash="x",
+)
+
+
+def _override_user():
+    return _mock_user
+
+
+def _bypass_plan_gate(*_args, **_kwargs):
+    """Replace require_plan(...) factory so the inner dependency just returns the user."""
+    def _ok():
+        return _mock_user
+    return _ok
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_current_user] = _override_user
+    # require_plan is a factory — patch by replacing the dependency it returns.
+    # Easiest: override every plan_gate dependency by inserting a passthrough for the
+    # specific Depends object. We accomplish this by overriding the factory output via
+    # FastAPI's dependency_overrides keyed on the inner callable.
+    # Since router builds Depends(require_plan(...)) at import time, the inner callable
+    # already exists — patch via app.dependency_overrides on the inner closure is awkward,
+    # so we monkeypatch the helper inside the call chain by overriding get_db plus a
+    # local DB-driven Subscription. For the simple aggregation tests below it's enough
+    # to mock the DB to return a Profissional plan.
+    session = MagicMock()
+    app.dependency_overrides[get_db] = lambda: session
+    yield TestClient(app), session
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _stub_active_profissional(session: MagicMock) -> None:
+    """Make plan_gate._get_active_subscription return ('active', 'profissional')."""
+    sub = MagicMock(status="active", current_period_end=None)
+    plan = MagicMock(slug="profissional")
+    # Subscription+Plan join returns (Subscription, Plan)
+    first_result = MagicMock()
+    first_result.__getitem__ = lambda self, i: (sub, plan)[i]
+    session.execute.return_value.first.return_value = first_result
+
+
+def _aggregation_rows():
+    """Two months × two statuses each — matches the SQL aggregation result shape."""
+    def row(bucket, status, cnt, total):
+        m = MagicMock()
+        m.__getitem__ = lambda self, k: {
+            "bucket": bucket, "status": status, "cnt": cnt, "total": total
+        }[k]
+        return m
+
+    return [
+        row(date(2026, 5, 1), "confirmed", 3, 1500.00),
+        row(date(2026, 5, 1), "credit_released", 2, 800.00),
+        row(date(2026, 5, 1), "failed", 1, 200.00),
+        row(date(2026, 4, 1), "confirmed", 5, 2500.00),
+        row(date(2026, 4, 1), "credit_released", 4, 1600.00),
+    ]
+
+
+def test_credit_balance_month_aggregation(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    # Subsequent calls (the actual aggregation query) return our rows
+    agg_result = MagicMock()
+    agg_result.mappings.return_value.all.return_value = _aggregation_rows()
+    # First execute() in plan_gate already consumed; chain side_effect for second:
+    session.execute.side_effect = [
+        session.execute.return_value,  # plan_gate subscription query
+        agg_result,                    # credits aggregation query
+    ]
+
+    resp = tc.get("/api/v1/credits/balance?period=month&months_back=6")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["period_type"] == "month"
+    assert len(body["periods"]) == 2
+
+    may = next(p for p in body["periods"] if p["period"] == "2026-05")
+    # generated = confirmed + released = 3+2 = 5 ; total = 1500+800 = 2300
+    assert may["generated_count"] == 5
+    assert may["generated_total"] == "2300.00"
+    assert may["apropriated_count"] == 2
+    assert may["apropriated_total"] == "800.00"
+    assert may["available_count"] == 3
+    assert may["available_total"] == "1500.00"
+    assert may["at_risk_count"] == 1
+    assert may["at_risk_total"] == "200.00"
+
+
+def test_credit_balance_empty(client):
+    tc, session = client
+    _stub_active_profissional(session)
+    empty_result = MagicMock()
+    empty_result.mappings.return_value.all.return_value = []
+    session.execute.side_effect = [session.execute.return_value, empty_result]
+
+    resp = tc.get("/api/v1/credits/balance")
+    assert resp.status_code == 200
+    assert resp.json() == {"period_type": "month", "periods": []}
+
+
+def test_credit_csv_export(client):
+    tc, session = client
+    _stub_active_profissional(session)
+    agg_result = MagicMock()
+    agg_result.mappings.return_value.all.return_value = _aggregation_rows()
+    session.execute.side_effect = [session.execute.return_value, agg_result]
+
+    resp = tc.get("/api/v1/credits/export.csv?period=month")
+    assert resp.status_code == 200
+    assert "text/csv" in resp.headers["content-type"]
+    assert "attachment" in resp.headers["content-disposition"]
+    body = resp.text
+    assert "PERIODO;GERADO_QTD" in body
+    assert "2026-05" in body
+    # generated total para maio = 2300.00
+    assert "2300.00" in body
+
+
+def test_credit_balance_quarter_label(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    def row(bucket, status, cnt, total):
+        m = MagicMock()
+        m.__getitem__ = lambda self, k: {
+            "bucket": bucket, "status": status, "cnt": cnt, "total": total
+        }[k]
+        return m
+
+    agg_result = MagicMock()
+    # Q2 starts at month 4
+    agg_result.mappings.return_value.all.return_value = [
+        row(date(2026, 4, 1), "confirmed", 10, 5000.00),
+    ]
+    session.execute.side_effect = [session.execute.return_value, agg_result]
+
+    resp = tc.get("/api/v1/credits/balance?period=quarter")
+    assert resp.status_code == 200
+    assert resp.json()["periods"][0]["period"] == "2026-Q2"
+
+
+def test_credit_requires_plan(client):
+    """User sem subscription → 403."""
+    tc, session = client
+    # Override the subscription query: return None
+    session.execute.return_value.first.return_value = None
+
+    resp = tc.get("/api/v1/credits/balance")
+    assert resp.status_code == 403
+    assert "profissional" in resp.json()["detail"].lower()

--- a/frontend/src/app/credits/page.tsx
+++ b/frontend/src/app/credits/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Skeleton } from "@/components/common/Skeleton";
+import { Toast } from "@/components/common/Toast";
+import { downloadCreditCsv, getCreditBalance } from "@/lib/api";
+import type { CreditBalanceResponse, CreditPeriodRow } from "@/lib/api";
+
+function fmtBrl(v: string): string {
+  const n = parseFloat(v);
+  if (isNaN(n)) return v;
+  return `R$ ${n.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function totals(rows: CreditPeriodRow[]) {
+  const sum = (k: keyof CreditPeriodRow) =>
+    rows.reduce((acc, r) => acc + parseFloat(String(r[k] ?? "0") || "0"), 0);
+  return {
+    generated: sum("generated_total"),
+    apropriated: sum("apropriated_total"),
+    available: sum("available_total"),
+    at_risk: sum("at_risk_total"),
+  };
+}
+
+function SummaryCard({
+  label,
+  value,
+  hint,
+  className,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  className: string;
+}) {
+  return (
+    <article className={`rounded-xl border p-4 ${className}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide opacity-70">{label}</p>
+      <p className="mt-2 text-2xl font-bold">{value}</p>
+      {hint ? <p className="mt-0.5 text-xs opacity-70">{hint}</p> : null}
+    </article>
+  );
+}
+
+export default function CreditsPage() {
+  const [period, setPeriod] = useState<"month" | "quarter">("month");
+  const [data, setData] = useState<CreditBalanceResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [downloading, setDownloading] = useState(false);
+  const [toast, setToast] = useState<{ tone: "success" | "error"; message: string } | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    getCreditBalance(period, 12)
+      .then(setData)
+      .catch(() => setToast({ tone: "error", message: "Erro ao carregar saldo de crédito" }))
+      .finally(() => setLoading(false));
+  }, [period]);
+
+  async function handleExportCsv(): Promise<void> {
+    setDownloading(true);
+    try {
+      const blob = await downloadCreditCsv(period, 12);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `credito-ibs-cbs-${period}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setToast({ tone: "success", message: "CSV exportado" });
+    } catch {
+      setToast({ tone: "error", message: "Erro ao exportar CSV" });
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  const rows = data?.periods ?? [];
+  const agg = totals(rows);
+
+  return (
+    <section className="space-y-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Crédito IBS/CBS</h1>
+          <p className="text-sm text-slate-500">
+            Saldo e fluxo de crédito por período — LC 214 (não-cumulatividade plena). Derivado dos
+            documentos rastreados em Split Payment.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleExportCsv()}
+          disabled={downloading || rows.length === 0}
+          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+        >
+          {downloading ? "Exportando…" : "Exportar CSV"}
+        </button>
+      </header>
+
+      {loading ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <SummaryCard
+            label="Gerado"
+            value={fmtBrl(agg.generated.toFixed(2))}
+            hint="Confirmado + Apropriado"
+            className="border-emerald-200 bg-emerald-50 text-emerald-900"
+          />
+          <SummaryCard
+            label="Apropriado"
+            value={fmtBrl(agg.apropriated.toFixed(2))}
+            hint="Crédito já utilizado"
+            className="border-tribultz-200 bg-tribultz-50 text-tribultz-900"
+          />
+          <SummaryCard
+            label="Disponível"
+            value={fmtBrl(agg.available.toFixed(2))}
+            hint="Formalizado, não utilizado"
+            className="border-amber-200 bg-amber-50 text-amber-900"
+          />
+          <SummaryCard
+            label="Em Risco"
+            value={fmtBrl(agg.at_risk.toFixed(2))}
+            hint="Falhas no Split Payment"
+            className="border-red-200 bg-red-50 text-red-900"
+          />
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {(["month", "quarter"] as const).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPeriod(p)}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              period === p
+                ? "border-tribultz-500 bg-tribultz-600 text-white"
+                : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+            }`}
+          >
+            {p === "month" ? "Mensal" : "Trimestral"}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white px-6 py-10 text-center text-sm text-slate-500">
+          Nenhum crédito IBS/CBS rastreado nos últimos 12 meses.
+          <br />
+          <span className="text-xs text-slate-400">
+            Os créditos aparecem aqui quando documentos têm status de Split Payment atribuído.
+          </span>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50">
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Período
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                  Gerado
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-tribultz-700">
+                  Apropriado
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-amber-700">
+                  Disponível
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-red-700">
+                  Em Risco
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.period} className="border-t border-slate-100">
+                  <td className="px-4 py-3 font-medium text-slate-800">{r.period}</td>
+                  <td className="px-4 py-3 text-right font-mono">
+                    {fmtBrl(r.generated_total)}
+                    <span className="ml-1 text-xs text-slate-400">({r.generated_count})</span>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono">
+                    {fmtBrl(r.apropriated_total)}
+                    <span className="ml-1 text-xs text-slate-400">({r.apropriated_count})</span>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono">
+                    {fmtBrl(r.available_total)}
+                    <span className="ml-1 text-xs text-slate-400">({r.available_count})</span>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono">
+                    {fmtBrl(r.at_risk_total)}
+                    <span className="ml-1 text-xs text-slate-400">({r.at_risk_count})</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {toast ? <Toast message={toast.message} tone={toast.tone} onClose={() => setToast(null)} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ const links = [
   { href: "/audit", label: "Auditoria" },
   { href: "/exceptions", label: "Exceções" },
   { href: "/split-payment", label: "Split Payment" },
+  { href: "/credits", label: "Crédito IBS/CBS" },
   { href: "/billing", label: "Faturamento" },
   { href: "/settings", label: "Configurações" },
   { href: "/support", label: "Suporte" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -596,3 +596,44 @@ export async function updateSplitPaymentStatus(
     body: JSON.stringify(payload),
   });
 }
+
+// ── Credits Dashboard (#258) ────────────────────────────────────────────────
+
+export type CreditPeriodRow = {
+  period: string;
+  generated_count: number;
+  generated_total: string;
+  apropriated_count: number;
+  apropriated_total: string;
+  available_count: number;
+  available_total: string;
+  at_risk_count: number;
+  at_risk_total: string;
+};
+
+export type CreditBalanceResponse = {
+  period_type: "month" | "quarter";
+  periods: CreditPeriodRow[];
+};
+
+export async function getCreditBalance(
+  period: "month" | "quarter" = "month",
+  monthsBack: number = 12,
+): Promise<CreditBalanceResponse> {
+  return apiFetch(`/api/v1/credits/balance?period=${period}&months_back=${monthsBack}`);
+}
+
+export async function downloadCreditCsv(
+  period: "month" | "quarter" = "month",
+  monthsBack: number = 12,
+): Promise<Blob> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/credits/export.csv?period=${period}&months_back=${monthsBack}`,
+    {
+      headers: { Authorization: `Bearer ${getToken()}`, "X-Tenant-Id": getTenantId() },
+      cache: "no-store",
+    },
+  );
+  if (!res.ok) throw new Error(`API ${res.status}`);
+  return res.blob();
+}


### PR DESCRIPTION
Fecha parcialmente #258 (Fase 1 — saldo agregado por período).

## Summary
- Novo router `/api/v1/credits` com `GET /balance` + `GET /export.csv`, agregando `documents.split_payment_status` (introduzido em #169) por mês ou trimestre via `date_trunc`. Sem tabela nova, sem migration.
- Frontend em `/credits`: 4 cards (Gerado, Apropriado, Disponível, Em Risco), toggle Mensal/Trimestral, tabela por período, export CSV (`;` para Excel pt-BR).
- Gating por plano profissional/empresarial/contador (mesmo padrão do Split Payment).
- 5 novos testes (mock de Session + plan_gate). Suite backend completa: 440/440. Frontend: 58/58.

## Fluxo de crédito (LC 214 art. 22)
| Coluna | Derivação |
|---|---|
| Gerado | `confirmed` + `credit_released` |
| Apropriado | `credit_released` |
| Disponível | `confirmed` |
| Em Risco | `failed` |

## Não-escopo (fica para Fase 2)
- Drill-down por NF
- Export PDF
- IBS/CBS separados (depende de enriquecer `fiscal_metadata`)
- Tabela `credit_events` dedicada

## Test plan
- [x] `pytest tests/test_credits.py` — 5/5
- [x] `pytest tests/` (suite completa) — 440/440
- [x] `ruff check` — clean
- [x] `npm test` — 58/58
- [x] `npm run build` — rota `/credits` registrada
- [x] Preview: página carrega, sidebar atualizada, sem erro de console
- [ ] Smoke em staging após merge: validar com tenant que tenha documentos Split Payment
