### PR TITLE
feat(rules): MONOFASICO_ZERO — CST 620 downstream deve ter vCBS=vIBS=0 (#277)

### DIFF
--- a/backend/app/crews/tools/validate_ibscbs_rules_tool.py
+++ b/backend/app/crews/tools/validate_ibscbs_rules_tool.py
@@ -171,6 +171,24 @@ class ValidateIBSCBSRulesTool(BaseTool):
                     ),
                 })
 
+        # Rule 5c: MONOFASICO_ZERO — CST 620 downstream should not have tax > 0 (#277)
+        if cst == "620":
+            tax_val = _safe_float(vcbs)
+            ibs_tax_val = _safe_float(vibs)
+            if tax_val > 0 or ibs_tax_val > 0:
+                findings.append({
+                    "rule_id": "MONOFASICO_ZERO",
+                    "severity": "FATAL",
+                    "field": "IBS/CBS",
+                    "xpath": f"{xpath_base}//IBSCBS",
+                    "snippet": f"<CST>{cst}</CST> vCBS={vcbs} vIBS={vibs}",
+                    "recommendation": (
+                        "CST 620 (regime monofasico): o IBS/CBS e recolhido integralmente "
+                        "pelo fabricante/importador. Operacoes downstream devem ter vCBS=0 e vIBS=0 "
+                        "(Reg. CBS cap. 8 / Reg. IBS cap. 6). Valor > 0 indica duplo recolhimento."
+                    ),
+                })
+
         # Rule 6: IBSCBS_MISSING
         has_ibscbs = "IBSCBS" in (layout_tags.split(",") if layout_tags else [])
         if not has_ibscbs:

--- a/backend/app/services/fiscal_justification.py
+++ b/backend/app/services/fiscal_justification.py
@@ -248,6 +248,18 @@ FISCAL_JUSTIFICATIONS: dict[str, FiscalJustification] = {
             "Se houver tributação, corrija o CST para o código correspondente ao regime efetivo."
         ),
     },
+    "MONOFASICO_ZERO": {
+        "base_legal": "LC 214/2025 — Regime monofásico (Reg. CBS cap. 8 / Reg. IBS cap. 6)",
+        "explicacao": (
+            "O CST 620 indica regime monofásico, no qual o IBS/CBS é recolhido integralmente "
+            "pelo fabricante ou importador. Operações posteriores (distribuição, varejo) devem "
+            "declarar vCBS e vIBS iguais a zero. Valores maiores que zero indicam duplo recolhimento."
+        ),
+        "correcao": (
+            "Em operações downstream com CST 620, zere os campos vCBS, vIBS, vIBSUF e vIBSMun. "
+            "O tributo já foi recolhido na origem da cadeia monofásica."
+        ),
+    },
     "LAYOUT_PORTAL": {
         "base_legal": (
             "NT 2025.002-RTC, Seção 4 — Requisitos de Leiaute para Nota Nacional "

--- a/backend/tests/test_crewai_nfe_tools.py
+++ b/backend/tests/test_crewai_nfe_tools.py
@@ -329,6 +329,72 @@ def test_validate_cst_semantic_070():
     assert "CST_SEMANTIC" in rule_ids
 
 
+def test_validate_monofasico_zero_620():
+    """CST 620 (monofásico) downstream com vCBS > 0 deve disparar MONOFASICO_ZERO."""
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>620</CST>
+            <cClassTrib>620001</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <gIBSUF><pIBSUF>0.0005</pIBSUF><vIBSUF>0.50</vIBSUF></gIBSUF>
+              <gIBSMun><pIBSMun>0.0005</pIBSMun><vIBSMun>0.50</vIBSMun></gIBSMun>
+              <vIBS>1.00</vIBS>
+              <gCBS><pCBS>0.0090</pCBS><vCBS>9.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total><IBSCBSTot><vCBS>9.00</vCBS><vIBS>1.00</vIBS></IBSCBSTot></total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+    result = _parse_and_validate(xml)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "MONOFASICO_ZERO" in rule_ids
+
+
+def test_validate_monofasico_zero_620_ok():
+    """CST 620 com vCBS=vIBS=0 (downstream correto) não deve disparar MONOFASICO_ZERO."""
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc versao="4.00">
+  <NFe>
+    <infNFe versao="4.00">
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>620</CST>
+            <cClassTrib>620001</cClassTrib>
+            <gIBSCBS>
+              <vBC>0.00</vBC>
+              <vIBS>0.00</vIBS>
+              <gCBS><pCBS>0.0000</pCBS><vCBS>0.00</vCBS></gCBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total><IBSCBSTot><vCBS>0.00</vCBS><vIBS>0.00</vIBS></IBSCBSTot></total>
+    </infNFe>
+  </NFe>
+</nfeProc>"""
+    result = _parse_and_validate(xml)
+    rule_ids = [f["rule_id"] for f in result["findings"]]
+    assert "MONOFASICO_ZERO" not in rule_ids
+
+
 def test_validate_cbs_calc_error():
     """vCBS wrong calculation should trigger IBSCBS_CALC."""
     xml = """\

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -399,6 +399,56 @@ test("CST_GROUP_MATCH: NF-e with CST 000 but no gIBSCBS gera FATAL", () => {
   assert.ok(f, "CST_GROUP_MATCH finding expected — CST 000 requires gIBSCBS");
 });
 
+// ── S22 (#277): MONOFASICO_ZERO — CST 620 downstream deve ter vCBS=vIBS=0 ────
+
+test("MONOFASICO_ZERO: NF-e com CST 620 e vCBS>0 gera FATAL", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod></ide>
+  <emit><CNPJ>12345678000195</CNPJ></emit>
+  <det nItem="1">
+    <prod><NCM>27101259</NCM><vProd>100</vProd></prod>
+    <imposto><IBSCBS>
+      <CST>620</CST>
+      <cClassTrib>620001</cClassTrib>
+      <gIBSCBSMono>
+        <vBC>1000.00</vBC>
+        <vIBS>1.00</vIBS>
+        <vCBS>9.00</vCBS>
+      </gIBSCBSMono>
+    </IBSCBS></imposto>
+  </det>
+  <total><IBSCBSTot><vIBS>1.00</vIBS><vCBS>9.00</vCBS></IBSCBSTot></total>
+</infNFe></NFe></nfeProc>`;
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  const f = result.findings.find((f) => f.rule_id === "MONOFASICO_ZERO");
+  assert.ok(f, "MONOFASICO_ZERO finding expected — CST 620 downstream com valor > 0");
+  assert.equal(f!.severity, "FATAL");
+});
+
+test("MONOFASICO_ZERO: NF-e com CST 620 e vCBS=vIBS=0 não gera finding", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod></ide>
+  <emit><CNPJ>12345678000195</CNPJ></emit>
+  <det nItem="1">
+    <prod><NCM>27101259</NCM><vProd>100</vProd></prod>
+    <imposto><IBSCBS>
+      <CST>620</CST>
+      <cClassTrib>620001</cClassTrib>
+      <gIBSCBSMono>
+        <vBC>1000.00</vBC>
+        <vIBS>0.00</vIBS>
+        <vCBS>0.00</vCBS>
+      </gIBSCBSMono>
+    </IBSCBS></imposto>
+  </det>
+  <total><IBSCBSTot><vIBS>0.00</vIBS><vCBS>0.00</vCBS></IBSCBSTot></total>
+</infNFe></NFe></nfeProc>`;
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  assert.equal(result.findings.find((f) => f.rule_id === "MONOFASICO_ZERO"), undefined);
+});
+
 // ── S11: LAYOUT_NFE — NF-e structure check ──────────────────────────────────
 
 test("LAYOUT_NFE: NF-e sem emit gera FATAL", () => {

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -369,6 +369,29 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
         );
       }
     }
