### PR TITLE
fix(deploy): alembic upgrade head automático + --no-deps para evitar downtime Redis

### DIFF
--- a/infra/scripts/db-migrate.sh
+++ b/infra/scripts/db-migrate.sh
@@ -54,12 +54,13 @@ echo "[migrate] Backup complete ($(du -h "$BACKUP_DIR/pre_migrate_$TIMESTAMP.dum
 
 # ── 2. Show current head ──────────────────────────────────
 echo "[migrate] Current revision:"
-docker compose -f "$COMPOSE_FILE" run --rm api \
+docker compose -f "$COMPOSE_FILE" run --rm --no-deps api \
     python -m alembic current 2>/dev/null || true
 
 # ── 3. Run migration ──────────────────────────────────────
+# --no-deps: evita recriar Redis/outros serviços durante a migration
 echo "[migrate] Running: alembic upgrade head"
-if docker compose -f "$COMPOSE_FILE" run --rm api \
+if docker compose -f "$COMPOSE_FILE" run --rm --no-deps api \
         python -m alembic upgrade head; then
     echo "[migrate] SUCCESS — all migrations applied"
 else
@@ -83,7 +84,7 @@ fi
 
 # ── 4. Show new head ──────────────────────────────────────
 echo "[migrate] New revision:"
-docker compose -f "$COMPOSE_FILE" run --rm api \
+docker compose -f "$COMPOSE_FILE" run --rm --no-deps api \
     python -m alembic current 2>/dev/null || true
 
 echo ""

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -72,12 +72,18 @@ docker compose -f "$COMPOSE_FILE" build --pull 2>&1 | tee -a "$LOG_FILE"
 log "    Build concluído"
 
 # ── 3. Migrações Alembic ─────────────────────────────────────
+# Sempre executa alembic upgrade head — idempotente, sem risco.
+# --no-deps evita recriar Redis/outros serviços durante a migration.
+# Se --migrate foi passado, usa o script completo (com backup pg_dump).
 if [ "$RUN_MIGRATE" = true ]; then
-    log "==> [3/6] Rodando migrações Alembic"
+    log "==> [3/6] Rodando migrações Alembic (modo completo com backup)"
     bash "$DEPLOY_DIR/infra/scripts/db-migrate.sh" --prod
     log "    Migrações concluídas"
 else
-    log "==> [3/6] Pulando migrações (use --migrate para executar)"
+    log "==> [3/6] Aplicando migrações pendentes (upgrade head)"
+    docker compose -f "$COMPOSE_FILE" run --rm --no-deps api \
+        python -m alembic upgrade head 2>&1 | tee -a "$LOG_FILE"
+    log "    Upgrade head concluído"
 fi
 
 # ── Função: aguardar health check ────────────────────────────


### PR DESCRIPTION
## Problema

Dois bugs no processo de deploy descobertos durante auditoria pós-merge de 31/mai/2026:

### 1. Migrations nunca aplicadas automaticamente

O auto-deploy via `deploy-prod.yml` nunca rodava `alembic upgrade head`. A migration 0018 (cClassTrib 80 códigos) ficou **3 dias sem ser aplicada** após o merge do PR #274 — descoberto manualmente na auditoria de infra.

### 2. `db-migrate.sh` com downtime de 2s

O script usava `docker compose run --rm api` sem `--no-deps`, fazendo o Docker Compose **recriar o Redis** como dependência. Isso causava 2s de downtime no worker a cada migration manual.

## Fix

**`deploy.sh`** — passo [3/6] agora sempre executa:
```bash
docker compose run --rm --no-deps api python -m alembic upgrade head
```
- Idempotente: se não há migrations pendentes, retorna imediatamente
- `--no-deps`: não recria Redis ou outros serviços
- Com `--migrate`: ainda usa `db-migrate.sh` com backup pg_dump completo

**`db-migrate.sh`** — todas as invocações `run --rm api` recebem `--no-deps`.

## Test plan

- [ ] Próximo deploy via GitHub Actions: verificar que alembic upgrade head executa sem erro no passo [3/6]
- [ ] Verificar que Redis não é recriado durante o deploy
- [ ] `alembic current` em prod bate com head do código