### PR TITLE
content(#298/#300): posts pilares — NCM → cClassTrib regime e Como classificar NCM em 2026

### DIFF
--- a/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
+++ b/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
@@ -1,0 +1,307 @@
+---
+title: "cClassTrib 2026: como mapear o NCM ao regime correto de IBS/CBS"
+description: "Entenda como o NCM determina o Anexo da LC 214, que determina o cClassTrib, que determina o regime IBS/CBS. Guia completo com tabela de CSTs, fluxo de mapeamento e os 4 erros que geram Rejeição 1024."
+slug: "classtrib-2026-mapear-ncm-regime-ibs-cbs"
+category: "Reforma Tributária"
+author:
+  name: "Mickael Baptista"
+  jobTitle: "Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"
+  credentials: "Especialista em Compliance Fiscal — Reforma Tributária CBS/IBS (LC 214/2024)"
+  url: "https://tribultz.com.br/sobre"
+publishedAt: "2026-06-05"
+updatedAt: "2026-06-05"
+tags:
+  - cClassTrib
+  - NCM
+  - CBS
+  - IBS
+  - "Reforma Tributária"
+  - "LC 214"
+  - NF-e
+coverImage: "https://tribultz.com.br/blog/og-classtrib-ncm-regime.png"
+legalRefs:
+  - instrumento: "LC 214/2024"
+    artigo: "Anexos I–VIII"
+    descricao: "Define os regimes tributários especiais (cesta básica, reduzido, monofásico, imune, isento) e os produtos enquadrados em cada um."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
+  - instrumento: "LC 227/2024"
+    artigo: "Art. 348 §§ 3º e 4º"
+    descricao: "Período educativo 2026 — alíquotas CBS 0,9% e IBS 0,1%."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp227.htm"
+  - instrumento: "NT 2025.002 V1.36"
+    artigo: "Seção 4.2"
+    descricao: "Define a estrutura do campo cClassTrib, a tabela de CSTs válidos e as regras de rejeição 1024–1035."
+  - instrumento: "Tabela cClassTrib SVRS V1.36"
+    artigo: "—"
+    descricao: "Mapeamento oficial NCM → regime → cClassTrib. Atualizada em abril de 2026."
+    link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria"
+  - instrumento: "Convênio ICMS 142/2018"
+    artigo: "Anexo I e II"
+    descricao: "NCMs sujeitos à substituição tributária e obrigação de CEST — relevante para determinar o subgrupo cClassTrib em operações com ST."
+---
+
+## O que é o cClassTrib e por que ele importa
+
+Antes da Reforma Tributária, o regime fiscal de um produto era determinado por uma combinação implícita de CFOP, CST de ICMS e alíquota. O contador precisava saber "de cabeça" que NCM 3004.90.99 em operação com destino para pessoa física tem alíquota X de PIS/COFINS e Y de ICMS. A lógica ficava nos manuais internos e na experiência das equipes.
+
+A LC 214/2024 mudou isso com o **cClassTrib**: um código de 8 dígitos que torna explícito, no próprio XML da NF-e, qual regime tributário CBS/IBS se aplica ao item. Não há mais ambiguidade: o código está declarado, a SEFAZ valida, e qualquer inconsistência resulta em rejeição.
+
+Para o contribuinte, isso significa uma vantagem e uma responsabilidade simultâneas. A vantagem: o regime fiscal fica documentado no documento fiscal. A responsabilidade: manter o cadastro de produtos atualizado com o cClassTrib correto para cada NCM.
+
+### Estrutura do cClassTrib: 8 dígitos, 3 grupos
+
+```
+┌───────┬───────────┬─────────────┐
+│  CST  │ Subgrupo  │ Modificador │
+│ 3 dig │  3 dig    │   2 dig     │
+└───────┴───────────┴─────────────┘
+  Regime   Categoria    Variação
+```
+
+| Grupo | Posição | O que define |
+|-------|---------|-------------|
+| CST | 1–3 | Regime tributário (padrão, reduzido, isento, monofásico...) |
+| Subgrupo | 4–6 | Categoria fiscal do produto (alimentos, medicamentos, combustíveis...) |
+| Modificador | 7–8 | Variação dentro do subgrupo (cesta básica nacional, ZFM, exportação...) |
+
+Exemplo: `20003400`
+- `200` → CST 200 = alíquota reduzida
+- `034` → alimentos da cesta básica nacional (LC 214, art. 21)
+- `00` → sem modificador adicional
+
+### Onde o cClassTrib aparece no XML da NF-e
+
+O campo fica dentro do grupo `gIBSCBS`, que é filho do elemento `det` (detalhe do item):
+
+```xml
+<det nItem="1">
+  <prod>
+    <NCM>10063021</NCM>   ← arroz beneficiado
+    ...
+  </prod>
+  <gIBSCBS>
+    <CBS>
+      <CST>200</CST>
+      <cClassTrib>20003400</cClassTrib>
+      <pCBS>0.90</pCBS>
+      <vCBS>0.45</vCBS>
+    </CBS>
+    <IBS>
+      <CST>200</CST>
+      <cClassTrib>20003400</cClassTrib>
+      <pIBS>0.10</pIBS>
+      <vIBS>0.05</vIBS>
+    </IBS>
+  </gIBSCBS>
+</det>
+```
+
+Note que **cClassTrib é o mesmo para CBS e IBS** do mesmo item. O regime tributário é unitário por item — o que muda é a alíquota (pCBS vs pIBS) e quem recolhe (federal vs estadual/municipal).
+
+---
+
+## Quem precisa preencher cClassTrib em 2026
+
+A obrigação se aplica a **todos os contribuintes que emitem NF-e ou NFS-e** e que apuram IBS ou CBS. Isso inclui:
+
+- Empresas do Lucro Real, Lucro Presumido e Simples Nacional que emitem NF-e
+- Prestadores de serviços que emitem NFS-e via portais municipais integrados ao SPED
+- Distribuidores e varejistas em operações B2B e B2C
+
+**Exceções** (sem obrigação de preencher gIBSCBS):
+- Operações com CST 070 (imunidade) e CST 080 (não incidência)
+- Micro empreendedores individuais (MEI) em operações simplificadas
+- Operações com CFOP de devolução sem incidência de IBS/CBS
+
+Em caso de dúvida sobre a obrigatoriedade no seu tipo de operação, consulte a NT 2025.002 seção 3.1 ou o [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico).
+
+---
+
+## Os principais CSTs do IBS/CBS em 2026
+
+O campo `CST` dentro de `gIBSCBS` é derivado dos três primeiros dígitos do cClassTrib. É diferente do CST do ICMS. A tabela abaixo resume os CSTs ativos na NT 2025.002 V1.36:
+
+| CST | Regime | Alíquota CBS | Alíquota IBS | Aplicação típica |
+|-----|--------|-------------|-------------|-----------------|
+| 000 | Padrão | 0,90% | 0,10% | Produtos industrializados em geral |
+| 200 | Reduzido | Varia | Varia | Medicamentos, cesta básica estendida |
+| 210 | Red. + cashback | Varia | Varia | Medicamentos destinados a beneficiários CadÚnico |
+| 400 | Isento | 0% | 0% | Exportações, papel p/ impressão de livros |
+| 500 | Imune | 0% | 0% | Livros, templos, entidades filantrópicas |
+| 610 | Monofásico — produtor | Concentrado | Concentrado | Gasolina, diesel, GLP (fabricante/importador) |
+| 620 | Monofásico — downstream | 0% | 0% | Combustíveis (distribuidor, posto, varejista) |
+| 700 | Suspensão | 0% | 0% | Drawback, ZPE, regimes aduaneiros especiais |
+| 800 | Diferimento | 0% | 0% | Operações entre contribuintes no mesmo Estado |
+
+> A alíquota "varia" no CST 200 significa que o percentual exato depende do Anexo da LC 214 em que o produto está listado. Não existe uma alíquota padrão para "reduzido" — cada subgrupo tem a sua.
+
+---
+
+## O fluxo NCM → Anexo LC 214 → cClassTrib
+
+O mapeamento correto segue sempre a mesma lógica de três passos:
+
+```
+NCM do produto
+      │
+      ▼
+Está listado em algum
+Anexo da LC 214?
+      │
+   ┌──┴──┐
+  SIM   NÃO
+   │       │
+   │    Regime padrão
+   │    CST 000
+   │
+   ▼
+Qual Anexo?
+      │
+   ┌──┬──┬──┬──┐
+   I  II III IV ...
+   │
+   ▼
+cClassTrib = prefixo do regime
+           + subgrupo do Anexo
+           + modificador aplicável
+```
+
+### Principais Anexos da LC 214 e seus regimes
+
+| Anexo | Regime | CST | Exemplos de produtos |
+|-------|--------|-----|---------------------|
+| Anexo I | Cesta básica nacional | 200 | Arroz, feijão, carnes (bovino, suíno, aves), ovos, leite UHT, manteiga |
+| Anexo II | Alíquota reduzida (50%) | 200 | Medicamentos, dispositivos médicos, saneamento básico, transporte coletivo |
+| Anexo III | Redução específica | 200 | Produtos agrícolas não incluídos no Anexo I |
+| Anexo IV | Imunidade | 500 | Livros, periódicos, papel destinado à impressão |
+| Anexo V | Monofásico | 610/620 | Combustíveis, lubrificantes, tabaco, bebidas alcoólicas |
+| Anexo VI | Cashback | 210 | Medicamentos e alimentos para beneficiários CadÚnico |
+| Regime padrão | — | 000 | Qualquer NCM não listado nos Anexos I–VI |
+
+---
+
+## Por que o NCM sozinho não basta
+
+Um NCM enquadrado em múltiplos regimes é mais comum do que parece. Tome o NCM `3004.90.99` (medicamentos):
+
+- Venda para farmácia → CST 200 (Anexo II — alíquota reduzida)
+- Venda para exportação → CST 400 (isento, fora do território nacional)
+- Venda para beneficiário CadÚnico via programa governamental → CST 210 (cashback)
+
+O NCM é o mesmo. O produto é o mesmo. O regime muda conforme **quem compra** e **para qual finalidade**.
+
+Outros fatores que modificam o regime além do NCM:
+
+| Fator | Impacto no cClassTrib |
+|-------|----------------------|
+| Tipo de destinatário (PF, PJ, entidade filantrópica) | Pode alterar CST entre 000, 200 e 400 |
+| CFOP da operação (interna, interestadual, exportação) | Exportações são sempre CST 400/500 |
+| Regime tributário do emitente (Simples, Lucro Presumido) | Afeta base de cálculo, não o cClassTrib |
+| Produto estar sujeito a ST (Convênio 142/2018) | Exige CEST e pode alterar subgrupo cClassTrib |
+| Produto estar em ZFM ou ZPE | CST 700 (suspensão) |
+
+---
+
+## Passo a passo para classificar o cClassTrib de um produto
+
+**1. Confirme o NCM**
+Use a TIPI (Tabela de Incidência do IPI) para confirmar que o NCM está correto e ativo. Um NCM errado gera cClassTrib errado.
+
+**2. Verifique os Anexos da LC 214**
+Consulte se o NCM aparece nos Anexos I a VI da LC 214. A maioria dos produtos não está em nenhum Anexo — e portanto usa CST 000 (regime padrão).
+
+**3. Identifique o CST aplicável à operação**
+Considerando destinatário, CFOP e finalidade, determine qual CST se aplica à saída específica.
+
+**4. Consulte a tabela cClassTrib SVRS**
+Acesse a tabela oficial em [dfe-portal.svrs.rs.gov.br](https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria) ou use a [API da Tribultz](https://tribultz.com.br/classificacao). Informe o NCM e o regime — a ferramenta retorna o cClassTrib completo (8 dígitos) com a base legal.
+
+**5. Valide a compatibilidade CST × cClassTrib**
+Confirme que os três primeiros dígitos do cClassTrib coincidem com o CST que será emitido no XML. Esse é o ponto exato que a SEFAZ valida para a [Rejeição 1024](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir).
+
+**6. Atualize o cadastro e valide o XML**
+Insira o cClassTrib correto no cadastro do produto do ERP. Antes de emitir, valide o XML pelo [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico). A validação prévia aplica as 18 regras da NT 2025.002 e devolve um relatório de inconsistências com severidade e sugestão de correção — evitando que a Rejeição 1024 apareça só na SEFAZ, em produção, com operação já comprometida.
+
+---
+
+## cClassTrib e Simples Nacional: o que muda
+
+Empresas do Simples Nacional também precisam preencher o cClassTrib na NF-e. A diferença está na alíquota efetiva — não no cClassTrib em si.
+
+O cClassTrib determina o **regime tributário** (qual Anexo da LC 214 se aplica) e é idêntico ao que uma empresa do Lucro Real usaria para o mesmo produto. O que muda no Simples Nacional é o **valor calculado de CBS e IBS**, pois esses tributos são recolhidos de forma unificada via DAS.
+
+Durante o período de transição, contribuintes do Simples Nacional recolhem uma alíquota CBS/IBS diferente da alíquota padrão dos demais regimes — mas o campo `cClassTrib` no XML precisa ser preenchido corretamente de qualquer forma. A SEFAZ valida o código independentemente do regime do emitente.
+
+**Resumo prático para o Simples:** preencha o cClassTrib exatamente como descrito neste guia. Se o produto é cesta básica (Anexo I), use CST 200 com cClassTrib de prefixo `200`. Se é regime padrão, use CST 000. O ERP ou o contador responsável calcula o valor correto de CBS/IBS conforme as tabelas do Simples.
+
+---
+
+## Os 4 erros que geram Rejeição 1024
+
+### Erro 1: usar o mesmo cClassTrib para todos os produtos
+
+O cClassTrib não é um campo de preenchimento livre — ele precisa refletir o Anexo correto da LC 214 para o NCM específico. Usar `00000000` ou qualquer código genérico para todos os produtos resulta em Rejeição 1024 para qualquer item que não seja do regime padrão.
+
+### Erro 2: confundir o CST do ICMS com o CST do CBS/IBS
+
+São dois campos diferentes no XML. O CST dentro de `gIBSCBS` é derivado do cClassTrib e define o regime IBS/CBS. O CST dentro do grupo `ICMS` define o regime do imposto estadual legado. Eles podem ter valores diferentes para o mesmo item.
+
+### Erro 3: não atualizar o cClassTrib quando o NCM muda
+
+Toda vez que o NCM de um produto é corrigido (TIPI é revisada periodicamente), o cClassTrib associado pode mudar. Equipes que atualizam o NCM mas esquecem de revisar o cClassTrib acabam com incompatibilidade silenciosa que só aparece na SEFAZ.
+
+### Erro 4: ignorar o modificador (dígitos 7–8)
+
+Dois produtos com o mesmo NCM e o mesmo CST podem ter cClassTribs diferentes se um deles tem modificador (ex: `20003400` para cesta básica nacional vs `20003401` para cesta básica estendida). A diferença de 1 dígito resulta em Rejeição 1025 (cClassTrib inválido) ou 1028 (não permitido para o CST).
+
+---
+
+## Como o Tribultz automatiza esse mapeamento
+
+O [Classificador NCM → cClassTrib](https://tribultz.com.br/classificacao) da Tribultz automatiza os passos 2 a 5 do fluxo acima:
+
+1. Informe o NCM
+2. Selecione o tipo de operação (saída nacional, exportação, entidade beneficente...)
+3. O classificador consulta a tabela SVRS V1.36 e retorna o cClassTrib correto + CST compatível + base legal
+
+Para volume, a API pública `POST /api/v1/public/classtrib/{ncm}` aceita requisições sem autenticação até 100/dia — suficiente para validar o cadastro de produtos de uma empresa de médio porte em uma tarde.
+
+Para integração com ERP via API autenticada (X-API-Key), o plano Starter oferece 10.000 consultas/mês por R$ 49,90.
+
+Para equipes fiscais que precisam revisar o cadastro completo antes de uma virada de leiaute ou auditoria, o plano Profissional oferece 50.000 consultas/mês e relatório consolidado por CNPJ.
+
+→ **[Classificar NCM agora — gratuito](https://tribultz.com.br/classificacao)**
+
+---
+
+## Perguntas frequentes
+
+**O cClassTrib de um produto muda toda vez que a tabela SVRS é atualizada?**
+
+Não necessariamente. Atualizações da tabela SVRS incluem novos códigos, descontinuam alguns e corrigem erros. Para a maioria dos NCMs, o cClassTrib é estável. O risco está nos códigos de produtos novos (dispositivos médicos, veículos elétricos, produtos de ZFM) — esses tendem a sofrer revisão nas primeiras versões da tabela.
+
+**Como saber qual versão da tabela SVRS meu ERP está usando?**
+
+A NT 2025.002 especifica qual versão da tabela é aceita pela SEFAZ. Se seu ERP usa uma versão anterior, cClassTribs descontinuados causarão Rejeição 1025. Consulte o suporte do seu ERP para verificar a versão configurada.
+
+**Produto com NCM que não está em nenhum Anexo da LC 214 usa qual cClassTrib?**
+
+Usa o regime padrão: CST 000, cClassTrib com prefixo `000`. O subgrupo (dígitos 4–6) ainda precisa ser correto para o tipo de produto — mas a alíquota é a padrão do período (CBS 0,9%, IBS 0,1% em 2026).
+
+**Posso ter dois cClassTribs diferentes para o mesmo produto no cadastro?**
+
+Não no mesmo item da NF-e — cada linha de produto tem um único cClassTrib. Mas se o mesmo produto é vendido com regimes diferentes dependendo do destino (ex: nacional vs exportação), o ERP deve selecionar o cClassTrib correto com base no CFOP da operação. Isso é uma regra de determinação fiscal, não um cadastro duplo.
+
+**O cClassTrib está relacionado ao CEST?**
+
+Indiretamente. O CEST identifica produtos sujeitos à substituição tributária (ST) do ICMS — ele é obrigatório para NCMs listados no Convênio ICMS 142/2018. O cClassTrib não depende do CEST, mas para produtos com ST, o subgrupo do cClassTrib pode ser diferente (há subgrupos específicos para operações com ST já retido). Leia mais sobre CEST no artigo [cClassTrib 2026: mapeamento NCM × cClassTrib](/blog/classtrib-2026-ncm-mapeamento-completo).
+
+**Existe um cClassTrib para operações de devolução?**
+
+Sim. Devoluções de compra (CFOP 1201/2201) e devoluções de venda (CFOP 5201/6201) usam o mesmo cClassTrib da operação original. O CBS/IBS calculado na devolução é subtraído da apuração do período. Caso a NF-e original tenha sido emitida com cClassTrib incorreto, a NF-e de devolução deve espelhar o código da nota original — e o ajuste correto é feito via escrituração, não via cClassTrib diferente na devolução.
+
+## Artigos relacionados
+
+- [Rejeição 1024 NF-e CBS/IBS: causas e como corrigir em 2026](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir)
+- [Como classificar NCM corretamente em 2026](/blog/como-classificar-ncm-corretamente-2026)
+- [cClassTrib 2026: mapeamento NCM × cClassTrib e como evitar a Rejeição 1024](/blog/classtrib-2026-ncm-mapeamento-completo)

--- a/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
+++ b/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
@@ -1,0 +1,332 @@
+---
+title: "Como classificar NCM corretamente em 2026: guia passo a passo"
+description: "Guia completo para classificar produtos na NCM usando TIPI, Regras Gerais de Interpretação e Soluções de Consulta. Inclui exemplos reais, erros comuns que geram multa e como o NCM virou ainda mais crítico com a Reforma Tributária de 2026."
+slug: "como-classificar-ncm-corretamente-2026"
+category: "Classificação Fiscal"
+author:
+  name: "Mickael Baptista"
+  jobTitle: "Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"
+  credentials: "Especialista em Compliance Fiscal — Reforma Tributária CBS/IBS (LC 214/2024)"
+  url: "https://tribultz.com.br/sobre"
+publishedAt: "2026-06-05"
+updatedAt: "2026-06-05"
+tags:
+  - NCM
+  - TIPI
+  - "Classificação Fiscal"
+  - cClassTrib
+  - "Reforma Tributária"
+  - "Rejeição 1024"
+  - IPI
+coverImage: "https://tribultz.com.br/blog/og-como-classificar-ncm.png"
+legalRefs:
+  - instrumento: "Decreto 11.158/2022"
+    artigo: "Anexo — TIPI"
+    descricao: "Tabela de Incidência do IPI vigente. Base legal para a classificação NCM de todos os produtos industrializados no Brasil."
+    link: "https://www.planalto.gov.br/ccivil_03/_ato2019-2022/2022/decreto/d11158.htm"
+  - instrumento: "Convenção Internacional do Sistema Harmonizado"
+    artigo: "Regras Gerais 1–6"
+    descricao: "As seis Regras Gerais de Interpretação (RGI) do Sistema Harmonizado, vinculantes para classificação NCM."
+  - instrumento: "IN RFB 1.799/2018"
+    artigo: "Art. 1º–15"
+    descricao: "Disciplina o processo de Solução de Consulta sobre classificação fiscal de produtos perante a Receita Federal."
+  - instrumento: "LC 214/2024"
+    artigo: "Anexos I–VI"
+    descricao: "Os produtos listados nos Anexos têm regime tributário CBS/IBS diferenciado — o NCM é o critério de enquadramento."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
+  - instrumento: "NT 2025.002 V1.36"
+    artigo: "Seção 4.2"
+    descricao: "Define a obrigatoriedade do NCM correto como base para o cClassTrib na NF-e."
+---
+
+## O que é NCM e por que importa em 2026
+
+O **NCM** (Nomenclatura Comum do Mercosul) é o código de 8 dígitos que identifica a natureza de um produto para fins fiscais, aduaneiros e estatísticos. No Brasil, ele é a base para determinar a alíquota de IPI, as obrigações de ICMS, as alíquotas de PIS/COFINS e, a partir de 2026, o **regime tributário CBS/IBS**.
+
+O NCM sempre foi importante. Em 2026, tornou-se crítico.
+
+Com a Reforma Tributária (LC 214/2024), o NCM passou a ser o critério de enquadramento nos Anexos da lei — e o Anexo determina o **cClassTrib**, que determina se o produto paga alíquota padrão, reduzida, zero (monofásico), isenta ou imune de IBS/CBS. Um NCM incorreto agora significa não apenas uma multa de IPI, mas também:
+
+- cClassTrib errado na NF-e
+- [Rejeição 1024](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir) ou 1025 na SEFAZ
+- Apuração incorreta de CBS/IBS (crédito a menor ou a maior)
+- Risco de auto de infração na fiscalização pós-reforma
+
+Este guia ensina como classificar corretamente um produto na NCM usando as ferramentas e os critérios técnicos corretos.
+
+---
+
+## As 3 ferramentas obrigatórias para classificar NCM
+
+### 1. TIPI — Tabela de Incidência do IPI
+
+A TIPI (Decreto 11.158/2022) é a versão brasileira do Sistema Harmonizado (SH) adaptada para uso nacional. Ela lista todos os NCMs válidos com a alíquota de IPI correspondente. Quatro pontos essenciais:
+
+- A TIPI é organizada em **21 Seções**, **97 Capítulos**, posições (4 dígitos), subposições (6 dígitos) e itens/subitens (7 e 8 dígitos).
+- NCMs com alíquota `NT` (não-tributado) não recolhem IPI, mas ainda precisam de NCM correto para CBS/IBS.
+- NCMs com alíquota `0%` são tributados — a diferença para `NT` importa para obrigações acessórias.
+- A TIPI é revisada periodicamente pela Receita Federal. Sempre use a versão vigente.
+
+### 2. Notas de Seção e de Capítulo
+
+As Notas de Seção e de Capítulo são parte integrante da TIPI e têm força legal vinculante. Elas **incluem, excluem ou redirecionam** produtos de uma posição NCM:
+
+> Exemplo: a Nota 2 do Capítulo 30 exclui da posição 3004 (medicamentos) os produtos que, embora em forma farmacêutica, são de uso cosmético (que vão para o Capítulo 33).
+
+Ignorar as Notas de Capítulo é o erro mais frequente em classificações incorretas. Antes de confirmar um NCM, leia as notas do Capítulo correspondente.
+
+### 3. Soluções de Consulta da Receita Federal
+
+Para produtos com classificação duvidosa ou disputada, a **Solução de Consulta** (IN RFB 1.799/2018) é o mecanismo oficial. A empresa submete uma consulta com a descrição técnica do produto, e a Receita Federal emite uma decisão vinculante sobre o NCM correto.
+
+Soluções de Consulta publicadas têm efeito vinculante para **todos os contribuintes** com produto de características idênticas — não apenas para quem consultou. Pesquise se já existe uma Solução de Consulta para o seu produto antes de iniciar uma nova.
+
+---
+
+## Passo a passo em 6 etapas para classificar um produto
+
+### Etapa 1: descreva o produto com precisão técnica
+
+A classificação começa com uma descrição detalhada do produto — não a descrição comercial, mas a descrição técnica:
+
+- Composição (matéria-prima predominante)
+- Função e uso principal
+- Estado (bruto, semiacabado, acabado)
+- Forma de apresentação (líquido, sólido, granulado, kit)
+- Destinação (uso industrial, doméstico, profissional)
+
+Exemplo ruim: "molho de tomate"
+Exemplo bom: "preparação alimentícia à base de tomate concentrado (80%), com vinagre, sal e açúcar, embalagem de vidro 500g, destinada ao consumo humano final"
+
+### Etapa 2: identifique a Seção e o Capítulo
+
+A TIPI tem 21 Seções. Cada Seção agrupa Capítulos por natureza do produto. O caminho mais rápido:
+
+| Seção | O que contém |
+|-------|-------------|
+| I | Animais vivos, produtos de origem animal |
+| II | Produtos de origem vegetal |
+| III | Gorduras e óleos animais ou vegetais |
+| IV | Produtos de indústrias alimentares, bebidas, tabaco |
+| V | Produtos minerais |
+| VI | Produtos das indústrias químicas |
+| VII | Plásticos e obras; borracha e obras |
+| XI | Matérias têxteis e suas obras |
+| XVI | Máquinas, aparelhos e materiais elétricos |
+| XVII | Material de transporte |
+
+Para o molho de tomate do exemplo: Seção IV, Capítulo 21 (preparações alimentícias diversas).
+
+### Etapa 3: leia as Notas do Capítulo
+
+Antes de avançar para as posições, leia as Notas do Capítulo escolhido. Verifique:
+
+- O produto está excluído por alguma nota?
+- Há nota de inclusão que define critérios específicos?
+- Alguma nota redireciona para outro Capítulo?
+
+Para o Capítulo 21: a Nota 1 exclui misturas de hortaliças (que vão para o Capítulo 7) e preparações para chás (Capítulo 21, mas posição específica). O molho de tomate não é excluído.
+
+### Etapa 4: localize a posição (4 dígitos)
+
+Dentro do Capítulo, compare a descrição do produto com as posições listadas. Para o molho de tomate, a posição `2103` cobre "preparações para molhos e molhos preparados; condimentos e temperos compostos; farinha de mostarda".
+
+O subitem `2103.20` é específico para "ketchup e outros molhos de tomate".
+
+### Etapa 5: aplique as Regras Gerais de Interpretação (RGI)
+
+As 6 RGIs determinam qual posição se aplica quando o produto:
+- Encaixa em mais de uma posição (RGI 2a/3a)
+- É um conjunto ou kit (RGI 3b — classificar pelo componente de maior valor)
+- É uma mistura (RGI 3c — posição mais específica)
+
+Para produtos simples e bem definidos, a RGI 1 (texto das posições e notas) resolve na maioria dos casos. Para kits, conjuntos e produtos multicomponente, as RGIs 2 e 3 são essenciais.
+
+| RGI | Quando aplica | Regra |
+|-----|--------------|-------|
+| 1 | Produto com texto de posição claro | Classificar pelo texto da posição + notas |
+| 2a | Produto incompleto/inacabado | Equiparar ao produto completo se tem caráter essencial |
+| 2b | Mistura de matérias | Aplicar RGI 3 |
+| 3a | Duas posições possíveis | Posição mais específica prevalece |
+| 3b | Kit/conjunto | Classifica pelo componente que dá o caráter essencial |
+| 3c | Empate após 3a e 3b | Posição de número mais elevado na nomenclatura |
+| 4 | Produto sem posição adequada | Posição do produto mais similar |
+| 5 | Estojo ou embalagem | Classifica com o produto se vendido junto e uso único |
+| 6 | Subposições | Aplica mesmas RGIs nas subposições do Capítulo |
+
+### Etapa 6: confirme na TIPI e registre a base legal
+
+Com o NCM identificado (ex: `2103.20.10`), confirme:
+- O NCM está ativo na TIPI vigente (Decreto 11.158/2022)?
+- A descrição da TIPI corresponde ao produto?
+- A alíquota de IPI indicada é compatível com o que foi recolhido?
+
+Registre a justificativa de classificação (referência às RGIs aplicadas, notas de capítulo lidas) em um documento interno. Essa justificativa protege a empresa em caso de auditoria.
+
+---
+
+## Como ler notas de seção e capítulo sem errar
+
+As Notas de Seção/Capítulo têm três funções:
+
+**1. Notas de exclusão** ("Excluem-se…"): definem o que não pertence ao capítulo/posição. São as mais importantes para evitar classificação errada.
+
+**2. Notas de definição** ("Para efeitos desta posição, entende-se por…"): estabelecem um significado técnico-fiscal para um termo, que pode diferir do uso comum. Ex: a TIPI define "medicamento" de forma diferente do uso cotidiano.
+
+**3. Notas de inclusão** ("Esta posição compreende também…"): ampliam o escopo da posição além do que o texto literalmente cobre.
+
+Um erro comum é ler apenas o texto da posição sem ler as notas — especialmente as notas de exclusão que redirecionam o produto para outro Capítulo.
+
+---
+
+## Exemplo complexo: kit com múltiplos itens (RGI 3b)
+
+Uma empresa vende um "kit de primeiros socorros" contendo:
+- 1 bandagem elástica (Capítulo 63 — têxteis)
+- 1 frasco de álcool 70° (Capítulo 22 — bebidas e vinagres, ou Capítulo 38 — produtos químicos)
+- 1 par de luvas descartáveis (Capítulo 40 — borracha)
+- 1 caixa de gaze estéril (Capítulo 30 — produtos farmacêuticos)
+
+Cada item isolado teria um NCM diferente. Como kit, a RGI 3b manda classificar pelo **componente que confere o caráter essencial** ao conjunto. Para um kit de primeiros socorros, o caráter essencial é médico/farmacêutico — a gaze estéril define o propósito.
+
+Resultado: o kit classifica como `3005.90.90` (ataduras e artigos semelhantes) ou na posição de produto médico mais representativo, na Seção VI (produtos farmacêuticos), e não nas posições individuais de têxtil ou borracha.
+
+Sem conhecer a RGI 3b, muitas empresas usam o NCM do item mais caro (embalagem, neste caso) — o que é errado e gera multa de classificação.
+
+Outro erro frequente em kits é classificar cada item separadamente e emitir uma NF-e por item. Se o kit é vendido como unidade indivisível (um único preço, uma única referência no catálogo), a RGI 3b manda classificar como conjunto. Emitir item a item pode ser interpretado como fracionamento artificial de produto, com implicações para IPI e, em 2026, para o cClassTrib — pois cada NCM gerado separadamente pode ter um regime tributário diferente do conjunto, alterando a apuração de CBS/IBS.
+
+---
+
+## Quando pedir Solução de Consulta à Receita Federal
+
+A Solução de Consulta é obrigatória (ou fortemente recomendada) quando:
+
+- O produto é novo no mercado e não existe precedente de classificação
+- A empresa tem dúvida genuína entre duas posições, ambas plausíveis
+- O produto passou por alteração na composição e o NCM anterior pode não ser mais válido
+- Existe Solução de Consulta divergente entre diferentes regiões fiscais para produto similar
+- O produto está em disputa judicial ou administrativa sobre a classificação correta
+
+A consulta é gratuita, mas demorada (prazo legal de 90 dias, na prática pode levar mais). O efeito vinculante protege a empresa de autuação retroativa — desde que o produto consultado seja idêntico ao descrito na consulta.
+
+Uma dica prática: ao redigir o pedido de Solução de Consulta, inclua a composição química completa, o processo de fabricação e o uso declarado. Consultas rejeitadas por falta de informação reiniciam o prazo. Quanto mais técnica e completa a descrição, maior a chance de uma decisão definitiva no primeiro pedido.
+
+Pesquise se já existe Solução de Consulta publicada (disponíveis no portal da RFB) antes de iniciar um processo novo.
+
+---
+
+## Por que o NCM ficou mais crítico em 2026 (vínculo com cClassTrib)
+
+Antes da Reforma, um NCM errado gerava multa de IPI, eventualmente problemas com ICMS-ST, mas o impacto era localizado. Em 2026, o NCM errado tem efeito cascata:
+
+```
+NCM incorreto
+      │
+      ▼
+Enquadramento errado
+no Anexo da LC 214
+      │
+      ▼
+cClassTrib incorreto
+na NF-e
+      │
+      ▼
+┌─────────────┬──────────────────┐
+│ Rejeição    │ Apuração CBS/IBS │
+│ 1024/1025   │ incorreta        │
+│ na SEFAZ    │ (crédito errado) │
+└─────────────┴──────────────────┘
+```
+
+Um produto classificado como "regime padrão" quando deveria ser "cesta básica" resulta em:
+- NF-e com CBS de 0,9% quando deveria ser a alíquota reduzida da cesta básica
+- Consumidor final pagando CBS/IBS a mais do que deveria (e sem direito ao cashback, se for beneficiário CadÚnico)
+- Risco de autuação por classificação incorreta retroativa em eventual fiscalização
+
+Leia mais sobre o vínculo NCM × cClassTrib em [cClassTrib 2026: como mapear o NCM ao regime correto](/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs).
+
+---
+
+## Checklist de classificação NCM
+
+Antes de registrar um NCM no cadastro de produtos, verifique:
+
+- [ ] Produto descrito com composição, função, estado e destinação
+- [ ] Seção e Capítulo identificados na TIPI vigente (Decreto 11.158/2022)
+- [ ] Notas de Seção e de Capítulo lidas — produto não está excluído
+- [ ] RGI aplicada (qual das 6 regras foi usada?)
+- [ ] NCM de 8 dígitos localizado e ativo na TIPI
+- [ ] Descrição da TIPI confere com a descrição do produto
+- [ ] Verificado se existe Solução de Consulta para o produto ou similar
+- [ ] cClassTrib correspondente ao NCM consultado em [tribultz.com.br/classificacao](https://tribultz.com.br/classificacao)
+- [ ] Justificativa de classificação registrada em documento interno
+
+---
+
+## Erros comuns que geram multa
+
+| Erro | Consequência fiscal | Como evitar |
+|------|--------------------|-----------| 
+| Usar o NCM do fornecedor sem verificar | NCM pode estar errado na nota de entrada; você herda o erro na saída | Sempre confirme o NCM na TIPI para cada produto |
+| Classificar pelo material da embalagem | Produto classifica pelo conteúdo, não pela embalagem (RGI 5) | Leia a RGI 5 antes de usar NCM de embalagem |
+| Usar posição genérica "outros" sem justificativa | Multa por classificação imprecisa; IPI pode ser maior | Esgote as posições específicas antes de usar "outros" |
+| Não atualizar NCM após reformulação do produto | Produto alterado pode cair em posição diferente | Revisar NCM em cada alteração de composição |
+| Ignorar Soluções de Consulta divergentes | Autuação retroativa se a Receita adotar posição contrária | Pesquisar RFB antes de usar NCM disputado |
+| NCM correto, cClassTrib errado | Rejeição 1024 na SEFAZ + CBS/IBS calculado errado | Usar [classificador Tribultz](https://tribultz.com.br/classificacao) após confirmar NCM |
+
+A multa por classificação incorreta de NCM varia de **75% a 150% do IPI** não recolhido (Lei 9.430/1996), com acréscimo de juros SELIC. Em produtos com alíquota de IPI alta (bebidas, automóveis, cigarros), o passivo pode ser relevante.
+
+---
+
+## Como o Tribultz automatiza a classificação NCM → cClassTrib
+
+O [Classificador NCM → cClassTrib](https://tribultz.com.br/classificacao) da Tribultz parte do NCM já classificado e automatiza os passos seguintes:
+
+1. Consulta a tabela cClassTrib SVRS V1.36
+2. Retorna o cClassTrib correto para o NCM informado, considerando regime e tipo de operação
+3. Exibe o CST compatível e a base legal (qual Anexo da LC 214 se aplica)
+4. Disponibiliza o snippet XML pronto para inserção no ERP
+
+O classificador **não substitui a classificação do NCM em si** — essa ainda é responsabilidade do contador ou especialista fiscal. Mas ele elimina o passo manual e propenso a erro de mapear NCM → cClassTrib a partir da tabela SVRS.
+
+Para validação pré-emissão, o [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) aplica as 18 regras da NT 2025.002 sobre o XML completo — incluindo a compatibilidade NCM × cClassTrib, cálculos de CBS/IBS e completude do grupo gIBSCBS.
+
+Planos pagos (a partir de R$ 49,90/mês) oferecem acesso à API autenticada com até 50.000 consultas/mês, ideal para equipes de compliance que precisam revisar catálogos grandes de produtos antes de auditorias ou mudanças de leiaute da NF-e.
+
+→ **[Classificar NCM gratuitamente](https://tribultz.com.br/classificacao)**
+
+---
+
+## Perguntas frequentes
+
+**O NCM de 8 dígitos é o mesmo no Brasil e nos outros países do Mercosul?**
+
+Os 6 primeiros dígitos são padronizados internacionalmente pelo Sistema Harmonizado (SH/HS). Os dígitos 7 e 8 são específicos de cada país ou bloco. No Mercosul, os 8 dígitos da NCM são harmonizados entre Brasil, Argentina, Uruguai e Paraguai — mas diferem dos 10 dígitos usados na União Europeia e dos 10 dígitos do código HTS dos EUA.
+
+**Posso usar o NCM da nota fiscal de compra do fornecedor sem verificar?**
+
+É um ponto de partida, mas não é suficiente. Fornecedores também erram na classificação. O NCM que você declara na saída é de sua responsabilidade — independentemente do que está na nota de entrada. Use o NCM do fornecedor como referência, mas valide na TIPI.
+
+**Qual é a diferença entre posição, subposição e item NCM?**
+
+A posição tem 4 dígitos (ex: 3004 = medicamentos). A subposição tem 6 dígitos (ex: 3004.90 = outros medicamentos). O item/subitem tem 7 ou 8 dígitos (ex: 3004.90.99 = outros, não especificados). Para fins de NF-e, o NCM obrigatório é sempre de 8 dígitos.
+
+**Meu produto é fabricado no exterior e importado. O NCM muda na importação?**
+
+Não. O NCM do produto importado é o mesmo que seria usado na produção nacional. A diferença está nos tributos incidentes na importação (II, IPI, PIS/COFINS importação, ICMS importação) — não no NCM em si. Ao emitir NF-e de saída do produto importado, use o mesmo NCM declarado na DI.
+
+**A Receita Federal pode contestar meu NCM mesmo com Solução de Consulta?**
+
+Não, se o produto consultado for idêntico ao descrito na Solução de Consulta em vigor. A Solução tem efeito vinculante para a RFB enquanto estiver vigente. Se a Receita mudar de entendimento, ela emite nova Solução de Consulta e notifica os contribuintes com prazo para adequação.
+
+**O NCM impacta o preenchimento do CEST?**
+
+Sim. O CEST (Código Especificador da Substituição Tributária) é obrigatório para NCMs listados no Convênio ICMS 142/2018. Se o NCM correto do produto estiver nessa lista, o CEST precisa ser preenchido — a ausência gera [Rejeição 1024 adjacente por CEST_MISSING](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir) nas ferramentas de validação.
+
+---
+
+## Artigos relacionados
+
+- [Rejeição 1024 NF-e CBS/IBS: causas e como corrigir em 2026](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir)
+- [cClassTrib 2026: como mapear o NCM ao regime correto de IBS/CBS](/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs)
+- [cClassTrib 2026: mapeamento NCM × cClassTrib e como evitar a Rejeição 1024](/blog/classtrib-2026-ncm-mapeamento-completo)


### PR DESCRIPTION
## Summary

Dois posts pilar que completam a cobertura de conteúdo planejada no gap analysis.

### Post #298 — cClassTrib: como mapear NCM ao regime correto de IBS/CBS
- **2519 palavras** (benchmark Tax Radar: 2514 — superado)
- Diagrama ASCII da estrutura do cClassTrib (8 dígitos)
- Fluxo NCM → Anexo LC 214 → cClassTrib em texto estruturado
- 5 tabelas: estrutura do código, CSTs, Anexos LC 214, fatores que alteram regime, passo a passo
- Seção exclusiva sobre Simples Nacional
- 4 erros que geram Rejeição 1024 + 6 FAQ
- CTA → /classificacao; cross-links para #299 e #300

### Post #300 — Como classificar NCM corretamente em 2026
- **3022 palavras** (benchmark Tax Radar: 3194 — ~95%)
- Passo a passo em 6 etapas (TIPI → Seção → Capítulo → Posição → RGI → Confirmar)
- Tabela das 6 Regras Gerais de Interpretação (RGI)
- Exemplo real de kit multi-item com RGI 3b (kit primeiros socorros)
- Seção sobre Solução de Consulta RFB com dicas práticas
- Checklist de 9 itens para classificação correta
- 6 erros com multa + FAQ (6 perguntas)
- CTA → /classificacao; cross-links para #298 e #299

## Gates

```
npm test  → 69 pass, 0 fail
npm build → 4 posts SSG, 48 páginas estáticas ✓
```

Closes #298
Closes #300