### PR TITLE
feat(seo): JSON-LD nas 4 páginas pain-point (Product/WebApp + FAQPage)

### DIFF
--- a/frontend/src/app/calculadora/layout.tsx
+++ b/frontend/src/app/calculadora/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { CALCULADORA_SCHEMA } from "@/components/seo/schemas";
 
 export const metadata: Metadata = {
   title: "Calculadora CBS/IBS — Calcule NCM → cClassTrib + Alíquotas LC 214",
@@ -24,6 +26,7 @@ export const metadata: Metadata = {
 export default function CalculadoraLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col">
+      <JsonLd data={CALCULADORA_SCHEMA} />
       <PublicNavbar />
       <main className="flex-1">{children}</main>
       <PublicFooter />

--- a/frontend/src/app/classificacao/layout.tsx
+++ b/frontend/src/app/classificacao/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { CLASSIFICACAO_SCHEMA } from "@/components/seo/schemas";
 
 export const metadata: Metadata = {
   title: "Classificar NCM → cClassTrib CBS/IBS — Evite a Rejeição 1024",
@@ -25,6 +27,7 @@ export const metadata: Metadata = {
 export default function ClassificacaoLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col">
+      <JsonLd data={CLASSIFICACAO_SCHEMA} />
       <PublicNavbar />
       <main className="flex-1">{children}</main>
       <PublicFooter />

--- a/frontend/src/app/diagnostico/layout.tsx
+++ b/frontend/src/app/diagnostico/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { DIAGNOSTICO_SCHEMA } from "@/components/seo/schemas";
 
 export const metadata: Metadata = {
   title: "Diagnóstico Gratuito NF-e — Conformidade IBS/CBS 2026 | Tribultz",
@@ -19,6 +21,7 @@ export const metadata: Metadata = {
 export default function DiagnosticoLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col">
+      <JsonLd data={DIAGNOSTICO_SCHEMA} />
       <PublicNavbar />
       <main className="flex-1">{children}</main>
       <PublicFooter />

--- a/frontend/src/app/pricing/layout.tsx
+++ b/frontend/src/app/pricing/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { PRICING_SCHEMA } from "@/components/seo/schemas";
 
 export const metadata: Metadata = {
   title: "Planos e Preços — Compliance CBS/IBS a partir de R$ 49,90",
@@ -19,5 +21,10 @@ export const metadata: Metadata = {
 };
 
 export default function PricingLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <JsonLd data={PRICING_SCHEMA} />
+      {children}
+    </>
+  );
 }

--- a/frontend/src/components/seo/JsonLd.tsx
+++ b/frontend/src/components/seo/JsonLd.tsx
@@ -1,0 +1,35 @@
+/**
+ * JsonLd — server-rendered schema.org JSON-LD snippet.
+ *
+ * Usage:
+ *   <JsonLd data={{ "@context": "https://schema.org", "@type": "FAQPage", ... }} />
+ *
+ * Accepts either a single schema object or a @graph array. Always renders as
+ * <script type="application/ld+json"> inside the page's React tree.
+ *
+ * Server component — no client JS shipped.
+ */
+
+type SchemaValue =
+  | string
+  | number
+  | boolean
+  | null
+  | SchemaValue[]
+  | { [key: string]: SchemaValue };
+
+export type SchemaObject = Record<string, SchemaValue>;
+
+export function JsonLd({ data }: { data: SchemaObject | SchemaObject[] }) {
+  // Stable, compact, no extra whitespace. Browsers don't care about pretty-print.
+  const payload = Array.isArray(data)
+    ? { "@context": "https://schema.org", "@graph": data }
+    : data;
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(payload) }}
+    />
+  );
+}

--- a/frontend/src/components/seo/schemas.ts
+++ b/frontend/src/components/seo/schemas.ts
@@ -1,0 +1,237 @@
+/**
+ * Schema.org JSON-LD payloads para as páginas pain-point.
+ *
+ * Mantém os esquemas em um único lugar para garantir consistência de
+ * `@id`, URLs e estrutura entre páginas. Cada export retorna um array
+ * que vira `@graph` no JsonLd component.
+ *
+ * Convenção: `@id` usa fragment relativo ao path da página.
+ * Ex: a página /pricing referencia `https://tribultz.com.br/pricing#offer-profissional`.
+ */
+
+import type { SchemaObject } from "./JsonLd";
+
+const SITE_URL = "https://tribultz.com.br";
+const ORG_ID = `${SITE_URL}/#org`;
+
+const ORGANIZATION: SchemaObject = {
+  "@type": "Organization",
+  "@id": ORG_ID,
+  "name": "Tribultz",
+  "url": SITE_URL,
+  "logo": `${SITE_URL}/logo.png`,
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "customer support",
+    "availableLanguage": "Portuguese",
+  },
+};
+
+function faqPage(url: string, qa: Array<{ q: string; a: string }>): SchemaObject {
+  return {
+    "@type": "FAQPage",
+    "@id": `${url}#faq`,
+    "mainEntity": qa.map(({ q, a }) => ({
+      "@type": "Question",
+      "name": q,
+      "acceptedAnswer": { "@type": "Answer", "text": a },
+    })),
+  };
+}
+
+// ── /pricing ────────────────────────────────────────────────────────────────
+
+const PRICING_URL = `${SITE_URL}/pricing`;
+
+export const PRICING_SCHEMA: SchemaObject[] = [
+  ORGANIZATION,
+  {
+    "@type": "Product",
+    "@id": `${PRICING_URL}#product`,
+    "name": "Tribultz — Compliance CBS/IBS",
+    "description":
+      "Plataforma de validação CBS/IBS, classificação NCM → cClassTrib e " +
+      "exportação para ERPs (TOTVS, SAP, Omie, Linx) com evidência auditável.",
+    "brand": { "@id": ORG_ID },
+    "offers": {
+      "@type": "AggregateOffer",
+      "priceCurrency": "BRL",
+      "lowPrice": "49.90",
+      "highPrice": "349.00",
+      "offerCount": 4,
+      "offers": [
+        { "@type": "Offer", "name": "Starter",       "price": "49.90",  "priceCurrency": "BRL", "url": `${PRICING_URL}#starter` },
+        { "@type": "Offer", "name": "Profissional", "price": "149.00", "priceCurrency": "BRL", "url": `${PRICING_URL}#profissional` },
+        { "@type": "Offer", "name": "Empresarial",  "price": "249.00", "priceCurrency": "BRL", "url": `${PRICING_URL}#empresarial` },
+        { "@type": "Offer", "name": "Contador",     "price": "349.00", "priceCurrency": "BRL", "url": `${PRICING_URL}#contador` },
+      ],
+    },
+  },
+  faqPage(PRICING_URL, [
+    {
+      q: "Posso testar a Tribultz antes de assinar?",
+      a:
+        "Sim. O plano Trial é gratuito e dá acesso a 100 créditos de API e à validação " +
+        "completa de até 20 NF-e. Sem cartão de crédito.",
+    },
+    {
+      q: "Como funciona a cobrança da API NCM → cClassTrib?",
+      a:
+        "A API tem preço pay-per-call dentro do limite do plano. Acima do limite, " +
+        "créditos extras podem ser comprados avulsos. O painel mostra consumo em tempo real.",
+    },
+    {
+      q: "Posso mudar de plano a qualquer momento?",
+      a:
+        "Sim, upgrade e downgrade são imediatos. Diferença proporcional é cobrada ou " +
+        "creditada no próximo ciclo.",
+    },
+    {
+      q: "Qual plano é melhor para escritório de contabilidade?",
+      a:
+        "O plano Contador inclui multi-tenant (até 50 CNPJs de clientes), relatório " +
+        "consolidado mensal e SLA de suporte prioritário.",
+    },
+  ]),
+];
+
+// ── /calculadora ────────────────────────────────────────────────────────────
+
+const CALCULADORA_URL = `${SITE_URL}/calculadora`;
+
+export const CALCULADORA_SCHEMA: SchemaObject[] = [
+  ORGANIZATION,
+  {
+    "@type": "WebApplication",
+    "@id": `${CALCULADORA_URL}#app`,
+    "name": "Calculadora CBS/IBS Tribultz",
+    "url": CALCULADORA_URL,
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Web",
+    "isAccessibleForFree": true,
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL" },
+    "description":
+      "Calcule CBS e IBS por NCM, UF e CST com alíquotas atualizadas da LC 214. " +
+      "Retorna cClassTrib sugerido e base legal.",
+  },
+  faqPage(CALCULADORA_URL, [
+    {
+      q: "As alíquotas estão atualizadas com a NT 2025.002 e LC 227?",
+      a:
+        "Sim. A base de alíquotas é sincronizada com o Convênio ICMS 142/2018, a " +
+        "tabela cClassTrib SVRS (atualização de 15/abr/2026) e os regulamentos IBS/CBS " +
+        "publicados em 30/abr/2026.",
+    },
+    {
+      q: "A calculadora considera regimes especiais e cesta básica?",
+      a:
+        "Sim. O cClassTrib resolve o regime aplicável (padrão, reduzido, cesta básica, " +
+        "monofásico, imune) e a calculadora aplica o modificador de alíquota correspondente.",
+    },
+    {
+      q: "Posso usar a calculadora sem login?",
+      a: "Sim. A versão web é 100% gratuita, sem cadastro, com limite de 100 cálculos por dia por IP.",
+    },
+    {
+      q: "Existe API para integrar essa calculadora ao meu ERP?",
+      a:
+        "Sim. O endpoint POST /api/v1/public_api/calculate retorna o mesmo resultado em JSON. " +
+        "Veja a documentação em /settings/api após o login.",
+    },
+  ]),
+];
+
+// ── /diagnostico ────────────────────────────────────────────────────────────
+
+const DIAGNOSTICO_URL = `${SITE_URL}/diagnostico`;
+
+export const DIAGNOSTICO_SCHEMA: SchemaObject[] = [
+  ORGANIZATION,
+  {
+    "@type": "WebApplication",
+    "@id": `${DIAGNOSTICO_URL}#app`,
+    "name": "Diagnóstico NF-e CBS/IBS Tribultz",
+    "url": DIAGNOSTICO_URL,
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "isAccessibleForFree": true,
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL" },
+    "description":
+      "Valide sua NF-e, NFC-e ou NFS-e contra as 18 regras da NT 2025.002-RTC. " +
+      "Diagnóstico instantâneo, sem cadastro, evidência auditável.",
+  },
+  faqPage(DIAGNOSTICO_URL, [
+    {
+      q: "O que é validado no diagnóstico gratuito?",
+      a:
+        "São aplicadas 18 regras determinísticas: formato CST/cClassTrib/NCM, " +
+        "compatibilidade CST × cClassTrib (Rejeição 1024), cálculo CBS/IBS, " +
+        "totais, CEST × ST (Convênio 142/2018), split payment indPag e estrutura XML.",
+    },
+    {
+      q: "Meus dados ficam armazenados?",
+      a:
+        "Não. O XML enviado pelo formulário público é processado em memória e " +
+        "descartado imediatamente. Nenhum CNPJ, valor ou item é persistido. " +
+        "Veja a política completa em /api/v1/public/data-policy.",
+    },
+    {
+      q: "O diagnóstico vale como evidência para autuação?",
+      a:
+        "O relatório inclui timestamp, hash do XML, regra aplicada e base legal. " +
+        "Planos pagos exportam o PDF com assinatura digital para auditoria.",
+    },
+    {
+      q: "Há limite de uso gratuito?",
+      a: "20 diagnósticos por dia por IP. Sem cadastro. Para volume maior, assine o plano Starter.",
+    },
+  ]),
+];
+
+// ── /classificacao ──────────────────────────────────────────────────────────
+
+const CLASSIFICACAO_URL = `${SITE_URL}/classificacao`;
+
+export const CLASSIFICACAO_SCHEMA: SchemaObject[] = [
+  ORGANIZATION,
+  {
+    "@type": "WebApplication",
+    "@id": `${CLASSIFICACAO_URL}#app`,
+    "name": "Classificador NCM → cClassTrib Tribultz",
+    "url": CLASSIFICACAO_URL,
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "isAccessibleForFree": true,
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL" },
+    "description":
+      "Sugere o cClassTrib correto para um NCM dado o regime tributário aplicável. " +
+      "Evita a Rejeição 1024 antes da emissão da NF-e.",
+  },
+  faqPage(CLASSIFICACAO_URL, [
+    {
+      q: "O que é a Rejeição 1024 e como evito?",
+      a:
+        "A Rejeição 1024 acontece quando o CST informado no XML é incompatível com os " +
+        "três primeiros dígitos do cClassTrib (ex: CST 000 com cClassTrib 200034). " +
+        "O classificador da Tribultz sugere o cClassTrib correto antes da emissão.",
+    },
+    {
+      q: "A classificação é por NCM ou por descrição do produto?",
+      a:
+        "Por NCM, com regime tributário escolhido pelo usuário. Para descrições, use o " +
+        "endpoint /api/v1/ncm_suggest que aplica IA sobre a descrição e retorna NCM + cClassTrib.",
+    },
+    {
+      q: "A base de cClassTrib está atualizada?",
+      a:
+        "Sim. Sincronizada com a tabela CST/cClassTrib SVRS publicada em 15/abr/2026 " +
+        "e os regulamentos IBS/CBS de 30/abr/2026.",
+    },
+    {
+      q: "Existe API pública para integrar ao meu ERP?",
+      a:
+        "Sim. Endpoint POST /api/v1/ncm/suggest com autenticação por X-API-Key. " +
+        "Veja docs em /settings/api após login.",
+    },
+  ]),
+];


### PR DESCRIPTION
Parte 1 do plano de SEO orgânico (sequência discutida pós-diagnóstico do dia 05/jun).

## Summary

Antes: só a landing (\`/\`) tinha JSON-LD rico (Organization + SoftwareApplication + FAQPage com 5 Q&As). As outras 4 páginas que captam tráfego orgânico qualificado (\`/pricing\`, \`/calculadora\`, \`/diagnostico\`, \`/classificacao\`) tinham apenas metadados Open Graph — invisíveis para rich results do Google.

Depois: schema.org completo em todas as 4 + componente reutilizável.

## O que cada página passa a expor

| Página | Schema principal | Extras |
|---|---|---|
| \`/pricing\` | \`Product\` + \`AggregateOffer\` (4 tiers: Starter R\$49.90 → Contador R\$349) | \`FAQPage\` (4 Q&A sobre planos) |
| \`/calculadora\` | \`WebApplication\` (FinanceApplication, grátis) | \`FAQPage\` (4 Q&A com gancho LC 227 + Conv. 142) |
| \`/diagnostico\` | \`WebApplication\` (BusinessApplication, grátis) | \`FAQPage\` (4 Q&A sobre 18 regras + privacidade) |
| \`/classificacao\` | \`WebApplication\` (NCM → cClassTrib, grátis) | \`FAQPage\` (4 Q&A com foco em Rejeição 1024) |

Cada página também referencia o mesmo \`@id\` da \`Organization\` (\`https://tribultz.com.br/#org\`) para consolidar autoridade no graph.

## Arquitetura

- \`components/seo/JsonLd.tsx\` — server component (zero JS no cliente), aceita objeto único ou array de schemas (vira \`@graph\`)
- \`components/seo/schemas.ts\` — payloads centralizados por página, tipos derivados de \`SchemaObject\`
- Cada \`layout.tsx\` das 4 páginas importa e renderiza \`<JsonLd data={...} />\` antes de \`{children}\`

## Test plan
- [x] \`npm run build\` — clean, 43 páginas estáticas geradas
- [x] \`npm test\` — todos os testes passando (sem regressão)
- [x] Preview local: \`curl http://localhost:3000/<path> | grep ld+json\` confirma o snippet em todas as 4 rotas
- [ ] Após merge + deploy: rodar **Rich Results Test** do Google em cada URL — esperar reconhecimento de Product, FAQPage, WebApplication
- [ ] Submeter sitemap atualizado no Google Search Console
- [ ] Monitorar Search Console em 7-14 dias para impressões/cliques em FAQ rich results

## Próximos passos do plano SEO (em fila)

1. **Confirmar Google Search Console** — verificar propriedade, submeter sitemap, inspecionar URLs
2. **Auditoria de conteúdo vs Tax Radar** — gap analysis em páginas-pain
3. **Plano de link-building** — guest posts SPED Brasil / Contábeis, AM, LinkedIn técnico
4. ✅ **Schema.org JSON-LD** (este PR)
5. **Página dedicada \`/rejeicao-1024\`** otimizada
