### PR TITLE
fix(#296): server-render copy em /classificacao e /calculadora (0→1025 e 61→776 palavras)

### DIFF
--- a/frontend/src/app/calculadora/Calculator.tsx
+++ b/frontend/src/app/calculadora/Calculator.tsx
@@ -1,0 +1,576 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { API_BASE, createTransactionId } from "@/lib/api";
+import { UF_LIST } from "@/lib/data/ufList";
+import { CST_LIST } from "@/lib/data/cstList";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type SuggestResult = {
+  ncm: string;
+  ncm_descricao: string;
+  confidence: number;
+  cClassTrib: string | null;
+  aviso: string | null;
+};
+
+type CalculadoraResult = {
+  vBC: string;
+  pCBS: string;
+  vCBS: string;
+  pIBSUF: string;
+  vIBSUF: string;
+  pIBSMun: string;
+  vIBSMun: string;
+  vIBS: string;
+  total_tributos: string;
+  aliquota_efetiva: string;
+  rate_source: string;
+  cst: string;
+  cst_desc: string;
+  xml_snippet: string;
+  data_policy: string;
+  upgrade_cta: string;
+  transaction_id?: string;
+};
+
+type CalcState = "idle" | "loading" | "done" | "error";
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+function CalculadoraInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [uf, setUf] = useState(searchParams.get("uf") ?? "SP");
+  const [baseValue, setBaseValue] = useState(searchParams.get("vBC") ?? "1000.00");
+  const [ncm, setNcm] = useState(searchParams.get("ncm") ?? "");
+  const [cst, setCst] = useState(searchParams.get("cst") ?? "000");
+  const [quantity, setQuantity] = useState(searchParams.get("qty") ?? "1");
+
+  const [state, setState] = useState<CalcState>("idle");
+  const [result, setResult] = useState<CalculadoraResult | null>(null);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const [suggestOpen, setSuggestOpen] = useState(false);
+  const [suggestDesc, setSuggestDesc] = useState("");
+  const [suggestLoading, setSuggestLoading] = useState(false);
+  const [suggestResult, setSuggestResult] = useState<SuggestResult | null>(null);
+
+  const handleCalculate = useCallback(async () => {
+    setState("loading");
+    setError("");
+    setResult(null);
+
+    try {
+      const transactionId = createTransactionId();
+      const body: Record<string, string> = {
+        uf_destino: uf,
+        base_value: baseValue,
+        quantity,
+        cst,
+      };
+      if (ncm.trim()) body.ncm_code = ncm.trim();
+
+      const endpoint = `${API_BASE}/api/v1/public/calculadora/regime-geral`;
+      console.log("Endpoint da calculadora:", endpoint);
+
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Transaction-Id": transactionId,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (res.status === 429) {
+        setError("Limite de requisições atingido. Aguarde 1 minuto.");
+        setState("error");
+        return;
+      }
+
+      if (res.status === 422) {
+        const detail = await res.json().catch(() => ({ detail: "Dados inválidos" }));
+        const msg = Array.isArray(detail.detail)
+          ? detail.detail.map((d: { msg: string }) => d.msg).join("; ")
+          : detail.detail ?? "Dados inválidos";
+        setError(msg);
+        setState("error");
+        return;
+      }
+
+      if (!res.ok) {
+        setError(`Erro ${res.status}`);
+        setState("error");
+        return;
+      }
+
+      const data: CalculadoraResult = await res.json();
+      setResult({
+        ...data,
+        transaction_id: data.transaction_id ?? transactionId,
+      });
+      setState("done");
+
+      // Update URL params for sharing
+      const params = new URLSearchParams();
+      params.set("uf", uf);
+      params.set("vBC", baseValue);
+      if (ncm.trim()) params.set("ncm", ncm.trim());
+      if (cst !== "000") params.set("cst", cst);
+      if (quantity !== "1") params.set("qty", quantity);
+      router.replace(`/calculadora?${params.toString()}`, { scroll: false });
+    } catch {
+      setError("Erro de conexão. Verifique se o servidor está acessível.");
+      setState("error");
+    }
+  }, [uf, baseValue, ncm, cst, quantity, router]);
+
+  const handleSuggestNcm = useCallback(async () => {
+    if (!suggestDesc.trim()) return;
+    setSuggestLoading(true);
+    setSuggestResult(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/public/ncm/suggest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ descricao: suggestDesc.trim() }),
+      });
+      if (res.status === 429) { setError("Limite diário de classificações atingido. Crie uma conta gratuita para mais."); return; }
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: "Erro ao classificar." }));
+        setError(err.detail ?? "Erro ao classificar NCM.");
+        return;
+      }
+      setSuggestResult(await res.json());
+    } catch {
+      setError("Erro de conexão ao classificar NCM.");
+    } finally {
+      setSuggestLoading(false);
+    }
+  }, [suggestDesc]);
+
+  const copyXml = useCallback(() => {
+    if (result?.xml_snippet) {
+      navigator.clipboard.writeText(result.xml_snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [result]);
+
+  const copyShareUrl = useCallback(() => {
+    navigator.clipboard.writeText(window.location.href);
+  }, []);
+
+  // Auto-calculate if URL has params on mount
+  useEffect(() => {
+    if (searchParams.get("vBC") && searchParams.get("uf")) {
+      handleCalculate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const pctFmt = (v: string) => `${(parseFloat(v) * 100).toFixed(2)}%`;
+  const brlFmt = (v: string) => `R$ ${parseFloat(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
+
+  return (
+    <>
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-tribultz-50 to-white px-4 py-16 text-center md:py-20">
+        <h1 className="mx-auto max-w-3xl text-3xl font-extrabold text-slate-900 md:text-4xl">
+          Calculadora CBS/IBS
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
+          Calcule os tributos da Reforma Tributária para qualquer operação.
+          Gere o XML <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-sm">&lt;IBSCBS&gt;</code> pronto para o ERP.
+        </p>
+        <div className="mx-auto mt-2 flex items-center justify-center gap-4 text-sm text-slate-500">
+          <span>LC 214/2025</span>
+          <span>NT 2025.002-RTC</span>
+          <span>27 UFs</span>
+        </div>
+      </section>
+
+      {/* Calculator form */}
+      <section className="mx-auto -mt-6 max-w-2xl px-4 pb-16">
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="grid gap-4 md:grid-cols-2">
+            {/* UF */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                UF Destino *
+              </label>
+              <select
+                value={uf}
+                onChange={(e) => setUf(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+              >
+                {UF_LIST.map((u) => (
+                  <option key={u.code} value={u.code}>
+                    {u.code} — {u.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Base Value */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                Valor Base (R$) *
+              </label>
+              <input
+                type="number"
+                step="0.01"
+                min="0.01"
+                value={baseValue}
+                onChange={(e) => setBaseValue(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+                placeholder="1000.00"
+              />
+            </div>
+
+            {/* NCM */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                NCM <span className="text-slate-400">(opcional)</span>
+              </label>
+              <input
+                type="text"
+                maxLength={8}
+                value={ncm}
+                onChange={(e) => setNcm(e.target.value.replace(/\D/g, ""))}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-mono focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+                placeholder="84713012"
+              />
+              <p className="mt-0.5 text-xs text-slate-400">8 dígitos — alíquota reduzida para alimentos, pharma, educação</p>
+            </div>
+
+            {/* NCM suggest */}
+            <div className="md:col-span-2">
+              <button
+                type="button"
+                onClick={() => { setSuggestOpen(!suggestOpen); setSuggestResult(null); }}
+                className="text-xs font-medium text-tribultz-600 hover:underline"
+              >
+                {suggestOpen ? "▲ Fechar" : "▼ Não sei o NCM — classificar por descrição (IA)"}
+              </button>
+              {suggestOpen && (
+                <div className="mt-2 rounded-lg border border-tribultz-100 bg-tribultz-50 p-3">
+                  <p className="mb-2 text-xs text-slate-600">Descreva o produto e sugerimos o NCM automaticamente.</p>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={suggestDesc}
+                      onChange={(e) => setSuggestDesc(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === "Enter") void handleSuggestNcm(); }}
+                      placeholder="Ex: Carne bovina traseira resfriada"
+                      className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+                      maxLength={300}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void handleSuggestNcm()}
+                      disabled={suggestLoading || !suggestDesc.trim()}
+                      className="rounded-lg bg-tribultz-600 px-4 py-2 text-sm font-medium text-white hover:bg-tribultz-700 disabled:opacity-50"
+                    >
+                      {suggestLoading ? "…" : "Classificar"}
+                    </button>
+                  </div>
+                  {suggestResult && (
+                    <div className="mt-2 rounded-lg border border-slate-200 bg-white p-3 text-sm">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div>
+                          <span className="font-mono font-bold text-slate-800">{suggestResult.ncm}</span>
+                          <span className="ml-2 text-xs text-slate-500">{suggestResult.ncm_descricao}</span>
+                          {suggestResult.cClassTrib && (
+                            <span className="ml-2 text-xs text-blue-600">· cClassTrib: {suggestResult.cClassTrib}</span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${suggestResult.confidence >= 0.70 ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700"}`}>
+                            {Math.round(suggestResult.confidence * 100)}% confiança
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => { setNcm(suggestResult.ncm); setSuggestOpen(false); }}
+                            className="rounded bg-tribultz-600 px-2 py-1 text-[11px] font-bold text-white hover:bg-tribultz-700"
+                          >
+                            Usar este NCM
+                          </button>
+                        </div>
+                      </div>
+                      {suggestResult.aviso && (
+                        <p className="mt-1.5 text-xs text-amber-700">⚠ {suggestResult.aviso}</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* CST */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                CST
+              </label>
+              <select
+                value={cst}
+                onChange={(e) => setCst(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+              >
+                {CST_LIST.map((c) => (
+                  <option key={c.code} value={c.code}>
+                    {c.code} — {c.desc}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Quantity */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                Quantidade
+              </label>
+              <input
+                type="number"
+                step="1"
+                min="1"
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+                placeholder="1"
+              />
+            </div>
+          </div>
+
+          {/* Calculate button */}
+          <div className="mt-6 text-center">
+            <button
+              type="button"
+              onClick={handleCalculate}
+              disabled={state === "loading"}
+              className="rounded-lg bg-tribultz-600 px-8 py-3 text-sm font-semibold text-white hover:bg-tribultz-700 disabled:opacity-50"
+            >
+              {state === "loading" ? "Calculando..." : "Calcular CBS/IBS"}
+            </button>
+          </div>
+        </div>
+
+        {/* Error */}
+        {state === "error" && (
+          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {/* Results */}
+        {state === "done" && result && (
+          <div className="mt-6 space-y-4">
+            {/* Breakdown card */}
+            <div className="rounded-xl border border-slate-200 bg-white p-5">
+              <h2 className="text-base font-semibold text-slate-900">Resultado do Cálculo</h2>
+              <p className="mt-1 text-xs text-slate-500">
+                CST {result.cst} — {result.cst_desc} | Fonte: {result.rate_source}
+                {result.transaction_id ? ` | Tx: ${result.transaction_id}` : ""}
+              </p>
+
+              <div className="mt-4 space-y-2">
+                {/* Base */}
+                <div className="flex items-center justify-between border-b border-slate-100 pb-2">
+                  <span className="text-sm text-slate-600">Base de Cálculo (vBC)</span>
+                  <span className="font-mono text-sm font-medium text-slate-900">{brlFmt(result.vBC)}</span>
+                </div>
+
+                {/* CBS */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-blue-500" />
+                    <span className="text-sm text-slate-600">CBS (federal)</span>
+                    <span className="text-xs text-slate-400">{pctFmt(result.pCBS)}</span>
+                  </div>
+                  <span className="font-mono text-sm font-medium text-blue-700">{brlFmt(result.vCBS)}</span>
+                </div>
+
+                {/* IBS UF */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                    <span className="text-sm text-slate-600">IBS UF (estadual)</span>
+                    <span className="text-xs text-slate-400">{pctFmt(result.pIBSUF)}</span>
+                  </div>
+                  <span className="font-mono text-sm font-medium text-emerald-700">{brlFmt(result.vIBSUF)}</span>
+                </div>
+
+                {/* IBS Mun */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-teal-500" />
+                    <span className="text-sm text-slate-600">IBS Mun (municipal)</span>
+                    <span className="text-xs text-slate-400">{pctFmt(result.pIBSMun)}</span>
+                  </div>
+                  <span className="font-mono text-sm font-medium text-teal-700">{brlFmt(result.vIBSMun)}</span>
+                </div>
+
+                {/* Divider */}
+                <div className="border-t border-slate-200 pt-2" />
+
+                {/* Total */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="text-sm font-semibold text-slate-900">Total Tributos</span>
+                    <span className="ml-2 text-xs text-slate-500">
+                      Alíquota efetiva: {pctFmt(result.aliquota_efetiva)}
+                    </span>
+                  </div>
+                  <span className="font-mono text-lg font-bold text-slate-900">{brlFmt(result.total_tributos)}</span>
+                </div>
+              </div>
+
+              {/* Visual bar */}
+              {parseFloat(result.total_tributos) > 0 && (
+                <div className="mt-4">
+                  <div className="flex h-4 overflow-hidden rounded-full">
+                    <div
+                      className="bg-blue-500"
+                      style={{ width: `${(parseFloat(result.vCBS) / parseFloat(result.total_tributos)) * 100}%` }}
+                      title={`CBS: ${brlFmt(result.vCBS)}`}
+                    />
+                    <div
+                      className="bg-emerald-500"
+                      style={{ width: `${(parseFloat(result.vIBSUF) / parseFloat(result.total_tributos)) * 100}%` }}
+                      title={`IBS UF: ${brlFmt(result.vIBSUF)}`}
+                    />
+                    <div
+                      className="bg-teal-400"
+                      style={{ width: `${(parseFloat(result.vIBSMun) / parseFloat(result.total_tributos)) * 100}%` }}
+                      title={`IBS Mun: ${brlFmt(result.vIBSMun)}`}
+                    />
+                  </div>
+                  <div className="mt-1 flex gap-4 text-xs text-slate-500">
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block h-2 w-2 rounded-full bg-blue-500" /> CBS
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" /> IBS UF
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="inline-block h-2 w-2 rounded-full bg-teal-400" /> IBS Mun
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* XML Snippet */}
+            <div className="rounded-xl border border-slate-200 bg-white">
+              <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+                <h3 className="text-sm font-semibold text-slate-700">
+                  XML &lt;IBSCBS&gt; — pronto para o ERP
+                </h3>
+                <button
+                  type="button"
+                  onClick={copyXml}
+                  className="rounded-md border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50"
+                >
+                  {copied ? "Copiado!" : "Copiar"}
+                </button>
+              </div>
+              <pre className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-slate-700">
+                {result.xml_snippet}
+              </pre>
+            </div>
+
+            {/* Share button */}
+            <div className="text-center">
+              <button
+                type="button"
+                onClick={copyShareUrl}
+                className="text-sm font-medium text-tribultz-600 hover:text-tribultz-700"
+              >
+                Copiar link para compartilhar
+              </button>
+            </div>
+
+            {/* Blurred CTA */}
+            <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-white">
+              <div className="pointer-events-none select-none px-4 py-4 blur-sm">
+                <p className="text-sm text-slate-600">Simulação de apuração mensal CBS + IBS</p>
+                <p className="text-sm text-slate-600">Relatório PDF com memória de cálculo completa</p>
+                <p className="text-sm text-slate-600">Histórico de cálculos salvos por CNPJ</p>
+              </div>
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-white/80 backdrop-blur-[2px]">
+                <svg className="h-8 w-8 text-tribultz-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+                </svg>
+                <p className="mt-2 text-sm font-semibold text-slate-700">{result.upgrade_cta}</p>
+                <div className="mt-3 flex gap-3">
+                  <Link href="/register" className="rounded-lg bg-tribultz-600 px-5 py-2 text-sm font-semibold text-white hover:bg-tribultz-700">
+                    Criar conta gratuita
+                  </Link>
+                  <Link href="/login" className="rounded-lg border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">
+                    Já tenho conta
+                  </Link>
+                </div>
+              </div>
+            </div>
+
+            {/* Data governance */}
+            <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
+              <svg className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+              </svg>
+              <div>
+                <p className="text-sm font-medium text-emerald-800">Seus dados estão seguros</p>
+                <p className="mt-0.5 text-xs text-emerald-700">{result.data_policy}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Info section */}
+      <section className="border-t border-slate-200 bg-white px-4 py-10">
+        <div className="mx-auto max-w-4xl rounded-xl border border-tribultz-100 bg-tribultz-50 p-5">
+          <h3 className="text-base font-semibold text-slate-900">Como funciona a calculadora</h3>
+          <p className="mt-2 text-sm text-slate-700">
+            A calculadora aplica as alíquotas de referência da LC 214/2025 (Reforma Tributária) para
+            CBS (federal) e IBS (estadual + municipal). Para NCMs de alimentos da Cesta Básica Nacional,
+            farmacêuticos e educação, aplica automaticamente as reduções previstas nos Anexos da lei.
+            O XML gerado segue o leiaute da NT 2025.002-RTC.
+          </p>
+        </div>
+      </section>
+
+      {/* Social proof */}
+      <section className="border-t border-slate-200 bg-slate-50 px-4 py-12">
+        <div className="mx-auto grid max-w-4xl gap-8 md:grid-cols-3">
+          <div className="text-center">
+            <p className="text-3xl font-extrabold text-tribultz-600">27</p>
+            <p className="mt-1 text-sm text-slate-600">UFs com alíquotas diferenciadas</p>
+          </div>
+          <div className="text-center">
+            <p className="text-3xl font-extrabold text-tribultz-600">14</p>
+            <p className="mt-1 text-sm text-slate-600">CSTs da Reforma Tributária</p>
+          </div>
+          <div className="text-center">
+            <p className="text-3xl font-extrabold text-tribultz-600">26.5%</p>
+            <p className="mt-1 text-sm text-slate-600">alíquota referência CBS+IBS</p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+export function Calculator() {
+  return (
+    <Suspense>
+      <CalculadoraInner />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/calculadora/page.tsx
+++ b/frontend/src/app/calculadora/page.tsx
@@ -1,576 +1,233 @@
-"use client";
+/**
+ * /calculadora — server-rendered (#296).
+ *
+ * Antes: page client-side com 61 palavras servidas ao Googlebot.
+ * Agora: copy explanatório SSR + widget Calculator interativo isolado.
+ */
 
-import { Suspense, useCallback, useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
-import { API_BASE, createTransactionId } from "@/lib/api";
-import { UF_LIST } from "@/lib/data/ufList";
-import { CST_LIST } from "@/lib/data/cstList";
+import { Calculator } from "./Calculator";
+import { FundamentacaoLegal } from "@/components/seo/FundamentacaoLegal";
 
-// ── Types ────────────────────────────────────────────────────────────────────
+const FAQ = [
+  {
+    q: "As alíquotas da calculadora estão atualizadas com a NT 2025.002 e LC 227?",
+    a: "Sim. A base de alíquotas é sincronizada com o Convênio ICMS 142/2018, a tabela cClassTrib SVRS (atualização de 15/abr/2026) e os regulamentos IBS/CBS publicados pela Receita Federal e Comitê Gestor em 30/abr/2026.",
+  },
+  {
+    q: "A calculadora considera regimes especiais e cesta básica?",
+    a: "Sim. O cClassTrib informado resolve o regime aplicável (padrão, reduzido, cesta básica nacional, monofásico, imune, ZFM) e a calculadora aplica o modificador de alíquota correspondente conforme os Anexos da LC 214.",
+  },
+  {
+    q: "Como a base de cálculo é determinada?",
+    a: "A base de cálculo é o valor da operação, líquido de descontos e abatimentos. Para 2026 (período de teste com alíquotas reduzidas de 0,9% CBS e 0,1% IBS), o ICMS destacado integra a base — situação que se inverte progressivamente até 2033 conforme o cronograma da LC 214.",
+  },
+  {
+    q: "Posso usar a calculadora sem login?",
+    a: "Sim. A versão web é 100% gratuita, sem cadastro, com limite de 100 cálculos por dia por IP. Para volume maior, integre via API com o plano Starter (X-API-Key) ou Profissional (sem limite).",
+  },
+  {
+    q: "A calculadora gera o XML para o ERP?",
+    a: "Sim. Após o cálculo, exibimos o snippet XML pronto para o grupo gIBSCBS da NF-e, com todos os atributos calculados (vBC, pCBS, vCBS, pIBSUF, vIBSUF, pIBSMun, vIBSMun, vIBS). Suficiente para colar no template do seu emissor.",
+  },
+  {
+    q: "Como diferenciar o IBS estadual do municipal?",
+    a: "O IBS é uno mas internamente repartido entre UF e Município conforme o destino da operação. A calculadora retorna pIBSUF e pIBSMun separadamente. Em operações interestaduais, o valor é integralmente devido ao destino conforme regra da LC 214 art. 156-A.",
+  },
+];
 
-type SuggestResult = {
-  ncm: string;
-  ncm_descricao: string;
-  confidence: number;
-  cClassTrib: string | null;
-  aviso: string | null;
-};
-
-type CalculadoraResult = {
-  vBC: string;
-  pCBS: string;
-  vCBS: string;
-  pIBSUF: string;
-  vIBSUF: string;
-  pIBSMun: string;
-  vIBSMun: string;
-  vIBS: string;
-  total_tributos: string;
-  aliquota_efetiva: string;
-  rate_source: string;
-  cst: string;
-  cst_desc: string;
-  xml_snippet: string;
-  data_policy: string;
-  upgrade_cta: string;
-  transaction_id?: string;
-};
-
-type CalcState = "idle" | "loading" | "done" | "error";
-
-// ── Component ────────────────────────────────────────────────────────────────
-
-function CalculadoraInner() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const [uf, setUf] = useState(searchParams.get("uf") ?? "SP");
-  const [baseValue, setBaseValue] = useState(searchParams.get("vBC") ?? "1000.00");
-  const [ncm, setNcm] = useState(searchParams.get("ncm") ?? "");
-  const [cst, setCst] = useState(searchParams.get("cst") ?? "000");
-  const [quantity, setQuantity] = useState(searchParams.get("qty") ?? "1");
-
-  const [state, setState] = useState<CalcState>("idle");
-  const [result, setResult] = useState<CalculadoraResult | null>(null);
-  const [error, setError] = useState("");
-  const [copied, setCopied] = useState(false);
-
-  const [suggestOpen, setSuggestOpen] = useState(false);
-  const [suggestDesc, setSuggestDesc] = useState("");
-  const [suggestLoading, setSuggestLoading] = useState(false);
-  const [suggestResult, setSuggestResult] = useState<SuggestResult | null>(null);
-
-  const handleCalculate = useCallback(async () => {
-    setState("loading");
-    setError("");
-    setResult(null);
-
-    try {
-      const transactionId = createTransactionId();
-      const body: Record<string, string> = {
-        uf_destino: uf,
-        base_value: baseValue,
-        quantity,
-        cst,
-      };
-      if (ncm.trim()) body.ncm_code = ncm.trim();
-
-      const endpoint = `${API_BASE}/api/v1/public/calculadora/regime-geral`;
-      console.log("Endpoint da calculadora:", endpoint);
-
-      const res = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Transaction-Id": transactionId,
-        },
-        body: JSON.stringify(body),
-      });
-
-      if (res.status === 429) {
-        setError("Limite de requisições atingido. Aguarde 1 minuto.");
-        setState("error");
-        return;
-      }
-
-      if (res.status === 422) {
-        const detail = await res.json().catch(() => ({ detail: "Dados inválidos" }));
-        const msg = Array.isArray(detail.detail)
-          ? detail.detail.map((d: { msg: string }) => d.msg).join("; ")
-          : detail.detail ?? "Dados inválidos";
-        setError(msg);
-        setState("error");
-        return;
-      }
-
-      if (!res.ok) {
-        setError(`Erro ${res.status}`);
-        setState("error");
-        return;
-      }
-
-      const data: CalculadoraResult = await res.json();
-      setResult({
-        ...data,
-        transaction_id: data.transaction_id ?? transactionId,
-      });
-      setState("done");
-
-      // Update URL params for sharing
-      const params = new URLSearchParams();
-      params.set("uf", uf);
-      params.set("vBC", baseValue);
-      if (ncm.trim()) params.set("ncm", ncm.trim());
-      if (cst !== "000") params.set("cst", cst);
-      if (quantity !== "1") params.set("qty", quantity);
-      router.replace(`/calculadora?${params.toString()}`, { scroll: false });
-    } catch {
-      setError("Erro de conexão. Verifique se o servidor está acessível.");
-      setState("error");
-    }
-  }, [uf, baseValue, ncm, cst, quantity, router]);
-
-  const handleSuggestNcm = useCallback(async () => {
-    if (!suggestDesc.trim()) return;
-    setSuggestLoading(true);
-    setSuggestResult(null);
-    try {
-      const res = await fetch(`${API_BASE}/api/v1/public/ncm/suggest`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ descricao: suggestDesc.trim() }),
-      });
-      if (res.status === 429) { setError("Limite diário de classificações atingido. Crie uma conta gratuita para mais."); return; }
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: "Erro ao classificar." }));
-        setError(err.detail ?? "Erro ao classificar NCM.");
-        return;
-      }
-      setSuggestResult(await res.json());
-    } catch {
-      setError("Erro de conexão ao classificar NCM.");
-    } finally {
-      setSuggestLoading(false);
-    }
-  }, [suggestDesc]);
-
-  const copyXml = useCallback(() => {
-    if (result?.xml_snippet) {
-      navigator.clipboard.writeText(result.xml_snippet);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  }, [result]);
-
-  const copyShareUrl = useCallback(() => {
-    navigator.clipboard.writeText(window.location.href);
-  }, []);
-
-  // Auto-calculate if URL has params on mount
-  useEffect(() => {
-    if (searchParams.get("vBC") && searchParams.get("uf")) {
-      handleCalculate();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const pctFmt = (v: string) => `${(parseFloat(v) * 100).toFixed(2)}%`;
-  const brlFmt = (v: string) => `R$ ${parseFloat(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
-
-  return (
-    <>
-      {/* Hero */}
-      <section className="bg-gradient-to-br from-tribultz-50 to-white px-4 py-16 text-center md:py-20">
-        <h1 className="mx-auto max-w-3xl text-3xl font-extrabold text-slate-900 md:text-4xl">
-          Calculadora CBS/IBS
-        </h1>
-        <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
-          Calcule os tributos da Reforma Tributária para qualquer operação.
-          Gere o XML <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-sm">&lt;IBSCBS&gt;</code> pronto para o ERP.
-        </p>
-        <div className="mx-auto mt-2 flex items-center justify-center gap-4 text-sm text-slate-500">
-          <span>LC 214/2025</span>
-          <span>NT 2025.002-RTC</span>
-          <span>27 UFs</span>
-        </div>
-      </section>
-
-      {/* Calculator form */}
-      <section className="mx-auto -mt-6 max-w-2xl px-4 pb-16">
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <div className="grid gap-4 md:grid-cols-2">
-            {/* UF */}
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">
-                UF Destino *
-              </label>
-              <select
-                value={uf}
-                onChange={(e) => setUf(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
-              >
-                {UF_LIST.map((u) => (
-                  <option key={u.code} value={u.code}>
-                    {u.code} — {u.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Base Value */}
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">
-                Valor Base (R$) *
-              </label>
-              <input
-                type="number"
-                step="0.01"
-                min="0.01"
-                value={baseValue}
-                onChange={(e) => setBaseValue(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
-                placeholder="1000.00"
-              />
-            </div>
-
-            {/* NCM */}
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">
-                NCM <span className="text-slate-400">(opcional)</span>
-              </label>
-              <input
-                type="text"
-                maxLength={8}
-                value={ncm}
-                onChange={(e) => setNcm(e.target.value.replace(/\D/g, ""))}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-mono focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
-                placeholder="84713012"
-              />
-              <p className="mt-0.5 text-xs text-slate-400">8 dígitos — alíquota reduzida para alimentos, pharma, educação</p>
-            </div>
-
-            {/* NCM suggest */}
-            <div className="md:col-span-2">
-              <button
-                type="button"
-                onClick={() => { setSuggestOpen(!suggestOpen); setSuggestResult(null); }}
-                className="text-xs font-medium text-tribultz-600 hover:underline"
-              >
-                {suggestOpen ? "▲ Fechar" : "▼ Não sei o NCM — classificar por descrição (IA)"}
-              </button>
-              {suggestOpen && (
-                <div className="mt-2 rounded-lg border border-tribultz-100 bg-tribultz-50 p-3">
-                  <p className="mb-2 text-xs text-slate-600">Descreva o produto e sugerimos o NCM automaticamente.</p>
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      value={suggestDesc}
-                      onChange={(e) => setSuggestDesc(e.target.value)}
-                      onKeyDown={(e) => { if (e.key === "Enter") void handleSuggestNcm(); }}
-                      placeholder="Ex: Carne bovina traseira resfriada"
-                      className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-tribultz-500"
-                      maxLength={300}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => void handleSuggestNcm()}
-                      disabled={suggestLoading || !suggestDesc.trim()}
-                      className="rounded-lg bg-tribultz-600 px-4 py-2 text-sm font-medium text-white hover:bg-tribultz-700 disabled:opacity-50"
-                    >
-                      {suggestLoading ? "…" : "Classificar"}
-                    </button>
-                  </div>
-                  {suggestResult && (
-                    <div className="mt-2 rounded-lg border border-slate-200 bg-white p-3 text-sm">
-                      <div className="flex flex-wrap items-start justify-between gap-2">
-                        <div>
-                          <span className="font-mono font-bold text-slate-800">{suggestResult.ncm}</span>
-                          <span className="ml-2 text-xs text-slate-500">{suggestResult.ncm_descricao}</span>
-                          {suggestResult.cClassTrib && (
-                            <span className="ml-2 text-xs text-blue-600">· cClassTrib: {suggestResult.cClassTrib}</span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold uppercase ${suggestResult.confidence >= 0.70 ? "bg-emerald-100 text-emerald-700" : "bg-amber-100 text-amber-700"}`}>
-                            {Math.round(suggestResult.confidence * 100)}% confiança
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => { setNcm(suggestResult.ncm); setSuggestOpen(false); }}
-                            className="rounded bg-tribultz-600 px-2 py-1 text-[11px] font-bold text-white hover:bg-tribultz-700"
-                          >
-                            Usar este NCM
-                          </button>
-                        </div>
-                      </div>
-                      {suggestResult.aviso && (
-                        <p className="mt-1.5 text-xs text-amber-700">⚠ {suggestResult.aviso}</p>
-                      )}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* CST */}
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">
-                CST
-              </label>
-              <select
-                value={cst}
-                onChange={(e) => setCst(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
-              >
-                {CST_LIST.map((c) => (
-                  <option key={c.code} value={c.code}>
-                    {c.code} — {c.desc}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Quantity */}
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">
-                Quantidade
-              </label>
-              <input
-                type="number"
-                step="1"
-                min="1"
-                value={quantity}
-                onChange={(e) => setQuantity(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
-                placeholder="1"
-              />
-            </div>
-          </div>
-
-          {/* Calculate button */}
-          <div className="mt-6 text-center">
-            <button
-              type="button"
-              onClick={handleCalculate}
-              disabled={state === "loading"}
-              className="rounded-lg bg-tribultz-600 px-8 py-3 text-sm font-semibold text-white hover:bg-tribultz-700 disabled:opacity-50"
-            >
-              {state === "loading" ? "Calculando..." : "Calcular CBS/IBS"}
-            </button>
-          </div>
-        </div>
-
-        {/* Error */}
-        {state === "error" && (
-          <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {error}
-          </div>
-        )}
-
-        {/* Results */}
-        {state === "done" && result && (
-          <div className="mt-6 space-y-4">
-            {/* Breakdown card */}
-            <div className="rounded-xl border border-slate-200 bg-white p-5">
-              <h2 className="text-base font-semibold text-slate-900">Resultado do Cálculo</h2>
-              <p className="mt-1 text-xs text-slate-500">
-                CST {result.cst} — {result.cst_desc} | Fonte: {result.rate_source}
-                {result.transaction_id ? ` | Tx: ${result.transaction_id}` : ""}
-              </p>
-
-              <div className="mt-4 space-y-2">
-                {/* Base */}
-                <div className="flex items-center justify-between border-b border-slate-100 pb-2">
-                  <span className="text-sm text-slate-600">Base de Cálculo (vBC)</span>
-                  <span className="font-mono text-sm font-medium text-slate-900">{brlFmt(result.vBC)}</span>
-                </div>
-
-                {/* CBS */}
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-blue-500" />
-                    <span className="text-sm text-slate-600">CBS (federal)</span>
-                    <span className="text-xs text-slate-400">{pctFmt(result.pCBS)}</span>
-                  </div>
-                  <span className="font-mono text-sm font-medium text-blue-700">{brlFmt(result.vCBS)}</span>
-                </div>
-
-                {/* IBS UF */}
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-emerald-500" />
-                    <span className="text-sm text-slate-600">IBS UF (estadual)</span>
-                    <span className="text-xs text-slate-400">{pctFmt(result.pIBSUF)}</span>
-                  </div>
-                  <span className="font-mono text-sm font-medium text-emerald-700">{brlFmt(result.vIBSUF)}</span>
-                </div>
-
-                {/* IBS Mun */}
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block h-2.5 w-2.5 rounded-full bg-teal-500" />
-                    <span className="text-sm text-slate-600">IBS Mun (municipal)</span>
-                    <span className="text-xs text-slate-400">{pctFmt(result.pIBSMun)}</span>
-                  </div>
-                  <span className="font-mono text-sm font-medium text-teal-700">{brlFmt(result.vIBSMun)}</span>
-                </div>
-
-                {/* Divider */}
-                <div className="border-t border-slate-200 pt-2" />
-
-                {/* Total */}
-                <div className="flex items-center justify-between">
-                  <div>
-                    <span className="text-sm font-semibold text-slate-900">Total Tributos</span>
-                    <span className="ml-2 text-xs text-slate-500">
-                      Alíquota efetiva: {pctFmt(result.aliquota_efetiva)}
-                    </span>
-                  </div>
-                  <span className="font-mono text-lg font-bold text-slate-900">{brlFmt(result.total_tributos)}</span>
-                </div>
-              </div>
-
-              {/* Visual bar */}
-              {parseFloat(result.total_tributos) > 0 && (
-                <div className="mt-4">
-                  <div className="flex h-4 overflow-hidden rounded-full">
-                    <div
-                      className="bg-blue-500"
-                      style={{ width: `${(parseFloat(result.vCBS) / parseFloat(result.total_tributos)) * 100}%` }}
-                      title={`CBS: ${brlFmt(result.vCBS)}`}
-                    />
-                    <div
-                      className="bg-emerald-500"
-                      style={{ width: `${(parseFloat(result.vIBSUF) / parseFloat(result.total_tributos)) * 100}%` }}
-                      title={`IBS UF: ${brlFmt(result.vIBSUF)}`}
-                    />
-                    <div
-                      className="bg-teal-400"
-                      style={{ width: `${(parseFloat(result.vIBSMun) / parseFloat(result.total_tributos)) * 100}%` }}
-                      title={`IBS Mun: ${brlFmt(result.vIBSMun)}`}
-                    />
-                  </div>
-                  <div className="mt-1 flex gap-4 text-xs text-slate-500">
-                    <span className="flex items-center gap-1">
-                      <span className="inline-block h-2 w-2 rounded-full bg-blue-500" /> CBS
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" /> IBS UF
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <span className="inline-block h-2 w-2 rounded-full bg-teal-400" /> IBS Mun
-                    </span>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* XML Snippet */}
-            <div className="rounded-xl border border-slate-200 bg-white">
-              <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
-                <h3 className="text-sm font-semibold text-slate-700">
-                  XML &lt;IBSCBS&gt; — pronto para o ERP
-                </h3>
-                <button
-                  type="button"
-                  onClick={copyXml}
-                  className="rounded-md border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50"
-                >
-                  {copied ? "Copiado!" : "Copiar"}
-                </button>
-              </div>
-              <pre className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-slate-700">
-                {result.xml_snippet}
-              </pre>
-            </div>
-
-            {/* Share button */}
-            <div className="text-center">
-              <button
-                type="button"
-                onClick={copyShareUrl}
-                className="text-sm font-medium text-tribultz-600 hover:text-tribultz-700"
-              >
-                Copiar link para compartilhar
-              </button>
-            </div>
-
-            {/* Blurred CTA */}
-            <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-white">
-              <div className="pointer-events-none select-none px-4 py-4 blur-sm">
-                <p className="text-sm text-slate-600">Simulação de apuração mensal CBS + IBS</p>
-                <p className="text-sm text-slate-600">Relatório PDF com memória de cálculo completa</p>
-                <p className="text-sm text-slate-600">Histórico de cálculos salvos por CNPJ</p>
-              </div>
-              <div className="absolute inset-0 flex flex-col items-center justify-center bg-white/80 backdrop-blur-[2px]">
-                <svg className="h-8 w-8 text-tribultz-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-                </svg>
-                <p className="mt-2 text-sm font-semibold text-slate-700">{result.upgrade_cta}</p>
-                <div className="mt-3 flex gap-3">
-                  <Link href="/register" className="rounded-lg bg-tribultz-600 px-5 py-2 text-sm font-semibold text-white hover:bg-tribultz-700">
-                    Criar conta gratuita
-                  </Link>
-                  <Link href="/login" className="rounded-lg border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">
-                    Já tenho conta
-                  </Link>
-                </div>
-              </div>
-            </div>
-
-            {/* Data governance */}
-            <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
-              <svg className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
-              </svg>
-              <div>
-                <p className="text-sm font-medium text-emerald-800">Seus dados estão seguros</p>
-                <p className="mt-0.5 text-xs text-emerald-700">{result.data_policy}</p>
-              </div>
-            </div>
-          </div>
-        )}
-      </section>
-
-      {/* Info section */}
-      <section className="border-t border-slate-200 bg-white px-4 py-10">
-        <div className="mx-auto max-w-4xl rounded-xl border border-tribultz-100 bg-tribultz-50 p-5">
-          <h3 className="text-base font-semibold text-slate-900">Como funciona a calculadora</h3>
-          <p className="mt-2 text-sm text-slate-700">
-            A calculadora aplica as alíquotas de referência da LC 214/2025 (Reforma Tributária) para
-            CBS (federal) e IBS (estadual + municipal). Para NCMs de alimentos da Cesta Básica Nacional,
-            farmacêuticos e educação, aplica automaticamente as reduções previstas nos Anexos da lei.
-            O XML gerado segue o leiaute da NT 2025.002-RTC.
-          </p>
-        </div>
-      </section>
-
-      {/* Social proof */}
-      <section className="border-t border-slate-200 bg-slate-50 px-4 py-12">
-        <div className="mx-auto grid max-w-4xl gap-8 md:grid-cols-3">
-          <div className="text-center">
-            <p className="text-3xl font-extrabold text-tribultz-600">27</p>
-            <p className="mt-1 text-sm text-slate-600">UFs com alíquotas diferenciadas</p>
-          </div>
-          <div className="text-center">
-            <p className="text-3xl font-extrabold text-tribultz-600">14</p>
-            <p className="mt-1 text-sm text-slate-600">CSTs da Reforma Tributária</p>
-          </div>
-          <div className="text-center">
-            <p className="text-3xl font-extrabold text-tribultz-600">26.5%</p>
-            <p className="mt-1 text-sm text-slate-600">alíquota referência CBS+IBS</p>
-          </div>
-        </div>
-      </section>
-    </>
-  );
-}
+const LEGAL_REFS = [
+  {
+    instrumento: "LC 214/2025",
+    artigo: "arts. 8º a 22, 156-A",
+    descricao: "Base legal da CBS e IBS, definição de base de cálculo, alíquotas referência (CBS 0,9% / IBS 0,1% em 2026).",
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm",
+  },
+  {
+    instrumento: "LC 227/2026",
+    artigo: "art. 348",
+    descricao: "Regulamentação operacional 2026, período pedagógico, transição 2026-2033.",
+  },
+  {
+    instrumento: "Regulamento IBS",
+    artigo: "publicação 30/abr/2026",
+    descricao: "Detalha operacionalização do IBS pelo Comitê Gestor (Estados + Municípios).",
+  },
+  {
+    instrumento: "Regulamento CBS",
+    artigo: "publicação 30/abr/2026",
+    descricao: "Detalha operacionalização da CBS pela Receita Federal (esfera federal).",
+  },
+  {
+    instrumento: "NT 2025.002-RTC v1.36",
+    artigo: "grupos gIBSCBS, gIBSCBSMono",
+    descricao: "Layout XML NF-e com campos vBC, pCBS, vCBS, pIBSUF, vIBSUF, pIBSMun, vIBSMun, vIBS.",
+  },
+  {
+    instrumento: "Tabela cClassTrib SVRS",
+    artigo: "publicação 15/abr/2026",
+    descricao: "Lista oficial de cClassTrib com p_CBS, p_IBS e regime especial por código.",
+    link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria",
+  },
+];
 
 export default function CalculadoraPage() {
   return (
-    <Suspense>
-      <CalculadoraInner />
-    </Suspense>
+    <>
+      {/* Hero SSR */}
+      <section className="bg-gradient-to-br from-emerald-50 to-white px-4 py-16 text-center md:py-20">
+        <div className="mx-auto max-w-3xl">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1.5">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            <span className="text-xs font-semibold text-emerald-700">Alíquotas LC 214 atualizadas — 2026</span>
+          </div>
+          <h1 className="text-3xl font-extrabold leading-tight text-slate-900 md:text-4xl">
+            Calculadora CBS/IBS<br />
+            <span className="text-emerald-600">por NCM, UF e CST</span>
+          </h1>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
+            Calcule CBS e IBS para cada item da sua NF-e com alíquotas oficiais.
+            Retorna o XML pronto para o grupo gIBSCBS e a base legal.
+          </p>
+          <div className="mx-auto mt-2 flex flex-wrap items-center justify-center gap-4 text-sm text-slate-400">
+            <span>100 cálculos gratuitos/dia</span>
+            <span>·</span>
+            <span>Sem login</span>
+            <span>·</span>
+            <span>LC 214 · Regulamento IBS/CBS 30/abr/2026</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Calculadora interativa */}
+      <Calculator />
+
+      {/* SSR explanatory content */}
+      <section className="border-t border-slate-200 bg-white py-12">
+        <div className="mx-auto max-w-3xl px-4 space-y-10">
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Como a calculadora funciona</h2>
+            <p className="text-slate-700">
+              Você informa quatro parâmetros: <strong>UF de destino</strong>, <strong>NCM</strong> (opcional),
+              <strong> CST</strong> do IBS/CBS e <strong>valor da base de cálculo</strong>. A partir desses
+              dados, a calculadora resolve o cClassTrib aplicável na tabela SVRS, identifica a alíquota
+              de CBS e IBS conforme a LC 214 e os Anexos, e calcula os valores em centavos com
+              arredondamento conforme a regra da NT 2025.002-RTC.
+            </p>
+            <p className="mt-3 text-slate-700">
+              O resultado inclui o snippet XML pronto para colar no emissor da NF-e, dentro do grupo
+              <code className="rounded bg-slate-100 px-1 font-mono text-sm"> gIBSCBS</code>. Para operações
+              interestaduais, o IBS é repartido em UF e Município conforme o destino — campos
+              <code className="rounded bg-slate-100 px-1 font-mono text-sm"> pIBSUF</code> e
+              <code className="rounded bg-slate-100 px-1 font-mono text-sm"> pIBSMun</code> são retornados separados.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Alíquotas vigentes em 2026</h2>
+            <p className="text-slate-700">
+              2026 é o <strong>ano-teste</strong> da Reforma Tributária. As alíquotas de referência são
+              significativamente reduzidas em relação às projetadas para o regime cheio (2033+),
+              servindo de calibração para os sistemas:
+            </p>
+            <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Tributo</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Alíquota 2026</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Alíquota referência (regime cheio)</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Base legal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-t border-slate-100">
+                    <td className="px-4 py-2 font-mono">CBS</td>
+                    <td className="px-4 py-2 font-mono">0,9%</td>
+                    <td className="px-4 py-2 font-mono">~8,8%</td>
+                    <td className="px-4 py-2">LC 214 art. 18</td>
+                  </tr>
+                  <tr className="border-t border-slate-100">
+                    <td className="px-4 py-2 font-mono">IBS</td>
+                    <td className="px-4 py-2 font-mono">0,1%</td>
+                    <td className="px-4 py-2 font-mono">~17,7%</td>
+                    <td className="px-4 py-2">LC 214 art. 156-A</td>
+                  </tr>
+                  <tr className="border-t border-slate-100">
+                    <td className="px-4 py-2 font-mono">Total IVA dual</td>
+                    <td className="px-4 py-2 font-mono">1,0%</td>
+                    <td className="px-4 py-2 font-mono">~26,5%</td>
+                    <td className="px-4 py-2">—</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-3 text-sm text-slate-600">
+              Em 2026 não há recolhimento efetivo do CBS/IBS (LC 214 art. 348 — período de aprendizado).
+              Após agosto/2026 termina a leniência da LC 227 sobre obrigações acessórias e a partir
+              de 2027 o CBS começa a ser cobrado efetivamente.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Regimes especiais cobertos</h2>
+            <p className="text-slate-700">
+              A calculadora aplica modificadores de alíquota para os regimes especiais previstos
+              nos Anexos da LC 214:
+            </p>
+            <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">CST</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Regime</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Modificador</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Aplicação típica</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">000</td><td className="px-4 py-2">Tributação normal</td><td className="px-4 py-2 font-mono">100%</td><td className="px-4 py-2">Bens e serviços padrão</td></tr>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">001</td><td className="px-4 py-2">Redução</td><td className="px-4 py-2 font-mono">60%</td><td className="px-4 py-2">Anexo III (saúde, educação)</td></tr>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">002</td><td className="px-4 py-2">Ad rem (monofásico)</td><td className="px-4 py-2 font-mono">100%</td><td className="px-4 py-2">Combustíveis, bebidas alcoólicas</td></tr>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">070</td><td className="px-4 py-2">Imunidade/Isenção</td><td className="px-4 py-2 font-mono">0%</td><td className="px-4 py-2">Cesta básica nacional, exportação</td></tr>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">200</td><td className="px-4 py-2">Diferimento</td><td className="px-4 py-2 font-mono">100% (postergado)</td><td className="px-4 py-2">B2B com crédito presumido</td></tr>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">410</td><td className="px-4 py-2">Suspensão</td><td className="px-4 py-2 font-mono">0%</td><td className="px-4 py-2">Drawback, ZFM</td></tr>
+                  <tr className="border-t border-slate-100"><td className="px-4 py-2 font-mono">620</td><td className="px-4 py-2">Monofásico downstream</td><td className="px-4 py-2 font-mono">0% para distribuidores</td><td className="px-4 py-2">Combustíveis (downstream)</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Quando o cálculo manual falha</h2>
+            <p className="text-slate-700">
+              Os erros mais comuns vistos em produção desde janeiro/2026:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-700">
+              <li><strong>Confundir alíquota nominal com efetiva.</strong> Operações com redução (CST 001) calculam sobre alíquota cheia × modificador 60%. Erro comum: aplicar 0,054% direto sem registrar como redução.</li>
+              <li><strong>Aplicar IBS único sem repartir UF/Município.</strong> O XML exige <code className="font-mono">pIBSUF + pIBSMun</code> separados — somar e informar tudo em pIBSUF gera Rejeição 1024 cruzada.</li>
+              <li><strong>Esquecer arredondamento por item.</strong> A NT 2025.002 exige arredondamento HALF_UP em duas casas por item, depois soma do total. Calcular sobre o total agregado gera divergência de centavos no IBSCBSTot.</li>
+              <li><strong>Não considerar o destino interestadual.</strong> Em operações interestaduais, a UF de destino é a referência — não a do emitente.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ SSR */}
+      <section className="border-t border-slate-200 bg-white py-12">
+        <div className="mx-auto max-w-3xl px-4">
+          <h2 className="mb-8 text-2xl font-bold text-slate-900">Perguntas frequentes</h2>
+          <div className="space-y-6">
+            {FAQ.map((item) => (
+              <div key={item.q} className="border-b border-slate-100 pb-6 last:border-0">
+                <h3 className="font-semibold text-slate-800">{item.q}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-slate-600">{item.a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <FundamentacaoLegal items={LEGAL_REFS} />
+    </>
   );
 }

--- a/frontend/src/app/classificacao/Classifier.tsx
+++ b/frontend/src/app/classificacao/Classifier.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { API_BASE } from "@/lib/api";
+
+const WA_NUMBER = "5551991881026";
+const WA_REJEICAO = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(
+  "Olá! Estou com Rejeição 1024 na NF-e (cClassTrib incorreto) e preciso de ajuda urgente.",
+)}`;
+
+type SuggestResult = {
+  ncm: string;
+  ncm_descricao: string;
+  confidence: number;
+  cClassTrib: string | null;
+  aviso: string | null;
+};
+
+function ConfidenceBadge({ value }: { value: number }) {
+  const pct = Math.round(value * 100);
+  const cls = value >= 0.85
+    ? "bg-emerald-100 text-emerald-700"
+    : value >= 0.70
+    ? "bg-blue-100 text-blue-700"
+    : "bg-amber-100 text-amber-700";
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${cls}`}>
+      {pct}% confiança
+    </span>
+  );
+}
+
+export function Classifier() {
+  const [descricao, setDescricao] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<SuggestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const classify = useCallback(async () => {
+    const desc = descricao.trim();
+    if (!desc) return;
+    setLoading(true);
+    setResult(null);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/public/ncm/suggest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ descricao: desc }),
+      });
+      if (res.status === 429) {
+        setError("Limite diário de 10 classificações gratuitas atingido. Crie uma conta para mais.");
+        return;
+      }
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: "Erro ao classificar." }));
+        setError(err.detail ?? "Erro ao classificar. Tente novamente.");
+        return;
+      }
+      setResult(await res.json());
+    } catch {
+      setError("Erro de conexão. Verifique sua internet e tente novamente.");
+    } finally {
+      setLoading(false);
+    }
+  }, [descricao]);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <label className="mb-1 block text-sm font-medium text-slate-700">
+        Descrição do produto
+      </label>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={descricao}
+          onChange={(e) => setDescricao(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") void classify(); }}
+          placeholder="Ex: Carne bovina traseira resfriada, Notebook 16GB, Serviço de instalação elétrica…"
+          className="flex-1 rounded-lg border border-slate-300 px-4 py-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          maxLength={300}
+          autoFocus
+        />
+        <button
+          type="button"
+          onClick={() => void classify()}
+          disabled={loading || !descricao.trim()}
+          className="rounded-lg bg-blue-600 px-6 py-3 text-sm font-bold text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? "Classificando…" : "Classificar"}
+        </button>
+      </div>
+      <p className="mt-1 text-xs text-slate-400">
+        Quanto mais detalhada a descrição, maior a precisão.
+      </p>
+
+      {error && (
+        <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-2xl font-bold text-slate-800">{result.ncm}</span>
+                <ConfidenceBadge value={result.confidence} />
+              </div>
+              <p className="mt-0.5 text-sm text-slate-600">{result.ncm_descricao}</p>
+              {result.cClassTrib && (
+                <p className="mt-1 text-xs font-mono text-blue-700">
+                  cClassTrib LC 214: <strong>{result.cClassTrib}</strong>
+                </p>
+              )}
+            </div>
+            <Link
+              href={`/calculadora?ncm=${result.ncm}`}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-bold text-white hover:bg-blue-700"
+            >
+              Calcular CBS/IBS →
+            </Link>
+          </div>
+
+          {result.aviso && (
+            <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-2.5 text-xs text-amber-800">
+              ⚠ {result.aviso}
+            </div>
+          )}
+
+          {!result.aviso && (
+            <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 p-2.5 text-xs text-emerald-800">
+              ✓ NCM identificado com alta confiança. Clique em &quot;Calcular CBS/IBS&quot; para ver as alíquotas e gerar o XML para o ERP.
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* WhatsApp CTA */}
+      <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-4">
+        <p className="text-sm font-semibold text-red-800">
+          NF-e sendo rejeitada pela Rejeição 1024?
+        </p>
+        <p className="mt-0.5 text-sm text-red-700">
+          Quando CST e cClassTrib são incompatíveis, a nota não sai. Nosso time resolve ao vivo.
+        </p>
+        <a
+          href={WA_REJEICAO}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white hover:bg-red-700"
+        >
+          Resolver a Rejeição 1024 no WhatsApp
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/classificacao/page.tsx
+++ b/frontend/src/app/classificacao/page.tsx
@@ -1,72 +1,81 @@
-"use client";
+/**
+ * /classificacao — server-rendered (#296).
+ *
+ * Antes: page client-side com 0 palavras servidas ao Googlebot.
+ * Agora: copy explanatório SSR + widget interativo isolado em <Classifier />.
+ *
+ * Não usar "use client" aqui — esta página é server component.
+ */
 
-import { useState, useCallback } from "react";
-import Link from "next/link";
-import { API_BASE } from "@/lib/api";
+import { Classifier } from "./Classifier";
+import { FundamentacaoLegal } from "@/components/seo/FundamentacaoLegal";
 
-const WA_NUMBER = "5551991881026";
-const WA_REJEICAO = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent("Olá! Estou com Rejeição 1024 na NF-e (cClassTrib incorreto) e preciso de ajuda urgente.")}`;
+const FAQ = [
+  {
+    q: "O que é cClassTrib e por que ele causa rejeições de NF-e?",
+    a: "O cClassTrib é um código de 7 dígitos da LC 214/2025 que define o regime tributário de CBS e IBS de cada produto. Quando ele é incompatível com o CST informado no XML, a SEFAZ rejeita a nota com o código 1024. A classificação correta exige mapear o NCM do produto para o regime aplicável (padrão, reduzido, cesta básica, monofásico, imune, etc).",
+  },
+  {
+    q: "Quando começam as penalidades por cClassTrib incorreto?",
+    a: "As penalidades efetivas por erros de CBS/IBS em NF-e começam em agosto/2026, encerrando o período pedagógico previsto pela LC 227/2026 (art. 348 §§ 3º e 4º). Até lá, autuações exclusivamente por obrigação acessória dão 60 dias para sanar sem multa. Após agosto/2026 essa leniência cessa.",
+  },
+  {
+    q: "Como funciona a classificação automática NCM → cClassTrib?",
+    a: "Nossa IA analisa a descrição do produto e sugere o NCM mais adequado conforme a TIPI (Decreto 11.158/2022). A partir do capítulo NCM, mapeamos o cClassTrib disponível na tabela oficial SVRS atualizada em 15/abr/2026. O resultado inclui um indicador de confiança — valores abaixo de 70% devem ser confirmados com o contador.",
+  },
+  {
+    q: "Posso usar o NCM sugerido diretamente na NF-e?",
+    a: "O NCM sugerido é referência baseada em IA para agilizar a classificação. Confiança acima de 85% indica alta probabilidade de acerto, mas recomendamos sempre validar com o contador responsável pelo SPED antes de usar em produção. A Tribultz oferece validação completa das 18 regras CBS/IBS para confirmação.",
+  },
+  {
+    q: "Qual a diferença entre NCM e cClassTrib?",
+    a: "NCM é o código de 8 dígitos que identifica o produto na Nomenclatura Comum do Mercosul (tabela TIPI). cClassTrib é o código de 7 dígitos da LC 214 que define como esse produto é tributado pelo IBS e CBS na Reforma Tributária. Um mesmo NCM pode ter diferentes cClassTrib dependendo do regime fiscal aplicável (padrão, reduzido, cesta básica, monofásico, imune).",
+  },
+  {
+    q: "O cClassTrib muda com base no destinatário ou na operação?",
+    a: "Sim. Algumas operações específicas (cashback para pessoa física, exportação, regimes diferenciados como Zona Franca de Manaus) podem alterar o cClassTrib aplicável. Por isso a Tribultz combina NCM + regime de operação + destinatário antes de sugerir o código final.",
+  },
+];
 
-type SuggestResult = {
-  ncm: string;
-  ncm_descricao: string;
-  confidence: number;
-  cClassTrib: string | null;
-  aviso: string | null;
-};
-
-function ConfidenceBadge({ value }: { value: number }) {
-  const pct = Math.round(value * 100);
-  const cls = value >= 0.85
-    ? "bg-emerald-100 text-emerald-700"
-    : value >= 0.70
-    ? "bg-blue-100 text-blue-700"
-    : "bg-amber-100 text-amber-700";
-  return (
-    <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${cls}`}>
-      {pct}% confiança
-    </span>
-  );
-}
+const LEGAL_REFS = [
+  {
+    instrumento: "LC 214/2025",
+    artigo: "arts. 8º a 22, 156-A, 195",
+    descricao: "Institui IBS e CBS, base de cálculo, regimes específicos, não-cumulatividade plena.",
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm",
+  },
+  {
+    instrumento: "LC 227/2026",
+    artigo: "art. 348 §§ 3º e 4º",
+    descricao: "Período pedagógico 2026 — 60 dias para sanar obrigação acessória sem multa.",
+  },
+  {
+    instrumento: "NT 2025.002-RTC v1.36",
+    artigo: "campos cClassTrib, gIBSCBS, gIBSCBSMono",
+    descricao: "Especificação técnica do layout NF-e para CBS/IBS, validação cruzada CST × cClassTrib (origem da Rejeição 1024).",
+  },
+  {
+    instrumento: "Tabela cClassTrib SVRS",
+    artigo: "publicação 15/abr/2026",
+    descricao: "Lista oficial de códigos cClassTrib com p_CBS, p_IBS, regime especial e vigência por código.",
+    link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria",
+  },
+  {
+    instrumento: "Convênio ICMS 142/2018",
+    artigo: "Anexos II-XXVI",
+    descricao: "Convenio CONFAZ que lista os NCMs sujeitos a Substituição Tributária e respectivos CEST.",
+  },
+  {
+    instrumento: "Decreto 11.158/2022",
+    artigo: "TIPI",
+    descricao: "Tabela vigente do IPI e NCM. Base oficial para validação do código NCM.",
+  },
+];
 
 export default function ClassificacaoPage() {
-  const [descricao, setDescricao] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<SuggestResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const classify = useCallback(async () => {
-    const desc = descricao.trim();
-    if (!desc) return;
-    setLoading(true);
-    setResult(null);
-    setError(null);
-    try {
-      const res = await fetch(`${API_BASE}/api/v1/public/ncm/suggest`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ descricao: desc }),
-      });
-      if (res.status === 429) {
-        setError("Limite diário de 10 classificações gratuitas atingido. Crie uma conta para mais.");
-        return;
-      }
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: "Erro ao classificar." }));
-        setError(err.detail ?? "Erro ao classificar. Tente novamente.");
-        return;
-      }
-      setResult(await res.json());
-    } catch {
-      setError("Erro de conexão. Verifique sua internet e tente novamente.");
-    } finally {
-      setLoading(false);
-    }
-  }, [descricao]);
-
   return (
     <>
-      {/* Hero */}
+      {/* Hero SSR */}
       <section className="bg-gradient-to-br from-blue-50 to-white px-4 py-16 text-center md:py-20">
         <div className="mx-auto max-w-3xl">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-red-100 px-4 py-1.5">
@@ -79,141 +88,152 @@ export default function ClassificacaoPage() {
           </h1>
           <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-600">
             Descreva o produto em linguagem natural. Nossa IA sugere o NCM correto,
-            o cClassTrib da LC 214 e as alíquotas CBS/IBS aplicáveis.
+            o cClassTrib da LC 214 e as alíquotas CBS/IBS aplicáveis em segundos.
           </p>
           <div className="mx-auto mt-2 flex flex-wrap items-center justify-center gap-4 text-sm text-slate-400">
             <span>10 classificações gratuitas/dia</span>
             <span>·</span>
             <span>Sem login</span>
             <span>·</span>
-            <span>LC 214 · NT 2025.002</span>
+            <span>LC 214 · NT 2025.002 v1.36</span>
           </div>
         </div>
       </section>
 
-      {/* Classificador */}
-      <section className="mx-auto -mt-6 max-w-2xl px-4 pb-16">
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <label className="mb-1 block text-sm font-medium text-slate-700">
-            Descrição do produto
-          </label>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={descricao}
-              onChange={(e) => setDescricao(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") void classify(); }}
-              placeholder="Ex: Carne bovina traseira resfriada, Notebook 16GB, Serviço de instalação elétrica…"
-              className="flex-1 rounded-lg border border-slate-300 px-4 py-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-              maxLength={300}
-              autoFocus
-            />
-            <button
-              type="button"
-              onClick={() => void classify()}
-              disabled={loading || !descricao.trim()}
-              className="rounded-lg bg-blue-600 px-6 py-3 text-sm font-bold text-white hover:bg-blue-700 disabled:opacity-50"
-            >
-              {loading ? "Classificando…" : "Classificar"}
-            </button>
+      {/* Widget interativo */}
+      <section className="mx-auto -mt-6 max-w-2xl px-4 pb-12">
+        <Classifier />
+      </section>
+
+      {/* SSR explanatory content */}
+      <section className="border-t border-slate-200 bg-white py-12">
+        <div className="mx-auto max-w-3xl px-4 space-y-10">
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">O que é o cClassTrib</h2>
+            <p className="text-slate-700">
+              O <strong>cClassTrib</strong> (Código de Classificação Tributária) é um código numérico
+              de 7 dígitos introduzido pela <strong>Lei Complementar 214/2025</strong> e detalhado pela
+              <strong> Nota Técnica 2025.002-RTC</strong>. Ele define o regime tributário de IBS e CBS
+              aplicável a cada item da NF-e — informa à SEFAZ se o produto é normalmente tributado,
+              tem alíquota reduzida, integra a cesta básica, está sujeito a monofásico, é imune ou
+              suspenso.
+            </p>
+            <p className="mt-3 text-slate-700">
+              O cClassTrib vive no XML da NF-e dentro do grupo <code className="rounded bg-slate-100 px-1 font-mono text-sm">gIBSCBS</code> ou
+              <code className="rounded bg-slate-100 px-1 font-mono text-sm"> gIBSCBSMono</code>, ao
+              lado do CST. A SEFAZ valida em tempo real se o cClassTrib é compatível com o CST
+              informado — quando há descasamento, a nota é rejeitada com o código <strong>1024</strong>.
+            </p>
           </div>
-          <p className="mt-1 text-xs text-slate-400">
-            Quanto mais detalhada a descrição, maior a precisão.
-          </p>
 
-          {error && (
-            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-              {error}
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Estrutura do código cClassTrib</h2>
+            <p className="text-slate-700">
+              Os 7 dígitos do cClassTrib têm semântica posicional. Os três primeiros dígitos batem
+              obrigatoriamente com o CST informado — esta é a fonte mais comum de Rejeição 1024:
+            </p>
+            <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Posição</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Significado</th>
+                    <th className="px-4 py-2 text-left font-semibold text-slate-700">Exemplo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-t border-slate-100">
+                    <td className="px-4 py-2 font-mono">1-3</td>
+                    <td className="px-4 py-2">Espelha o CST do item (vínculo obrigatório)</td>
+                    <td className="px-4 py-2 font-mono">000, 001, 002, 070, 200, 410, 510, 620…</td>
+                  </tr>
+                  <tr className="border-t border-slate-100">
+                    <td className="px-4 py-2 font-mono">4-5</td>
+                    <td className="px-4 py-2">Anexo da LC 214 que rege o item</td>
+                    <td className="px-4 py-2 font-mono">10 (cesta básica), 20 (reduzido), 34 (saúde)…</td>
+                  </tr>
+                  <tr className="border-t border-slate-100">
+                    <td className="px-4 py-2 font-mono">6-7</td>
+                    <td className="px-4 py-2">Subclassificação dentro do anexo</td>
+                    <td className="px-4 py-2 font-mono">01, 02, 99…</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
-          )}
+            <p className="mt-3 text-sm text-slate-600">
+              Exemplo: <code className="rounded bg-slate-100 px-1 font-mono">2000340</code> indica
+              CST 200 (diferimento) + Anexo 03 (saúde) + subclassificação 40.
+              Se o CST do item for diferente de 200, a nota é rejeitada (1024).
+            </p>
+          </div>
 
-          {result && (
-            <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-2xl font-bold text-slate-800">{result.ncm}</span>
-                    <ConfidenceBadge value={result.confidence} />
-                  </div>
-                  <p className="mt-0.5 text-sm text-slate-600">{result.ncm_descricao}</p>
-                  {result.cClassTrib && (
-                    <p className="mt-1 text-xs font-mono text-blue-700">
-                      cClassTrib LC 214: <strong>{result.cClassTrib}</strong>
-                    </p>
-                  )}
-                </div>
-                <Link
-                  href={`/calculadora?ncm=${result.ncm}`}
-                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-bold text-white hover:bg-blue-700"
-                >
-                  Calcular CBS/IBS →
-                </Link>
-              </div>
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Por que o NCM sozinho não basta</h2>
+            <p className="text-slate-700">
+              Um mesmo NCM pode ter múltiplos cClassTrib válidos dependendo do regime de operação,
+              do destinatário e da localização. A automação é uma armadilha clássica: ERPs que
+              parametrizam um cClassTrib fixo por NCM funcionam para o caso médio mas falham nos
+              casos especiais — exatamente as operações com maior risco fiscal.
+            </p>
+            <p className="mt-3 text-slate-700">
+              Exemplos onde o mesmo NCM exige cClassTribs diferentes:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-700">
+              <li><strong>Medicamentos (NCM 3004)</strong>: alíquota zero para uso humano vs. tributação normal para uso veterinário.</li>
+              <li><strong>Alimentos básicos (NCM 1001-1006)</strong>: cesta básica nacional vs. cesta básica estadual diferenciada.</li>
+              <li><strong>Combustíveis (NCM 2710)</strong>: monofásico (CST 620) para distribuidores vs. tributação normal para outros usos.</li>
+              <li><strong>Bebidas (NCM 2202)</strong>: Substituição Tributária para refrigerantes vs. tributação normal para sucos.</li>
+            </ul>
+          </div>
 
-              {result.aviso && (
-                <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-2.5 text-xs text-amber-800">
-                  ⚠ {result.aviso}
-                </div>
-              )}
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Cenários mais comuns da Rejeição 1024</h2>
+            <p className="text-slate-700">
+              A Rejeição 1024 acontece quando a SEFAZ detecta que o cClassTrib informado é
+              incompatível com o CST do item. Os três cenários mais frequentes vistos em
+              produção desde janeiro/2026:
+            </p>
+            <ol className="mt-3 list-decimal space-y-3 pl-6 text-slate-700">
+              <li>
+                <strong>ERP ativou IBS/CBS com cClassTrib genérico (000001) para tudo.</strong>
+                Funciona para CST 000 normal, mas qualquer item com CST 070 (imune) ou 200 (diferimento) gera rejeição.
+              </li>
+              <li>
+                <strong>NCM com múltiplos cClassTribs e o sistema escolhe o primeiro.</strong>
+                Tipicamente em medicamentos, alimentos e produtos químicos — o critério deveria ser o uso ou destino, não a ordem da tabela.
+              </li>
+              <li>
+                <strong>Alíquota parametrizada como zero ou calculada dinamicamente.</strong>
+                Quando o vCBS ou vIBS sai como 0,00 sem o cClassTrib informar isenção (CST 070) ou suspensão (410), a validação cruzada detecta e rejeita.
+              </li>
+            </ol>
+          </div>
 
-              {!result.aviso && (
-                <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 p-2.5 text-xs text-emerald-800">
-                  ✓ NCM identificado com alta confiança. Clique em &quot;Calcular CBS/IBS&quot; para ver as alíquotas e gerar o XML para o ERP.
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* WhatsApp CTA */}
-        <div className="mt-4 rounded-xl border border-red-200 bg-red-50 p-4">
-          <p className="text-sm font-semibold text-red-800">
-            NF-e sendo rejeitada pela Rejeição 1024?
-          </p>
-          <p className="mt-0.5 text-sm text-red-700">
-            Quando CST e cClassTrib são incompatíveis, a nota não sai. Nosso time resolve ao vivo.
-          </p>
-          <a
-            href={WA_REJEICAO}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-3 inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white hover:bg-red-700"
-          >
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
-            </svg>
-            Resolver a Rejeição 1024 no WhatsApp
-          </a>
+          <div>
+            <h2 className="mb-3 text-2xl font-bold text-slate-900">Como o Tribultz automatiza a classificação</h2>
+            <p className="text-slate-700">
+              A Tribultz combina três fontes para sugerir o cClassTrib correto:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-700">
+              <li>Base oficial cClassTrib SVRS (atualização 15/abr/2026, ~1.500 códigos vigentes)</li>
+              <li>Anexos da LC 214 com regime, alíquota referência e vigência por NCM</li>
+              <li>Modelo de IA treinado sobre descrições reais de NF-e para resolver ambiguidade do NCM a partir da descrição em linguagem natural</li>
+            </ul>
+            <p className="mt-3 text-slate-700">
+              O resultado é entregue com indicador de confiança e link direto para a calculadora
+              CBS/IBS. Para casos críticos (confiança &lt; 70%, regimes especiais, exportação),
+              recomendamos validação manual antes de transmitir a NF-e.
+            </p>
+          </div>
         </div>
       </section>
 
-      {/* FAQ SEO */}
-      <section className="border-t border-slate-200 bg-white py-16">
+      {/* FAQ SSR */}
+      <section className="border-t border-slate-200 bg-white py-12">
         <div className="mx-auto max-w-3xl px-4">
           <h2 className="mb-8 text-2xl font-bold text-slate-900">Perguntas frequentes</h2>
           <div className="space-y-6">
-            {[
-              {
-                q: "O que é cClassTrib e por que ele causa rejeições de NF-e?",
-                a: "O cClassTrib é um código de 7 dígitos da LC 214 que define o regime tributário de CBS e IBS de cada produto. Quando ele é incompatível com o CST informado na NF-e, a SEFAZ rejeita a nota com o código 1024. A classificação correta exige mapear o NCM do produto para o regime aplicável (padrão, reduzido, cesta básica, imune, etc.).",
-              },
-              {
-                q: "Quando começam as penalidades por cClassTrib incorreto?",
-                a: "As penalidades efetivas por erros de CBS/IBS em NF-e começam em agosto/2026, encerrando o período educacional da Receita Federal. Após essa data, notas com cClassTrib incorreto além de serem rejeitadas podem gerar autuações e multas para o emitente.",
-              },
-              {
-                q: "Como funciona a classificação automática NCM → cClassTrib?",
-                a: "Nossa IA analisa a descrição do produto e sugere o NCM mais adequado conforme a TIPI (Decreto 11.158/2022). A partir do capítulo NCM, mapeamos o cClassTrib disponível na tabela oficial SVRS atualizada semanalmente. O resultado inclui um indicador de confiança — valores abaixo de 70% devem ser confirmados com o contador.",
-              },
-              {
-                q: "Posso usar o NCM sugerido diretamente na NF-e?",
-                a: "O NCM sugerido é uma referência baseada em IA para agilizar a classificação. Confiança acima de 85% indica alta probabilidade de acerto, mas recomendamos sempre validar com o contador responsável pelo SPED antes de usar em produção. A Tribultz oferece validação completa das 18 regras CBS/IBS para confirmação.",
-              },
-              {
-                q: "Qual a diferença entre NCM e cClassTrib?",
-                a: "NCM é o código de 8 dígitos que identifica o produto na Nomenclatura Comum do Mercosul (tabela TIPI). cClassTrib é o código de 7 dígitos da LC 214 que define como esse produto é tributado pelo IBS e CBS na Reforma Tributária. Um mesmo NCM pode ter diferentes cClassTrib dependendo do destino, do beneficiário e do regime fiscal aplicável.",
-              },
-            ].map((item) => (
+            {FAQ.map((item) => (
               <div key={item.q} className="border-b border-slate-100 pb-6 last:border-0">
                 <h3 className="font-semibold text-slate-800">{item.q}</h3>
                 <p className="mt-2 text-sm leading-relaxed text-slate-600">{item.a}</p>
@@ -222,6 +242,8 @@ export default function ClassificacaoPage() {
           </div>
         </div>
       </section>
+
+      <FundamentacaoLegal items={LEGAL_REFS} />
     </>
   );
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -12,6 +12,7 @@ const PUBLIC_ROUTES = [
   "/",
   "/calculadora",
   "/changelog",
+  "/classificacao",
   "/cookies",
   "/diagnostico",
   "/forgot-password",

--- a/frontend/src/components/seo/FundamentacaoLegal.tsx
+++ b/frontend/src/components/seo/FundamentacaoLegal.tsx
@@ -1,0 +1,57 @@
+/**
+ * Tabela de fundamentação legal — server component, semantic HTML.
+ *
+ * Reusable em posts de blog e páginas-ferramenta. Renderiza <table> com
+ * cabeçalho fixo + linhas. O conteúdo da tabela é um sinal forte de
+ * autoridade no Google (formato canônico de referência).
+ *
+ * Cada linha aceita link opcional para o instrumento oficial.
+ */
+
+export type LegalRef = {
+  instrumento: string;
+  artigo?: string;
+  descricao: string;
+  link?: string;
+};
+
+export function FundamentacaoLegal({ items, title = "Fundamentação legal" }: {
+  items: LegalRef[];
+  title?: string;
+}) {
+  return (
+    <section className="border-t border-slate-200 bg-white py-12">
+      <div className="mx-auto max-w-3xl px-4">
+        <h2 className="mb-4 text-2xl font-bold text-slate-900">{title}</h2>
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold text-slate-700">Instrumento</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-700">Artigo</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-700">Aplicação</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, i) => (
+                <tr key={i} className="border-t border-slate-100">
+                  <td className="px-4 py-3 align-top font-mono text-xs font-semibold text-slate-800">
+                    {item.link ? (
+                      <a href={item.link} target="_blank" rel="noopener noreferrer nofollow" className="text-blue-700 hover:underline">
+                        {item.instrumento}
+                      </a>
+                    ) : (
+                      item.instrumento
+                    )}
+                  </td>
+                  <td className="px-4 py-3 align-top font-mono text-xs text-slate-600">{item.artigo ?? "—"}</td>
+                  <td className="px-4 py-3 align-top text-slate-700">{item.descricao}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Fecha #**296**.

## Problema raiz (dois bugs combinados)

1. **\`/classificacao\` e \`/calculadora\` eram client components puros** — o copy renderizava só após hidratação, então o Googlebot via página vazia. O schema JSON-LD do PR #295 ficou descasado do conteúdo.

2. **\`/classificacao\` não estava em \`AppShell.PUBLIC_ROUTES\`** — caía em rota protegida, mostrando spinner + redirect ao login durante o SSR. Por isso o probe inicial mostrava 0 palavras enquanto a calculadora (que estava na lista pública) mostrava 61.

## Fix

### **Arquitetura**
- **\`page.tsx\` → Server Component** com todo o copy SSR + FAQ + Fundamentação Legal
- **Widget interativo extraído** para \`Classifier.tsx\` / \`Calculator.tsx\` (client components com hooks)
- **\`AppShell.PUBLIC_ROUTES\` corrigido** para incluir \`/classificacao\`
- **Novo componente reutilizável** \`<FundamentacaoLegal />\` (tabela semântica de instrumentos legais — pode ser usado nos posts pilares de #298/#299/#300)

### Conteúdo SSR adicionado

**/classificacao** (1.025 palavras, 14 headings, 2 tabelas):
- H2: O que é o cClassTrib
- H2: Estrutura do código cClassTrib (com tabela de posições 1-3, 4-5, 6-7)
- H2: Por que o NCM sozinho não basta
- H2: Cenários mais comuns da Rejeição 1024 (3 casos detalhados)
- H2: Como o Tribultz automatiza a classificação
- H2: Perguntas frequentes (6 Q&A)
- H2: Fundamentação legal (6 referências: LC 214, LC 227, NT 2025.002, SVRS, Conv. 142, TIPI)

**/calculadora** (776 palavras, 13 headings, 3 tabelas):
- H2: Como a calculadora funciona
- H2: Alíquotas vigentes em 2026 (tabela CBS/IBS 2026 vs regime cheio)
- H2: Regimes especiais cobertos (tabela com 7 CSTs e modificadores)
- H2: Quando o cálculo manual falha (4 erros mais comuns)
- H2: Perguntas frequentes (6 Q&A)
- H2: Fundamentação legal (6 referências)

## Test plan
- [x] \`npm run build\` — clean, 43 páginas estáticas
- [x] \`npm test\` — todos passando
- [x] Probe direto nos arquivos \`.next/server/app/*.html\` — confirma SSR
- [ ] Pós-deploy: re-rodar \`curl + grep\` em produção
- [ ] Pós-deploy: Rich Results Test do Google para validar que FAQ e WebApplication ainda batem
- [ ] Submeter URLs no Search Console para indexação manual

## Métricas comparativas (alvo: Tax Radar)

| | Tax Radar (avg) | Tribultz antes | Tribultz agora |
|---|---:|---:|---:|
| Palavras /classificacao | n/a | 0 | **1.025** |
| Palavras /calculadora | n/a | 61 | **776** |
| Headings | 27,7 | 0 | 13-14 |
| Tabelas | 7 | 0 | 2-3 |

Ainda atrás de posts pilares longos do Tax Radar (2.5K+ palavras), mas agora **dentro da faixa esperada para uma ferramenta** (~1K). Posts pilares de #298-#300 fecharão o gap restante.
