### PR TITLE
feat(rules): anotar códigos de rejeição da NT v1.40 (1115/1106/960) nas detecções (#311)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -238,6 +238,20 @@ _LC227_RECOMMENDATION = (
     "há 60 dias para regularizar sem aplicação de multa."
 )
 
+# ── NT 2025.002 v1.40 — códigos de rejeição SEFAZ (#311) ─────────────────────
+# Anota o código oficial de rejeição nas detecções que o antecipam (NF-e/NFC-e),
+# para o usuário saber como a SEFAZ rejeitará. Precedente: Rejeição 1157.
+_REJECTION_CODES = {
+    "IBSCBS_MISSING": (
+        " — SEFAZ: Rejeição 1115 (regra UB12-10): preenchimento de IBS/CBS obrigatório — "
+        "produção a partir de 03/08/2026 (Regime Normal/CRT 3) e 04/01/2027 (Simples/MEI), NT 2025.002 v1.40."
+    ),
+    "CCLASSTRIB_6_DIGITS": (
+        " — SEFAZ: Rejeição 1106 (regra LA01-30) / 960 (regra N12-110): cClassTrib obrigatório "
+        "e com classificação tributária adequada (NT 2025.002 v1.40)."
+    ),
+}
+
 
 def _pedagogical_severity(rule_id: str, pedagogical_mode: bool) -> str:
     """Return 'WARNING' for accessory rules in pedagogical mode, 'FATAL' otherwise."""
@@ -779,6 +793,14 @@ def validate_xml(
                     ),
                     Evidence(id=ev_id, type="xml", label="Emitente PF (CPF) — verificar CNPJ", xpath=_xpath("CPF", doc_type), snippet=emit_cpf["snippet"]),
                 )
+
+    # ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────
+    # Apenas NF-e/NFC-e (rejeições da SEFAZ NF-e; NFS-e tem regras próprias).
+    if is_nfe:
+        for f in findings:
+            code = _REJECTION_CODES.get(f.rule_id)
+            if code:
+                f.recommendation = (f.recommendation or "") + code
 
     # ── Janela sem penalidades (Ato Conjunto RFB/CGIBS 1/25) — passe final ────
     # Downgrade automático FATAL → WARNING das obrigações acessórias quando a

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -397,3 +397,48 @@ class TestPfContribCnpj:
         )
         f = self._find(xml, "NFSE")
         assert f and f[0].severity == "ALERT"
+
+
+# ── Item #311: códigos de rejeição da NT v1.40 (1115, 1106, 960) ─────────────
+
+
+class TestRejectionCodesV140:
+    """Anota o código oficial SEFAZ na recomendação das detecções (NF-e/NFC-e)."""
+
+    _NFE_NO_CLASSTRIB = (
+        '<nfeProc><NFe><infNFe><ide><mod>55</mod><dhEmi>2026-09-10T10:00:00-03:00</dhEmi></ide>'
+        '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+        '<det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>'
+        '<imposto><IBSCBS><CST>000</CST></IBSCBS></imposto></det><total></total></infNFe></NFe></nfeProc>'
+    )
+    _NFE_NO_IBSCBS = (
+        '<nfeProc><NFe><infNFe><ide><mod>55</mod><dhEmi>2026-09-10T10:00:00-03:00</dhEmi></ide>'
+        '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+        '<det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>'
+        '<imposto><ICMS><ICMSSN101><CST>101</CST></ICMSSN101></ICMS></imposto></det><total></total>'
+        '</infNFe></NFe></nfeProc>'
+    )
+
+    def test_ibscbs_missing_cita_1115(self):
+        r = validate_xml(self._NFE_NO_IBSCBS, "NFE")
+        f = [x for x in r.findings if x.rule_id == "IBSCBS_MISSING"]
+        assert f and "Rejeição 1115" in f[0].recommendation
+
+    def test_cclasstrib_cita_1106_e_960(self):
+        r = validate_xml(self._NFE_NO_CLASSTRIB, "NFE")
+        f = [x for x in r.findings if x.rule_id == "CCLASSTRIB_6_DIGITS"]
+        assert f and "1106" in f[0].recommendation and "960" in f[0].recommendation
+
+    def test_nfse_nao_recebe_codigo_nfe(self):
+        xml = (
+            '<NFS-e><infNfse><PrestadorServico><RazaoSocial>X</RazaoSocial></PrestadorServico>'
+            '<TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>'
+            '<PrestacaoServico><Servico><CodigoServico>123456</CodigoServico>'
+            '<CST>090</CST><NCM>84713012</NCM><CEST>2104900</CEST></Servico>'
+            '<Valores><BaseCalculo>1000.00</BaseCalculo><AliquotaCBS>0.0010</AliquotaCBS><ValorCBS>1.00</ValorCBS>'
+            '<AliquotaIBS>0.0090</AliquotaIBS><ValorIBS>9.00</ValorIBS></Valores></PrestacaoServico>'
+            '</infNfse></NFS-e>'
+        )
+        r = validate_xml(xml, "NFSE")
+        f = [x for x in r.findings if x.rule_id == "CCLASSTRIB_6_DIGITS"]
+        assert f and "1106" not in f[0].recommendation

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -882,3 +882,47 @@ test("PF_CNPJ: NFS-e prestador CPF + DataEmissao ≥ 01/07/2026 → ALERT", () =
   assert.ok(f, "PF_CONTRIB_CNPJ esperado em NFS-e");
   assert.equal(f!.severity, "ALERT");
 });
