### PR TITLE
feat(rules): janela sem penalidades IBS/CBS — auto-downgrade por dhEmi (Ato Conjunto RFB/CGIBS 1/25)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -231,6 +231,35 @@ def _pedagogical_severity(rule_id: str, pedagogical_mode: bool) -> str:
     return "FATAL"
 
 
+# ── Ato Conjunto RFB/CGIBS nº 1/2025 — janela sem penalidades ────────────────
+# Art. 3º: penalidades por descumprimento de obrigações acessórias de IBS/CBS
+# suspensas até o 1º dia do 4º mês subsequente à publicação da parte comum dos
+# regulamentos (Decreto 12.955/2026 + Resolução CGIBS 6/2026, publicados em
+# 30/04/2026). Sem multa para fatos geradores até 31/07/2026; a partir de
+# 01/08/2026 a penalidade volta a ser aplicável → FATAL. Distinto e combinável
+# com o pedagogical_mode (LC 227/2026 art. 348), que é override manual.
+_NO_PENALTY_WINDOW_START = "2026-01-01"
+_NO_PENALTY_WINDOW_END = "2026-08-01"  # exclusivo: notas a partir desta data são penalizáveis
+
+_ATO_CONJUNTO_RECOMMENDATION = (
+    " — Período sem penalidades (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º): "
+    "obrigação acessória de IBS/CBS sem multa para fatos geradores até 31/07/2026 "
+    "(parte comum dos regulamentos publicada em 30/04/2026). "
+    "A partir de 01/08/2026 a penalidade é aplicável."
+)
+
+
+def _within_no_penalty_window(emission_date: dict | None) -> bool:
+    """True se a data de emissão (dhEmi/NFS-e) cai na janela sem penalidades do Ato Conjunto 1/25."""
+    if not emission_date:
+        return False
+    date_part = emission_date["value"][:10]  # YYYY-MM-DD
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_part):
+        return False
+    # Comparação lexicográfica é válida para datas ISO YYYY-MM-DD.
+    return _NO_PENALTY_WINDOW_START <= date_part < _NO_PENALTY_WINDOW_END
+
+
 def validate_xml(
     xml: str,
     doc_type: str | None = None,
@@ -292,6 +321,10 @@ def validate_xml(
     d_prev_entrega = _first_tag(xml, ["dPrevEntrega"])
     dh_emi = _first_tag(xml, ["dhEmi"])
     mod_frete = _first_tag(xml, ["modFrete"])
+
+    # Data de emissão para a janela sem penalidades (Ato Conjunto 1/25): NF-e usa
+    # dhEmi; NFS-e legado usa DataEmissao/dhEmissao/dhProc/dEmi.
+    emission_date = dh_emi or _first_tag(xml, ["DataEmissao", "dhEmissao", "dhProc", "dEmi"])
 
     # NFS-e legacy fields
     valor_cbs = _first_tag(xml, ["ValorCBS", "vCBS"])
@@ -653,6 +686,16 @@ def validate_xml(
                 Finding(id="F_CNPJ_UNAVAIL", severity="ALERT", rule_id="CNPJ_ACTIVE", title="Verificação de CNPJ indisponível — API fora do ar", where=FindingWhere(field="CNPJ", xpath=_xpath("CNPJ", doc_type)), recommendation="APIs de consulta CNPJ temporariamente indisponíveis. Verifique manualmente.", evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="CNPJ — API indisponível", xpath=_xpath("CNPJ", doc_type)),
             )
+
+    # ── Janela sem penalidades (Ato Conjunto RFB/CGIBS 1/25) — passe final ────
+    # Downgrade automático FATAL → WARNING das obrigações acessórias quando a
+    # nota cai na janela (por dhEmi). O pedagogical_mode (LC 227) já foi aplicado
+    # inline acima; esta passada cobre o caso automático por data.
+    if _within_no_penalty_window(emission_date):
+        for f in findings:
+            if f.severity == "FATAL" and f.rule_id in _PEDAGOGICAL_ACCESSORY_RULES:
+                f.severity = "WARNING"
+                f.recommendation = (f.recommendation or "") + _ATO_CONJUNTO_RECOMMENDATION
 
     fatals = sum(1 for f in findings if f.severity == "FATAL")
     alerts = sum(1 for f in findings if f.severity in ("ALERT", "WARNING"))

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -221,3 +221,61 @@ class TestRouterRegistered:
         from app.main import app
         paths = [getattr(r, "path", "") for r in app.routes]
         assert "/api/v1/validate/xml" in paths
+
+
+# ── Item 1: janela sem penalidades — Ato Conjunto RFB/CGIBS nº 1/2025 art. 3º ──
+
+
+class TestNoPenaltyWindow:
+    """Multas por obrigação acessória suspensas para fatos geradores até 31/07/2026.
+    A partir de 01/08/2026 a penalidade volta a ser FATAL. pedagogical_mode (LC 227)
+    permanece como override manual independente da data."""
+
+    _NFE = """<nfeProc><NFe><infNFe>
+      <ide><mod>55</mod>{dh}</ide>
+      <emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>
+        <imposto><ICMS><ICMSSN101><CST>101</CST></ICMSSN101></ICMS></imposto>
+      </det>
+      <total></total>
+    </infNFe></NFe></nfeProc>"""
+
+    def _nfe(self, dh=None):
+        return self._NFE.format(dh=f"<dhEmi>{dh}</dhEmi>" if dh else "")
+
+    def test_dentro_da_janela_downgrade_para_warning(self):
+        result = validate_xml(self._nfe("2026-07-31T10:00:00-03:00"), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing, "IBSCBS_MISSING esperado"
+        assert all(f.severity == "WARNING" for f in missing)
+        assert any("Ato Conjunto RFB/CGIBS" in (f.recommendation or "") for f in missing)
+
+    def test_limite_01_08_2026_volta_a_fatal(self):
+        result = validate_xml(self._nfe("2026-08-01T10:00:00-03:00"), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing and all(f.severity == "FATAL" for f in missing)
+
+    def test_fora_da_janela_fatal(self):
+        result = validate_xml(self._nfe("2026-08-15T10:00:00-03:00"), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing and all(f.severity == "FATAL" for f in missing)
+
+    def test_sem_dhemi_preserva_fatal(self):
+        result = validate_xml(self._nfe(), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing and all(f.severity == "FATAL" for f in missing)
+
+    def test_pedagogical_mode_fora_da_janela_warning(self):
+        result = validate_xml(self._nfe("2026-09-10T10:00:00-03:00"), "NFE", pedagogical_mode=True)
+        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
+        assert missing and all(f.severity == "WARNING" for f in missing)
+        assert any("LC 227/2026" in (f.recommendation or "") for f in missing)
+
+    def test_regra_nao_acessoria_permanece_fatal_na_janela(self):
+        # IBSCBS_SPLIT é regra de cálculo, não obrigação acessória → não entra na janela.
+        xml = NFE_OK.replace("<mod>55</mod>", "<mod>55</mod><dhEmi>2026-05-10T10:00:00-03:00</dhEmi>", 1)
+        xml = xml.replace("<vIBS>1.00</vIBS>", "<vIBS>1.50</vIBS>", 1)
+        result = validate_xml(xml, "NFE")
+        split = [f for f in result.findings if f.rule_id == "IBSCBS_SPLIT"]
+        assert split and all(f.severity == "FATAL" for f in split)

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -664,3 +664,86 @@ test("SPLIT_PAYMENT_INDPAG: indPag=0 (à vista) sem CBS/IBS não gera finding", 
   const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
   assert.equal(result.findings.find((f) => f.rule_id === "SPLIT_PAYMENT_INDPAG"), undefined);
 });
+
+// ── Item 1: janela sem penalidades — Ato Conjunto RFB/CGIBS nº 1/2025 art. 3º ──
+// Multas por obrigação acessória de IBS/CBS suspensas para fatos geradores até
+// 31/07/2026 (regulamentos publicados 30/04/2026). A partir de 01/08/2026 a
+// penalidade volta a ser aplicável → severidade FATAL. pedagogicalMode (LC 227)
+// permanece como override manual independente da data.
+
+const nfeAcessoriaErr = (crt: string, dhEmi?: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod>${dhEmi ? `<dhEmi>${dhEmi}</dhEmi>` : ""}</ide>
+  <emit><CNPJ>12345678000195</CNPJ><CRT>${crt}</CRT></emit>
+  <det nItem="1">
+    <prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>
+    <imposto><ICMS><ICMSSN101><CST>101</CST></ICMSSN101></ICMS></imposto>
+  </det>
+  <total></total>
+</infNFe></NFe></nfeProc>`;
+
+test("janela: CRT 3 com dhEmi 2026-07-31 → IBSCBS_MISSING WARNING (sem penalidade)", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-07-31T10:00:00-03:00"),
+  });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.ok(f, "IBSCBS_MISSING esperado");
+  assert.equal(f!.severity, "WARNING");
+  assert.match(f!.recommendation ?? "", /Ato Conjunto RFB\/CGIBS/);
+});
+
+test("janela: CRT 3 com dhEmi 2026-08-01 → IBSCBS_MISSING FATAL (janela fechada)", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-08-01T10:00:00-03:00"),
+  });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.equal(f?.severity, "FATAL");
+});
+
+test("janela: CRT 3 com dhEmi 2026-08-15 → IBSCBS_MISSING FATAL", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-08-15T10:00:00-03:00"),
+  });
+  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBS_MISSING")?.severity, "FATAL");
+});
+
+test("janela: CRT 3 sem dhEmi → IBSCBS_MISSING FATAL (comportamento preservado)", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3"),
+  });
+  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBS_MISSING")?.severity, "FATAL");
+});
+
+test("janela: fora da janela + pedagogicalMode → WARNING com nota LC 227", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-09-10T10:00:00-03:00"),
+    pedagogicalMode: true,
+  });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.equal(f?.severity, "WARNING");
+  assert.match(f!.recommendation ?? "", /LC 227\/2026/);
+});
+
+test("janela: regra de formato (CST_3_DIGITS) dentro da janela → WARNING", () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod><dhEmi>2026-05-10T10:00:00-03:00</dhEmi></ide>
+  <emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>
+  <det nItem="1">
+    <prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>
+    <imposto><IBSCBS><CST>00</CST><cClassTrib>000001</cClassTrib></IBSCBS></imposto>
+  </det>
+  <total></total>
+</infNFe></NFe></nfeProc>`;
+  const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml });
+  assert.equal(result.findings.find((f) => f.rule_id === "CST_3_DIGITS")?.severity, "WARNING");
+});
+
+test("janela: regra NÃO-acessória (IBSCBS_SPLIT) dentro da janela permanece FATAL", () => {
+  // fixture nfe-ibs-split-error.xml tem dhEmi 2026-03-23 (dentro da janela)
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: fixture("nfe-ibs-split-error.xml"),
+  });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_SPLIT");
+  assert.equal(f?.severity, "FATAL", "regra de cálculo não é obrigação acessória — não entra na janela");
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -41,11 +41,30 @@ const LC227_NOTE =
   "se autuado exclusivamente por esta obrigação acessória, " +
   "há 60 dias para regularizar sem aplicação de multa.";
 
-function pedagogicalSeverity(
-  ruleId: string,
-  pedagogicalMode: boolean,
-): "FATAL" | "WARNING" {
-  return pedagogicalMode && PEDAGOGICAL_ACCESSORY_RULES.has(ruleId) ? "WARNING" : "FATAL";
+// ── Ato Conjunto RFB/CGIBS nº 1/2025 — janela sem penalidades ─────────────────
+// Art. 3º: penalidades por descumprimento de obrigações acessórias de IBS/CBS
+// ficam suspensas até o 1º dia do 4º mês subsequente à publicação da parte comum
+// dos regulamentos (Decreto 12.955/2026 + Resolução CGIBS 6/2026, publicados em
+// 30/04/2026). Logo: sem multa para fatos geradores até 31/07/2026; a partir de
+// 01/08/2026 a penalidade volta a ser aplicável → severidade FATAL.
+// A dispensa de *recolhimento* (pagamento) cobre 2026 inteiro, mas aqui tratamos
+// apenas a suspensão de *multa* por obrigação acessória (o que o motor valida).
+const NO_PENALTY_WINDOW_START = "2026-01-01";
+const NO_PENALTY_WINDOW_END = "2026-08-01"; // exclusivo: notas a partir desta data são penalizáveis
+
+const ATO_CONJUNTO_NOTE =
+  " — Período sem penalidades (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º): " +
+  "obrigação acessória de IBS/CBS sem multa para fatos geradores até 31/07/2026 " +
+  "(parte comum dos regulamentos publicada em 30/04/2026). " +
+  "A partir de 01/08/2026 a penalidade é aplicável.";
+
+/** Data de emissão (dhEmi/NFS-e) dentro da janela sem penalidades do Ato Conjunto 1/25. */
+function isWithinNoPenaltyWindow(emissionDate: string | undefined): boolean {
+  if (!emissionDate) return false;
+  const datePart = emissionDate.slice(0, 10); // YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return false;
+  // Comparação lexicográfica é válida para datas ISO YYYY-MM-DD.
+  return datePart >= NO_PENALTY_WINDOW_START && datePart < NO_PENALTY_WINDOW_END;
 }
 
 // ── CST table (NT 2025.002-RTC) ────────────────────────────────────────────
@@ -226,6 +245,11 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   const dhEmi = firstTag(xml, ["dhEmi"]);
   const modFrete = firstTag(xml, ["modFrete"]);
 
+  // Data de emissão para a janela sem penalidades (Ato Conjunto 1/25): NF-e usa
+  // dhEmi; NFS-e legado usa DataEmissao/dhEmissao/dhProc/dEmi. Mantemos dhEmi
+  // separado para as regras de competência (dPrevEntrega).
+  const emissionDate = dhEmi ?? firstTag(xml, ["DataEmissao", "dhEmissao", "dhProc", "dEmi"]);
+
   // NFS-e legacy fields
   const serviceCode = firstTag(xml, ["CodigoServico", "cServ", "codigoServico"]);
   const valorCbs = firstTag(xml, ["ValorCBS", "vCBS"]);
@@ -250,9 +274,10 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   const crt = firstTag(xml, ["CRT"]);
   const crtVal = crt?.value?.trim() ?? "";
   const isSimplesOrMei = crtVal === "1" || crtVal === "2" || crtVal === "4";
-  const ibsCbsMissingSev: FindingSeverity = isSimplesOrMei
-    ? "WARNING"
-    : pedagogicalSeverity("IBSCBS_MISSING", pedMode);
+  // Simples/MEI: WARNING por faseamento (obrigatório só 04/01/2027). Demais: FATAL —
+  // o downgrade por pedagogicalMode (LC 227) e pela janela sem penalidades (Ato
+  // Conjunto 1/25) é centralizado no passe final, como nas outras regras acessórias.
+  const ibsCbsMissingSev: FindingSeverity = isSimplesOrMei ? "WARNING" : "FATAL";
   const SIMPLES_MEI_NOTE =
     " Simples Nacional/MEI: obrigatório a partir de 04/01/2027 (NT 2025.002 v1.40).";
 
@@ -966,13 +991,20 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
     }),
   );
 
