### PR TITLE
feat(#276): SPLIT_PAYMENT_INDPAG — valida indPag vs vCBS/vIBS

### DIFF
--- a/backend/app/crews/tools/parse_nfe_xml_tool.py
+++ b/backend/app/crews/tools/parse_nfe_xml_tool.py
@@ -95,6 +95,8 @@ class ParseNFeXMLTool(BaseTool):
             # Totals from IBSCBSTot
             "tot_vcbs": "",
             "tot_vibs": "",
+            # Split payment (#276) — <cobr>/<dup>/<indPag>
+            "indpag": "",
         }
         parse_error: str | None = None
 
@@ -188,6 +190,8 @@ class ParseNFeXMLTool(BaseTool):
                     fields["ncm"] = text
                 elif tag == "CEST" and not fields["cest"]:
                     fields["cest"] = text
+                elif tag == "indPag" and not fields["indpag"]:
+                    fields["indpag"] = text
 
         except ET.ParseError as exc:
             parse_error = str(exc)

--- a/backend/app/crews/tools/validate_ibscbs_rules_tool.py
+++ b/backend/app/crews/tools/validate_ibscbs_rules_tool.py
@@ -71,6 +71,10 @@ class ValidateIBSCBSRulesTool(BaseTool):
         tot_vcbs = (fields.get("tot_vcbs") or "").strip()
         tot_vibs = (fields.get("tot_vibs") or "").strip()
         layout_tags = (fields.get("layout_tags") or "").strip()
+        indpag = (fields.get("indpag") or "").strip()
+
+        # CSTs que legitimamente não geram CBS/IBS (imunidade, suspensão, etc)
+        NO_TAX_CSTS = {"070", "410", "800", "810", "811", "830"}
 
         findings: list[dict[str, str]] = []
         xpath_base = "/nfeProc/NFe/infNFe"
@@ -336,6 +340,34 @@ class ValidateIBSCBSRulesTool(BaseTool):
                 "snippet": f"<CEST>{cest}</CEST>",
                 "recommendation": "CEST deve ter exatamente 7 digitos.",
             })
+
+        # Rule 9b: SPLIT_PAYMENT_INDPAG (#276)
+        # Regulamento IBS cap. 5: operações com pagamento eletrônico sujeito a
+        # split (indPag=3 Pix/TED, indPag=4 cartão) devem lançar CBS+IBS.
+        # Exceção: CSTs sem tributo (070 imunidade, 410 suspensão, etc).
+        if indpag in {"3", "4"}:
+            try:
+                v_cbs_num = float(vcbs or 0)
+                v_ibs_num = float(vibs or 0)
+            except ValueError:
+                v_cbs_num = v_ibs_num = 0.0
+
+            tax_total = v_cbs_num + v_ibs_num
+            if tax_total == 0 and cst not in NO_TAX_CSTS:
+                method = "Pix/TED" if indpag == "3" else "cartão"
+                findings.append({
+                    "rule_id": "SPLIT_PAYMENT_INDPAG",
+                    "severity": "FATAL",
+                    "field": "indPag",
+                    "xpath": f"{xpath_base}//cobr/dup/indPag",
+                    "snippet": f"<indPag>{indpag}</indPag> com vCBS=0 e vIBS=0",
+                    "recommendation": (
+                        f"Pagamento via {method} (indPag={indpag}) sujeito a split payment "
+                        f"(Regulamento IBS cap. 5), mas a NF-e não lança CBS nem IBS. "
+                        f"Confirme se o CST {cst or '(ausente)'} é apropriado ou ajuste "
+                        f"vCBS/vIBS."
+                    ),
+                })
 
         # Rule 10b: LAYOUT_NFE — required NF-e structure
         required = ["emit", "det", "total"]

--- a/backend/tests/test_crewai_nfe_tools.py
+++ b/backend/tests/test_crewai_nfe_tools.py
@@ -394,3 +394,73 @@ def test_validate_layout_nfe_missing_emit():
     result = _parse_and_validate(xml)
     rule_ids = [f["rule_id"] for f in result["findings"]]
     assert "LAYOUT_NFE" in rule_ids
