### PR TITLE
chore(ci): actions v4→v5 + uptime monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       PYTHONUNBUFFERED: "1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Python (pin)
         uses: actions/setup-python@v5
@@ -68,7 +68,7 @@ jobs:
             backend/pyproject.toml
 
       - name: Setup Node (pin) # needed for pyright via npx
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.12.0"
 
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload QA report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: qa_gates_report
           path: reports/qa_gates_report.md
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node (pin)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.12.0"
           cache: "npm"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout (para referência do commit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolver flags do deploy.sh
         id: flags

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,0 +1,83 @@
+name: Uptime Monitor
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"   # a cada 5 minutos
+  workflow_dispatch:
+
+concurrency:
+  group: monitor
+  cancel-in-progress: true
+
+jobs:
+  health-check:
+    name: GET /health/deep
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Probe health endpoint
+        id: probe
+        run: |
+          RESPONSE=$(curl -sf --max-time 10 \
+            https://api.tribultz.com.br/health/deep 2>&1) || {
+            echo "status=unreachable" >> "$GITHUB_OUTPUT"
+            echo "body=$RESPONSE"     >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          echo "body=$RESPONSE" >> "$GITHUB_OUTPUT"
+          STATUS=$(echo "$RESPONSE" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); print(d.get('status','unknown'))")
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Fail on error
+        if: steps.probe.outputs.status == 'error' || steps.probe.outputs.status == 'unreachable'
+        run: |
+          echo "::error::Health check FAILED — status: ${{ steps.probe.outputs.status }}"
+          echo "Response: ${{ steps.probe.outputs.body }}"
+          exit 1
+
+      - name: Send alert email (Resend)
+        if: failure()
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          PROBE_STATUS:   ${{ steps.probe.outputs.status }}
+          PROBE_BODY:     ${{ steps.probe.outputs.body }}
+        run: |
+          python3 - << 'PY'
+          import os, json, urllib.request, urllib.error
+
+          key    = os.environ["RESEND_API_KEY"]
+          status = os.environ.get("PROBE_STATUS", "unknown")
+          body   = os.environ.get("PROBE_BODY", "")
+
+          payload = json.dumps({
+            "from": "noreply@tribultz.com.br",
+            "to":   ["mickel@tribultz.com.br"],
+            "subject": f"[ALERTA] Tribultz API — status: {status}",
+            "html": f"<h2>Tribultz API degradada</h2>"
+                    f"<p><b>Status:</b> {status}</p>"
+                    f"<pre>{body[:2000]}</pre>"
+                    f"<p><a href='https://api.tribultz.com.br/health/deep'>Ver health</a></p>",
+          }).encode()
+
+          req = urllib.request.Request(
+            "https://api.resend.com/emails",
+            data=payload,
+            headers={
+              "Authorization": f"Bearer {key}",
+              "Content-Type":  "application/json",
+            },
+          )
+          try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+              print("Alert sent:", r.status)
+          except urllib.error.HTTPError as e:
+            print("Resend error:", e.read().decode())
+          PY
+
+      - name: Log status (degraded warning)
+        if: steps.probe.outputs.status == 'degraded'
+        run: |
+          echo "::warning::API degraded — serviços opcionais com falha"
+          echo "${{ steps.probe.outputs.body }}"

--- a/.github/workflows/publish-news.yml
+++ b/.github/workflows/publish-news.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # 0 = histórico completo. Necessário para workflow_dispatch poder
           # re-publicar entradas a partir de SHAs antigos (caso contrário


### PR DESCRIPTION
## Problema

GitHub depreca Node.js 20 nos runners em **02/06/2026** (5 dias). Os três workflows usavam `actions/checkout@v4`, `setup-node@v4` e `upload-artifact@v4` — todos baseados em Node.js 20.

## O que muda

### Actions atualizados (Node.js 20 → 22)

| Action | Antes | Depois |
|---|---|---|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/setup-node` | `@v4` | `@v5` |
| `actions/upload-artifact` | `@v4` | `@v5` |

Arquivos afetados: `ci.yml`, `deploy-prod.yml`, `publish-news.yml`.

### Novo: `monitor.yml` — Uptime Monitor

- Roda a cada 5 minutos via cron
- `GET https://api.tribultz.com.br/health/deep`
- `status=error` ou `unreachable` → job falha + envia email de alerta via Resend para `mickel@tribultz.com.br`
- `status=degraded` → warning no log (não bloqueia)
- Secret `RESEND_API_KEY` já cadastrado no repositório

## Test plan

- [ ] CI passa nos dois jobs (backend-gates + frontend-build)
- [ ] Após merge: confirmar que `monitor.yml` aparece em Actions e dispara no próximo tick de 5 min
- [ ] Confirmar email de alerta chegando (disparar manualmente via workflow_dispatch com endpoint simulado para testar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)