### PR TITLE
feat(rules): IMPORT_IBSCBS_REQUIRED — incidência de IBS/CBS na importação (Decreto 12.955/2026)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -120,6 +120,14 @@ def _first_tag(xml: str, tags: list[str]) -> dict[str, Any] | None:
     return None
 
 
+def _to_float(value: str | None) -> float:
+    """Parse a numeric string to float; returns 0.0 on missing/invalid input."""
+    try:
+        return float(value) if value is not None else 0.0
+    except (ValueError, TypeError):
+        return 0.0
+
+
 def _all_tags(xml: str, tag: str) -> list[dict[str, Any]]:
     """Return all occurrences of a tag."""
     results = []
@@ -214,9 +222,15 @@ _PEDAGOGICAL_ACCESSORY_RULES = {
     "CST_3_DIGITS", "CCLASSTRIB_6_DIGITS", "SERVICE_CODE_6_DIGITS",
     "CST_VALID", "CST_GROUP_MATCH", "CST_SEMANTIC",
     "IBSCBS_MISSING", "CEST_MISSING", "CEST_FORMAT",
-    "LAYOUT_NFE", "LAYOUT_PORTAL",
+    "LAYOUT_NFE", "LAYOUT_PORTAL", "IMPORT_IBSCBS_REQUIRED",
     "NCM_FORMAT", "NCM_VALID", "CLASSTRIB_VALID",
 }