+
+// ── Item #311: códigos de rejeição da NT v1.40 (1115, 1106, 960) ─────────────
+// Anota o código oficial SEFAZ na recomendação das detecções que os antecipam
+// (NF-e/NFC-e apenas). Precedente: Rejeição 1157 em DPREV_ENTREGA_FRETE.
+
+test("#311: IBSCBS_MISSING (NF-e) cita Rejeição 1115 (UB12-10)", () => {
+  const r = validateXmlWithRules({ tenantId: "t", documentType: "NFE",
+    xml: nfeAcessoriaErr("3", "2026-09-10T10:00:00-03:00") });
+  const f = r.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.ok(f, "IBSCBS_MISSING esperado");
+  assert.match(f!.recommendation ?? "", /Rejeição 1115/);
+});
+
+const nfeNoClassTrib = `<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc><NFe><infNFe>
+  <ide><mod>55</mod><dhEmi>2026-09-10T10:00:00-03:00</dhEmi></ide>
+  <emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>
+  <det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>
+    <imposto><IBSCBS><CST>000</CST></IBSCBS></imposto></det>
+  <total></total>
+</infNFe></NFe></nfeProc>`;
+
+test("#311: CCLASSTRIB_6_DIGITS (NF-e) cita Rejeição 1106 e 960", () => {
+  const r = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: nfeNoClassTrib });
+  const f = r.findings.find((f) => f.rule_id === "CCLASSTRIB_6_DIGITS");
+  assert.ok(f, "CCLASSTRIB_6_DIGITS esperado");
+  assert.match(f!.recommendation ?? "", /1106/);
+  assert.match(f!.recommendation ?? "", /960/);
+});
+
+test("#311: NFS-e NÃO recebe código de rejeição NF-e (1106)", () => {
+  const xml = `<NFS-e><infNfse>
+    <PrestadorServico><RazaoSocial>X</RazaoSocial></PrestadorServico>
+    <TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>
+    <PrestacaoServico><Servico><CodigoServico>123456</CodigoServico>
+      <CST>090</CST><NCM>84713012</NCM><CEST>2104900</CEST></Servico>
+      <Valores><BaseCalculo>1000.00</BaseCalculo><AliquotaCBS>0.0010</AliquotaCBS><ValorCBS>1.00</ValorCBS>
+      <AliquotaIBS>0.0090</AliquotaIBS><ValorIBS>9.00</ValorIBS></Valores></PrestacaoServico>
+  </infNfse></NFS-e>`;
+  const r = validateXmlWithRules({ tenantId: "t", documentType: "NFSE", xml });
+  const f = r.findings.find((f) => f.rule_id === "CCLASSTRIB_6_DIGITS");
+  assert.ok(f, "CCLASSTRIB_6_DIGITS esperado em NFS-e");
+  assert.doesNotMatch(f!.recommendation ?? "", /1106/);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -41,6 +41,18 @@ const LC227_NOTE =
   "se autuado exclusivamente por esta obrigação acessória, " +
   "há 60 dias para regularizar sem aplicação de multa.";
 
+// ── NT 2025.002 v1.40 — códigos de rejeição SEFAZ (#311) ─────────────────────
+// Anota o código oficial de rejeição nas detecções que o antecipam (NF-e/NFC-e),
+// para o usuário saber exatamente como a SEFAZ rejeitará. Precedente: Rejeição 1157.
+const REJECTION_CODES: Record<string, string> = {
+  IBSCBS_MISSING:
+    " — SEFAZ: Rejeição 1115 (regra UB12-10): preenchimento de IBS/CBS obrigatório — " +
+    "produção a partir de 03/08/2026 (Regime Normal/CRT 3) e 04/01/2027 (Simples/MEI), NT 2025.002 v1.40.",
+  CCLASSTRIB_6_DIGITS:
+    " — SEFAZ: Rejeição 1106 (regra LA01-30) / 960 (regra N12-110): cClassTrib obrigatório " +
+    "e com classificação tributária adequada (NT 2025.002 v1.40).",
+};
+
 // ── Ato Conjunto RFB/CGIBS nº 1/2025 — janela sem penalidades ─────────────────
 // Art. 3º: penalidades por descumprimento de obrigações acessórias de IBS/CBS
 // ficam suspensas até o 1º dia do 4º mês subsequente à publicação da parte comum
@@ -1077,6 +1089,17 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
       recommendation: "Documentar justificativa fiscal para benefícios e créditos utilizados.",
     }),
   );
