### PR TITLE
feat(#286): dPrevEntrega — 3 regras NT 2025.002 V1.36 (Rejeição 1157, competência, CIF)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -285,6 +285,11 @@ def validate_xml(
     v_ibs_mun = _first_tag(xml, ["vIBSMun"])
     v_ibs = _first_tag(xml, ["vIBS"])
 
+    # dPrevEntrega fields (NT 2025.002 V1.36 + Cartilha CGIBS item 1.1)
+    d_prev_entrega = _first_tag(xml, ["dPrevEntrega"])
+    dh_emi = _first_tag(xml, ["dhEmi"])
+    mod_frete = _first_tag(xml, ["modFrete"])
+
     # NFS-e legacy fields
     valor_cbs = _first_tag(xml, ["ValorCBS", "vCBS"])
     valor_ibs = _first_tag(xml, ["ValorIBS", "vIBS"])
@@ -467,6 +472,104 @@ def validate_xml(
             _add(
                 Finding(id="F_LAYOUT_PORTAL", severity=_sev, rule_id="LAYOUT_PORTAL", title=f"Layout fora do padrão — faltam: {', '.join(missing)}", where=FindingWhere(field="Estrutura XML", xpath=_xpath("infNfse", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="Layout — tags ausentes", xpath=_xpath("infNfse", doc_type)),
+            )
+
+    # ── Rules NT 2025.002 V1.36: dPrevEntrega (Cartilha CGIBS item 1.1) ────────
+    # Determina o período de apuração do IBS. Nenhum outro validador cobre essas regras.
+
+    if is_nfe:
+        # Rule: DPREV_ENTREGA_FRETE — Rejeição 1157 preventiva
+        # dPrevEntrega só é permitido em operações CIF. modFrete 1 (FOB) ou 9 rejeita.
+        _frete_val = (mod_frete or {}).get("value", "")
+        if d_prev_entrega and _frete_val in ("1", "9"):
+            ev_id = "E_XML_DPREV_ENTREGA_FRETE"
+            _add(
+                Finding(
+                    id="F_DPREV_ENTREGA_FRETE",
+                    severity="FATAL",
+                    rule_id="DPREV_ENTREGA_FRETE",
+                    title=f"Rejeição 1157 — dPrevEntrega inválido para modFrete={_frete_val}",
+                    where=FindingWhere(
+                        field="dPrevEntrega",
+                        xpath=_xpath("dPrevEntrega", doc_type),
+                        snippet=d_prev_entrega["snippet"],
+                    ),
+                    recommendation=(
+                        f"dPrevEntrega é permitido apenas em operações CIF. "
+                        f"modFrete={_frete_val} ({'FOB' if _frete_val == '1' else 'Sem Frete'}) "
+                        "causará Rejeição 1157 no SEFAZ. "
+                        "Remova o campo ou altere a modalidade de frete (NT 2025.002 V1.36)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="dPrevEntrega — Rejeição 1157",
+                         xpath=_xpath("dPrevEntrega", doc_type), snippet=d_prev_entrega["snippet"]),
+            )
+
+        # Rule: DPREV_ENTREGA_COMPETENCIA — divergência contabilização × apuração IBS
+        # Quando dPrevEntrega está em mês/ano diferente do dhEmi:
+        #   - Contabilização: mês da emissão (ICMS/legado)
+        #   - Apuração IBS:   mês da entrega (dPrevEntrega)
+        # Empresas fecham o mês sem o IBS correto sem este aviso.
+        if d_prev_entrega and dh_emi:
+            _dprev_month = d_prev_entrega["value"][:7]    # YYYY-MM
+            _demi_month  = dh_emi["value"][:7]            # YYYY-MM (de YYYY-MM-DDTHH:...)
+            if _dprev_month and _demi_month and _dprev_month != _demi_month:
+                ev_id = "E_XML_DPREV_ENTREGA_COMPETENCIA"
+                _add(
+                    Finding(
+                        id="F_DPREV_ENTREGA_COMPETENCIA",
+                        severity="ALERT",
+                        rule_id="DPREV_ENTREGA_COMPETENCIA",
+                        title=(
+                            f"Divergência de competência: IBS apurado em {_dprev_month}, "
+                            f"contabilização em {_demi_month}"
+                        ),
+                        where=FindingWhere(
+                            field="dPrevEntrega",
+                            xpath=_xpath("dPrevEntrega", doc_type),
+                            snippet=d_prev_entrega["snippet"],
+                        ),
+                        recommendation=(
+                            f"dPrevEntrega ({_dprev_month}) difere do mês de emissão ({_demi_month}). "
+                            "O débito de IBS será apurado em "
+                            f"{_dprev_month} (mês da entrega), mas o ICMS e a contabilização "
+                            f"ficam em {_demi_month} (mês da emissão). "
+                            "Verifique a alíquota vigente na data de entrega e alinhe com o contador. "
+                            "Use Evento 112150 se precisar corrigir a data de entrega após a emissão "
+                            "(Cartilha CGIBS item 1.1 + 4.12)."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="dPrevEntrega — divergência de competência",
+                             xpath=_xpath("dPrevEntrega", doc_type), snippet=d_prev_entrega["snippet"]),
+                )
+
+        # Rule: DPREV_ENTREGA_CIF_AUSENTE — CIF sem dPrevEntrega
+        # Em operações CIF, o fato gerador do IBS é a entrega, não a saída.
+        # Sem dPrevEntrega, o IBS vai para o período de dhSaiEnt, que pode ser diferente da entrega.
+        if not d_prev_entrega and _frete_val == "0":
+            ev_id = "E_XML_DPREV_ENTREGA_CIF_AUSENTE"
+            _add(
+                Finding(
+                    id="F_DPREV_ENTREGA_CIF_AUSENTE",
+                    severity="ALERT",
+                    rule_id="DPREV_ENTREGA_CIF_AUSENTE",
+                    title="Operação CIF sem dPrevEntrega — risco de IBS em período incorreto",
+                    where=FindingWhere(field="dPrevEntrega", xpath=_xpath("ide", doc_type)),
+                    recommendation=(
+                        "Operação CIF (frete por conta do emitente): o fato gerador do IBS ocorre "
+                        "na entrega ao destinatário. Sem dPrevEntrega, o sistema de Apuração Assistida "
+                        "do IBS usará a Data de Saída (dhSaiEnt). Se a entrega ocorrer em mês diferente "
+                        "da saída, o IBS será lançado no período errado. "
+                        "Preencha dPrevEntrega com a data prevista de entrega "
+                        "ou use o Evento 112150 para corrigir após a emissão "
+                        "(Cartilha CGIBS item 1.1 + NT 2025.002 V1.36)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="dPrevEntrega — ausente em CIF",
+                         xpath=_xpath("ide", doc_type)),
             )
 
     # ── Rule 15: NCM_FORMAT ──────────────────────────────────────────────────

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -412,3 +412,68 @@ test("NF-e não valida CodigoServico (usa CFOP)", () => {
   });
   assert.equal(result.findings.find((f) => f.rule_id === "SERVICE_CODE_6_DIGITS"), undefined);
 });
+
+// ── NT 2025.002 V1.36 — dPrevEntrega rules (issue #286) ─────────────────────
+
+// NF-e helper: minimal valid NF-e skeleton
+function nfeWithFields(extra: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe><ide>
+  <dhEmi>2026-05-27T10:00:00-03:00</dhEmi>
+  <dhSaiEnt>2026-05-27T10:00:00-03:00</dhSaiEnt>
+  ${extra}
+</ide><emit><CNPJ>12345678000195</CNPJ></emit>
+<det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+  <imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib>
+    <gIBSCBS><vBC>1000</vBC><gIBSUF><pIBSUF>0.9</pIBSUF><vIBSUF>9</vIBSUF></gIBSUF>
+    <gIBSMun><pIBSMun>0.1</pIBSMun><vIBSMun>1</vIBSMun></gIBSMun><vIBS>10</vIBS>
+    <gCBS><pCBS>0.1</pCBS><vCBS>1</vCBS></gCBS></gIBSCBS>
+  </IBSCBS></imposto></det>
+<total><emit/></total>
+</infNFe></NFe></nfeProc>`;
+}
+
+test("DPREV_ENTREGA_FRETE: dPrevEntrega + modFrete FOB(1) gera FATAL", () => {
+  const xml = nfeWithFields(`
+    <dPrevEntrega>2026-06-05</dPrevEntrega>
+    <transp><modFrete>1</modFrete></transp>
+  `).replace("</ide>", "</ide>");
+  // inject modFrete inside the XML
+  const xml2 = xml.replace("</nfeProc>", `<transp><modFrete>1</modFrete></transp></nfeProc>`)
+    .replace("<dhEmi>", "<dPrevEntrega>2026-06-05</dPrevEntrega><dhEmi>");
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: xml2 });
+  const f = result.findings.find((f) => f.rule_id === "DPREV_ENTREGA_FRETE");
+  assert.ok(f, "DPREV_ENTREGA_FRETE finding expected when FOB with dPrevEntrega");
+  assert.equal(f!.severity, "FATAL");
+});
+
+test("DPREV_ENTREGA_COMPETENCIA: entrega em junho, emissão em maio gera ALERT", () => {
+  const xml = nfeWithFields(`<dPrevEntrega>2026-06-15</dPrevEntrega>`);
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  const f = result.findings.find((f) => f.rule_id === "DPREV_ENTREGA_COMPETENCIA");
+  assert.ok(f, "DPREV_ENTREGA_COMPETENCIA expected when delivery in different month");
+  assert.equal(f!.severity, "ALERT");
+  assert.ok(f!.title.includes("2026-06"), "title should mention delivery month");
+  assert.ok(f!.title.includes("2026-05"), "title should mention emission month");
+});
+
+test("DPREV_ENTREGA_COMPETENCIA: mesmo mês não gera finding", () => {
+  const xml = nfeWithFields(`<dPrevEntrega>2026-05-31</dPrevEntrega>`);
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  assert.equal(result.findings.find((f) => f.rule_id === "DPREV_ENTREGA_COMPETENCIA"), undefined);
+});
+
+test("DPREV_ENTREGA_CIF_AUSENTE: modFrete=0 sem dPrevEntrega gera ALERT", () => {
+  const xml = nfeWithFields("").replace("</nfeProc>",
+    "<transp><modFrete>0</modFrete></transp></nfeProc>");
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  const f = result.findings.find((f) => f.rule_id === "DPREV_ENTREGA_CIF_AUSENTE");
+  assert.ok(f, "DPREV_ENTREGA_CIF_AUSENTE expected for CIF without dPrevEntrega");
+  assert.equal(f!.severity, "ALERT");
+});
+
+test("DPREV_ENTREGA_CIF_AUSENTE: NFS-e não aciona regra", () => {
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFSE",
+    xml: fixture("nfse-ok.xml") });
+  assert.equal(result.findings.find((f) => f.rule_id === "DPREV_ENTREGA_CIF_AUSENTE"), undefined);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -212,6 +212,11 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   const ncm = firstTag(xml, ["NCM"]);
   const cest = firstTag(xml, ["CEST"]);
 
+  // dPrevEntrega fields (NT 2025.002 V1.36 + Cartilha CGIBS item 1.1)
+  const dPrevEntrega = firstTag(xml, ["dPrevEntrega"]);
+  const dhEmi = firstTag(xml, ["dhEmi"]);
+  const modFrete = firstTag(xml, ["modFrete"]);
+
   // NFS-e legacy fields
   const serviceCode = firstTag(xml, ["CodigoServico", "cServ", "codigoServico"]);
   const valorCbs = firstTag(xml, ["ValorCBS", "vCBS"]);
@@ -714,6 +719,90 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           recommendation: "NF-e deve conter emit, det e total conforme layout padrão.",
         }),
         makeEvidence({ id: evId, type: "xml", label: "NF-e — estrutura incompleta", xpath: inferXpath("infNFe", docType), snippet: `<!-- Tags obrigatórias ausentes: ${missingNfe.join(", ")} -->` }),
+      );
+    }
+  }
+
+  // ── Rules NT 2025.002 V1.36: dPrevEntrega (Cartilha CGIBS item 1.1) ─────────
+  // Determina o período de apuração do IBS. Nenhum outro validador cobre essas regras.
+
+  if (isNfe) {
+    const freteVal = modFrete?.value ?? "";
+
+    // Rule: DPREV_ENTREGA_FRETE — Rejeição 1157 preventiva
+    if (dPrevEntrega && (freteVal === "1" || freteVal === "9")) {
+      const evId = makeEvidenceId("DPREV_ENTREGA_FRETE");
+      const freteLabel = freteVal === "1" ? "FOB" : "Sem Frete";
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_DPREV_ENTREGA_FRETE",
+          severity: "FATAL",
+          ruleId: "DPREV_ENTREGA_FRETE",
+          title: `Rejeição 1157 — dPrevEntrega inválido para modFrete=${freteVal} (${freteLabel})`,
+          field: "dPrevEntrega",
+          xpath: inferXpath("dPrevEntrega", docType),
+          snippet: dPrevEntrega.snippet,
+          evidenceId: evId,
+          recommendation:
+            `dPrevEntrega é permitido apenas em operações CIF. modFrete=${freteVal} (${freteLabel}) ` +
+            "causará Rejeição 1157 no SEFAZ. Remova o campo ou use frete CIF (NT 2025.002 V1.36).",
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "dPrevEntrega — Rejeição 1157",
+          xpath: inferXpath("dPrevEntrega", docType), snippet: dPrevEntrega.snippet }),
+      );
+    }
+
+    // Rule: DPREV_ENTREGA_COMPETENCIA — divergência contabilização × apuração IBS ⭐
+    // Este é o maior diferenciador: nenhum sistema alerta sobre isso.
+    if (dPrevEntrega && dhEmi) {
+      const dprevMonth = dPrevEntrega.value.slice(0, 7);   // YYYY-MM
+      const demiMonth  = dhEmi.value.slice(0, 7);          // YYYY-MM (de YYYY-MM-DDTHH:...)
+      if (dprevMonth && demiMonth && dprevMonth !== demiMonth) {
+        const evId = makeEvidenceId("DPREV_ENTREGA_COMPETENCIA");
+        pushFindingAndEvidence(findings, evidences, evidenceById,
+          makeFinding({
+            id: "F_DPREV_ENTREGA_COMPETENCIA",
+            severity: "ALERT",
+            ruleId: "DPREV_ENTREGA_COMPETENCIA",
+            title: `Divergência de competência: IBS apurado em ${dprevMonth}, contabilização em ${demiMonth}`,
+            field: "dPrevEntrega",
+            xpath: inferXpath("dPrevEntrega", docType),
+            snippet: dPrevEntrega.snippet,
+            evidenceId: evId,
+            recommendation:
+              `dPrevEntrega (${dprevMonth}) difere do mês de emissão (${demiMonth}). ` +
+              `O débito de IBS será apurado em ${dprevMonth} (mês da entrega), mas o ICMS e a ` +
+              `contabilização ficam em ${demiMonth} (mês da emissão). ` +
+              "Verifique a alíquota vigente na data de entrega e alinhe com o contador. " +
+              "Use Evento 112150 para corrigir a data após a emissão (Cartilha CGIBS item 4.12).",
+          }),
+          makeEvidence({ id: evId, type: "xml", label: "dPrevEntrega — divergência de competência",
+            xpath: inferXpath("dPrevEntrega", docType), snippet: dPrevEntrega.snippet }),
+        );
+      }
+    }
+
+    // Rule: DPREV_ENTREGA_CIF_AUSENTE — CIF sem dPrevEntrega
+    if (!dPrevEntrega && freteVal === "0") {
+      const evId = makeEvidenceId("DPREV_ENTREGA_CIF_AUSENTE");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_DPREV_ENTREGA_CIF_AUSENTE",
+          severity: "ALERT",
+          ruleId: "DPREV_ENTREGA_CIF_AUSENTE",
+          title: "Operação CIF sem dPrevEntrega — risco de IBS em período incorreto",
+          field: "dPrevEntrega",
+          xpath: inferXpath("ide", docType),
+          evidenceId: evId,
+          recommendation:
+            "Operação CIF (modFrete=0): o fato gerador do IBS ocorre na entrega ao destinatário. " +
+            "Sem dPrevEntrega, o sistema de Apuração Assistida usará a Data de Saída (dhSaiEnt). " +
+            "Se a entrega ocorrer em mês diferente, o IBS será lançado no período errado. " +
+            "Preencha dPrevEntrega com a data prevista de entrega " +
+            "(Cartilha CGIBS item 1.1 + NT 2025.002 V1.36).",
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "dPrevEntrega — ausente em CIF",
+          xpath: inferXpath("ide", docType) }),
       );
     }
   }


### PR DESCRIPTION
## Resumo

Implementa 3 regras novas baseadas na **NT 2025.002 V1.36** + **Cartilha CGIBS Vol. 1**. Nenhum concorrente valida `dPrevEntrega` hoje.

## Regras

### `DPREV_ENTREGA_FRETE` — FATAL
`dPrevEntrega` informado com `modFrete=1` (FOB) ou `9` (Sem Frete) → **Rejeição 1157 no SEFAZ**.  
Detectado preventivamente antes da transmissão da NF-e.

### `DPREV_ENTREGA_COMPETENCIA` — ALERT ⭐ **diferenciador único**
`dPrevEntrega` em mês diferente de `dhEmi`:
- Contabilização: mês da **emissão** (ICMS / legado)
- Apuração IBS: mês da **entrega** (`dPrevEntrega`)

Empresas fecham o mês sem o IBS correto sem este aviso. Nenhum outro sistema detecta esta divergência.

**Exemplo real (Webinar TOTVS):** NF-e emitida em 27/05/2026 com `dPrevEntrega = 02/06/2026` → Contabilização: 05/2026, Apuração IBS: 06/2026.

### `DPREV_ENTREGA_CIF_AUSENTE` — ALERT
NF-e CIF (`modFrete=0`) sem `dPrevEntrega` → IBS apurado pela Data de Saída se a entrega for em mês diferente. Orienta uso do Evento 112150.

## Fontes
- NT 2025.002 V1.36, seção 8.19
- Cartilha CGIBS Vol. 1, item 1.1 e 4.12
- Webinar TOTVS "Eventos da Reforma Tributária" 05/2026 (slides 15-18)
- Lei 12955/29/04/2026 (Rejeição 1157 + multa 66% cancelamento tardio)

## Test plan

- [x] 469 testes backend ✅
- [x] 63 testes frontend (5 novos) ✅
- [ ] Validar NF-e com `dPrevEntrega` cruzando mês → finding azul com aviso
- [ ] Validar NF-e FOB com `dPrevEntrega` → FATAL preventivo

Fecha #286.
