### PR TITLE
fix(compliance): CAST(:param AS type) em vez de :param::type em sqlalchemy.text() (#272)

### DIFF
--- a/backend/app/routers/compliance.py
+++ b/backend/app/routers/compliance.py
@@ -59,8 +59,8 @@ def _compute_score_realtime(tenant_id: str, period: str, db: Session) -> dict:
             FROM jobs
             WHERE tenant_id = CAST(:tid AS uuid)
               AND job_type IN ('validate_xml', 'task_a_validate_cbs_ibs', 'sped_validation')
-              AND created_at >= :start::date
-              AND created_at < (:start::date + INTERVAL '1 month')
+              AND created_at >= CAST(:start AS date)
+              AND created_at < (CAST(:start AS date) + INTERVAL '1 month')
         """),
         {"tid": tenant_id, "start": period_start},
     ).mappings().fetchone()
@@ -79,8 +79,8 @@ def _compute_score_realtime(tenant_id: str, period: str, db: Session) -> dict:
             FROM jobs
             WHERE tenant_id = CAST(:tid AS uuid)
               AND job_type IN ('validate_xml', 'task_a_validate_cbs_ibs')
-              AND created_at >= :start::date
-              AND created_at < (:start::date + INTERVAL '1 month')
+              AND created_at >= CAST(:start AS date)
+              AND created_at < (CAST(:start AS date) + INTERVAL '1 month')
         """),
         {"tid": tenant_id, "start": period_start},
     ).mappings().fetchone()

--- a/backend/app/tasks/task_i_compliance.py
+++ b/backend/app/tasks/task_i_compliance.py
@@ -32,8 +32,8 @@ def compute_monthly_scores() -> dict:
             text("""
                 SELECT DISTINCT tenant_id::text
                 FROM jobs
-                WHERE created_at >= :start::date
-                  AND created_at < (:start::date + INTERVAL '1 month')
+                WHERE created_at >= CAST(:start AS date)
+                  AND created_at < (CAST(:start AS date) + INTERVAL '1 month')
                   AND job_type IN ('validate_xml', 'task_a_validate_cbs_ibs', 'sped_validation')
             """),
             {"start": period_start},
@@ -113,8 +113,8 @@ def _upsert_score(db, tenant_id: str, period: str, period_start: str) -> None:
             FROM jobs
             WHERE tenant_id = CAST(:tid AS uuid)
               AND job_type IN ('validate_xml', 'task_a_validate_cbs_ibs', 'sped_validation')
-              AND created_at >= :start::date
-              AND created_at < (:start::date + INTERVAL '1 month')
+              AND created_at >= CAST(:start AS date)
+              AND created_at < (CAST(:start AS date) + INTERVAL '1 month')
         """),
         {"tid": tenant_id, "start": period_start},
     ).mappings().fetchone()
@@ -130,8 +130,8 @@ def _upsert_score(db, tenant_id: str, period: str, period_start: str) -> None:
             WHERE tenant_id = CAST(:tid AS uuid)
               AND job_type IN ('validate_xml', 'task_a_validate_cbs_ibs')
               AND status = 'FAILED'
-              AND created_at >= :start::date
-              AND created_at < (:start::date + INTERVAL '1 month')
+              AND created_at >= CAST(:start AS date)
+              AND created_at < (CAST(:start AS date) + INTERVAL '1 month')
         """),
         {"tid": tenant_id, "start": period_start},
     ).scalar_one_or_none()


### PR DESCRIPTION
## Problema

Dashboard retornava **HTTP 500** para todos os usuários logados.

```
psycopg2.errors.SyntaxError: syntax error at or near ":"
LINE 8: AND created_at >= :start::date
```

## Causa raiz

O SQLAlchemy processa `:start::date` e interpreta `:start:` (com o segundo `:` do cast PostgreSQL) como nome de parâmetro malformado. O psycopg2 não consegue substituir o bind e lança `SyntaxError`.

## Fix

```sql
-- ❌ Antes
AND created_at >= :start::date
AND created_at < (:start::date + INTERVAL '1 month')

-- ✅ Depois  
AND created_at >= CAST(:start AS date)
AND created_at < (CAST(:start AS date) + INTERVAL '1 month')
```

7 ocorrências em 2 arquivos: `compliance.py` (4) + `task_i_compliance.py` (3).

## Impacto

- Corrige HTTP 500 no dashboard (compliance score) para todos os usuários
- Corrige `compliance.compute_monthly_scores` (beat mensal) que também falhava silenciosamente

## Contexto

Descoberto em 30/05/2026 durante o primeiro teste de pagamento real em produção. Fecha #272.

## Test plan
- [ ] 401 testes passando
- [ ] `ruff check` limpo
- [ ] Deploy em prod → abrir dashboard → sem 500
