### PR TITLE
feat(tracking): HubSpot tracking code — portal 49735644

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 ﻿import type { Metadata } from "next";
 import { Montserrat, Source_Sans_3, Roboto_Mono } from "next/font/google";
+import Script from "next/script";
 import { AppShell } from "@/components/layout/AppShell";
 import "./globals.css";
 
@@ -71,6 +72,11 @@ export default function RootLayout({
     <html lang="pt-BR">
       <body className={`${montserrat.variable} ${sourceSans.variable} ${robotoMono.variable}`}>
         <AppShell>{children}</AppShell>
+        <Script
+          id="hs-script-loader"
+          src="//js.hs-scripts.com/49735644.js"
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## O que faz

Adiciona o script de rastreamento do HubSpot (`js.hs-scripts.com/49735644.js`) em todas as páginas do site via `next/script`.

## Como funciona

- `strategy="afterInteractive"`: script carrega **após** a página ser interativa — sem impacto no LCP, FID ou CLS (Core Web Vitals)
- Cobre todas as rotas: landing, calculadora, diagnóstico, pricing, dashboard
- Para visitantes **anônimos**: HubSpot registra pageviews e comportamento (sem identificação pessoal)
- Para **contatos conhecidos** (quem preencheu qualquer formulário): HubSpot os reconhece pelo cookie e permite automações de retorno

## Próximos passos habilitados

- Automações de re-engajamento: "visitou pricing 2x sem assinar → enviar email"
- Lead scoring baseado em comportamento no site
- Rastrear jornada completa: landing → calculadora → registro → upgrade

## Test plan

- [ ] Build passando ✅
- [ ] Verificar no HubSpot → Analytics → Traffic Analytics que pageviews aparecem após deploy
- [ ] Inspecionar `<head>` em tribultz.com.br: script `hs-script-loader` presente
