### PR TITLE
fix(#275): CEST_MISSING cruza NCM × ST (Convênio ICMS 142/2018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Motor determinístico de validação CBS/IBS · Multi-tenant SaaS · LC 214 + LC 227
 
 [![CI Backend](https://github.com/mickbap/tribultz/actions/workflows/ci.yml/badge.svg)](https://github.com/mickbap/tribultz/actions/workflows/ci.yml)
-[![Testes](https://img.shields.io/badge/testes-401%20passing-brightgreen)](#ci--cd)
+[![Testes](https://img.shields.io/badge/testes-469%20passing-brightgreen)](#ci--cd)
 [![Python](https://img.shields.io/badge/python-3.12-blue)](https://www.python.org)
 [![Next.js](https://img.shields.io/badge/next.js-16-black)](https://nextjs.org)
 [![Licença](https://img.shields.io/badge/licença-proprietária-red)](#licença)
@@ -22,6 +22,9 @@ O motor determinístico aplica 14 regras de conformidade contra XML de NF-e, NFC
 
 **Diferenciais:**
 - Único validador que gera o snippet XML `<IBSCBS>` pronto para o ERP
+- **Simulador de Impacto** — compara carga tributária atual (ICMS+PIS/COFINS+ISS) vs CBS+IBS por regime e setor
+- **Modo Período Educativo LC 227** — downgrade automático de obrigações acessórias em 2026 (nenhum concorrente faz isso)
+- **dPrevEntrega** — único sistema que detecta divergência de competência entre contabilização e apuração IBS
 - Calculadora CBS/IBS pública como primeiro ponto de conversão freemium
 - Diagnóstico XML gratuito (3 findings) — captura o lead no momento da dor
 - Arquitetura multi-tenant pronta para contadores que gerenciam múltiplos CNPJs
@@ -36,6 +39,7 @@ O motor determinístico aplica 14 regras de conformidade contra XML de NF-e, NFC
 | Funcionalidade | Endpoint | Limite |
 |---|---|---|
 | Calculadora CBS/IBS | `GET /calculadora` | 20 cálculos/dia por IP |
+| **Simulador de Impacto** | `POST /api/v1/public/simulator/regime` | 30 req/min por IP |
 | Diagnóstico XML | `GET /diagnostico` | 3 findings por arquivo |
 | Validação pública | `POST /api/v1/public/validate-xml` | 20 req/dia por IP |
 
@@ -43,7 +47,9 @@ O motor determinístico aplica 14 regras de conformidade contra XML de NF-e, NFC
 
 | Funcionalidade | Descrição |
 |---|---|
-| **Validação XML** | Upload de NF-e, NFC-e e NFS-e; 14 regras NT 2025.002-RTC; resultado em <2s |
+| **Validação XML** | Upload de NF-e, NFC-e e NFS-e; 22 regras NT 2025.002-RTC v1.36; resultado em <2s |
+| **Modo Período Educativo** | Toggle LC 227/2026 art. 348: obrigações acessórias viram WARNING em vez de FATAL com badge legal |
+| **dPrevEntrega (NT V1.36)** | 3 regras: Rejeição 1157 preventiva, divergência competência CBS/IBS, CIF sem data entrega |
 | **Validação em lote** | Fila Celery; N arquivos em paralelo; relatório consolidado |
 | **Chat AI Fiscal** | CrewAI (Triager → Operator → Narrator); responde perguntas sobre conformidade com citação de regra |
 | **Relatório auditável** | PDF + Markdown; campos NF · BASE ICMS · VALOR ICMS · IBS · CBS · CEST · CLASSTRIB |
@@ -94,15 +100,15 @@ O motor determinístico aplica 14 regras de conformidade contra XML de NF-e, NFC
                        ▼
 ┌─────────────────────────────────────────────────────────┐
 │                   FASTAPI (api)                         │
-│   14 routers · JWT auth · multi-tenant · Pydantic v2    │
+│   16 routers · JWT auth · multi-tenant · Pydantic v2    │
 │   CrewAI crews · LiteLLM · OpenRouter                   │
 └──────┬──────────────────────────┬───────────────────────┘
        │ SQLAlchemy                │ Celery tasks
        ▼                          ▼
 ┌─────────────┐         ┌─────────────────────────┐
 │ PostgreSQL  │         │   CELERY (worker + beat) │
-│  16 (DBaaS) │         │   7 tasks · concurrency=2│
-│  15 tabelas │         │   Redis broker           │
+│  16 (DBaaS) │         │  10 tasks · concurrency=2│
+│  16 tabelas │         │   Redis broker           │
 │  multi-tenant│        └──────────┬──────────────┘
 └─────────────┘                    │
                           ┌────────┴────────┐
@@ -117,7 +123,7 @@ O motor determinístico aplica 14 regras de conformidade contra XML de NF-e, NFC
 │                  APIS EXTERNAS                          │
 │  Asaas (pagamentos)  ·  ClassTrib SVRS  ·  CNPJ.ws     │
 │  OpenRouter (LLM)   ·  Cloudflare Turnstile             │
-│  HubSpot CRM (HUBSPOT_ENABLED)                          │
+│  HubSpot CRM (ativo) · HubSpot Tracking (portal 49735644)│
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -191,6 +197,12 @@ As duas implementações são determinísticas e produzem o mesmo resultado para
 |---|---|---|---|
 | `POST` | `/api/v1/public/calculadora/regime-geral` | Calcular CBS/IBS por NCM/UF | — |
 | `POST` | `/api/v1/calculadora/regime-geral` | Calcular com alíquotas do tenant | JWT |
+
+### Simulador de Impacto
+
+| Método | Rota | Descrição | Auth |
+|---|---|---|---|
+| `POST` | `/api/v1/public/simulator/regime` | Simular impacto CBS/IBS por regime e setor | — |
 | `GET` | `/api/v1/calculadora/uf-rates` | Alíquotas por estado | JWT |
 
 ### Jobs & Tasks
@@ -253,6 +265,7 @@ As duas implementações são determinísticas e produzem o mesmo resultado para
 |---|---|---|
 | `/` | Pública | Landing page |
 | `/calculadora` | Pública | Calculadora CBS/IBS com snippet XML |
+| `/simulador` | Pública | Simulador de Impacto por Regime Tributário |
 | `/diagnostico` | Pública | Diagnóstico fiscal gratuito (3 findings) |
 | `/pricing` | Pública | Planos e preços |
 | `/register` | Pública | Cadastro (Turnstile + e-mail verification) |
@@ -307,7 +320,7 @@ tenants ──┬── users ──── user_tenants
 
 ---
 
-## Regras de Validação (NT 2025.002-RTC)
+## Regras de Validação (NT 2025.002-RTC v1.36)
 
 | # | Regra | Severidade | Descrição |
 |---|---|---|---|
@@ -318,10 +331,18 @@ tenants ──┬── users ──── user_tenants
 | 5 | `NCM_PLACEHOLDER` | ALERT | NCM não pode ser todos zeros |
 | 6 | `IBSCBS_MISSING` | FATAL | Grupo `<IBSCBS>` obrigatório para CSTs 000-550 |
 | 7 | `IBSCBS_CALC` | FATAL | Cálculo CBS/IBS deve conferir (tolerância ±R$0,01) |
-| 8 | `CEST_MISSING` | FATAL | CEST obrigatório para produtos com substituição tributária |
+| 8 | `CEST_MISSING` | ALERT | CEST obrigatório apenas para produtos com substituição tributária (ST) |
 | 9 | `CEST_FORMAT` | FATAL | CEST deve ter 7 dígitos no formato correto |
 | 10 | `LAYOUT_PORTAL` | FATAL | Estrutura do XML deve seguir o layout da NT |
 | 11–14 | Regras S11–S13 | WARNING | Validações complementares de alíquotas e créditos |
+| 15 | `NCM_FORMAT` / `NCM_VALID` | FATAL | NCM deve ter 8 dígitos e ser válido na TIPI |
+| 16 | `CLASSTRIB_VALID` | FATAL/ALERT | cClassTrib deve existir na tabela SVRS |
+| 17 | `CNPJ_ACTIVE` | FATAL | CNPJ emitente deve estar ativo na Receita Federal |
+| 18 | `DPREV_ENTREGA_FRETE` | **FATAL** | dPrevEntrega inválido para modFrete FOB/Sem Frete — Rejeição 1157 |
+| 19 | `DPREV_ENTREGA_COMPETENCIA` | **ALERT** | dPrevEntrega em mês diferente de dhEmi — divergência contabilização × apuração IBS |
+| 20 | `DPREV_ENTREGA_CIF_AUSENTE` | **ALERT** | Operação CIF sem dPrevEntrega — risco de IBS em período incorreto |
+
+**Modo Período Educativo (LC 227/2026 art. 348):** quando ativo, as regras de obrigação acessória (8 regras) são downgraded de FATAL para WARNING com badge ⚖️ e nota dos 60 dias para sanar sem multa.
 
 **CSTs suportados:** 000 · 001 · 002 · 070 · 200 · 410 · 510 · 515 · 550 · 620 · 800 · 810 · 811 · 830
 
@@ -468,7 +489,7 @@ Push / PR
     │       ├── ruff check app/ tests/
     │       ├── pyright (type check)
     │       ├── alembic upgrade head
-    │       ├── pytest tests/ -q  (401 testes)
+    │       ├── pytest tests/ -q  (469 testes)
     │       ├── crewai import sanity
     │       └── qa_gates/run_gates.py → artifact: qa_gates_report.md
     │
@@ -570,15 +591,26 @@ cd frontend && npm install && npm run dev
 | #268 | Monitoring contínuo · GitHub Actions uptime check 5min · alerta email |
 | #269 | Billing recorrente Asaas · notificações trial D-3/D-1/expirado · fix login pós-pagamento |
 | #270 | CRM Engagement Crew · HubSpot lifecycle automático · dunning e win-back via CrewAI |
+| #273 | Fix SQL syntax 500 no dashboard — `CAST(:param AS type)` em sqlalchemy.text() |
+| #274 | cClassTrib SVRS — migration 75 códigos · regulamentos 30/abr/2026 · `last_synced_at` |
+| #279 | Diff regulamentos IBS/CBS 30/abr/2026 × 22 regras · `docs/regulamentos_2026_diff.md` |
+| #280 | Deploy automático `alembic upgrade head` · `--no-deps` para zero-downtime Redis |
+| #282 | HubSpot tracking code — portal 49735644 · pageviews em todas as páginas |
+| #283–284 | HubSpot CRM sync · deal stages pipeline padrão · deduplicação via search API |
+| #285 | **Modo Período Educativo LC 227** · toggle tenant · badge ⚖️ · 14 regras acessórias |
+| #287 | **dPrevEntrega** · Rejeição 1157 preventiva · divergência competência CBS/IBS · CIF alert |
+| #288–289 | **Simulador de Impacto** · `/simulador` público · endpoint `POST /simulator/regime` |
 | Infra | Magalu Cloud · docker-compose.prod · rolling deploy · SecDevOps |
 
 ### Em andamento
 
 | Item | Descrição | Prioridade |
 |---|---|---|
-| HubSpot em prod | `HUBSPOT_ENABLED=true` + `HUBSPOT_PRIVATE_APP_TOKEN` na VM — crew e sync prontos, aguarda configuração | Alta |
 | `no-new-privileges` + `cap_drop` | Adicionar ao docker-compose.prod.yml | Alta |
 | `unattended-upgrades` | Patches automáticos de segurança na VM | Média |
+| CEST × tabela ST (#275) | Cruzar NCM com tabela CEST/CONFAZ para identificar produtos ST | P1 |
+| MONOFASICO_ZERO (#278) | CST 620 downstream deve ter vCBS=vIBS=0 | P2 |
+| Simulador Fase B | Regimes diferenciados, cashback, setor específico por NCM | P2 |
 
 ### Próximos sprints
 

--- a/backend/app/crews/tools/validate_fiscal_rules_tool.py
+++ b/backend/app/crews/tools/validate_fiscal_rules_tool.py
@@ -7,6 +7,8 @@ from typing import Type
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from app.data.cest_ncm import lookup_ncm_st
+
 
 class ValidateFiscalInput(BaseModel):
     invoice_id: str = Field(description="Invoice ID returned by parse_nfse_xml")
@@ -165,16 +167,37 @@ class ValidateFiscalRulesTool(BaseTool):
             except ValueError:
                 pass  # non-numeric values — skip calc check
 
-        # Rule 8: CEST_MISSING — CEST must be present
+        # Rule 8: CEST_MISSING (#275 fase 2)
+        # CEST obrigatório só para produtos em Substituição Tributária
+        # (Convênio ICMS 142/2018). Cruza NCM declarado com subset curado.
         if not cest:
-            findings.append({
-                "rule_id": "CEST_MISSING",
-                "severity": "FATAL",
-                "field": "CEST",
-                "xpath": "/NFS-e/infNfse//CEST",
-                "snippet": "(não encontrado)",
-                "recommendation": "Informar código CEST conforme nova classificação tributária.",
-            })
+            st_info = lookup_ncm_st(ncm)
+            if st_info["is_st"]:
+                seg_label = ", ".join(st_info["segments"]) or "ST"
+                findings.append({
+                    "rule_id": "CEST_MISSING",
+                    "severity": "FATAL",
+                    "field": "CEST",
+                    "xpath": "/NFS-e/infNfse//CEST",
+                    "snippet": f"NCM={ncm} (segmento ST: {seg_label}) sem CEST",
+                    "recommendation": (
+                        f"CEST obrigatório: NCM {ncm} pertence ao segmento de Substituição "
+                        f"Tributária ({seg_label}, Convênio ICMS 142/2018)."
+                    ),
+                })
+            else:
+                findings.append({
+                    "rule_id": "CEST_MISSING",
+                    "severity": "ALERT",
+                    "field": "CEST",
+                    "xpath": "/NFS-e/infNfse//CEST",
+                    "snippet": "(não encontrado)",
+                    "recommendation": (
+                        f"CEST ausente. NCM {ncm} não consta no subset ST conhecido "
+                        f"(Convênio ICMS 142/2018). Se o produto for sujeito a ST, "
+                        f"informe o CEST; caso contrário, este aviso pode ser desconsiderado."
+                    ),
+                })
 
         # Rule 9: CEST_FORMAT — CEST must be exactly 7 digits
         if cest and not re.fullmatch(r"\d{7}", cest):

--- a/backend/app/crews/tools/validate_ibscbs_rules_tool.py
+++ b/backend/app/crews/tools/validate_ibscbs_rules_tool.py
@@ -8,6 +8,7 @@ from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from app.crews.tools.parse_nfe_xml_tool import CST_TABLE
+from app.data.cest_ncm import lookup_ncm_st
 
 VALID_CST_CODES = set(CST_TABLE.keys())
 
@@ -288,22 +289,42 @@ class ValidateIBSCBSRulesTool(BaseTool):
                     ),
                 })
 
-        # Rule 8: CEST_MISSING
-        # Regulamento 30/abr/2026: CEST é obrigatório apenas para produtos ST
-        # (substituição tributária). Produtos sem ST podem emitir sem CEST.
-        # Downgrade para WARNING até implementação do cruzamento ST (issue #275).
+        # Rule 8: CEST_MISSING (#275 fase 2)
+        # Regulamento 30/abr/2026 + Convênio ICMS 142/2018: CEST é obrigatório
+        # apenas para produtos sujeitos a Substituição Tributária. Cruzamos o
+        # NCM declarado contra subset curado (app/data/cest_ncm.py):
+        #   - NCM em segmento ST conhecido → FATAL (CEST realmente obrigatório)
+        #   - NCM fora do subset → ALERT (subset não cobre 100% do Conv. 142,
+        #     então tratamos como incerto, não como erro)
         if not cest:
-            findings.append({
-                "rule_id": "CEST_MISSING",
-                "severity": "ALERT",
-                "field": "CEST",
-                "xpath": f"{xpath_base}//prod/CEST",
-                "snippet": "(nao encontrado)",
-                "recommendation": (
-                    "CEST ausente. Necessario apenas para produtos com substituicao tributaria (ST). "
-                    "Se o produto nao e sujeito a ST, este aviso pode ser ignorado."
-                ),
-            })
+            st_info = lookup_ncm_st(ncm)
+            if st_info["is_st"]:
+                segments_label = ", ".join(st_info["segments"]) or "ST"
+                findings.append({
+                    "rule_id": "CEST_MISSING",
+                    "severity": "FATAL",
+                    "field": "CEST",
+                    "xpath": f"{xpath_base}//prod/CEST",
+                    "snippet": f"NCM={ncm} (segmento ST: {segments_label}) sem CEST",
+                    "recommendation": (
+                        f"CEST obrigatório: NCM {ncm} pertence ao segmento de Substituição "
+                        f"Tributária ({segments_label}, Convênio ICMS 142/2018). Informe o "
+                        f"CEST correspondente em <prod/CEST>."
+                    ),
+                })
+            else:
+                findings.append({
+                    "rule_id": "CEST_MISSING",
+                    "severity": "ALERT",
+                    "field": "CEST",
+                    "xpath": f"{xpath_base}//prod/CEST",
+                    "snippet": "(nao encontrado)",
+                    "recommendation": (
+                        f"CEST ausente. NCM {ncm} não consta no subset ST conhecido "
+                        f"(Convênio ICMS 142/2018). Se o produto for sujeito a ST, informe "
+                        f"o CEST; se não for, este aviso pode ser desconsiderado."
+                    ),
+                })
 
         # Rule 9: CEST_FORMAT
         if cest and not re.fullmatch(r"\d{7}", cest):

--- a/backend/app/data/cest_ncm.py
+++ b/backend/app/data/cest_ncm.py
@@ -1,0 +1,221 @@
+"""NCM → ST (Substituição Tributária) lookup.
+
+**Fonte:** Convênio ICMS 142/2018 (CONFAZ) + alterações até 2026.
+
+Este módulo entrega um **subset curado** dos NCMs com maior volume de NF-e
+sujeitos a substituição tributária no Brasil, organizados por segmento.
+
+Para cada NCM declarado em uma NF-e, o lookup verifica se o prefixo está em
+qualquer segmento ST conhecido. Se sim, o produto **deve** declarar `<CEST>`
+(LC 214 + Regulamento IBS/CBS de 30/abr/2026 mantém vinculação ST↔CEST).
+
+## Limitações conhecidas
+
+- Subset cobre os ~12 segmentos de maior volume; entradas raras do Conv. 142
+  podem não estar listadas. NCMs ausentes são tratados como **possivelmente
+  ST** (severidade `ALERT`, não `FATAL`).
+- Seed completo dos ~1300 NCMs do Conv. 142 fica pendente como issue de
+  expansão. Quando feito, virar para tabela DB + endpoint integrado SVRS.
+
+## Como atualizar
+
+1. Baixar a versão mais recente do Convênio 142 e seus anexos (CONFAZ).
+2. Adicionar prefixos novos ao `ST_NCM_PREFIXES` por segmento.
+3. Bumpar `CEST_DATA_VERSION`.
+4. Atualizar `frontend/src/lib/validation/cestNcm.ts` (mesmo conteúdo).
+"""
+
+from __future__ import annotations
+
+CEST_DATA_VERSION = "2026-06-05"
+CEST_DATA_SOURCE = "Convênio ICMS 142/2018 (CONFAZ) — subset curado"
+
+# Mapeamento segmento → lista de prefixos NCM (string variável, ex: "2202", "8714.10").
+# Match é por prefixo: NCM do XML "comeca com" qualquer prefixo listado.
+ST_NCM_PREFIXES: dict[str, list[str]] = {
+    "bebidas_alcoolicas": [
+        "2203",      # cervejas
+        "2204",      # vinhos
+        "2205",      # vermutes
+        "2206",      # outras bebidas fermentadas
+        "2208",      # destilados (cachaça, vodka, whisky)
+    ],
+    "bebidas_nao_alcoolicas": [
+        "2201",      # águas, gelo
+        "2202",      # refrigerantes, isotônicos, energéticos
+    ],
+    "fumo": [
+        "2402",      # charutos, cigarrilhas, cigarros
+        "2403",      # outros produtos de fumo
+    ],
+    "combustiveis_lubrificantes": [
+        # Predominantemente monofásico CBS/IBS (CST 620), mas ST de ICMS mantida na transição
+        "2710",      # óleos de petróleo (gasolina, diesel, querosene, lubrificantes)
+        "2711",      # GLP, GNV
+        "2713",      # coque de petróleo
+    ],
+    "cimento_e_construcao": [
+        "2523",      # cimento
+        "3214",      # massa para vidraceiro, rejunte
+        "3208", "3209", "3210",   # tintas e vernizes
+        "6802",      # pedras para construção
+        "6810",      # artefatos de cimento, concreto
+    ],
+    "pneus_e_camaras": [
+        "4011",      # pneus novos
+        "4012",      # pneus recauchutados
+        "4013",      # câmaras de ar
+    ],
+    "veiculos_automotores": [
+        "8701",      # tratores
+        "8702",      # ônibus
+        "8703",      # automóveis de passageiros
+        "8704",      # veículos para transporte de mercadorias
+        "8711",      # motocicletas
+    ],
+    "autopecas": [
+        "4009",      # tubos, mangueiras de borracha
+        "4016",      # outras obras de borracha
+        "7007",      # vidros temperados/laminados (vidros automotivos)
+        "7009",      # espelhos retrovisores
+        "8407", "8408",   # motores
+        "8409",      # partes de motores
+        "8413",      # bombas
+        "8415",      # ar-condicionado
+        "8421",      # filtros
+        "8482",      # rolamentos
+        "8483",      # eixos, engrenagens
+        "8507",      # acumuladores (baterias)
+        "8511",      # ignição
+        "8512",      # iluminação automotiva
+        "8527",      # rádios
+        "8536",      # disjuntores, conectores
+        "8544",      # chicotes elétricos
+        "8708",      # partes e acessórios de veículos
+        "8714",      # partes de motocicletas
+        "9026", "9029",   # instrumentos automotivos
+        "9032",      # reguladores
+    ],
+    "sorvetes": [
+        "2105",      # sorvetes e congelados
+    ],
+    "produtos_alimenticios_industrializados": [
+        # Subset — não todos. Lista CONFAZ tem ~150 itens.
+        "1601",      # embutidos
+        "1602",      # outras preparações de carne
+        "1704",      # balas, chicletes
+        "1806",      # chocolates
+        "1905",      # biscoitos, bolachas
+        "2007",      # geleias, doces de fruta
+        "2009",      # sucos de fruta
+        "2103",      # molhos, condimentos
+        "2104",      # caldos, sopas
+        "2106",      # preparações alimentícias diversas (achocolatado, etc)
+    ],
+    "ferramentas": [
+        "8201",      # ferramentas manuais agrícolas
+        "8202",      # serras
+        "8203",      # limas, alicates
+        "8204",      # chaves de porca
+        "8205",      # ferramentas manuais
+        "8207",      # ferramentas intercambiáveis
+        "8211",      # facas
+    ],
+    "material_eletrico": [
+        "8504",      # transformadores
+        "8516",      # aquecedores, ferros de passar
+        "8517",      # telefones, modems
+        "8528",      # TVs, monitores
+        "8539",      # lâmpadas
+        "8544.49",   # fios e cabos elétricos comuns
+    ],
+    "cosmeticos_perfumaria_higiene": [
+        "3303",      # perfumes
+        "3304",      # maquiagem
+        "3305",      # cosméticos capilares
+        "3306",      # higiene bucal
+        "3307",      # desodorantes, depilatórios
+        "3401",      # sabões
+        "3402",      # detergentes
+        "9603.21",   # escovas de dente
+    ],
+    "medicamentos": [
+        "3003",      # medicamentos a granel
+        "3004",      # medicamentos em dose
+        "3005",      # algodão, gaze, ataduras
+        "3006",      # preparações farmacêuticas
+    ],
+}
+
+# Set "plano" para lookup O(1) por prefixo
+_FLAT_ST_PREFIXES: set[str] = {
+    prefix
+    for prefixes in ST_NCM_PREFIXES.values()
+    for prefix in prefixes
+}
+
+
+def _normalize_ncm(ncm: str) -> str:
+    """Remove pontos, espaços; mantém só dígitos."""
+    return "".join(c for c in (ncm or "") if c.isdigit())
+
+
+def lookup_ncm_st(ncm: str) -> dict:
+    """Determina se o NCM está sujeito a Substituição Tributária.
+
+    Returns:
+        {
+          "ncm": "22021000",
+          "is_st": True,
+          "matched_prefix": "2202",
+          "segments": ["bebidas_nao_alcoolicas"],
+          "source": "...",
+          "data_version": "...",
+        }
+    """
+    norm = _normalize_ncm(ncm)
+    if not norm:
+        return {
+            "ncm": ncm,
+            "is_st": False,
+            "matched_prefix": None,
+            "segments": [],
+            "source": CEST_DATA_SOURCE,
+            "data_version": CEST_DATA_VERSION,
+        }
+
+    matched: list[tuple[str, str]] = []  # [(prefix, segment)]
+    for segment, prefixes in ST_NCM_PREFIXES.items():
+        for prefix in prefixes:
+            clean_prefix = _normalize_ncm(prefix)
+            if norm.startswith(clean_prefix):
+                matched.append((prefix, segment))
+
+    if not matched:
+        return {
+            "ncm": norm,
+            "is_st": False,
+            "matched_prefix": None,
+            "segments": [],
+            "source": CEST_DATA_SOURCE,
+            "data_version": CEST_DATA_VERSION,
+        }
+
+    # Pega o prefixo mais específico (maior comprimento)
+    matched.sort(key=lambda t: len(_normalize_ncm(t[0])), reverse=True)
+    best_prefix, _ = matched[0]
+    segments = sorted({seg for _, seg in matched})
+
+    return {
+        "ncm": norm,
+        "is_st": True,
+        "matched_prefix": best_prefix,
+        "segments": segments,
+        "source": CEST_DATA_SOURCE,
+        "data_version": CEST_DATA_VERSION,
+    }
+
+
+def is_st_ncm(ncm: str) -> bool:
+    """Retorna True se o NCM tem prefixo conhecido como ST. Wrapper conveniente."""
+    return lookup_ncm_st(ncm).get("is_st", False)

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -14,6 +14,11 @@ import logging
 from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Form
 from pydantic import BaseModel
 
+from app.data.cest_ncm import (
+    CEST_DATA_SOURCE,
+    CEST_DATA_VERSION,
+    lookup_ncm_st,
+)
 from app.routers.validate_xml import validate_xml, ValidationResult
 from app.services.rate_limit import RateLimiter
 
@@ -242,3 +247,47 @@ def public_data_policy():
 def public_health():
     """Public health check — useful for uptime monitoring."""
     return {"status": "ok", "service": "tribultz-public"}
+
+
+# ── CEST × NCM lookup (#275 fase 2) ──────────────────────────────────────────
+
+class CestNcmLookupResponse(BaseModel):
+    ncm: str
+    is_st: bool
+    matched_prefix: str | None
+    segments: list[str]
+    source: str
+    data_version: str
+
+
+@router.get(
+    "/cest/_meta",
+    summary="Metadados da base CEST (versão, fonte, prefixos cobertos)",
+)
+def get_cest_meta() -> dict:
+    # NOTE: este endpoint deve vir ANTES de /cest/{ncm} para não ser capturado
+    # pela rota dinâmica.
+    from app.data.cest_ncm import ST_NCM_PREFIXES
+    return {
+        "source": CEST_DATA_SOURCE,
+        "data_version": CEST_DATA_VERSION,
+        "segments_count": len(ST_NCM_PREFIXES),
+        "prefixes_count": sum(len(v) for v in ST_NCM_PREFIXES.values()),
+        "segments": list(ST_NCM_PREFIXES.keys()),
+    }
+
+
+@router.get(
+    "/cest/{ncm}",
+    response_model=CestNcmLookupResponse,
+    summary="Verifica se NCM está sujeito a Substituição Tributária (ST)",
+)
+def get_cest_for_ncm(ncm: str) -> CestNcmLookupResponse:
+    """Lookup NCM → ST (Convênio ICMS 142/2018, subset curado).
+
+    Quando `is_st=True`, o produto **deve** declarar `<CEST>` na NF-e.
+    Quando `is_st=False`, o NCM não consta no subset conhecido —
+    o cliente deve tratar a ausência de CEST como ALERT informativo,
+    não como erro fatal (subset não cobre 100% do Conv. 142).
+    """
+    return CestNcmLookupResponse(**lookup_ncm_st(ncm))

--- a/backend/tests/test_cest_ncm.py
+++ b/backend/tests/test_cest_ncm.py
@@ -1,0 +1,96 @@
+"""Tests for NCM × CEST/ST lookup (#275 fase 2).
+
+Covers:
+- Data module (`app.data.cest_ncm`)
+- Public endpoint `/api/v1/public/cest/{ncm}` + `/cest/_meta`
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.data.cest_ncm import is_st_ncm, lookup_ncm_st
+from app.main import app
+
+client = TestClient(app)
+
+
+# ── Data module ──────────────────────────────────────────────────────────────
+
+class TestLookupNcmSt:
+    def test_st_ncm_refrigerante(self):
+        """22021000 (refrigerantes) — bebidas não alcoólicas."""
+        r = lookup_ncm_st("22021000")
+        assert r["is_st"] is True
+        assert r["matched_prefix"] == "2202"
+        assert "bebidas_nao_alcoolicas" in r["segments"]
+
+    def test_st_ncm_cigarro(self):
+        r = lookup_ncm_st("24022000")
+        assert r["is_st"] is True
+        assert "fumo" in r["segments"]
+
+    def test_st_ncm_with_dots_normalized(self):
+        """Aceita NCM com pontos (formato pt-BR)."""
+        r = lookup_ncm_st("2202.10.00")
+        assert r["is_st"] is True
+        assert r["matched_prefix"] == "2202"
+
+    def test_non_st_ncm(self):
+        """84713012 (equipamento de informática) não é ST."""
+        r = lookup_ncm_st("84713012")
+        assert r["is_st"] is False
+        assert r["matched_prefix"] is None
+        assert r["segments"] == []
+
+    def test_empty_ncm(self):
+        r = lookup_ncm_st("")
+        assert r["is_st"] is False
+
+    def test_longest_prefix_wins(self):
+        """8544.49 deve bater contra material_eletrico, não só autopecas (8544)."""
+        r = lookup_ncm_st("85444900")
+        assert r["is_st"] is True
+        # Tanto autopecas (prefix 8544) quanto material_eletrico (prefix 8544.49) batem
+        assert "material_eletrico" in r["segments"]
+        assert r["matched_prefix"] == "8544.49"  # mais específico
+
+    def test_metadata_present(self):
+        r = lookup_ncm_st("22020000")
+        assert "source" in r
+        assert "data_version" in r
+        assert "Convênio ICMS 142/2018" in r["source"]
+
+    def test_is_st_wrapper(self):
+        assert is_st_ncm("22020000") is True
+        assert is_st_ncm("84713012") is False
+        assert is_st_ncm("") is False
+
+
+# ── Endpoint ─────────────────────────────────────────────────────────────────
+
+def test_endpoint_cest_st_ncm():
+    resp = client.get("/api/v1/public/cest/22021000")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_st"] is True
+    assert body["matched_prefix"] == "2202"
+    assert "bebidas_nao_alcoolicas" in body["segments"]
+
+
+def test_endpoint_cest_non_st_ncm():
+    resp = client.get("/api/v1/public/cest/84713012")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_st"] is False
+    assert body["segments"] == []
+
+
+def test_endpoint_cest_meta():
+    resp = client.get("/api/v1/public/cest/_meta")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["segments_count"] >= 10
+    assert body["prefixes_count"] >= 60
+    assert "bebidas_nao_alcoolicas" in body["segments"]
+    assert "Convênio ICMS 142/2018" in body["source"]

--- a/backend/tests/tools/test_nfse_tools.py
+++ b/backend/tests/tools/test_nfse_tools.py
@@ -190,12 +190,22 @@ class TestValidateFiscalRulesTool:
         calc_findings = [f for f in result["findings"] if f["rule_id"] == "IBSCBS_CALC"]
         assert calc_findings == []
 
-    def test_cest_missing_is_fatal(self):
+    def test_cest_missing_non_st_ncm_is_alert(self):
+        """NCM default (12345678) não é ST → ALERT (Convênio 142/2018, #275 fase 2)."""
         result = json.loads(self._tool()._run("inv-1", self._fields_json(cest="")))
-        rule_ids = [f["rule_id"] for f in result["findings"]]
-        assert "CEST_MISSING" in rule_ids
+        f = next(f for f in result["findings"] if f["rule_id"] == "CEST_MISSING")
+        assert f["severity"] == "ALERT"
+        assert "não consta no subset ST" in f["recommendation"]
+
+    def test_cest_missing_st_ncm_is_fatal(self):
+        """NCM 22020000 (refrigerantes) é ST → FATAL com segmento explícito."""
+        result = json.loads(self._tool()._run(
+            "inv-1", self._fields_json(cest="", ncm="22020000")
+        ))
         f = next(f for f in result["findings"] if f["rule_id"] == "CEST_MISSING")
         assert f["severity"] == "FATAL"
+        assert "bebidas_nao_alcoolicas" in f["snippet"]
+        assert "Convênio ICMS 142/2018" in f["recommendation"]
 
     def test_cest_format_wrong_is_fatal(self):
         result = json.loads(self._tool()._run("inv-1", self._fields_json(cest="21049")))

--- a/frontend/src/lib/validation/cestNcm.ts
+++ b/frontend/src/lib/validation/cestNcm.ts
@@ -1,0 +1,101 @@
+/**
+ * NCM → ST (Substituição Tributária) lookup.
+ *
+ * Source: Convênio ICMS 142/2018 (CONFAZ) + alterações até 2026.
+ *
+ * Mirror of `backend/app/data/cest_ncm.py`. Keep in sync when updating.
+ */
+
+export const CEST_DATA_VERSION = "2026-06-05";
+export const CEST_DATA_SOURCE = "Convênio ICMS 142/2018 (CONFAZ) — subset curado";
+
+export const ST_NCM_PREFIXES: Record<string, string[]> = {
+  bebidas_alcoolicas: ["2203", "2204", "2205", "2206", "2208"],
+  bebidas_nao_alcoolicas: ["2201", "2202"],
+  fumo: ["2402", "2403"],
+  combustiveis_lubrificantes: ["2710", "2711", "2713"],
+  cimento_e_construcao: ["2523", "3214", "3208", "3209", "3210", "6802", "6810"],
+  pneus_e_camaras: ["4011", "4012", "4013"],
+  veiculos_automotores: ["8701", "8702", "8703", "8704", "8711"],
+  autopecas: [
+    "4009", "4016", "7007", "7009", "8407", "8408", "8409", "8413",
+    "8415", "8421", "8482", "8483", "8507", "8511", "8512", "8527",
+    "8536", "8544", "8708", "8714", "9026", "9029", "9032",
+  ],
+  sorvetes: ["2105"],
+  produtos_alimenticios_industrializados: [
+    "1601", "1602", "1704", "1806", "1905",
+    "2007", "2009", "2103", "2104", "2106",
+  ],
+  ferramentas: ["8201", "8202", "8203", "8204", "8205", "8207", "8211"],
+  material_eletrico: ["8504", "8516", "8517", "8528", "8539", "8544.49"],
+  cosmeticos_perfumaria_higiene: [
+    "3303", "3304", "3305", "3306", "3307",
+    "3401", "3402", "9603.21",
+  ],
+  medicamentos: ["3003", "3004", "3005", "3006"],
+};
+
+export type NcmStLookup = {
+  ncm: string;
+  is_st: boolean;
+  matched_prefix: string | null;
+  segments: string[];
+  source: string;
+  data_version: string;
+};
+
+function normalizeNcm(ncm: string): string {
+  return (ncm ?? "").replace(/\D/g, "");
+}
+
+export function lookupNcmSt(ncm: string): NcmStLookup {
+  const norm = normalizeNcm(ncm);
+  if (!norm) {
+    return {
+      ncm,
+      is_st: false,
+      matched_prefix: null,
+      segments: [],
+      source: CEST_DATA_SOURCE,
+      data_version: CEST_DATA_VERSION,
+    };
+  }
+
+  const matched: Array<{ prefix: string; segment: string }> = [];
+  for (const [segment, prefixes] of Object.entries(ST_NCM_PREFIXES)) {
+    for (const prefix of prefixes) {
+      if (norm.startsWith(normalizeNcm(prefix))) {
+        matched.push({ prefix, segment });
+      }
+    }
+  }
+
+  if (matched.length === 0) {
+    return {
+      ncm: norm,
+      is_st: false,
+      matched_prefix: null,
+      segments: [],
+      source: CEST_DATA_SOURCE,
+      data_version: CEST_DATA_VERSION,
+    };
+  }
+
+  matched.sort((a, b) => normalizeNcm(b.prefix).length - normalizeNcm(a.prefix).length);
+  const bestPrefix = matched[0].prefix;
+  const segments = Array.from(new Set(matched.map((m) => m.segment))).sort();
+
+  return {
+    ncm: norm,
+    is_st: true,
+    matched_prefix: bestPrefix,
+    segments,
+    source: CEST_DATA_SOURCE,
+    data_version: CEST_DATA_VERSION,
+  };
+}
+
+export function isStNcm(ncm: string): boolean {
+  return lookupNcmSt(ncm).is_st;
+}

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -159,7 +159,7 @@ test("IBSCBS_CALC: valores corretos não geram finding de cálculo", () => {
 
 // ── New rules (S7) — CEST_MISSING ───────────────────────────────────────────
 
-test("CEST_MISSING: nota sem CEST gera ALERT (regulamento 30/abr/2026 — apenas ST)", () => {
+test("CEST_MISSING: NCM não-ST sem CEST gera ALERT (Conv. 142/2018, #275)", () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <NFS-e><infNfse>
   <PrestadorServico><RazaoSocial>X</RazaoSocial></PrestadorServico>
@@ -180,7 +180,32 @@ test("CEST_MISSING: nota sem CEST gera ALERT (regulamento 30/abr/2026 — apenas
   const result = validateXmlWithRules({ tenantId: "t", documentType: "NFSE", xml });
   const f = result.findings.find((f) => f.rule_id === "CEST_MISSING");
   assert.ok(f, "CEST_MISSING finding expected");
-  assert.equal(f!.severity, "ALERT"); // downgraded per regulamento 30/abr/2026
+  assert.equal(f!.severity, "ALERT"); // NCM 84713012 fora do subset ST
+});
+
+test("CEST_MISSING: NCM ST sem CEST gera FATAL com segmento (#275 fase 2)", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<NFS-e><infNfse>
+  <PrestadorServico><RazaoSocial>X</RazaoSocial></PrestadorServico>
+  <TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>
+  <PrestacaoServico>
+    <Servico>
+      <CodigoServico>123456</CodigoServico>
+      <cClassTrib>654321</cClassTrib>
+      <CST>090</CST><NCM>22021000</NCM>
+    </Servico>
+    <Valores>
+      <BaseCalculo>10000.00</BaseCalculo>
+      <AliquotaCBS>0.0010</AliquotaCBS><ValorCBS>10.00</ValorCBS>
+      <AliquotaIBS>0.0090</AliquotaIBS><ValorIBS>90.00</ValorIBS>
+    </Valores>
+  </PrestacaoServico>
+</infNfse></NFS-e>`;
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFSE", xml });
+  const f = result.findings.find((f) => f.rule_id === "CEST_MISSING");
+  assert.ok(f, "CEST_MISSING finding expected");
+  assert.equal(f!.severity, "FATAL"); // NCM 22021000 (refrigerante) é ST
+  assert.match(f!.title, /bebidas_nao_alcoolicas/);
 });
 
 // ── New rules (S7) — CEST_FORMAT ────────────────────────────────────────────

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -7,6 +7,7 @@ import type {
   ValidationResultV11,
   XmlDocumentType,
 } from "@/lib/types";
+import { lookupNcmSt } from "./cestNcm";
 
 export type ValidationInput = {
   tenantId: string;
@@ -631,28 +632,55 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
     }
   }
 
-  // ── Rule 8: CEST_MISSING — CEST must be present ──────────────────────────
-
-  // Rule 8: CEST_MISSING
-  // Regulamento 30/abr/2026: CEST é obrigatório apenas para produtos sujeitos à
-  // substituição tributária (ST). Produtos sem ST podem emitir sem CEST.
-  // Downgrade para ALERT até cruzamento com tabela ST (issue #275).
+  // ── Rule 8: CEST_MISSING — CEST must be present (#275 fase 2) ────────────
+  // Regulamento 30/abr/2026 + Convênio ICMS 142/2018: CEST é obrigatório
+  // apenas para produtos sujeitos a Substituição Tributária. Cruzamos o NCM
+  // declarado contra subset curado (lib/validation/cestNcm.ts):
+  //   - NCM em segmento ST conhecido → FATAL (CEST realmente obrigatório)
+  //   - NCM fora do subset → ALERT (subset não cobre 100% do Conv. 142)
   if (!cest) {
+    const ncmValue = ncm?.value ?? "";
+    const stLookup = lookupNcmSt(ncmValue);
     const evId = makeEvidenceId("CEST_MISSING");
-    pushFindingAndEvidence(findings, evidences, evidenceById,
-      makeFinding({
-        id: "F_CEST_MISSING",
-        severity: "ALERT",
-        ruleId: "CEST_MISSING",
-        title: "CEST ausente — verificar se produto é sujeito à substituição tributária",
-        field: "CEST",
-        xpath: inferXpath("CEST", docType),
-        snippet: "<!-- Tag CEST não encontrada no XML -->",
-        evidenceId: evId,
-        recommendation: "CEST é obrigatório apenas para produtos com substituição tributária (ST). Se o produto não for sujeito a ST, este aviso pode ser desconsiderado.",
-      }),
-      makeEvidence({ id: evId, type: "xml", label: "CEST — ausente (verificar ST)", xpath: inferXpath("CEST", docType), snippet: "<!-- Tag CEST não encontrada no XML -->" }),
-    );
+
+    if (stLookup.is_st) {
+      const segLabel = stLookup.segments.join(", ");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_CEST_MISSING",
+          severity: "FATAL",
+          ruleId: "CEST_MISSING",
+          title: `CEST obrigatório — NCM ${ncmValue} pertence a segmento ST (${segLabel})`,
+          field: "CEST",
+          xpath: inferXpath("CEST", docType),
+          snippet: "<!-- Tag CEST não encontrada no XML -->",
+          evidenceId: evId,
+          recommendation: `NCM ${ncmValue} consta no Convênio ICMS 142/2018 (${segLabel}). Informe o CEST correspondente em <prod/CEST>.`,
+        }),
+        makeEvidence({
+          id: evId,
+          type: "xml",
+          label: `CEST obrigatório (segmento ST: ${segLabel})`,
+          xpath: inferXpath("CEST", docType),
+          snippet: "<!-- Tag CEST não encontrada no XML -->",
+        }),
+      );
+    } else {
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_CEST_MISSING",
+          severity: "ALERT",
+          ruleId: "CEST_MISSING",
+          title: "CEST ausente — verificar se produto é sujeito à substituição tributária",
+          field: "CEST",
+          xpath: inferXpath("CEST", docType),
+          snippet: "<!-- Tag CEST não encontrada no XML -->",
+          evidenceId: evId,
+          recommendation: `NCM ${ncmValue || "(não informado)"} não consta no subset ST conhecido (Convênio ICMS 142/2018). Se for sujeito a ST, informe o CEST; caso contrário, este aviso pode ser desconsiderado.`,
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "CEST — ausente (verificar ST)", xpath: inferXpath("CEST", docType), snippet: "<!-- Tag CEST não encontrada no XML -->" }),
+      );
+    }
   }
 
   // ── Rule 9: CEST_FORMAT — CEST must be exactly 7 digits ──────────────────


### PR DESCRIPTION
Fecha #275 (fase 2).

## Summary

A regra `CEST_MISSING` agora cruza o **NCM declarado** contra o **Convênio ICMS 142/2018** para decidir a severidade:

| Cenário | Antes (#265 fase 1) | Agora (#275 fase 2) |
|---|---|---|
| NCM em segmento ST (refrigerante, cigarro, combustível, autopeça, cosmético, medicamento…) | `ALERT` genérico | **`FATAL`** com segmento explícito |
| NCM fora do subset conhecido | `ALERT` genérico | `ALERT` com explicação melhor |
| NCM ausente | `ALERT` genérico | `ALERT` (mesmo caminho) |

### Base de dados

- **Fonte**: Convênio ICMS 142/2018 (CONFAZ)
- **Versão**: `2026-06-05`
- **Cobertura**: 14 segmentos, ~70 prefixos NCM (subset curado de alto volume)
- **Limite**: subset não cobre 100% das ~1300 entradas. NCMs fora do subset caem em ALERT em vez de FATAL — comportamento conservador, sem false positive.

Arquivos espelho:
- `backend/app/data/cest_ncm.py` (autoritativo)
- `frontend/src/lib/validation/cestNcm.ts` (mirror)

### Endpoints novos

- `GET /api/v1/public/cest/{ncm}` — lookup público, sem auth
- `GET /api/v1/public/cest/_meta` — versão, fonte, prefixos cobertos

## Test plan
- [x] `pytest tests/test_cest_ncm.py tests/tools/test_nfse_tools.py` — 32/32
- [x] `pytest tests/` (suite completa) — **477/477** (era 465, +12)
- [x] `ruff check` — clean
- [x] `npm test` — **64/64** (era 63, +1)
- [x] `npm run build` — clean
- [ ] Smoke em staging com NF-e real de bebida (NCM 2202) sem CEST → esperar FATAL com mensagem do segmento

## Não-escopo (issue de expansão futura)

- Seed completo dos ~1300 NCMs do Convênio 142 via parser do Excel CONFAZ + migration DB (em vez de Python data file)
- Integração com API gratuita SVRS para sync automático de tabelas
- Tabela CEST→descrição (mapear o código CEST específico, não só "é ST")