-  // ── Modo Pedagógico LC 227/2026 — downgrade obrigações acessórias ─────────
-  if (pedMode) {
+  // ── Downgrade de obrigações acessórias FATAL → WARNING ────────────────────
+  // Duas bases legais independentes e combináveis:
+  //  - pedagogicalMode (LC 227/2026 art. 348): flag manual, 60 dias p/ regularizar;
+  //  - janela sem penalidades (Ato Conjunto RFB/CGIBS 1/25): automática por dhEmi,
+  //    fatos geradores até 31/07/2026.
+  const noPenaltyWindow = isWithinNoPenaltyWindow(emissionDate?.value);
+  if (pedMode || noPenaltyWindow) {
     for (const f of findings) {
       if (f.severity === "FATAL" && PEDAGOGICAL_ACCESSORY_RULES.has(f.rule_id)) {
         (f as { severity: string }).severity = "WARNING";
-        (f as { recommendation: string }).recommendation =
-          (f.recommendation || "") + LC227_NOTE;
+        let note = "";
+        if (pedMode) note += LC227_NOTE;
+        if (noPenaltyWindow) note += ATO_CONJUNTO_NOTE;
+        (f as { recommendation: string }).recommendation = (f.recommendation || "") + note;
       }
     }
   }


### PR DESCRIPTION
## Contexto

Em **2026** a apuração de IBS/CBS é meramente informativa. O **Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º** suspende as penalidades por descumprimento de **obrigações acessórias** até o 1º dia do 4º mês subsequente à publicação da parte comum dos regulamentos (Decreto 12.955/2026 + Resolução CGIBS 6/2026, publicados em **30/04/2026**).

➡️ Sem multa para fatos geradores **até 31/07/2026**; a partir de **01/08/2026** a penalidade volta a ser aplicável.

## O que muda

- **Auto-downgrade `FATAL` → `WARNING`** das obrigações acessórias quando o **fato gerador (`dhEmi`) ≤ 31/07/2026**, com nota do Ato Conjunto 1/25.
- A partir de **01/08/2026** volta a `FATAL` (rigor legal).
- Critério automático por data de emissão (`dhEmi`; NFS-e: `DataEmissao`/`dhEmissao`/`dhProc`/`dEmi`). Combinável com o `pedagogicalMode` manual (LC 227/2026 art. 348).
- Regras de cálculo (`IBSCBS_CALC`/`SPLIT`) nunca entram na janela.
- Espelhado: frontend (`xmlRules.ts`) + backend (`validate_xml.py`).
- Correção de paridade: `IBSCBS_MISSING` agora é `FATAL` (exceto Simples/MEI), downgrade pedagógico centralizado no passe final.

## Testes & Verificação

- +7 frontend, +6 backend (cobrindo também o `pedagogicalMode`, antes sem cobertura).
- Frontend **83/83** + build OK; Backend **72/72** + `ruff` limpo.
- Fronteiras verificadas: 2025→FATAL, 2026-01..07→WARNING, 08-01/2027→FATAL, malformada→FATAL, NFS-e fallback→WARNING.