+
+
+# ── SPLIT_PAYMENT_INDPAG (#276) ─────────────────────────────────────────────
+
+
+def _nfe_with_indpag(ind_pag: str, vcbs: str, vibs: str, cst: str = "000") -> str:
+    """Minimal NFe XML with indPag + IBSCBS group (for split payment tests)."""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe><infNFe versao="4.00">
+    <ide><mod>55</mod></ide>
+    <emit><CNPJ>12345678000195</CNPJ></emit>
+    <det nItem="1">
+      <prod><NCM>22021000</NCM><CEST>0301400</CEST></prod>
+      <imposto>
+        <IBSCBS>
+          <gIBSCBS>
+            <CST>{cst}</CST><cClassTrib>100100</cClassTrib>
+            <vBC>1000.00</vBC>
+            <pCBS>0.0010</pCBS><vCBS>{vcbs}</vCBS>
+            <pIBSUF>0.0040</pIBSUF><vIBSUF>{float(vibs) / 2:.2f}</vIBSUF>
+            <pIBSMun>0.0050</pIBSMun><vIBSMun>{float(vibs) / 2:.2f}</vIBSMun>
+            <vIBS>{vibs}</vIBS>
+          </gIBSCBS>
+        </IBSCBS>
+      </imposto>
+    </det>
+    <total><IBSCBSTot><vCBS>{vcbs}</vCBS><vIBS>{vibs}</vIBS></IBSCBSTot></total>
+    <cobr><dup><indPag>{ind_pag}</indPag></dup></cobr>
+  </infNFe></NFe>
+</nfeProc>"""
+
+
+def test_split_payment_indpag_3_no_tax_is_fatal():
+    """indPag=3 (Pix/TED) sem CBS/IBS lançados → FATAL."""
+    result = _parse_and_validate(_nfe_with_indpag("3", "0.00", "0.00"))
+    f = next((f for f in result["findings"] if f["rule_id"] == "SPLIT_PAYMENT_INDPAG"), None)
+    assert f is not None
+    assert f["severity"] == "FATAL"
+    assert "Pix/TED" in f["recommendation"]
+
+
+def test_split_payment_indpag_4_no_tax_is_fatal():
+    """indPag=4 (cartão) sem CBS/IBS lançados → FATAL."""
+    result = _parse_and_validate(_nfe_with_indpag("4", "0.00", "0.00"))
+    f = next((f for f in result["findings"] if f["rule_id"] == "SPLIT_PAYMENT_INDPAG"), None)
+    assert f is not None
+    assert f["severity"] == "FATAL"
+    assert "cartão" in f["recommendation"]
+
+
+def test_split_payment_indpag_3_with_tax_no_finding():
+    """indPag=3 com CBS/IBS lançados → sem finding."""
+    result = _parse_and_validate(_nfe_with_indpag("3", "1.00", "9.00"))
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "SPLIT_PAYMENT_INDPAG" not in rule_ids
+
+
+def test_split_payment_indpag_3_cst_070_no_finding():
+    """indPag=3 com CST 070 (imunidade) sem tributo → sem finding (exceção legítima)."""
+    result = _parse_and_validate(_nfe_with_indpag("3", "0.00", "0.00", cst="070"))
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "SPLIT_PAYMENT_INDPAG" not in rule_ids
+
+
+def test_split_payment_indpag_0_no_finding():
+    """indPag=0 (à vista) sem tributo → sem finding (não sujeito a split)."""
+    result = _parse_and_validate(_nfe_with_indpag("0", "0.00", "0.00"))
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "SPLIT_PAYMENT_INDPAG" not in rule_ids

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -502,3 +502,60 @@ test("DPREV_ENTREGA_CIF_AUSENTE: NFS-e não aciona regra", () => {
     xml: fixture("nfse-ok.xml") });
   assert.equal(result.findings.find((f) => f.rule_id === "DPREV_ENTREGA_CIF_AUSENTE"), undefined);
 });
+
+// ── SPLIT_PAYMENT_INDPAG (#276) ─────────────────────────────────────────────
+
+function nfeWithIndPag(opts: { indPag: string; vCBS: string; vIBS: string; cst?: string }): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <emit><CNPJ>11111111000111</CNPJ></emit>
+  <det><prod><NCM>22021000</NCM></prod>
+    <IBSCBS>
+      <CST>${opts.cst ?? "000"}</CST><cClassTrib>100100</cClassTrib>
+      <vBC>1000.00</vBC>
+      <pCBS>0.0010</pCBS><vCBS>${opts.vCBS}</vCBS>
+      <pIBSUF>0.0040</pIBSUF><vIBSUF>${(parseFloat(opts.vIBS) / 2).toFixed(2)}</vIBSUF>
+      <pIBSMun>0.0050</pIBSMun><vIBSMun>${(parseFloat(opts.vIBS) / 2).toFixed(2)}</vIBSMun>
+      <vIBS>${opts.vIBS}</vIBS>
+    </IBSCBS>
+  </det>
+  <total><IBSCBSTot><vCBS>${opts.vCBS}</vCBS><vIBS>${opts.vIBS}</vIBS></IBSCBSTot></total>
+  <cobr><dup><indPag>${opts.indPag}</indPag></dup></cobr>
+</infNFe></NFe></nfeProc>`;
+}
+
+test("SPLIT_PAYMENT_INDPAG: indPag=3 (Pix) sem CBS/IBS gera FATAL", () => {
+  const xml = nfeWithIndPag({ indPag: "3", vCBS: "0.00", vIBS: "0.00" });
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  const f = result.findings.find((f) => f.rule_id === "SPLIT_PAYMENT_INDPAG");
+  assert.ok(f, "SPLIT_PAYMENT_INDPAG expected");
+  assert.equal(f!.severity, "FATAL");
+  assert.match(f!.title, /Pix\/TED/);
+});
+
+test("SPLIT_PAYMENT_INDPAG: indPag=4 (cartão) sem CBS/IBS gera FATAL", () => {
+  const xml = nfeWithIndPag({ indPag: "4", vCBS: "0.00", vIBS: "0.00" });
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  const f = result.findings.find((f) => f.rule_id === "SPLIT_PAYMENT_INDPAG");
+  assert.ok(f, "SPLIT_PAYMENT_INDPAG expected");
+  assert.equal(f!.severity, "FATAL");
+  assert.match(f!.title, /cartão/);
+});
+
+test("SPLIT_PAYMENT_INDPAG: indPag=3 com CBS/IBS lançados não gera finding", () => {
+  const xml = nfeWithIndPag({ indPag: "3", vCBS: "1.00", vIBS: "9.00" });
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  assert.equal(result.findings.find((f) => f.rule_id === "SPLIT_PAYMENT_INDPAG"), undefined);
+});
+
+test("SPLIT_PAYMENT_INDPAG: indPag=3 com CST 070 (imunidade) não gera finding", () => {
+  const xml = nfeWithIndPag({ indPag: "3", vCBS: "0.00", vIBS: "0.00", cst: "070" });
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  assert.equal(result.findings.find((f) => f.rule_id === "SPLIT_PAYMENT_INDPAG"), undefined);
+});
+
+test("SPLIT_PAYMENT_INDPAG: indPag=0 (à vista) sem CBS/IBS não gera finding", () => {
+  const xml = nfeWithIndPag({ indPag: "0", vCBS: "0.00", vIBS: "0.00" });
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  assert.equal(result.findings.find((f) => f.rule_id === "SPLIT_PAYMENT_INDPAG"), undefined);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -241,6 +241,10 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   const totVIBS = ibscbsTot ? firstTag(ibscbsTot.snippet, ["vIBS"]) : null;
   const totVCBS = ibscbsTot ? firstTag(ibscbsTot.snippet, ["vCBS"]) : null;
 
+  // Split payment (#276) — <cobr>/<dup>/<indPag>
+  const indPag = firstTag(xml, ["indPag"]);
+  const NO_TAX_CSTS = new Set(["070", "410", "800", "810", "811", "830"]);
+
   // ── Rules 1-3: field format checks ────────────────────────────────────────
 
   const formatFields = [
@@ -679,6 +683,39 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           recommendation: `NCM ${ncmValue || "(não informado)"} não consta no subset ST conhecido (Convênio ICMS 142/2018). Se for sujeito a ST, informe o CEST; caso contrário, este aviso pode ser desconsiderado.`,
         }),
         makeEvidence({ id: evId, type: "xml", label: "CEST — ausente (verificar ST)", xpath: inferXpath("CEST", docType), snippet: "<!-- Tag CEST não encontrada no XML -->" }),
+      );
+    }
+  }
+
+  // ── Rule 9b: SPLIT_PAYMENT_INDPAG (#276) ─────────────────────────────────
+  // Regulamento IBS cap. 5: indPag=3 (Pix/TED) ou 4 (cartão) sujeito a split
+  // payment automático → CBS/IBS devem ser lançados, exceto CSTs sem tributo.
+  if (indPag && (indPag.value === "3" || indPag.value === "4")) {
+    const cstValue = firstTag(xml, ["CST"])?.value ?? "";
+    const vCbsNum = parseFloat(vCBS?.value ?? "0") || 0;
+    const vIbsNum = parseFloat(vIBS?.value ?? "0") || 0;
+    if (vCbsNum + vIbsNum === 0 && !NO_TAX_CSTS.has(cstValue)) {
+      const method = indPag.value === "3" ? "Pix/TED" : "cartão";
+      const evId = makeEvidenceId("SPLIT_PAYMENT_INDPAG");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_SPLIT_PAYMENT_INDPAG",
+          severity: "FATAL",
+          ruleId: "SPLIT_PAYMENT_INDPAG",
+          title: `Pagamento via ${method} sujeito a split payment sem CBS/IBS lançados`,
+          field: "indPag",
+          xpath: inferXpath("indPag", docType),
+          snippet: indPag.snippet,
+          evidenceId: evId,
+          recommendation: `indPag=${indPag.value} (${method}) está sujeito a split payment automático (Regulamento IBS cap. 5), mas a NF-e não lança CBS nem IBS. Confirme se o CST ${cstValue || "(ausente)"} é apropriado ou ajuste vCBS/vIBS.`,
+        }),
+        makeEvidence({
+          id: evId,
+          type: "xml",
+          label: `Split payment sem tributo (indPag=${indPag.value})`,
+          xpath: inferXpath("indPag", docType),
+          snippet: indPag.snippet,
+        }),
       );
     }
   }


### PR DESCRIPTION
Fecha #276.

## Summary

Nova regra fiscal `SPLIT_PAYMENT_INDPAG` baseada no Regulamento IBS cap. 5 (30/abr/2026):

| indPag | Significado | Regra |
|---|---|---|
| `0` | À vista | Fora do escopo (não sujeito a split) |
| `1` | A prazo | Fora do escopo |
| `3` | Pix/TED com split automático | **vCBS+vIBS > 0 obrigatório** (exceto CSTs imunes) |
| `4` | Cartão com split automático | **vCBS+vIBS > 0 obrigatório** (exceto CSTs imunes) |

Exceção: CSTs sem geração de tributo (`070` imunidade, `410` suspensão, `800/810/811/830` transferência/ajuste/estorno) → sem finding.

## Implementação

- **Parser** (`parse_nfe_xml_tool.py`): nova extração de `<indPag>` do grupo `<cobr>/<dup>` → campo `indpag` no JSON
- **Validator backend** (`validate_ibscbs_rules_tool.py`): nova regra com lógica acima
- **Validator frontend** (`xmlRules.ts`): espelho TypeScript da mesma lógica
- 5 testes backend (`test_crewai_nfe_tools.py`) + 5 testes frontend (`xmlRules.test.ts`) cobrindo:
  - indPag=3 sem tributo → FATAL
  - indPag=4 sem tributo → FATAL
  - indPag=3 com tributo → sem finding
  - indPag=3 + CST 070 → sem finding (exceção)
  - indPag=0 sem tributo → sem finding

## Test plan
- [x] `pytest tests/test_crewai_nfe_tools.py` — 22/22
- [x] `pytest tests/` — **482/482** (era 477, +5)
- [x] `ruff check` — clean
- [x] `npm test` — **69/69** (era 64, +5)
- [x] `npm run build` — clean

## Não-escopo (issue futura)

- Cruzamento com lista de estabelecimentos obrigados ao split (fase plena: 2027)
- Validação reversa: indPag ausente em operações cujo CST sugere split
