### PR TITLE
feat(#266): Modo Período Educativo 2026 — LC 227 art. 348 §§ 3º e 4º

### DIFF
--- a/backend/app/alembic/versions/2026_05_31_0019_add_pedagogical_mode_2026.py
+++ b/backend/app/alembic/versions/2026_05_31_0019_add_pedagogical_mode_2026.py
@@ -1,0 +1,40 @@
+"""add_pedagogical_mode_2026
+
+Adiciona flag pedagogical_mode_2026 à tabela tenants.
+
+Quando True (padrão): findings de obrigação acessória CBS/IBS são
+downgraded de FATAL para WARNING, com badge "Período Pedagógico LC 227
+art. 348" e nota de 60 dias para sanar sem multa.
+
+Referência legal: LC 227/2026 art. 348 §§ 3º e 4º.
+
+Revision ID: 2026_05_31_0019
+Revises: 2026_05_31_0018
+Create Date: 2026-05-31
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2026_05_31_0019"
+down_revision = "2026_05_31_0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "pedagogical_mode_2026",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("TRUE"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenants", "pedagogical_mode_2026")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -25,6 +25,7 @@ class Tenant(Base):
     name = Column(String(200), nullable=False)
     slug = Column(String(100), nullable=False, unique=True)
     is_active = Column(Boolean, nullable=False, default=True)
+    pedagogical_mode_2026 = Column(Boolean, nullable=False, server_default="TRUE")
     # Using server_default=func.now() for creation
     # Using onupdate=func.now() to ensure python-side updates trigger the timestamp update
     # Schema just says DEFAULT now(), so DB side auto-update depends on triggers (not present in standard schema dump).

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -22,6 +22,7 @@ from app.core.security import (
     create_password_reset_token,
     verify_password_reset_token,
 )
+from app.api.deps import get_current_user
 from app.services.captcha_service import verify_captcha
 from app.services.cnpj_validator import validate_cnpj
 from app.services.email_service import send_verification_email, send_password_reset_email
@@ -774,3 +775,44 @@ def auth_health(db: Session = Depends(get_db)):
     except Exception as exc:
         logger.error("auth_health_db_error: %s", exc)
         raise HTTPException(status_code=503, detail="Auth DB unavailable")
+
+
+# ── Tenant settings ──────────────────────────────────────────────────────────
+
+class TenantSettingsResponse(BaseModel):
+    pedagogical_mode_2026: bool
+
+
+class TenantSettingsUpdate(BaseModel):
+    pedagogical_mode_2026: bool
+
+
+@router.get("/settings/tenant", response_model=TenantSettingsResponse)
+def get_tenant_settings(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TenantSettingsResponse:
+    """Get tenant settings (pedagogical mode, etc.)."""
+    tenant = db.execute(select(Tenant).where(Tenant.id == current_user.tenant_id)).scalar_one_or_none()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant não encontrado.")
+    return TenantSettingsResponse(pedagogical_mode_2026=bool(tenant.pedagogical_mode_2026))
+
+
+@router.patch("/settings/tenant", response_model=TenantSettingsResponse)
+def patch_tenant_settings(
+    data: TenantSettingsUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> TenantSettingsResponse:
+    """Update tenant settings."""
+    tenant = db.execute(select(Tenant).where(Tenant.id == current_user.tenant_id)).scalar_one_or_none()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant não encontrado.")
+    tenant.pedagogical_mode_2026 = data.pedagogical_mode_2026  # type: ignore[assignment]
+    db.commit()
+    logger.info(
+        "tenant_settings_updated tenant=%s pedagogical_mode_2026=%s",
+        current_user.tenant_id, data.pedagogical_mode_2026,
+    )
+    return TenantSettingsResponse(pedagogical_mode_2026=bool(tenant.pedagogical_mode_2026))

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -206,18 +206,46 @@ def _extract_regime_comparison(xml: str, has_ibscbs: bool) -> RegimeComparison |
 
 # ── Validation engine ───────────────────────────────────────────────────────
 
+# ── LC 227/2026 — regras de obrigação acessória ─────────────────────────────
+# Quando pedagogical_mode_2026=True, findings dessas regras são downgraded
+# de FATAL para WARNING com badge do período pedagógico.
+_PEDAGOGICAL_ACCESSORY_RULES = {
+    "CST_3_DIGITS", "CCLASSTRIB_6_DIGITS", "SERVICE_CODE_6_DIGITS",
+    "CST_VALID", "CST_GROUP_MATCH", "CST_SEMANTIC",
+    "IBSCBS_MISSING", "CEST_MISSING", "CEST_FORMAT",
+    "LAYOUT_NFE", "LAYOUT_PORTAL",
+    "NCM_FORMAT", "NCM_VALID", "CLASSTRIB_VALID",
+}
+
+_LC227_RECOMMENDATION = (
+    " — Período Pedagógico LC 227/2026 (art. 348 §§ 3º e 4º): "
+    "se autuado exclusivamente por esta obrigação acessória, "
+    "há 60 dias para regularizar sem aplicação de multa."
+)
+
+
+def _pedagogical_severity(rule_id: str, pedagogical_mode: bool) -> str:
+    """Return 'WARNING' for accessory rules in pedagogical mode, 'FATAL' otherwise."""
+    if pedagogical_mode and rule_id in _PEDAGOGICAL_ACCESSORY_RULES:
+        return "WARNING"
+    return "FATAL"
+
+
 def validate_xml(
     xml: str,
     doc_type: str | None = None,
     *,
     classtrib_results: dict[str, bool | None] | None = None,
     cnpj_result: tuple[bool, str] | None = None,
+    pedagogical_mode: bool = False,
 ) -> ValidationResult:
     """Apply deterministic validation rules to XML. Returns structured result.
 
     Optional enrichment parameters (pre-fetched by async caller):
       classtrib_results: {code: True/False/None} from ClassTrib API batch lookup
       cnpj_result: (is_active: bool, status: str) from CNPJ API lookup
+      pedagogical_mode: when True, accessory-rule FATALs become WARNINGs
+                        with LC 227/2026 art. 348 annotation
     """
     xml = xml.strip()
     if not doc_type:
@@ -281,9 +309,13 @@ def validate_xml(
         val = source["value"] if source else ""
         snip = source["snippet"] if source else f"<!-- Campo {field} não encontrado -->"
         xp = _xpath(source["tag"] if source else field, doc_type)
+        sev = _pedagogical_severity(rid, pedagogical_mode)
+        rec = "Corrigir no ERP e reemitir."
+        if sev == "WARNING":
+            rec += _LC227_RECOMMENDATION
         if not re.match(pattern, val):
             _add(
-                Finding(id=fid, severity="FATAL", rule_id=rid, title=title, where=FindingWhere(field=field, xpath=xp, snippet=snip), recommendation="Corrigir no ERP e reemitir.", evidence_ids=[ev_id]),
+                Finding(id=fid, severity=sev, rule_id=rid, title=title, where=FindingWhere(field=field, xpath=xp, snippet=snip), recommendation=rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label=f"Trecho XML — {field}", xpath=xp, snippet=snip),
             )
 
@@ -291,8 +323,12 @@ def validate_xml(
 
     if has_ibscbs and cst and re.match(r"^\d{3}$", cst["value"]) and cst["value"] not in VALID_CST_CODES:
         ev_id = "E_XML_CST_VALID"
+        _sev = _pedagogical_severity("CST_VALID", pedagogical_mode)
+        _rec = f"CSTs válidos: {', '.join(sorted(VALID_CST_CODES))}."
+        if _sev == "WARNING":
+            _rec += _LC227_RECOMMENDATION
         _add(
-            Finding(id="F_CST_VALID", severity="FATAL", rule_id="CST_VALID", title=f'CST "{cst["value"]}" não é código válido conforme NT 2025.002-RTC', where=FindingWhere(field="CST", xpath=_xpath("CST", doc_type), snippet=cst["snippet"]), recommendation=f"CSTs válidos: {', '.join(sorted(VALID_CST_CODES))}.", evidence_ids=[ev_id]),
+            Finding(id="F_CST_VALID", severity=_sev, rule_id="CST_VALID", title=f'CST "{cst["value"]}" não é código válido conforme NT 2025.002-RTC', where=FindingWhere(field="CST", xpath=_xpath("CST", doc_type), snippet=cst["snippet"]), recommendation=_rec, evidence_ids=[ev_id]),
             Evidence(id=ev_id, type="xml", label="CST — código desconhecido", xpath=_xpath("CST", doc_type), snippet=cst["snippet"]),
         )
 
@@ -302,26 +338,37 @@ def validate_xml(
         expected_group = CST_TABLE[cst["value"]]["group"]
         if expected_group and not _first_tag(xml, [expected_group]):
             ev_id = "E_XML_CST_GROUP_MATCH"
+            _sev = _pedagogical_severity("CST_GROUP_MATCH", pedagogical_mode)
+            _rec = f'CST {cst["value"]} requer <{expected_group}>. Preencher conforme NT 2025.002.'
+            if _sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_CST_GROUP_MATCH", severity="FATAL", rule_id="CST_GROUP_MATCH", title=f'CST {cst["value"]} exige grupo <{expected_group}>', where=FindingWhere(field="IBSCBS", xpath=_xpath("IBSCBS", doc_type)), recommendation=f'CST {cst["value"]} requer <{expected_group}>. Preencher conforme NT 2025.002.', evidence_ids=[ev_id]),
+                Finding(id="F_CST_GROUP_MATCH", severity=_sev, rule_id="CST_GROUP_MATCH", title=f'CST {cst["value"]} exige grupo <{expected_group}>', where=FindingWhere(field="IBSCBS", xpath=_xpath("IBSCBS", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label=f"CST {cst['value']} — grupo ausente", xpath=_xpath("IBSCBS", doc_type)),
             )
 
     # ── Rule 6: IBSCBS_MISSING ───────────────────────────────────────────────
 
+    _ibscbs_sev = _pedagogical_severity("IBSCBS_MISSING", pedagogical_mode)
     if has_ibscbs:
         if not ibscbs_block:
             ev_id = "E_XML_IBSCBS_MISSING"
+            _rec = "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo."
+            if _ibscbs_sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_IBSCBS_MISSING", severity="FATAL", rule_id="IBSCBS_MISSING", title="Grupo IBSCBS ausente — obrigatório conforme NT 2025.002", where=FindingWhere(field="IBSCBS", xpath=_xpath("imposto", doc_type)), recommendation="Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo.", evidence_ids=[ev_id]),
+                Finding(id="F_IBSCBS_MISSING", severity=_ibscbs_sev, rule_id="IBSCBS_MISSING", title="Grupo IBSCBS ausente — obrigatório conforme NT 2025.002", where=FindingWhere(field="IBSCBS", xpath=_xpath("imposto", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="IBSCBS — grupo ausente", xpath=_xpath("imposto", doc_type)),
             )
     else:
         has_legacy = all([valor_cbs, valor_ibs, aliq_cbs, aliq_ibs])
         if not has_legacy:
             ev_id = "E_XML_IBSCBS_MISSING"
+            _rec = "Informar alíquota e valor de IBS e CBS conforme LC 214."
+            if _ibscbs_sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_IBSCBS_MISSING", severity="FATAL", rule_id="IBSCBS_MISSING", title="IBS/CBS ausentes na nota", where=FindingWhere(field="IBS/CBS", xpath=_xpath("Valores", doc_type)), recommendation="Informar alíquota e valor de IBS e CBS conforme LC 214.", evidence_ids=[ev_id]),
+                Finding(id="F_IBSCBS_MISSING", severity=_ibscbs_sev, rule_id="IBSCBS_MISSING", title="IBS/CBS ausentes na nota", where=FindingWhere(field="IBS/CBS", xpath=_xpath("Valores", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="IBS/CBS — campos ausentes", xpath=_xpath("Valores", doc_type)),
             )
 
@@ -376,14 +423,22 @@ def validate_xml(
 
     if not cest:
         ev_id = "E_XML_CEST_MISSING"
+        _sev = _pedagogical_severity("CEST_MISSING", pedagogical_mode)
+        _rec = "CEST obrigatório apenas para produtos com substituição tributária (ST)."
+        if _sev == "WARNING":
+            _rec += _LC227_RECOMMENDATION
         _add(
-            Finding(id="F_CEST_MISSING", severity="FATAL", rule_id="CEST_MISSING", title="CEST ausente", where=FindingWhere(field="CEST", xpath=_xpath("CEST", doc_type)), recommendation="Informar código CEST.", evidence_ids=[ev_id]),
+            Finding(id="F_CEST_MISSING", severity=_sev, rule_id="CEST_MISSING", title="CEST ausente — verificar se produto é ST", where=FindingWhere(field="CEST", xpath=_xpath("CEST", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
             Evidence(id=ev_id, type="xml", label="CEST — ausente", xpath=_xpath("CEST", doc_type)),
         )
     elif not re.match(r"^\d{7}$", cest["value"]):
         ev_id = "E_XML_CEST_FORMAT"
+        _sev = _pedagogical_severity("CEST_FORMAT", pedagogical_mode)
+        _rec = "CEST deve ter 7 dígitos."
+        if _sev == "WARNING":
+            _rec += _LC227_RECOMMENDATION
         _add(
-            Finding(id="F_CEST_FORMAT", severity="FATAL", rule_id="CEST_FORMAT", title=f'CEST inválido (esperado 7 dígitos, encontrado "{cest["value"]}")', where=FindingWhere(field="CEST", xpath=_xpath(cest["tag"], doc_type), snippet=cest["snippet"]), recommendation="CEST deve ter 7 dígitos.", evidence_ids=[ev_id]),
+            Finding(id="F_CEST_FORMAT", severity=_sev, rule_id="CEST_FORMAT", title=f'CEST inválido (esperado 7 dígitos, encontrado "{cest["value"]}")', where=FindingWhere(field="CEST", xpath=_xpath(cest["tag"], doc_type), snippet=cest["snippet"]), recommendation=_rec, evidence_ids=[ev_id]),
             Evidence(id=ev_id, type="xml", label="CEST — formato inválido", xpath=_xpath(cest["tag"], doc_type), snippet=cest["snippet"]),
         )
 
@@ -393,16 +448,24 @@ def validate_xml(
         missing = [t for t in ["emit", "det", "total"] if not _first_tag(xml, [t])]
         if missing:
             ev_id = "E_XML_LAYOUT_NFE"
+            _sev = _pedagogical_severity("LAYOUT_NFE", pedagogical_mode)
+            _rec = "NF-e deve conter emit, det e total."
+            if _sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_LAYOUT_NFE", severity="FATAL", rule_id="LAYOUT_NFE", title=f"Estrutura NF-e incompleta — faltam: {', '.join(missing)}", where=FindingWhere(field="Estrutura XML", xpath=_xpath("infNFe", doc_type)), recommendation="NF-e deve conter emit, det e total.", evidence_ids=[ev_id]),
+                Finding(id="F_LAYOUT_NFE", severity=_sev, rule_id="LAYOUT_NFE", title=f"Estrutura NF-e incompleta — faltam: {', '.join(missing)}", where=FindingWhere(field="Estrutura XML", xpath=_xpath("infNFe", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="NF-e — estrutura incompleta", xpath=_xpath("infNFe", doc_type)),
             )
     else:
         missing = [t for t in ["Valores", "PrestadorServico", "TomadorServico"] if not _first_tag(xml, [t])]
         if missing:
             ev_id = "E_XML_LAYOUT_PORTAL"
+            _sev = _pedagogical_severity("LAYOUT_PORTAL", pedagogical_mode)
+            _rec = "Seguir layout do Portal Nacional."
+            if _sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_LAYOUT_PORTAL", severity="FATAL", rule_id="LAYOUT_PORTAL", title=f"Layout fora do padrão — faltam: {', '.join(missing)}", where=FindingWhere(field="Estrutura XML", xpath=_xpath("infNfse", doc_type)), recommendation="Seguir layout do Portal Nacional.", evidence_ids=[ev_id]),
+                Finding(id="F_LAYOUT_PORTAL", severity=_sev, rule_id="LAYOUT_PORTAL", title=f"Layout fora do padrão — faltam: {', '.join(missing)}", where=FindingWhere(field="Estrutura XML", xpath=_xpath("infNfse", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="Layout — tags ausentes", xpath=_xpath("infNfse", doc_type)),
             )
 
@@ -411,8 +474,12 @@ def validate_xml(
     if ncm:
         if not re.match(r"^\d{8}$", ncm["value"]):
             ev_id = "E_XML_NCM_FORMAT"
+            _sev = _pedagogical_severity("NCM_FORMAT", pedagogical_mode)
+            _rec = "NCM deve ter exatamente 8 dígitos conforme TIPI."
+            if _sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_NCM_FORMAT", severity="FATAL", rule_id="NCM_FORMAT", title=f'NCM inválido (esperado 8 dígitos, encontrado "{ncm["value"]}")', where=FindingWhere(field="NCM", xpath=_xpath("NCM", doc_type), snippet=ncm["snippet"]), recommendation="NCM deve ter exatamente 8 dígitos conforme TIPI.", evidence_ids=[ev_id]),
+                Finding(id="F_NCM_FORMAT", severity=_sev, rule_id="NCM_FORMAT", title=f'NCM inválido (esperado 8 dígitos, encontrado "{ncm["value"]}")', where=FindingWhere(field="NCM", xpath=_xpath("NCM", doc_type), snippet=ncm["snippet"]), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="NCM — formato inválido", xpath=_xpath("NCM", doc_type), snippet=ncm["snippet"]),
             )
 
@@ -420,8 +487,12 @@ def validate_xml(
 
     if ncm and re.match(r"^\d{8}$", ncm["value"]) and ncm["value"] not in VALID_NCM_CODES:
         ev_id = "E_XML_NCM_VALID"
+        _sev = _pedagogical_severity("NCM_VALID", pedagogical_mode)
+        _rec = "Verificar código NCM conforme Tabela TIPI vigente."
+        if _sev == "WARNING":
+            _rec += _LC227_RECOMMENDATION
         _add(
-            Finding(id="F_NCM_VALID", severity="FATAL", rule_id="NCM_VALID", title=f'NCM "{ncm["value"]}" não encontrado na tabela TIPI', where=FindingWhere(field="NCM", xpath=_xpath("NCM", doc_type), snippet=ncm["snippet"]), recommendation="Verificar código NCM conforme Tabela TIPI vigente.", evidence_ids=[ev_id]),
+            Finding(id="F_NCM_VALID", severity=_sev, rule_id="NCM_VALID", title=f'NCM "{ncm["value"]}" não encontrado na tabela TIPI', where=FindingWhere(field="NCM", xpath=_xpath("NCM", doc_type), snippet=ncm["snippet"]), recommendation=_rec, evidence_ids=[ev_id]),
             Evidence(id=ev_id, type="xml", label="NCM — código desconhecido", xpath=_xpath("NCM", doc_type), snippet=ncm["snippet"]),
         )
 
@@ -432,8 +503,12 @@ def validate_xml(
         lookup = classtrib_results.get(code)
         if lookup is False:
             ev_id = "E_XML_CLASSTRIB_VALID"
+            _sev = _pedagogical_severity("CLASSTRIB_VALID", pedagogical_mode)
+            _rec = "Verificar código cClassTrib no portal Conformidade Fácil (SVRS)."
+            if _sev == "WARNING":
+                _rec += _LC227_RECOMMENDATION
             _add(
-                Finding(id="F_CLASSTRIB_VALID", severity="FATAL", rule_id="CLASSTRIB_VALID", title=f'cClassTrib "{code}" não encontrado no registro SVRS', where=FindingWhere(field="cClassTrib", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]), recommendation="Verificar código cClassTrib no portal Conformidade Fácil (SVRS).", evidence_ids=[ev_id]),
+                Finding(id="F_CLASSTRIB_VALID", severity=_sev, rule_id="CLASSTRIB_VALID", title=f'cClassTrib "{code}" não encontrado no registro SVRS', where=FindingWhere(field="cClassTrib", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="cClassTrib — não encontrado", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]),
             )
         elif lookup is None:
@@ -464,7 +539,7 @@ def validate_xml(
             )
 
     fatals = sum(1 for f in findings if f.severity == "FATAL")
-    alerts = sum(1 for f in findings if f.severity == "ALERT")
+    alerts = sum(1 for f in findings if f.severity in ("ALERT", "WARNING"))
     regime_comparison = _extract_regime_comparison(xml, has_ibscbs)
 
     return ValidationResult(
@@ -517,10 +592,16 @@ async def validate_xml_endpoint(
     classtrib_data = await _enrich_classtrib(xml)
     cnpj_data = await _enrich_cnpj(xml)
 
+    # Lê flag pedagógico do tenant
+    from app.models.auth import Tenant
+    tenant = db.get(Tenant, current_user.tenant_id)
+    pedagogical = bool(tenant.pedagogical_mode_2026) if tenant else True
+
     result = validate_xml(
         xml, doc_type,
         classtrib_results=classtrib_data,
         cnpj_result=cnpj_data,
+        pedagogical_mode=pedagogical,
     )
 
     tenant_id = str(current_user.tenant_id)

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -10,11 +10,47 @@ export default function SettingsPage() {
   const [tenant, setTenant] = useState("");
   const [tokenDisplay, setTokenDisplay] = useState("");
   const [toast, setToast] = useState<{ tone: "error" | "success" | "info"; msg: string } | null>(null);
+  const [pedagogicalMode, setPedagogicalMode] = useState<boolean | null>(null);
+  const [pedagogicalLoading, setPedagogicalLoading] = useState(false);
 
   useEffect(() => {
     setTenant(getTenantId());
     setTokenDisplay(getToken() ? "••••••••" : "(não autenticado)");
+    // Carregar configuração do modo pedagógico
+    const tok = getToken();
+    if (tok) {
+      fetch(`${API_BASE}/api/v1/auth/settings/tenant`, {
+        headers: { Authorization: `Bearer ${tok}` },
+      })
+        .then((r) => r.json())
+        .then((d) => setPedagogicalMode(d.pedagogical_mode_2026 ?? true))
+        .catch(() => setPedagogicalMode(true));
+    }
   }, []);
+
+  async function togglePedagogicalMode() {
+    const tok = getToken();
+    if (!tok || pedagogicalMode === null) return;
+    const next = !pedagogicalMode;
+    setPedagogicalLoading(true);
+    try {
+      const r = await fetch(`${API_BASE}/api/v1/auth/settings/tenant`, {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${tok}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ pedagogical_mode_2026: next }),
+      });
+      if (r.ok) {
+        setPedagogicalMode(next);
+        setToast({ tone: "success", msg: `Modo Pedagógico ${next ? "ativado" : "desativado"}.` });
+      } else {
+        setToast({ tone: "error", msg: "Falha ao atualizar configuração." });
+      }
+    } catch {
+      setToast({ tone: "error", msg: "Erro de conexão." });
+    } finally {
+      setPedagogicalLoading(false);
+    }
+  }
 
   return (
     <section className="space-y-4">
@@ -38,6 +74,46 @@ export default function SettingsPage() {
           <p className="text-sm font-medium text-slate-800">Token de sessão</p>
           <p className="mt-1 text-xs text-slate-500 font-mono">{tokenDisplay}</p>
         </div>
+      </section>
+
+      {/* ── Modo Período Educativo 2026 ── */}
+      <section className="rounded-xl border border-blue-200 bg-white p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">
+              Modo Período Educativo 2026
+            </h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Quando ativo, irregularidades em <strong>obrigações acessórias</strong> CBS/IBS
+              (formato CST, cClassTrib, layout XML) são sinalizadas como{" "}
+              <strong>Aviso</strong> em vez de bloqueio — conforme a{" "}
+              <strong>LC 227/2026 art. 348 §§ 3º e 4º</strong>: 60 dias para sanar sem multa.
+            </p>
+            <p className="mt-2 text-xs text-blue-700 font-medium">
+              ⚖️ Válido durante o período pedagógico de 2026. Recomendado manter ativo.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={togglePedagogicalMode}
+            disabled={pedagogicalLoading || pedagogicalMode === null}
+            className={`relative inline-flex h-7 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+              pedagogicalMode ? "bg-blue-600" : "bg-slate-300"
+            } disabled:cursor-not-allowed disabled:opacity-60`}
+            aria-label="Toggle modo pedagógico"
+          >
+            <span
+              className={`inline-block h-6 w-6 rounded-full bg-white shadow ring-0 transition-transform duration-200 ${
+                pedagogicalMode ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+        {pedagogicalMode !== null && (
+          <p className="mt-2 text-xs text-slate-400">
+            Status atual: <strong>{pedagogicalMode ? "Ativo — avisos pedagógicos habilitados" : "Inativo — todos os erros são bloqueantes"}</strong>
+          </p>
+        )}
       </section>
 
       <section className="rounded-xl border border-slate-200 bg-white p-4">

--- a/frontend/src/app/validate-xml/page.tsx
+++ b/frontend/src/app/validate-xml/page.tsx
@@ -10,14 +10,15 @@ import { Finding, Job, ValidateXmlRequest, ValidationEvidence, ValidationResultV
 import { CST_TABLE, detectDocumentType } from "@/lib/validation/xmlRules";
 
 function severityClasses(severity: Finding["severity"]): string {
-  if (severity === "FATAL") {
-    return "border-red-300 bg-red-50 text-red-800";
-  }
+  if (severity === "FATAL") return "border-red-300 bg-red-50 text-red-800";
+  if (severity === "WARNING") return "border-blue-300 bg-blue-50 text-blue-800";
   return "border-amber-300 bg-amber-50 text-amber-800";
 }
 
 function severityLabel(severity: Finding["severity"]): string {
-  return severity === "FATAL" ? "FATAL (bloqueante)" : "ALERT";
+  if (severity === "FATAL") return "FATAL (bloqueante)";
+  if (severity === "WARNING") return "Período Pedagógico LC 227";
+  return "ALERT";
 }
 
 function shortSnippet(value?: string): string {
@@ -375,7 +376,14 @@ export default function ValidateXmlPage() {
                 <article key={finding.id} className={`rounded-xl border p-3 ${severityClasses(finding.severity)}`}>
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide">{severityLabel(finding.severity)}</p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-xs font-semibold uppercase tracking-wide">{severityLabel(finding.severity)}</p>
+                        {finding.severity === "WARNING" && (
+                          <span className="inline-flex items-center gap-1 rounded-full border border-blue-300 bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-800">
+                            ⚖️ LC 227 art. 348 — 60 dias para sanar
+                          </span>
+                        )}
+                      </div>
                       <h2 className="text-base font-semibold">{finding.title}</h2>
                       <p className="text-xs">
                         rule_id: <span className="font-mono">{finding.rule_id}</span> | finding_id:{" "}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -14,7 +14,7 @@ export type Evidence = {
   payload?: Record<string, unknown> | null;
 };
 
-export type FindingSeverity = "FATAL" | "ALERT";
+export type FindingSeverity = "FATAL" | "ALERT" | "WARNING";
 
 export type FindingWhere = {
   field?: string;

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -12,11 +12,34 @@ export type ValidationInput = {
   tenantId: string;
   documentType: XmlDocumentType;
   xml: string;
+  /** LC 227/2026 art. 348: downgrade obrigações acessórias de FATAL → WARNING. Default: false */
+  pedagogicalMode?: boolean;
 };
 
 // ── CST table (NT 2025.002-RTC) ────────────────────────────────────────────
 // Maps valid CST codes to their required XML group and description.
 
+// ── LC 227/2026 — modo pedagógico ─────────────────────────────────────────
+const PEDAGOGICAL_ACCESSORY_RULES = new Set([
+  "CST_3_DIGITS", "CCLASSTRIB_6_DIGITS", "SERVICE_CODE_6_DIGITS",
+  "CST_VALID", "CST_GROUP_MATCH", "CST_SEMANTIC",
+  "IBSCBS_MISSING", "CEST_MISSING", "CEST_FORMAT",
+  "LAYOUT_NFE", "LAYOUT_PORTAL",
+]);
+
+const LC227_NOTE =
+  " — Período Pedagógico LC 227/2026 (art. 348 §§ 3º e 4º): " +
+  "se autuado exclusivamente por esta obrigação acessória, " +
+  "há 60 dias para regularizar sem aplicação de multa.";
+
+function pedagogicalSeverity(
+  ruleId: string,
+  pedagogicalMode: boolean,
+): "FATAL" | "WARNING" {
+  return pedagogicalMode && PEDAGOGICAL_ACCESSORY_RULES.has(ruleId) ? "WARNING" : "FATAL";
+}
+
+// ── CST table (NT 2025.002-RTC) ────────────────────────────────────────────
 export const CST_TABLE: Record<string, { group: string | null; description: string }> = {
   "000": { group: "gIBSCBS", description: "Tributação normal (ad valorem)" },
   "001": { group: "gIBSCBS", description: "Tributação normal com redução de base" },
@@ -165,6 +188,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   const fingerprint = fnv1a32(`${input.documentType}|${xml}`);
   const jobId = `job_xml_${fingerprint}`;
   const auditId = `audit_xml_${fingerprint}`;
+  const pedMode = input.pedagogicalMode === true;
 
   const findings: Finding[] = [];
   const evidences: ValidationEvidence[] = [];
@@ -740,6 +764,17 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
       recommendation: "Documentar justificativa fiscal para benefícios e créditos utilizados.",
     }),
   );
+
+  // ── Modo Pedagógico LC 227/2026 — downgrade obrigações acessórias ─────────
+  if (pedMode) {
+    for (const f of findings) {
+      if (f.severity === "FATAL" && PEDAGOGICAL_ACCESSORY_RULES.has(f.rule_id)) {
+        (f as { severity: string }).severity = "WARNING";
+        (f as { recommendation: string }).recommendation =
+          (f.recommendation || "") + LC227_NOTE;
+      }
+    }
+  }
 
   // ── Build result ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Diferenciação de mercado

Nenhum concorrente (Thomson Reuters, ClassTrib, e-Auditoria) posiciona explicitamente o período pedagógico da Reforma Tributária.

**Base legal:** LC 227/2026 art. 348 §§ 3º e 4º — auto de infração por *obrigação acessória* CBS/IBS → contribuinte tem 60 dias para sanar sem aplicação de multa.

## O que foi implementado

**Regras downgraded (FATAL → WARNING) no modo pedagógico:**
- Formato/estrutura: `CST_3_DIGITS`, `CCLASSTRIB_6_DIGITS`, `SERVICE_CODE_6_DIGITS`, `CEST_MISSING`, `CEST_FORMAT`, `LAYOUT_NFE`, `LAYOUT_PORTAL`, `NCM_FORMAT`, `NCM_VALID`
- Semântico/validação: `CST_VALID`, `CST_GROUP_MATCH`, `CST_SEMANTIC`, `IBSCBS_MISSING`, `CLASSTRIB_VALID`

**Continuam FATAL mesmo no modo pedagógico (obrigação principal):**
- `IBSCBS_CALC`, `IBSCBS_UF_CALC`, `IBSCBS_MUN_CALC`, `IBSCBS_SPLIT`, `IBSCBS_TOTAL`, `CNPJ_ACTIVE`

## Arquivos alterados

| Arquivo | Mudança |
|---|---|
| `migration 0019` | `pedagogical_mode_2026 BOOLEAN DEFAULT TRUE` em tenants |
| `models/auth.py` | Campo no model Tenant |
| `routers/auth.py` | `GET/PATCH /api/v1/auth/settings/tenant` |
| `routers/validate_xml.py` | `pedagogical_mode` param + downgrade + nota LC 227 |
| `lib/types.ts` | `FindingSeverity` inclui `"WARNING"` |
| `lib/validation/xmlRules.ts` | `pedagogicalMode` + post-processing downgrade |
| `app/validate-xml/page.tsx` | Badge azul ⚖️ LC 227 + label "Período Pedagógico" |
| `app/settings/page.tsx` | Toggle com carga/salvamento em tempo real |

## Test plan

- [ ] 469 testes backend + 58 frontend passando ✅
- [ ] Build Next.js sem erros ✅
- [ ] Após deploy: verificar toggle em `/settings`
- [ ] Validar XML com `CCLASSTRIB_6_DIGITS` inválido → finding azul com badge LC 227
- [ ] Desativar modo → mesmo XML → finding vermelho FATAL
- [ ] Cálculo errado `IBSCBS_CALC` → sempre FATAL independente do modo

Fecha #266.