+
+    // CST 620 (monofásico): operações downstream devem ter vCBS = vIBS = 0 (#277)
+    if (cst.value === "620") {
+      const taxVal = parseFloat(vCBS?.value ?? valorCbs?.value ?? "0");
+      const ibsTaxVal = parseFloat(vIBS?.value ?? valorIbs?.value ?? "0");
+      if (taxVal > 0 || ibsTaxVal > 0) {
+        const evId = makeEvidenceId("MONOFASICO_ZERO");
+        pushFindingAndEvidence(findings, evidences, evidenceById,
+          makeFinding({
+            id: "F_MONOFASICO_ZERO",
+            severity: "FATAL",
+            ruleId: "MONOFASICO_ZERO",
+            title: `CST 620 (Monofásico) não deve ter valores tributários > 0 — recolhimento é do fabricante/importador`,
+            field: "IBS/CBS",
+            xpath: inferXpath("IBSCBS", docType),
+            snippet: cst.snippet,
+            evidenceId: evId,
+            recommendation: `CST 620 (regime monofásico): o IBS/CBS é recolhido integralmente pelo fabricante/importador. Operações downstream devem ter vCBS=0 e vIBS=0 (Reg. CBS cap. 8 / Reg. IBS cap. 6). Valor > 0 indica duplo recolhimento.`,
+          }),
+          makeEvidence({ id: evId, type: "xml", label: `CST 620 — valor monofásico incoerente`, xpath: inferXpath("IBSCBS", docType), snippet: cst.snippet }),
+        );
+      }
+    }
   }
 
   // ── Rule 6: IBSCBS_MISSING — IBS/CBS fields must be present ──────────────


### PR DESCRIPTION
## O que

Nova regra determinística **`MONOFASICO_ZERO`**: em operações com **CST 620 (regime monofásico)**, o IBS/CBS é recolhido integralmente pelo fabricante/importador — operações downstream (distribuição/varejo) devem declarar `vCBS=0` e `vIBS=0`. Valor > 0 → **FATAL** (duplo recolhimento).

Espelha a regra irmã `CST_SEMANTIC` (070/410), que não cobria CST 620.

## Dual-stack
- `frontend/src/lib/validation/xmlRules.ts` — regra MONOFASICO_ZERO
- `backend/app/crews/tools/validate_ibscbs_rules_tool.py` — Rule 5c espelhada
- `backend/app/services/fiscal_justification.py` — base legal
- +4 testes (positivo/negativo nos dois stacks)

## Gates locais
- Frontend: 71/71 testes + build OK
- Backend rule engine (sem DB): 24/24 — inclui os novos + CST_SEMANTIC intacta
- Ruff: limpo
- Suíte backend completa depende de Postgres (validada no CI `backend-gates`)

## Base legal
LC 214/2025; Regulamentos IBS/CBS 30/abr/2026 (Reg. CBS cap. 8 / Reg. IBS cap. 6).

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)