### PR TITLE
feat(rules): IBS/CBS obrigatório ciente do CRT — Simples/MEI só em 2027 (#311)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -285,6 +285,9 @@ def validate_xml(
     v_ibs_mun = _first_tag(xml, ["vIBSMun"])
     v_ibs = _first_tag(xml, ["vIBS"])
 
+    # CRT do emitente (NT 2025.002 v1.40 #311): 1/2=Simples Nacional, 3=Regime Normal, 4=MEI
+    crt = _first_tag(xml, ["CRT"])
+
     # dPrevEntrega fields (NT 2025.002 V1.36 + Cartilha CGIBS item 1.1)
     d_prev_entrega = _first_tag(xml, ["dPrevEntrega"])
     dh_emi = _first_tag(xml, ["dhEmi"])
@@ -354,12 +357,20 @@ def validate_xml(
 
     # ── Rule 6: IBSCBS_MISSING ───────────────────────────────────────────────
 
-    _ibscbs_sev = _pedagogical_severity("IBSCBS_MISSING", pedagogical_mode)
+    # NT 2025.002 v1.40 (#311): obrigatoriedade de IBS/CBS é faseada por regime —
+    # Simples/MEI (CRT 1/2/4) só a partir de 04/01/2027. Não emitir FATAL por ausência
+    # nesses regimes; Regime Normal (CRT 3) segue o cronograma (03/08/2026).
+    _crt_val = crt["value"].strip() if crt else ""
+    _is_simples_mei = _crt_val in ("1", "2", "4")
+    _ibscbs_sev = "WARNING" if _is_simples_mei else _pedagogical_severity("IBSCBS_MISSING", pedagogical_mode)
+    _simples_note = " Simples Nacional/MEI: obrigatório a partir de 04/01/2027 (NT 2025.002 v1.40)."
     if has_ibscbs:
         if not ibscbs_block:
             ev_id = "E_XML_IBSCBS_MISSING"
             _rec = "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo."
-            if _ibscbs_sev == "WARNING":
+            if _is_simples_mei:
+                _rec += _simples_note
+            elif _ibscbs_sev == "WARNING":
                 _rec += _LC227_RECOMMENDATION
             _add(
                 Finding(id="F_IBSCBS_MISSING", severity=_ibscbs_sev, rule_id="IBSCBS_MISSING", title="Grupo IBSCBS ausente — obrigatório conforme NT 2025.002", where=FindingWhere(field="IBSCBS", xpath=_xpath("imposto", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
@@ -370,7 +381,9 @@ def validate_xml(
         if not has_legacy:
             ev_id = "E_XML_IBSCBS_MISSING"
             _rec = "Informar alíquota e valor de IBS e CBS conforme LC 214."
-            if _ibscbs_sev == "WARNING":
+            if _is_simples_mei:
+                _rec += _simples_note
+            elif _ibscbs_sev == "WARNING":
                 _rec += _LC227_RECOMMENDATION
             _add(
                 Finding(id="F_IBSCBS_MISSING", severity=_ibscbs_sev, rule_id="IBSCBS_MISSING", title="IBS/CBS ausentes na nota", where=FindingWhere(field="IBS/CBS", xpath=_xpath("Valores", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -166,6 +166,41 @@ class TestNfeValidation:
         rules = [f.rule_id for f in result.findings if f.severity == "FATAL"]
         assert "IBSCBS_CALC" in rules
 
+    # NT 2025.002 v1.40 (#311): obrigatoriedade de IBS/CBS é faseada por regime —
+    # CRT 3 (Regime Normal) 03/08/2026; CRT 1/2/4 (Simples/MEI) só 04/01/2027.
+    _NFE_SEM_IBSCBS = """<nfeProc><NFe><infNFe>
+      <ide><mod>55</mod></ide>
+      <emit><CNPJ>12345678000195</CNPJ><CRT>{crt}</CRT></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>
+        <imposto><ICMS><ICMSSN101><CST>101</CST></ICMSSN101></ICMS></imposto>
+      </det>
+      <total></total>
+    </infNFe></NFe></nfeProc>"""
+
+    def test_ibscbs_missing_simples_crt1_is_warning(self):
+        """Simples Nacional (CRT 1) sem IBS/CBS → WARNING, não FATAL (obrigatório só 04/01/2027)."""
+        result = validate_xml(self._NFE_SEM_IBSCBS.format(crt="1"), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing, "IBSCBS_MISSING esperado"
+        assert all(f.severity == "WARNING" for f in missing), \
+            f"CRT 1 (Simples) deve ser WARNING: {[f.severity for f in missing]}"
+
+    def test_ibscbs_missing_mei_crt4_is_warning(self):
+        """MEI (CRT 4) sem IBS/CBS → WARNING (obrigatório só 04/01/2027)."""
+        result = validate_xml(self._NFE_SEM_IBSCBS.format(crt="4"), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing and all(f.severity == "WARNING" for f in missing), \
+            f"CRT 4 (MEI) deve ser WARNING: {[f.severity for f in missing]}"
+
+    def test_ibscbs_missing_regime_normal_crt3_is_fatal(self):
+        """Regime Normal (CRT 3) sem IBS/CBS → FATAL (obrigatório 03/08/2026)."""
+        result = validate_xml(self._NFE_SEM_IBSCBS.format(crt="3"), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing, "IBSCBS_MISSING esperado"
+        assert all(f.severity == "FATAL" for f in missing), \
+            f"CRT 3 (Regime Normal) deve ser FATAL: {[f.severity for f in missing]}"
+
 
 # ── NFC-e validation ─────────────────────────────────────────────────────────
 

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -327,6 +327,41 @@ test("NF-e v1.40 (campos/grupos novos) não gera FATAL", () => {
   );
 });
 
+// ── S22 (#311): IBS/CBS obrigatório ciente do CRT (NT v1.40) ─────────────────
+// CRT 3 (Regime Normal): obrigatório 03/08/2026 → FATAL.
+// CRT 1/2/4 (Simples/MEI): obrigatório só 04/01/2027 → WARNING (não falso-rejeitar).
+
+const nfeSemIbscbs = (crt: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod></ide>
+  <emit><CNPJ>12345678000195</CNPJ><CRT>${crt}</CRT></emit>
+  <det nItem="1">
+    <prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>
+    <imposto><ICMS><ICMSSN101><CST>101</CST></ICMSSN101></ICMS></imposto>
+  </det>
+  <total></total>
+</infNFe></NFe></nfeProc>`;
+
+test("IBSCBS_MISSING: CRT 1 (Simples) sem IBS/CBS → WARNING (#311)", () => {
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: nfeSemIbscbs("1") });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.ok(f, "IBSCBS_MISSING esperado");
+  assert.equal(f!.severity, "WARNING");
+});
+
+test("IBSCBS_MISSING: CRT 4 (MEI) sem IBS/CBS → WARNING (#311)", () => {
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: nfeSemIbscbs("4") });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.equal(f?.severity, "WARNING");
+});
+
+test("IBSCBS_MISSING: CRT 3 (Regime Normal) sem IBS/CBS → FATAL (#311)", () => {
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: nfeSemIbscbs("3") });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.ok(f, "IBSCBS_MISSING esperado");
+  assert.equal(f!.severity, "FATAL");
+});
+
 // ── S11: NFC-e ok — no FATALs ──────────────────────────────────────────────
 
 test("NFC-e ok não gera FATAL", () => {

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -244,6 +244,18 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   const vIBSMun = firstTag(xml, ["vIBSMun"]);
   const vIBS = firstTag(xml, ["vIBS"]);
 
+  // CRT do emitente (NT 2025.002 v1.40 #311): 1/2=Simples Nacional, 3=Regime Normal, 4=MEI.
+  // Obrigatoriedade de IBS/CBS é faseada: Simples/MEI só a partir de 04/01/2027 → WARNING,
+  // não FATAL (evita falso-rejeitar); Regime Normal (CRT 3) segue o cronograma (03/08/2026).
+  const crt = firstTag(xml, ["CRT"]);
+  const crtVal = crt?.value?.trim() ?? "";
+  const isSimplesOrMei = crtVal === "1" || crtVal === "2" || crtVal === "4";
+  const ibsCbsMissingSev: FindingSeverity = isSimplesOrMei
+    ? "WARNING"
+    : pedagogicalSeverity("IBSCBS_MISSING", pedMode);
+  const SIMPLES_MEI_NOTE =
+    " Simples Nacional/MEI: obrigatório a partir de 04/01/2027 (NT 2025.002 v1.40).";
+
   // NF-e totals
   const ibscbsTot = firstTag(xml, ["IBSCBSTot"]);
   const totVIBS = ibscbsTot ? firstTag(ibscbsTot.snippet, ["vIBS"]) : null;
@@ -412,14 +424,16 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
       pushFindingAndEvidence(findings, evidences, evidenceById,
         makeFinding({
           id: "F_IBSCBS_MISSING",
-          severity: "FATAL",
+          severity: ibsCbsMissingSev,
           ruleId: "IBSCBS_MISSING",
           title: "Grupo IBSCBS ausente — obrigatório conforme NT 2025.002",
           field: "IBSCBS",
           xpath: inferXpath("imposto", docType),
           snippet: "<!-- Grupo <IBSCBS> não encontrado em <imposto> -->",
           evidenceId: evId,
-          recommendation: "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo conforme NT 2025.002.",
+          recommendation:
+            "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo conforme NT 2025.002." +
+            (isSimplesOrMei ? SIMPLES_MEI_NOTE : ""),
         }),
         makeEvidence({ id: evId, type: "xml", label: "IBSCBS — grupo ausente", xpath: inferXpath("imposto", docType), snippet: "<!-- Grupo <IBSCBS> não encontrado -->" }),
       );
@@ -432,14 +446,16 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
       pushFindingAndEvidence(findings, evidences, evidenceById,
         makeFinding({
           id: "F_IBSCBS_MISSING",
-          severity: "FATAL",
+          severity: ibsCbsMissingSev,
           ruleId: "IBSCBS_MISSING",
           title: "IBS/CBS ausentes na nota — obrigatório informar percentual e valor",
           field: "IBS/CBS",
           xpath: inferXpath("Valores", docType),
           snippet: "<!-- Tags ValorCBS, ValorIBS, AliquotaCBS, AliquotaIBS não encontradas -->",
           evidenceId: evId,
-          recommendation: "Informar alíquota e valor de IBS (0,90%) e CBS (0,10%) conforme LC 214.",
+          recommendation:
+            "Informar alíquota e valor de IBS (0,90%) e CBS (0,10%) conforme LC 214." +
+            (isSimplesOrMei ? SIMPLES_MEI_NOTE : ""),
         }),
         makeEvidence({ id: evId, type: "xml", label: "IBS/CBS — campos ausentes", xpath: inferXpath("Valores", docType), snippet: "<!-- Tags ValorCBS, ValorIBS, AliquotaCBS, AliquotaIBS não encontradas -->" }),
       );


### PR DESCRIPTION
## O que

NT 2025.002 v1.40 fasou a **obrigatoriedade de IBS/CBS por regime tributário**. Hoje o `IBSCBS_MISSING` dispara igual pra todos — o que **falso-rejeita** notas do Simples/MEI, que só são obrigadas em 2027.

| CRT | Regime | Obrigatório desde | Severidade IBSCBS_MISSING |
|---|---|---|---|
| 3 | Regime Normal | **03/08/2026** | FATAL (mantém) |
| 1, 2 | Simples Nacional | **04/01/2027** | **WARNING** |
| 4 | MEI | **04/01/2027** | **WARNING** |

Lê `<CRT>` do emitente e ajusta a severidade; recomendação informa o prazo de 2027 para Simples/MEI.

## Dual-stack
- `backend/app/routers/validate_xml.py` — validador de produção
- `frontend/src/lib/validation/xmlRules.ts` — paridade (e passa a respeitar o modo pedagógico no IBSCBS_MISSING)
- **+6 testes** (CRT 1/4 → WARNING, CRT 3 → FATAL nos dois stacks)

## Escopo (transparência)
Implementa a **obrigatoriedade faseada (Rej. 1115)** — o item de maior valor e menor risco do #311. As demais rejeições v1.40 ficam **deferidas** por exigirem dados/algoritmos externos que não temos:
- C22/UB66 (SUFRAMA/ZFM): DV SUFRAMA + lista de municípios incentivados
- BB05 (compras governamentais): 20 regras de estrutura de referência
- UB24/43/62/63 (devolução tributária)

`DFeReferenciado` (VC02/VC03/Rej. 321) → **#312**.

## Gates
- Backend `test_validate_xml.py`: 17/17 + ruff limpo
- Frontend: 76/76 + build OK
- **Toca backend → deploy Magalu no merge**

Refs #311