+
+# CSTs que legitimamente não destacam IBS/CBS no estágio atual — imunidade/isenção
+# (070), suspensão (410), diferimento (200, tributo postergado p/ operação seguinte)
+# e transferência/ressarcimento/ajuste/estorno de crédito (800/810/811/830).
+# Não exigem IBS/CBS destacado, inclusive em importação.
+_NO_TAX_CSTS = {"070", "200", "410", "800", "810", "811", "830"}
 
 _LC227_RECOMMENDATION = (
     " — Período Pedagógico LC 227/2026 (art. 348 §§ 3º e 4º): "
@@ -692,6 +706,40 @@ def validate_xml(
             _add(
                 Finding(id="F_CNPJ_UNAVAIL", severity="ALERT", rule_id="CNPJ_ACTIVE", title="Verificação de CNPJ indisponível — API fora do ar", where=FindingWhere(field="CNPJ", xpath=_xpath("CNPJ", doc_type)), recommendation="APIs de consulta CNPJ temporariamente indisponíveis. Verifique manualmente.", evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="CNPJ — API indisponível", xpath=_xpath("CNPJ", doc_type)),
+            )
+
+    # ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────
+    # Decreto 12.955/2026 art. 65 (LC 214 art. 63): IBS/CBS incidem sobre a importação
+    # de bens e serviços independentemente de o importador ser habitual. Detecção:
+    # CFOP iniciando em "3" (entrada do exterior) OU grupo de importação (<DI>/<DUIMP>).
+    # Export (CFOP 7xxx, imune) e internas ficam de fora. Escopo: grupo IBSCBS presente
+    # porém zerado com CST tributável — grupo ausente já é coberto por IBSCBS_MISSING.
+    if has_ibscbs and ibscbs_block:
+        is_import = (
+            any(c["value"].strip().startswith("3") for c in _all_tags(xml, "CFOP"))
+            or re.search(r"<DI(?=[\s>])", xml, re.IGNORECASE) is not None
+            or re.search(r"<DUIMP(?=[\s>])", xml, re.IGNORECASE) is not None
+        )
+        cst_value = cst["value"] if cst else ""
+        v_cbs_num = _to_float(v_cbs["value"]) if v_cbs else 0.0
+        v_ibs_num = _to_float(v_ibs["value"]) if v_ibs else 0.0
+        if is_import and v_cbs_num + v_ibs_num == 0 and cst_value not in _NO_TAX_CSTS:
+            ev_id = "E_XML_IMPORT_IBSCBS_REQUIRED"
+            _add(
+                Finding(
+                    id="F_IMPORT_IBSCBS_REQUIRED", severity="FATAL", rule_id="IMPORT_IBSCBS_REQUIRED",
+                    title="Importação tributável sem IBS/CBS destacado — incidência obrigatória",
+                    where=FindingWhere(field="IBS/CBS", xpath=_xpath("IBSCBS", doc_type), snippet=ibscbs_block["snippet"]),
+                    recommendation=(
+                        f'Operação de importação (CFOP 3xxx ou grupo DI/DUIMP) com IBS/CBS zerado e '
+                        f'CST {cst_value or "(ausente)"} tributável. O IBS e a CBS incidem sobre a importação '
+                        f'de bens e serviços independentemente de o importador ser habitual '
+                        f'(Decreto 12.955/2026 art. 65 / LC 214 art. 63). A alíquota deve corresponder à da '
+                        f'operação interna com o mesmo bem/serviço (art. 469-470). Informe vCBS/vIBS ou ajuste o CST.'
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="Importação — IBS/CBS ausente", xpath=_xpath("IBSCBS", doc_type), snippet=ibscbs_block["snippet"]),
             )
 
     # ── Janela sem penalidades (Ato Conjunto RFB/CGIBS 1/25) — passe final ────

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -279,3 +279,67 @@ class TestNoPenaltyWindow:
         result = validate_xml(xml, "NFE")
         split = [f for f in result.findings if f.rule_id == "IBSCBS_SPLIT"]
         assert split and all(f.severity == "FATAL" for f in split)
+
+
+# ── Item 2: IMPORT_IBSCBS_REQUIRED — incidência na importação (Decreto 12.955/2026) ──
+
+
+class TestImportIbscbsRequired:
+    """Importação (CFOP 3xxx ou grupo DI/DUIMP) é tributável por IBS/CBS independente
+    de importador habitual (art. 65). Escopo: grupo IBSCBS presente porém zerado com
+    CST tributável. Export (7xxx) e internas ficam fora."""
+
+    def _nfe(self, cfop="3102", cst="000", dh=None, vcbs="0.00", vibs="0.00", di=False, no_ibscbs=False):
+        di_xml = "<DI><nDI>2603001234</nDI></DI>" if di else ""
+        ibscbs = "" if no_ibscbs else (
+            f'<IBSCBS><CST>{cst}</CST><cClassTrib>000001</cClassTrib>'
+            f'<gIBSCBS><vBC>1000.00</vBC>'
+            f'<gIBSUF><pIBSUF>0</pIBSUF><vIBSUF>0.00</vIBSUF></gIBSUF>'
+            f'<gIBSMun><pIBSMun>0</pIBSMun><vIBSMun>0.00</vIBSMun></gIBSMun>'
+            f'<vIBS>{vibs}</vIBS><gCBS><pCBS>0</pCBS><vCBS>{vcbs}</vCBS></gCBS>'
+            f'</gIBSCBS></IBSCBS>'
+        )
+        dh_xml = f"<dhEmi>{dh}</dhEmi>" if dh else ""
+        return (
+            f'<nfeProc><NFe><infNFe><ide><mod>55</mod>{dh_xml}</ide>'
+            f'<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            f'<det nItem="1"><prod><CFOP>{cfop}</CFOP><NCM>84713012</NCM><CEST>2104900</CEST>'
+            f'<vProd>1000.00</vProd>{di_xml}</prod><imposto>{ibscbs}</imposto></det>'
+            f'<total><IBSCBSTot><vIBS>{vibs}</vIBS><vCBS>{vcbs}</vCBS></IBSCBSTot></total>'
+            f'</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml):
+        r = validate_xml(xml, "NFE")
+        return [f for f in r.findings if f.rule_id == "IMPORT_IBSCBS_REQUIRED"]
+
+    def test_cfop_3xxx_zerado_fora_da_janela_fatal(self):
+        f = self._find(self._nfe(cfop="3102", dh="2026-09-10T10:00:00-03:00"))
+        assert f and f[0].severity == "FATAL"
+        assert "Decreto 12.955/2026" in f[0].recommendation
+
+    def test_deteccao_via_di_com_cfop_interno(self):
+        f = self._find(self._nfe(cfop="1102", di=True, dh="2026-09-10T10:00:00-03:00"))
+        assert f and f[0].severity == "FATAL"
+
+    def test_importacao_tributada_sem_finding(self):
+        assert self._find(self._nfe(cfop="3102", vcbs="9.00", vibs="1.00")) == []
+
+    def test_cst_070_imunidade_sem_finding(self):
+        assert self._find(self._nfe(cfop="3102", cst="070")) == []
+
+    def test_cst_200_diferimento_sem_finding(self):
+        assert self._find(self._nfe(cfop="3102", cst="200")) == []
+
+    def test_interna_5102_sem_finding(self):
+        assert self._find(self._nfe(cfop="5102")) == []
+
+    def test_exportacao_7101_sem_finding(self):
+        assert self._find(self._nfe(cfop="7101")) == []
+
+    def test_dentro_da_janela_warning(self):
+        f = self._find(self._nfe(cfop="3102", dh="2026-05-10T10:00:00-03:00"))
+        assert f and f[0].severity == "WARNING"
+
+    def test_sem_grupo_ibscbs_nao_dispara(self):
+        assert self._find(self._nfe(cfop="3102", no_ibscbs=True)) == []

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -747,3 +747,81 @@ test("janela: regra NÃO-acessória (IBSCBS_SPLIT) dentro da janela permanece FA
   const f = result.findings.find((f) => f.rule_id === "IBSCBS_SPLIT");
   assert.equal(f?.severity, "FATAL", "regra de cálculo não é obrigação acessória — não entra na janela");
 });
+
+// ── Item 2: IMPORT_IBSCBS_REQUIRED — incidência na importação (Decreto 12.955/2026) ──
+// Importação (CFOP 3xxx ou grupo DI/DUIMP) é tributável por IBS/CBS independente
+// de importador habitual (art. 65). Escopo: grupo IBSCBS presente porém zerado com
+// CST tributável. Export (7xxx) e internas (1/2/5/6xxx) ficam fora.
+
+const nfeImport = (o: {
+  cfop?: string; cst?: string; dhEmi?: string; vCBS?: string; vIBS?: string;
+  di?: boolean; noIbscbs?: boolean;
+} = {}) => {
+  const cfop = o.cfop ?? "3102";
+  const cst = o.cst ?? "000";
+  const vCBS = o.vCBS ?? "0.00";
+  const vIBS = o.vIBS ?? "0.00";
+  const di = o.di ? "<DI><nDI>2603001234</nDI></DI>" : "";
+  const ibscbs = o.noIbscbs ? "" : `<IBSCBS><CST>${cst}</CST><cClassTrib>000001</cClassTrib>
+        <gIBSCBS><vBC>1000.00</vBC>
+          <gIBSUF><pIBSUF>0</pIBSUF><vIBSUF>0.00</vIBSUF></gIBSUF>
+          <gIBSMun><pIBSMun>0</pIBSMun><vIBSMun>0.00</vIBSMun></gIBSMun>
+          <vIBS>${vIBS}</vIBS><gCBS><pCBS>0</pCBS><vCBS>${vCBS}</vCBS></gCBS>
+        </gIBSCBS></IBSCBS>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod>${o.dhEmi ? `<dhEmi>${o.dhEmi}</dhEmi>` : ""}</ide>
+  <emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>
+  <det nItem="1">
+    <prod><CFOP>${cfop}</CFOP><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd>${di}</prod>
+    <imposto>${ibscbs}</imposto>
+  </det>
+  <total><IBSCBSTot><vIBS>${vIBS}</vIBS><vCBS>${vCBS}</vCBS></IBSCBSTot></total>
+</infNFe></NFe></nfeProc>`;
+};
+
+const importFinding = (xml: string) =>
+  validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml })
+    .findings.find((f) => f.rule_id === "IMPORT_IBSCBS_REQUIRED");
+
+test("IMPORT: CFOP 3xxx zerado + CST tributável (fora da janela) → FATAL", () => {
+  const f = importFinding(nfeImport({ cfop: "3102", dhEmi: "2026-09-10T10:00:00-03:00" }));
+  assert.ok(f, "IMPORT_IBSCBS_REQUIRED esperado");
+  assert.equal(f!.severity, "FATAL");
+  assert.match(f!.recommendation ?? "", /Decreto 12\.955\/2026/);
+});
+
+test("IMPORT: detecção via grupo DI mesmo com CFOP interno → FATAL", () => {
+  const f = importFinding(nfeImport({ cfop: "1102", di: true, dhEmi: "2026-09-10T10:00:00-03:00" }));
+  assert.ok(f, "IMPORT_IBSCBS_REQUIRED esperado (DI presente)");
+  assert.equal(f!.severity, "FATAL");
+});
+
+test("IMPORT: importação tributada (vCBS/vIBS > 0) → sem finding", () => {
+  assert.equal(importFinding(nfeImport({ cfop: "3102", vCBS: "9.00", vIBS: "1.00" })), undefined);
+});
+
+test("IMPORT: CST 070 (imunidade) zerado → sem finding", () => {
+  assert.equal(importFinding(nfeImport({ cfop: "3102", cst: "070" })), undefined);
+});
+
+test("IMPORT: CST 200 (diferimento) zerado → sem finding (tributo postergado)", () => {
+  assert.equal(importFinding(nfeImport({ cfop: "3102", cst: "200" })), undefined);
+});
+
+test("IMPORT: operação interna (CFOP 5102) zerada → sem finding", () => {
+  assert.equal(importFinding(nfeImport({ cfop: "5102" })), undefined);
+});
+
+test("IMPORT: exportação (CFOP 7101) zerada → sem finding (imune)", () => {
+  assert.equal(importFinding(nfeImport({ cfop: "7101" })), undefined);
+});
+
+test("IMPORT: dentro da janela sem penalidades → WARNING", () => {
+  const f = importFinding(nfeImport({ cfop: "3102", dhEmi: "2026-05-10T10:00:00-03:00" }));
+  assert.equal(f?.severity, "WARNING");
+});
+
+test("IMPORT: sem grupo IBSCBS → IMPORT não dispara (coberto por IBSCBS_MISSING)", () => {
+  assert.equal(importFinding(nfeImport({ cfop: "3102", noIbscbs: true })), undefined);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -33,7 +33,7 @@ const PEDAGOGICAL_ACCESSORY_RULES = new Set([
   "CST_3_DIGITS", "CCLASSTRIB_6_DIGITS", "SERVICE_CODE_6_DIGITS",
   "CST_VALID", "CST_GROUP_MATCH", "CST_SEMANTIC",
   "IBSCBS_MISSING", "CEST_MISSING", "CEST_FORMAT",
-  "LAYOUT_NFE", "LAYOUT_PORTAL",
+  "LAYOUT_NFE", "LAYOUT_PORTAL", "IMPORT_IBSCBS_REQUIRED",
 ]);
 
 const LC227_NOTE =
@@ -288,7 +288,10 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
 
   // Split payment (#276) — <cobr>/<dup>/<indPag>
   const indPag = firstTag(xml, ["indPag"]);
-  const NO_TAX_CSTS = new Set(["070", "410", "800", "810", "811", "830"]);
+  // CSTs que legitimamente não destacam IBS/CBS no estágio atual: imunidade/isenção
+  // (070), diferimento (200), suspensão (410) e transferência/ressarcimento/ajuste/
+  // estorno de crédito (800/810/811/830).
+  const NO_TAX_CSTS = new Set(["070", "200", "410", "800", "810", "811", "830"]);
 
   // ── Rules 1-3: field format checks ────────────────────────────────────────
 
@@ -788,6 +791,45 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           xpath: inferXpath("indPag", docType),
           snippet: indPag.snippet,
         }),
+      );
+    }
+  }
+
+  // ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────
+  // Decreto 12.955/2026 art. 65 (LC 214 art. 63): IBS/CBS incidem sobre a
+  // importação de bens e serviços independentemente de o importador ser habitual.
+  // Detecção: CFOP iniciando em "3" (entrada do exterior) OU grupo de importação
+  // (<DI>/<DUIMP>). Export (CFOP 7xxx, imune) e internas ficam de fora.
+  // Escopo: grupo IBSCBS presente porém zerado com CST tributável — o grupo ausente
+  // já é coberto por IBSCBS_MISSING (evita duplo apontamento).
+  if (hasIbscbsGroup && ibscbsBlock) {
+    const isImport =
+      allTags(xml, "CFOP").some((c) => c.value.trim().startsWith("3")) ||
+      /<DI(?=[\s>])/i.test(xml) ||
+      /<DUIMP(?=[\s>])/i.test(xml);
+    const cstValue = cst?.value ?? "";
+    const vCbsNum = parseFloat(vCBS?.value ?? "0") || 0;
+    const vIbsNum = parseFloat(vIBS?.value ?? "0") || 0;
+    if (isImport && vCbsNum + vIbsNum === 0 && !NO_TAX_CSTS.has(cstValue)) {
+      const evId = makeEvidenceId("IMPORT_IBSCBS_REQUIRED");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_IMPORT_IBSCBS_REQUIRED",
+          severity: "FATAL",
+          ruleId: "IMPORT_IBSCBS_REQUIRED",
+          title: "Importação tributável sem IBS/CBS destacado — incidência obrigatória",
+          field: "IBS/CBS",
+          xpath: inferXpath("IBSCBS", docType),
+          snippet: ibscbsBlock.snippet,
+          evidenceId: evId,
+          recommendation:
+            `Operação de importação (CFOP 3xxx ou grupo DI/DUIMP) com IBS/CBS zerado e ` +
+            `CST ${cstValue || "(ausente)"} tributável. O IBS e a CBS incidem sobre a importação ` +
+            `de bens e serviços independentemente de o importador ser habitual ` +
+            `(Decreto 12.955/2026 art. 65 / LC 214 art. 63). A alíquota deve corresponder à da ` +
+            `operação interna com o mesmo bem/serviço (art. 469-470). Informe vCBS/vIBS ou ajuste o CST.`,
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "Importação — IBS/CBS ausente", xpath: inferXpath("IBSCBS", docType), snippet: ibscbsBlock.snippet }),
       );
     }
   }


