### PR TITLE
feat(rules): PF_CONTRIB_CNPJ — alerta de inscrição no CNPJ p/ PF contribuinte (Comunicado CGIBS/RFB 01/2025)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -275,6 +275,13 @@ def _within_no_penalty_window(emission_date: dict | None) -> bool:
     return _NO_PENALTY_WINDOW_START <= date_part < _NO_PENALTY_WINDOW_END
 
 
+# ── Comunicado Conjunto CGIBS/RFB nº 01/2025 — CNPJ p/ PF contribuinte ───────
+# A partir de 01/07/2026, a PF contribuinte de IBS/CBS deve se inscrever no CNPJ e não
+# pode emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento como
+# contribuinte não é verificável do XML → ALERT informativo (verificar enquadramento).
+_PF_CNPJ_REQUIRED_DATE = "2026-07-01"
+
+
 def validate_xml(
     xml: str,
     doc_type: str | None = None,
@@ -741,6 +748,37 @@ def validate_xml(
                 ),
                 Evidence(id=ev_id, type="xml", label="Importação — IBS/CBS ausente", xpath=_xpath("IBSCBS", doc_type), snippet=ibscbs_block["snippet"]),
             )
+
+    # ── Rule: PF_CONTRIB_CNPJ — PF contribuinte deve se inscrever no CNPJ (#item3) ──
+    # Comunicado Conjunto CGIBS/RFB nº 01/2025 + LC 214 art. 251: a partir de 01/07/2026
+    # a PF contribuinte de IBS/CBS deve ter CNPJ (emissão por CPF não é permitida).
+    # Verificável do XML: emitente identificado por CPF + data ≥ 01/07/2026. O enquadramento
+    # como contribuinte não é verificável → ALERT informativo.
+    em_date = emission_date["value"][:10] if emission_date else ""
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", em_date) and em_date >= _PF_CNPJ_REQUIRED_DATE:
+        emit_block = _first_tag(xml, ["emit", "PrestadorServico", "prest", "Prestador"])
+        if emit_block:
+            emit_cpf = _first_tag(emit_block["snippet"], ["CPF"])
+            emit_cnpj = _first_tag(emit_block["snippet"], ["CNPJ"])
+            if emit_cpf and not emit_cnpj:
+                ev_id = "E_XML_PF_CONTRIB_CNPJ"
+                _add(
+                    Finding(
+                        id="F_PF_CONTRIB_CNPJ", severity="ALERT", rule_id="PF_CONTRIB_CNPJ",
+                        title="Emitente pessoa física (CPF) — verificar obrigação de inscrição no CNPJ",
+                        where=FindingWhere(field="emit/CPF", xpath=_xpath("CPF", doc_type), snippet=emit_cpf["snippet"]),
+                        recommendation=(
+                            "Emitente identificado por CPF. A partir de 01/07/2026, a pessoa física "
+                            "contribuinte de IBS/CBS deve se inscrever no CNPJ e não pode emitir documento "
+                            "fiscal por CPF (Comunicado Conjunto CGIBS/RFB nº 01/2025; LC 214 art. 251). "
+                            "Verifique o enquadramento como contribuinte (atividade econômica habitual; "
+                            "locação com mais de 3 imóveis e renda anual acima de R$ 240 mil) e, se for o "
+                            "caso, providencie a inscrição no CNPJ. A inscrição não transforma a PF em PJ."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="Emitente PF (CPF) — verificar CNPJ", xpath=_xpath("CPF", doc_type), snippet=emit_cpf["snippet"]),
+                )
 
     # ── Janela sem penalidades (Ato Conjunto RFB/CGIBS 1/25) — passe final ────
     # Downgrade automático FATAL → WARNING das obrigações acessórias quando a

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -343,3 +343,57 @@ class TestImportIbscbsRequired:
 
     def test_sem_grupo_ibscbs_nao_dispara(self):
         assert self._find(self._nfe(cfop="3102", no_ibscbs=True)) == []
+
+
+# ── Item 3: PF_CONTRIB_CNPJ — PF contribuinte deve ter CNPJ (Comunicado CGIBS/RFB 01/2025) ──
+
+
+class TestPfContribCnpj:
+    """A partir de 01/07/2026 a PF contribuinte de IBS/CBS deve ter CNPJ (emissão por CPF
+    não permitida, LC 214 art. 251). Enquadramento não verificável do XML → ALERT:
+    emitente CPF + data ≥ 01/07/2026."""
+
+    def _nfe(self, ident, dh=None):
+        dh_xml = f"<dhEmi>{dh}</dhEmi>" if dh else ""
+        return (
+            f'<nfeProc><NFe><infNFe><ide><mod>55</mod>{dh_xml}</ide>'
+            f'<emit>{ident}<CRT>1</CRT></emit><dest><CPF>11122233344</CPF></dest>'
+            f'<det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>100.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib></IBSCBS></imposto></det>'
+            f'<total></total></infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, doc="NFE"):
+        return [f for f in validate_xml(xml, doc).findings if f.rule_id == "PF_CONTRIB_CNPJ"]
+
+    def test_emit_cpf_apos_01_07_2026_alert(self):
+        f = self._find(self._nfe("<CPF>12345678909</CPF>", "2026-07-01T10:00:00-03:00"))
+        assert f and f[0].severity == "ALERT"
+        assert "Comunicado Conjunto CGIBS/RFB" in f[0].recommendation
+
+    def test_emit_cpf_antes_de_01_07_2026_sem_finding(self):
+        assert self._find(self._nfe("<CPF>12345678909</CPF>", "2026-06-30T10:00:00-03:00")) == []
+
+    def test_emit_cnpj_sem_finding(self):
+        assert self._find(self._nfe("<CNPJ>12345678000195</CNPJ>", "2026-08-10T10:00:00-03:00")) == []
+
+    def test_emit_cpf_sem_data_sem_finding(self):
+        assert self._find(self._nfe("<CPF>12345678909</CPF>")) == []
+
+    def test_dest_cpf_emit_cnpj_sem_finding(self):
+        # destinatário é CPF mas emitente é CNPJ → só o emitente importa
+        assert self._find(self._nfe("<CNPJ>12345678000195</CNPJ>", "2026-09-01T10:00:00-03:00")) == []
+
+    def test_nfse_prestador_cpf_alert(self):
+        xml = (
+            '<NFS-e><infNfse><DataEmissao>2026-07-15T10:00:00</DataEmissao>'
+            '<PrestadorServico><RazaoSocial>X</RazaoSocial><CPF>98765432100</CPF></PrestadorServico>'
+            '<TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>'
+            '<PrestacaoServico><Servico><CodigoServico>123456</CodigoServico><cClassTrib>654321</cClassTrib>'
+            '<CST>090</CST><NCM>84713012</NCM><CEST>2104900</CEST></Servico>'
+            '<Valores><BaseCalculo>1000.00</BaseCalculo><AliquotaCBS>0.0010</AliquotaCBS><ValorCBS>1.00</ValorCBS>'
+            '<AliquotaIBS>0.0090</AliquotaIBS><ValorIBS>9.00</ValorIBS></Valores></PrestacaoServico>'
+            '</infNfse></NFS-e>'
+        )
+        f = self._find(xml, "NFSE")
+        assert f and f[0].severity == "ALERT"

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -825,3 +825,60 @@ test("IMPORT: dentro da janela sem penalidades → WARNING", () => {
 test("IMPORT: sem grupo IBSCBS → IMPORT não dispara (coberto por IBSCBS_MISSING)", () => {
   assert.equal(importFinding(nfeImport({ cfop: "3102", noIbscbs: true })), undefined);
 });
+
+// ── Item 3: PF_CONTRIB_CNPJ — PF contribuinte deve ter CNPJ (Comunicado CGIBS/RFB 01/2025) ──
+// A partir de 01/07/2026 a PF contribuinte de IBS/CBS deve se inscrever no CNPJ e
+// não pode emitir por CPF (LC 214 art. 251). Como o enquadramento não é verificável
+// do XML, a regra é ALERT informativo: emitente CPF + data ≥ 01/07/2026.
+
+const nfeEmit = (ident: string, dhEmi?: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod>${dhEmi ? `<dhEmi>${dhEmi}</dhEmi>` : ""}</ide>
+  <emit>${ident}<CRT>1</CRT></emit>
+  <dest><CPF>11122233344</CPF></dest>
+  <det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>100.00</vProd></prod>
+    <imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib></IBSCBS></imposto></det>
+  <total></total>
+</infNFe></NFe></nfeProc>`;
+
+const pfFinding = (xml: string, doc: "NFE" | "NFSE" = "NFE") =>
+  validateXmlWithRules({ tenantId: "t", documentType: doc, xml }).findings
+    .find((f) => f.rule_id === "PF_CONTRIB_CNPJ");
+
+test("PF_CNPJ: emitente CPF + data ≥ 01/07/2026 → ALERT", () => {
+  const f = pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2026-07-01T10:00:00-03:00"));
+  assert.ok(f, "PF_CONTRIB_CNPJ esperado");
+  assert.equal(f!.severity, "ALERT");
+  assert.match(f!.recommendation ?? "", /Comunicado Conjunto CGIBS\/RFB/);
+});
+
+test("PF_CNPJ: emitente CPF antes de 01/07/2026 → sem finding", () => {
+  assert.equal(pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2026-06-30T10:00:00-03:00")), undefined);
+});
+
+test("PF_CNPJ: emitente CNPJ (PJ) → sem finding", () => {
+  assert.equal(pfFinding(nfeEmit("<CNPJ>12345678000195</CNPJ>", "2026-08-10T10:00:00-03:00")), undefined);
+});
+
+test("PF_CNPJ: emitente CPF sem data → sem finding (conservador)", () => {
+  assert.equal(pfFinding(nfeEmit("<CPF>12345678909</CPF>")), undefined);
+});
+
+test("PF_CNPJ: destinatário CPF mas emitente CNPJ → sem finding (só emitente importa)", () => {
+  assert.equal(pfFinding(nfeEmit("<CNPJ>12345678000195</CNPJ>", "2026-09-01T10:00:00-03:00")), undefined);
+});
+
+test("PF_CNPJ: NFS-e prestador CPF + DataEmissao ≥ 01/07/2026 → ALERT", () => {
+  const xml = `<NFS-e><infNfse>
+    <DataEmissao>2026-07-15T10:00:00</DataEmissao>
+    <PrestadorServico><RazaoSocial>X</RazaoSocial><CPF>98765432100</CPF></PrestadorServico>
+    <TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>
+    <PrestacaoServico><Servico><CodigoServico>123456</CodigoServico><cClassTrib>654321</cClassTrib>
+      <CST>090</CST><NCM>84713012</NCM><CEST>2104900</CEST></Servico>
+      <Valores><BaseCalculo>1000.00</BaseCalculo><AliquotaCBS>0.0010</AliquotaCBS><ValorCBS>1.00</ValorCBS>
+      <AliquotaIBS>0.0090</AliquotaIBS><ValorIBS>9.00</ValorIBS></Valores></PrestacaoServico>
+  </infNfse></NFS-e>`;
+  const f = pfFinding(xml, "NFSE");
+  assert.ok(f, "PF_CONTRIB_CNPJ esperado em NFS-e");
+  assert.equal(f!.severity, "ALERT");
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -67,6 +67,13 @@ function isWithinNoPenaltyWindow(emissionDate: string | undefined): boolean {
   return datePart >= NO_PENALTY_WINDOW_START && datePart < NO_PENALTY_WINDOW_END;
 }
 
+// ── Comunicado Conjunto CGIBS/RFB nº 01/2025 — CNPJ p/ PF contribuinte ───────
+// A partir de 01/07/2026, a pessoa física contribuinte de IBS/CBS deve se inscrever
+// no CNPJ e não pode emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento
+// como contribuinte (atividade habitual; locação com >3 imóveis e renda > R$ 240 mil/ano)
+// não é verificável do XML — por isso a regra é ALERT informativo (verificar enquadramento).
+const PF_CNPJ_REQUIRED_DATE = "2026-07-01";
+
 // ── CST table (NT 2025.002-RTC) ────────────────────────────────────────────
 export const CST_TABLE: Record<string, { group: string | null; description: string }> = {
   "000": { group: "gIBSCBS", description: "Tributação normal (ad valorem)" },
@@ -831,6 +838,44 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
         }),
         makeEvidence({ id: evId, type: "xml", label: "Importação — IBS/CBS ausente", xpath: inferXpath("IBSCBS", docType), snippet: ibscbsBlock.snippet }),
       );
+    }
+  }
+
+  // ── Rule: PF_CONTRIB_CNPJ — PF contribuinte deve se inscrever no CNPJ (#item3) ──
+  // Comunicado Conjunto CGIBS/RFB nº 01/2025 + LC 214 art. 251: a partir de
+  // 01/07/2026 a PF contribuinte de IBS/CBS deve ter CNPJ (emissão por CPF não é
+  // permitida). Verificável do XML: emitente identificado por CPF + data ≥ 01/07/2026.
+  // O enquadramento como contribuinte não é verificável → ALERT informativo.
+  {
+    const emitBlock = firstTag(xml, ["emit", "PrestadorServico", "prest", "Prestador"]);
+    const emDate = emissionDate?.value?.slice(0, 10) ?? "";
+    const dateOk = /^\d{4}-\d{2}-\d{2}$/.test(emDate) && emDate >= PF_CNPJ_REQUIRED_DATE;
+    if (emitBlock && dateOk) {
+      const emitCpf = firstTag(emitBlock.snippet, ["CPF"]);
+      const emitCnpj = firstTag(emitBlock.snippet, ["CNPJ"]);
+      if (emitCpf && !emitCnpj) {
+        const evId = makeEvidenceId("PF_CONTRIB_CNPJ");
+        pushFindingAndEvidence(findings, evidences, evidenceById,
+          makeFinding({
+            id: "F_PF_CONTRIB_CNPJ",
+            severity: "ALERT",
+            ruleId: "PF_CONTRIB_CNPJ",
+            title: "Emitente pessoa física (CPF) — verificar obrigação de inscrição no CNPJ",
+            field: "emit/CPF",
+            xpath: inferXpath("CPF", docType),
+            snippet: emitCpf.snippet,
+            evidenceId: evId,
+            recommendation:
+              `Emitente identificado por CPF. A partir de 01/07/2026, a pessoa física ` +
+              `contribuinte de IBS/CBS deve se inscrever no CNPJ e não pode emitir documento ` +
+              `fiscal por CPF (Comunicado Conjunto CGIBS/RFB nº 01/2025; LC 214 art. 251). ` +
+              `Verifique o enquadramento como contribuinte (atividade econômica habitual; ` +
+              `locação com mais de 3 imóveis e renda anual acima de R$ 240 mil) e, se for o ` +
+              `caso, providencie a inscrição no CNPJ. A inscrição não transforma a PF em PJ.`,
+          }),
+          makeEvidence({ id: evId, type: "xml", label: "Emitente PF (CPF) — verificar CNPJ", xpath: inferXpath("CPF", docType), snippet: emitCpf.snippet }),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Contexto

A partir de **01/07/2026**, a pessoa física **contribuinte de IBS/CBS** deve se inscrever no CNPJ e **não pode emitir documento fiscal por CPF** (Comunicado Conjunto CGIBS/RFB nº 01/2025; LC 214 art. 251). A inscrição é só cadastral — não transforma a PF em PJ.

## O que muda

Nova regra **`PF_CONTRIB_CNPJ`** (NF-e e NFS-e): emitente identificado por **CPF** (bloco `<emit>`/Prestador com CPF e sem CNPJ) + **data de emissão ≥ 01/07/2026** → finding.

- **Severidade `ALERT` (informativo), não FATAL.** O enquadramento como contribuinte depende de critérios **fora do XML** (atividade econômica habitual; locação com >3 imóveis e renda > R$ 240 mil/ano) e, em 2026, **todas** as notas preenchem IBS/CBS — logo não há como afirmar pelo XML que a PF é contribuinte. O alerta orienta a verificar o enquadramento, sem reprovar PF possivelmente não-contribuinte (evita falso-positivo). Mesmo princípio do CST 200 no #321: só bloqueia com confiança.
- **Detecção escopada ao emitente** — `dest`/tomador CPF é ignorado.
- **Sem data de emissão → não dispara** (conservador).

## Fora de escopo

Validar se a PF *é de fato* contribuinte (limiares de receita/atividade) — não verificável de um XML isolado.

## Testes & Verificação

- **+6 frontend, +6 backend**: emitente CPF/CNPJ, fronteira 30/06×01/07/2026, sem data, dest-CPF ignorado, NFS-e prestador.
- Frontend **98/98** + build OK + `tsc` limpo
- Backend **87/87** + `ruff` + `pyright` limpos

Fecha o ciclo das 3 atualizações regulatórias da semana (#320 janela sem penalidades, #321 importação, este).