### PR TITLE
feat(billing): recorrência Asaas + trial notifications

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -22,6 +22,10 @@ celery.conf.update(
             "task": "billing.expire_trials",
             "schedule": crontab(minute="0"),  # every hour at :00
         },
+        "warn-trial-expiring": {
+            "task": "billing.warn_trial_expiring",
+            "schedule": crontab(minute="30"),  # every hour at :30 (offset from expire)
+        },
         "reset-usage-monthly": {
             "task": "billing.reset_monthly_usage",
             "schedule": crontab(minute="0", hour="0", day_of_month="1"),  # 1st of month at midnight

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -323,15 +323,23 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
             asaas_customer_id = customer["id"]
             subscription.asaas_customer_id = asaas_customer_id  # type: ignore[assignment]
 
-            # Create Asaas payment (first charge)
+            # Create recurring Asaas subscription (monthly)
             price_reais = cast(int, plan.price_cents) / 100
-            payment = await asaas.create_payment(
+            sub_resp = await asaas.create_subscription(
                 customer_id=asaas_customer_id,
                 value=price_reais,
                 billing_type=data.billing_type,
                 description=f"Assinatura Tribultz — {cast(str, plan.name)}",
             )
-            asaas_payment_id = payment["id"]
+            asaas_subscription_id = sub_resp["id"]
+            subscription.asaas_subscription_id = asaas_subscription_id  # type: ignore[assignment]
+
+            # Asaas creates the first payment automatically — retrieve it
+            sub_payments = await asaas.get_subscription_payments(asaas_subscription_id)
+            if not sub_payments:
+                raise ValueError("Asaas subscription created but no payment found")
+            first_payment = sub_payments[0]
+            asaas_payment_id = first_payment["id"]
 
             # Store payment record
             from app.models.billing import Payment
@@ -364,17 +372,16 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
             # Don't fail registration — user can pay later via billing page
             checkout_url = None
 
-    # Trial: send verification email immediately
-    if is_trial:
-        verification_token = create_email_verification_token(str(user.id))
-        user.email_verification_token = verification_token  # type: ignore[assignment]
-        db.commit()
+    # Send email verification for all new accounts (trial and paid)
+    verification_token = create_email_verification_token(str(user.id))
+    user.email_verification_token = verification_token  # type: ignore[assignment]
+    db.commit()
 
-        send_verification_email(
-            to_email=data.email,
-            user_name=data.full_name,
-            token=verification_token,
-        )
+    send_verification_email(
+        to_email=data.email,
+        user_name=data.full_name,
+        token=verification_token,
+    )
 
     logger.info(
         "user_registered",

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -1,7 +1,7 @@
 """Billing router — Asaas webhooks, plan info, payments, upgrade, cancel."""
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -65,11 +65,43 @@ async def asaas_webhook(
 
     # ── PAYMENT_CONFIRMED / PAYMENT_RECEIVED ──
     if event in ("PAYMENT_CONFIRMED", "PAYMENT_RECEIVED"):
+        now = datetime.now(timezone.utc)
         payment = db.execute(
             select(Payment).where(Payment.asaas_payment_id == asaas_payment_id)
         ).scalar_one_or_none()
 
         if not payment:
+            # Unknown payment — may be a monthly renewal from an Asaas subscription
+            asaas_sub_id = payment_data.get("subscription") or payment_data.get("subscriptionId", "")
+            if asaas_sub_id:
+                sub = db.execute(
+                    select(Subscription).where(Subscription.asaas_subscription_id == asaas_sub_id)
+                ).scalar_one_or_none()
+                if sub:
+                    renewal = Payment(
+                        tenant_id=sub.tenant_id,
+                        subscription_id=sub.id,
+                        asaas_payment_id=asaas_payment_id,
+                        amount_cents=int(float(payment_data.get("value", 0)) * 100),
+                        status="confirmed",
+                        payment_method=payment_data.get("billingType", "PIX").lower(),
+                        paid_at=now,
+                    )
+                    db.add(renewal)
+                    db.execute(
+                        update(Subscription)
+                        .where(Subscription.id == sub.id)
+                        .values(
+                            status="active",
+                            current_period_start=now,
+                            current_period_end=now + timedelta(days=30),
+                        )
+                    )
+                    db.commit()
+                    logger.info(
+                        "Renewal confirmed | payment=%s subscription=%s", asaas_payment_id, sub.id
+                    )
+                    return {"status": "ok", "action": "renewal_confirmed"}
             logger.warning("Payment %s not found in DB", asaas_payment_id)
             return {"status": "ignored", "reason": "payment not found"}
 
@@ -79,16 +111,20 @@ async def asaas_webhook(
 
         # Update payment
         payment.status = "confirmed"  # type: ignore[assignment]
-        payment.paid_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+        payment.paid_at = now  # type: ignore[assignment]
 
-        # Activate subscription
+        # Activate subscription + extend period
         db.execute(
             update(Subscription)
             .where(Subscription.id == payment.subscription_id)
-            .values(status="active", current_period_start=datetime.now(timezone.utc))
+            .values(
+                status="active",
+                current_period_start=now,
+                current_period_end=now + timedelta(days=30),
+            )
         )
 
-        # Activate user (skip if LGPD-deleted)
+        # Activate user + auto-verify email (skip if LGPD-deleted)
         sub = db.execute(
             select(Subscription).where(Subscription.id == payment.subscription_id)
         ).scalar_one_or_none()
@@ -96,7 +132,9 @@ async def asaas_webhook(
             user = db.get(User, sub.user_id)
             if user and user.deleted_at is None:
                 db.execute(
-                    update(User).where(User.id == sub.user_id).values(is_active=True)
+                    update(User)
+                    .where(User.id == sub.user_id)
+                    .values(is_active=True, email_verified=True)
                 )
             elif user and user.deleted_at is not None:
                 logger.warning(
@@ -115,7 +153,6 @@ async def asaas_webhook(
                 sub.user_id,
                 sub.id,
             )
-            # Fetch user + plan for the email
             confirmed_user = db.execute(
                 select(User).where(User.id == sub.user_id)
             ).scalar_one_or_none()
@@ -308,13 +345,21 @@ async def upgrade_plan(
             )
             customer_id = cust["id"]
 
-        payment_resp = await asaas.create_payment(
+        # Create recurring Asaas subscription (monthly)
+        sub_resp = await asaas.create_subscription(
             customer_id=customer_id,
             value=value,
             billing_type=billing_type.upper(),
             description=f"Upgrade Tribultz — {cast(str, target_plan.name)}",
         )
-        asaas_payment_id = payment_resp["id"]
+        new_asaas_sub_id = sub_resp["id"]
+
+        # Retrieve first payment created automatically by Asaas
+        sub_payments = await asaas.get_subscription_payments(new_asaas_sub_id)
+        if not sub_payments:
+            raise ValueError("Asaas subscription created but no payment found")
+        first_payment = sub_payments[0]
+        asaas_payment_id = first_payment["id"]
 
         if billing_type.upper() == "PIX":
             pix_data = await asaas.get_pix_qr_code(asaas_payment_id)
@@ -323,7 +368,7 @@ async def upgrade_plan(
         else:
             checkout_url = asaas.get_checkout_url(asaas_payment_id)
     except Exception:
-        logger.exception("Erro ao criar pagamento Asaas no upgrade")
+        logger.exception("Erro ao criar assinatura Asaas no upgrade")
         raise HTTPException(status_code=502, detail="Erro ao processar pagamento. Tente novamente.")
 
     # Create new subscription
@@ -333,6 +378,7 @@ async def upgrade_plan(
         plan_id=target_plan.id,
         status="pending",
         asaas_customer_id=customer_id,
+        asaas_subscription_id=new_asaas_sub_id,
     )
     db.add(new_sub)
     db.flush()

--- a/backend/app/services/asaas_service.py
+++ b/backend/app/services/asaas_service.py
@@ -182,6 +182,14 @@ class AsaasService:
     async def get_subscription(self, subscription_id: str) -> dict[str, Any]:
         return await self._request("GET", f"/v3/subscriptions/{subscription_id}")
 
+    async def get_subscription_payments(self, subscription_id: str) -> list[dict[str, Any]]:
+        """Return payments for a subscription, sorted by dueDate ascending (first = current charge)."""
+        result = await self._request(
+            "GET",
+            f"/v3/subscriptions/{subscription_id}/payments",
+        )
+        return result.get("data", [])
+
     async def cancel_subscription(self, subscription_id: str) -> dict[str, Any]:
         return await self._request("DELETE", f"/v3/subscriptions/{subscription_id}")
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -269,6 +269,55 @@ def send_exception_notification_email(
     )
 
 
+def send_trial_expiring_email(to_email: str, user_name: str, days_remaining: int) -> bool:
+    """Warn user their trial expires in `days_remaining` days (sent at D-3 and D-1)."""
+    pricing_url = f"{settings.FRONTEND_URL}/pricing"
+    html_body = _render(
+        "trial_expiring.html",
+        user_name=user_name,
+        days_remaining=days_remaining,
+        pricing_url=pricing_url,
+        frontend_url=settings.FRONTEND_URL,
+    )
+    text_body = (
+        f"Olá, {user_name}!\n\n"
+        f"Seu trial do Tribultz expira em {days_remaining} dia(s).\n"
+        f"Assine um plano para manter o acesso: {pricing_url}\n\n"
+        "Tribultz Tecnologia Ltda."
+    )
+    return _send_email(
+        to_email=to_email,
+        subject=f"Tribultz — Seu trial expira em {days_remaining} dia(s)",
+        html_body=html_body,
+        text_body=text_body,
+        log_url=pricing_url,
+    )
+
+
+def send_trial_expired_email(to_email: str, user_name: str) -> bool:
+    """Notify user their trial has expired and invite them to upgrade."""
+    pricing_url = f"{settings.FRONTEND_URL}/pricing"
+    html_body = _render(
+        "trial_expired.html",
+        user_name=user_name,
+        pricing_url=pricing_url,
+        frontend_url=settings.FRONTEND_URL,
+    )
+    text_body = (
+        f"Olá, {user_name}!\n\n"
+        "Seu trial do Tribultz expirou. Para reativar o acesso:\n"
+        f"{pricing_url}\n\n"
+        "Tribultz Tecnologia Ltda."
+    )
+    return _send_email(
+        to_email=to_email,
+        subject="Tribultz — Seu trial expirou",
+        html_body=html_body,
+        text_body=text_body,
+        log_url=pricing_url,
+    )
+
+
 def send_staff_ticket_notification(ticket_title: str, user_email: str, priority: str) -> bool:
     """Notify contato@tribultz.com.br when a new ticket is opened."""
     priority_labels = {"low": "Baixa", "medium": "Média", "high": "Alta", "critical": "Crítica"}

--- a/backend/app/tasks/task_g_billing.py
+++ b/backend/app/tasks/task_g_billing.py
@@ -1,7 +1,7 @@
 """Celery tasks for billing lifecycle — trial expiry and monthly usage reset."""
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select, update
 
@@ -32,6 +32,8 @@ def expire_trials():
             )
         ).scalars().all()
 
+        from app.services.email_service import send_trial_expired_email
+
         count = 0
         for sub in expired_subs:
             sub.status = "expired"  # type: ignore[assignment]
@@ -39,6 +41,15 @@ def expire_trials():
             db.execute(
                 update(User).where(User.id == sub.user_id).values(is_active=False)
             )
+            # Notify user
+            user = db.execute(
+                select(User).where(User.id == sub.user_id)
+            ).scalar_one_or_none()
+            if user:
+                send_trial_expired_email(
+                    to_email=str(user.email),
+                    user_name=str(user.full_name),
+                )
             count += 1
             logger.info(
                 "trial_expired",
@@ -55,6 +66,52 @@ def expire_trials():
         db.rollback()
         logger.exception("expire_trials failed")
         raise
+    finally:
+        db.close()
+
+
+@celery.task(name="billing.warn_trial_expiring")
+def warn_trial_expiring():
+    """Send warning emails for trials expiring in ~3 days or ~1 day.
+
+    Runs hourly at :30. Uses a ±1h window around each threshold so a
+    single hourly run covers each user exactly once per warning level.
+    """
+    from app.services.email_service import send_trial_expiring_email
+
+    db = SessionLocal()
+    try:
+        now = datetime.now(timezone.utc)
+
+        for days_before in (3, 1):
+            window_start = now + timedelta(days=days_before) - timedelta(hours=1)
+            window_end   = now + timedelta(days=days_before) + timedelta(hours=1)
+
+            subs = db.execute(
+                select(Subscription).where(
+                    Subscription.status == "trial",
+                    Subscription.trial_ends_at >= window_start,
+                    Subscription.trial_ends_at < window_end,
+                )
+            ).scalars().all()
+
+            for sub in subs:
+                user = db.execute(
+                    select(User).where(User.id == sub.user_id)
+                ).scalar_one_or_none()
+                if user:
+                    send_trial_expiring_email(
+                        to_email=str(user.email),
+                        user_name=str(user.full_name),
+                        days_remaining=days_before,
+                    )
+                    logger.info(
+                        "trial_warning_sent",
+                        extra={"days": days_before, "user_id": str(sub.user_id)},
+                    )
+
+    except Exception:
+        logger.exception("warn_trial_expiring failed")
     finally:
         db.close()
 

--- a/backend/app/templates/emails/trial_expired.html
+++ b/backend/app/templates/emails/trial_expired.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Seu trial expirou — Tribultz</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:16px;border:1px solid #e2e8f0;overflow:hidden;max-width:560px;">
+
+        <!-- Header -->
+        <tr>
+          <td style="background:#0f172a;padding:28px 40px;">
+            <span style="color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.3px;">Tribultz</span>
+            <span style="color:#64748b;font-size:12px;margin-left:10px;letter-spacing:0.08em;text-transform:uppercase;">Console</span>
+          </td>
+        </tr>
+
+        <!-- Expired badge -->
+        <tr>
+          <td style="background:#fef2f2;border-bottom:1px solid #fecaca;padding:20px 40px;">
+            <p style="margin:0;font-size:14px;color:#991b1b;font-weight:700;">
+              🔒 Seu trial expirou — acesso suspenso
+            </p>
+          </td>
+        </tr>
+
+        <!-- Body -->
+        <tr>
+          <td style="padding:36px 40px 24px;">
+            <p style="margin:0 0 16px;font-size:16px;color:#1e293b;line-height:1.6;">
+              Olá, <strong>{{ user_name }}</strong>!
+            </p>
+            <p style="margin:0 0 20px;font-size:15px;color:#475569;line-height:1.7;">
+              Seu período de trial gratuito do Tribultz encerrou. Para retomar o acesso ao console
+              e continuar validando notas fiscais conforme a LC 214, escolha um plano pago.
+            </p>
+            <p style="margin:0 0 20px;font-size:15px;color:#475569;line-height:1.7;">
+              Lembre-se: as <strong>penalidades CBS/IBS entram em vigor em agosto/2026</strong>.
+              Documentação auditável agora é obrigatória.
+            </p>
+          </td>
+        </tr>
+
+        <!-- CTA -->
+        <tr>
+          <td align="center" style="padding:0 40px 36px;">
+            <a href="{{ pricing_url }}"
+               style="display:inline-block;background:#2956E3;color:#ffffff;font-size:15px;font-weight:700;
+                      text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:-0.2px;">
+              Reativar acesso
+            </a>
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="border-top:1px solid #e2e8f0;padding:20px 40px;">
+            <p style="margin:0;font-size:12px;color:#94a3b8;line-height:1.6;">
+              Tribultz Tecnologia Ltda. · <a href="{{ frontend_url }}" style="color:#94a3b8;">tribultz.com.br</a>
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/backend/app/templates/emails/trial_expiring.html
+++ b/backend/app/templates/emails/trial_expiring.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Seu trial expira em breve — Tribultz</title>
+</head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:16px;border:1px solid #e2e8f0;overflow:hidden;max-width:560px;">
+
+        <!-- Header -->
+        <tr>
+          <td style="background:#0f172a;padding:28px 40px;">
+            <span style="color:#ffffff;font-size:20px;font-weight:700;letter-spacing:-0.3px;">Tribultz</span>
+            <span style="color:#64748b;font-size:12px;margin-left:10px;letter-spacing:0.08em;text-transform:uppercase;">Console</span>
+          </td>
+        </tr>
+
+        <!-- Warning badge -->
+        <tr>
+          <td style="background:#fffbeb;border-bottom:1px solid #fde68a;padding:20px 40px;">
+            <p style="margin:0;font-size:14px;color:#92400e;font-weight:700;">
+              ⏳ Seu trial expira em {{ days_remaining }} dia{% if days_remaining > 1 %}s{% endif %}
+            </p>
+          </td>
+        </tr>
+
+        <!-- Body -->
+        <tr>
+          <td style="padding:36px 40px 24px;">
+            <p style="margin:0 0 16px;font-size:16px;color:#1e293b;line-height:1.6;">
+              Olá, <strong>{{ user_name }}</strong>!
+            </p>
+            <p style="margin:0 0 20px;font-size:15px;color:#475569;line-height:1.7;">
+              Seu período de trial do Tribultz encerra em <strong>{{ days_remaining }} dia{% if days_remaining > 1 %}s{% endif %}</strong>.
+              Para continuar validando notas fiscais e garantir conformidade com a LC 214 antes das
+              <strong>penalidades de agosto/2026</strong>, escolha um plano agora.
+            </p>
+            <p style="margin:0 0 28px;font-size:15px;color:#475569;line-height:1.7;">
+              Planos a partir de <strong>R$ 49,90/mês</strong>. Sem contrato de fidelidade.
+            </p>
+          </td>
+        </tr>
+
+        <!-- CTA -->
+        <tr>
+          <td align="center" style="padding:0 40px 36px;">
+            <a href="{{ pricing_url }}"
+               style="display:inline-block;background:#2956E3;color:#ffffff;font-size:15px;font-weight:700;
+                      text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:-0.2px;">
+              Ver planos e assinar
+            </a>
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="border-top:1px solid #e2e8f0;padding:20px 40px;">
+            <p style="margin:0;font-size:12px;color:#94a3b8;line-height:1.6;">
+              Tribultz Tecnologia Ltda. · <a href="{{ frontend_url }}" style="color:#94a3b8;">tribultz.com.br</a>
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Problema

Dois gaps críticos bloqueavam receita real:

1. **Clientes pagavam uma vez e nunca eram cobrados novamente** — `register()` e `upgrade()` criavam `Payment` único em vez de `Subscription` recorrente. `asaas_subscription_id` existia no modelo mas nunca era preenchido.

2. **Trial expirava silenciosamente** — `expire_trials` desativava o usuário sem notificar. Sem emails de aviso D-3/D-1.

3. **Bug de login pós-pagamento** — `email_verified` nunca era setado para `True` em usuários pagos, bloqueando o login mesmo após pagamento confirmado.

## O que muda

### Recorrência (`asaas_service.py`, `auth.py`, `billing.py`)

| Antes | Depois |
|---|---|
| `create_payment()` — pagamento único | `create_subscription()` — recorrência mensal |
| `asaas_subscription_id = NULL` | salvo em `Subscription` em register() e upgrade() |
| Webhook só ativava subscription | Webhook também estende `current_period_end = now+30d` |
| Renovações Asaas ignoradas | Novo handler: cria `Payment` de renovação e estende período |
| `email_verified` nunca setado no pagamento | `email_verified=True` no `PAYMENT_CONFIRMED` |

### Trial notifications (`task_g_billing.py`, `email_service.py`, templates)

- `expire_trials` agora envia `send_trial_expired_email` antes de desativar
- Nova task `billing.warn_trial_expiring` (beat `:30`, a cada hora):
  - Janela D-3: envia aviso 3 dias antes de expirar
  - Janela D-1: envia aviso 1 dia antes de expirar
  - Janela ±1h por threshold — cada usuário recebe exatamente 1 email por nível
- 2 novos templates HTML (`trial_expiring.html`, `trial_expired.html`)
- 2 novas funções em `email_service.py`

### Sem migration necessária
Planos já são seedados na migration `0004` com `ON CONFLICT DO NOTHING`.

## Test plan

- [ ] CI backend-gates passa (ruff + pyright + pytest)
- [ ] `register()` com plano pago: checar que `asaas_subscription_id` é preenchido
- [ ] `upgrade()`: checar que nova subscription tem `asaas_subscription_id`
- [ ] Webhook com `payment.subscription = "sub_xxx"` e payment_id desconhecido → `renewal_confirmed`
- [ ] Webhook `PAYMENT_CONFIRMED` → checar `email_verified=True` e `current_period_end` atualizado
- [ ] `billing.warn_trial_expiring` via `celery call billing.warn_trial_expiring` → emails no log
- [ ] `billing.expire_trials` → checar email de expiração no log