+
+  // ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────
+  // Apenas NF-e/NFC-e (rejeições da SEFAZ NF-e; NFS-e tem regras próprias).
+  if (isNfe) {
+    for (const f of findings) {
+      const code = REJECTION_CODES[f.rule_id];
+      if (code) {
+        (f as { recommendation: string }).recommendation = (f.recommendation || "") + code;
+      }
+    }
+  }
 
   // ── Downgrade de obrigações acessórias FATAL → WARNING ────────────────────
   // Duas bases legais independentes e combináveis:


### PR DESCRIPTION
## Contexto

A NT 2025.002-RTC v1.40 introduz rejeições da SEFAZ sobre IBS/CBS e cClassTrib que entram em produção em **03/08/2026**. O motor já antecipa as condições; falta o usuário saber **qual código de rejeição** cada uma dispara. Parte do EPIC #309, atende o critério de aceite do #311 ("evidência referencia o código de rejeição").

## O que muda

Passe de enriquecimento (**NF-e/NFC-e apenas**) que anota o código oficial de rejeição na recomendação das detecções que o antecipam — no precedente da Rejeição 1157 (`DPREV_ENTREGA_FRETE`).

| Código | Regra SEFAZ | Detecção |
|---|---|---|
| **1115** | UB12-10 | `IBSCBS_MISSING` (IBS/CBS não informado; 03/08/2026 CRT 3, 04/01/2027 Simples/MEI) |
| **1106** | LA01-30 | `CCLASSTRIB_6_DIGITS` (cClassTrib obrigatório) |
| **960** | N12-110 | `CCLASSTRIB_6_DIGITS` (classificação tributária adequada) |

- NFS-e **não** recebe códigos de rejeição NF-e (regras próprias).
- Espelhado nos dois motores (`xmlRules.ts` + `validate_xml.py`).

## Escopo (slice focado) e follow-up

Entrega os **códigos nomeados** no #311. **Não fecha #311** — o catálogo amplo da v1.40 (B25d/cIndOp, BB05/refDFeAnt, C22/SUFRAMA, UB66/alíquota-zero, UB14/compat-cClassTrib) fica como follow-up: exige parsing de campos novos + tabelas de referência e sobrepõe #312 (devolução) e #313 (cClassTrib).

## Testes & Verificação

- **+3 frontend, +3 backend** (1115 em IBSCBS_MISSING; 1106/960 em cClassTrib; NFS-e sem código NF-e).
- Frontend **101/101** + build OK + `tsc` limpo
- Backend **90/90** + `ruff` + `pyright` limpos

Refs #311 · parte do EPIC #309