### PR DESCRIPTION
## Contexto

IBS e CBS **incidem sobre a importação** de bens e serviços, por qualquer pessoa, **independentemente de o importador ser habitual** (Decreto 12.955/2026 art. 65 / LC 214 art. 63). O motor não tinha nenhum tratamento de importação.

## O que muda

Nova regra **`IMPORT_IBSCBS_REQUIRED`** (NF-e): operação de importação com o grupo `IBSCBS` **presente** porém com IBS/CBS **zerado** e CST **tributável** → finding.

- **Detecção:** CFOP iniciando em `3` (entrada do exterior) **ou** grupo de importação (`<DI>`/`<DUIMP>`). Exportação (CFOP `7xxx`, imune) e operações internas ficam de fora.
- **Escopo deliberado** ao caso "grupo presente mas zerado" — grupo ausente já é coberto por `IBSCBS_MISSING` (evita duplo apontamento).
- **Severidade:** entra no conjunto de obrigações acessórias → herda a **janela sem penalidades** (Ato Conjunto 1/25): `WARNING` até 31/07/2026, `FATAL` a partir de 01/08/2026 — alinhado ao art. 112 do Decreto.
- **CST 200 (diferimento)** incluído no `NO_TAX_CSTS` (junto de imunidade 070 / suspensão 410): diferimento legitimamente zera o destaque no estágio atual → evita falso-positivo. Efeito consistente no `SPLIT_PAYMENT_INDPAG`.

## Fora de escopo (não verificável de um XML isolado)

- Harmonia de alíquota importação×interna (art. 469-470) — exigiria tabela de referência NCM→alíquota.
- Timing de pagamento (despacho/DI/OEA).

## Testes & Verificação

- **+9 frontend, +9 backend**: CFOP 3xxx, DI/DUIMP, export, interna, CST imune/diferimento, tributada, dentro/fora da janela, grupo ausente.
- Frontend **92/92** + build OK + `tsc` limpo
- Backend **81/81** + `ruff` + `pyright` limpos
- Bordas empíricas: DUIMP, CFOP com espaço, multi-item — todas OK.

## Nota

Os dois motores já haviam divergido em cobertura de regras; esta regra foi implementada em ambos para consistência (helpers `_to_float` e `_NO_TAX_CSTS` adicionados ao backend).
