### PR TITLE
feat(classtrib): tornar sync SVRS credential-ready com Authorization Bearer (#313)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -79,6 +79,10 @@ class Settings(BaseSettings):
 
     # ── External APIs ─────────────────────────────────────────
     CLASSTRIB_API_URL: str = "https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib"
+    # Token institucional da SVRS Conformidade Fácil (#313). Vazio = sem auth
+    # (mantém o comportamento atual: API responde 403 e usamos os dados locais).
+    # Quando provisionado, vai como secret/env e habilita a sincronização real.
+    CLASSTRIB_API_TOKEN: str = ""
     CNPJ_PRIMARY_URL: str = "https://brasilapi.com.br/api/cnpj/v1/{cnpj}"
     CNPJ_FALLBACK_URL: str = "https://receitaws.com.br/v1/cnpj/{cnpj}"
 

--- a/backend/app/services/classtrib_service.py
+++ b/backend/app/services/classtrib_service.py
@@ -48,6 +48,23 @@ class _LRUCache:
         self._store.clear()
 
 
+def svrs_auth_headers() -> dict[str, str]:
+    """Headers para a API SVRS Conformidade Fácil (#313).
+
+    Inclui Authorization: Bearer <token> quando CLASSTRIB_API_TOKEN está configurado
+    (token institucional da SVRS). Sem token, retorna apenas headers base — a API
+    responde 403 e mantemos os dados locais (migration 0018).
+    """
+    headers = {
+        "User-Agent": "Tribultz/1.0 (contato@tribultz.com.br)",
+        "Accept": "application/json",
+    }
+    token = (settings.CLASSTRIB_API_TOKEN or "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
 class ClassTribService:
     """Client for the Conformidade Fácil ClassTrib API."""
 
@@ -66,7 +83,7 @@ class ClassTribService:
             return cached
 
         try:
-            async with httpx.AsyncClient(timeout=self.timeout) as client:
+            async with httpx.AsyncClient(timeout=self.timeout, headers=svrs_auth_headers()) as client:
                 resp = await client.get(f"{self.base_url}/{code}")
                 if resp.status_code == 200:
                     data = resp.json()

--- a/backend/app/tasks/task_i_compliance.py
+++ b/backend/app/tasks/task_i_compliance.py
@@ -54,22 +54,20 @@ def sync_classtrib_svrs() -> dict:
     """Sincroniza tabela cClassTrib com a API SVRS. Roda semanalmente.
 
     A API SVRS exige credenciais institucionais (retorna 403 sem autenticação).
-    Enquanto não configuradas, mantém os dados da migration 0018
-    (regulamentos 30/abr/2026). Quando as credenciais forem obtidas, adicionar
-    o header Authorization abaixo.
+    Configure CLASSTRIB_API_TOKEN (env/secret) para enviar o header Authorization
+    Bearer; sem token, a API responde 403 e mantemos os dados da migration 0018
+    (regulamentos 30/abr/2026).
     """
+    from app.config import settings
     from app.database import SessionLocal
+    from app.services.classtrib_service import svrs_auth_headers
     from sqlalchemy import text
 
-    SVRS_URL = "https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib"
-    HEADERS = {
-        "User-Agent": "Tribultz/1.0 (contato@tribultz.com.br)",
-        "Accept": "application/json",
-    }
+    SVRS_URL = settings.CLASSTRIB_API_URL
 
     try:
         import httpx
-        with httpx.Client(timeout=30, headers=HEADERS) as client:
+        with httpx.Client(timeout=30, headers=svrs_auth_headers()) as client:
             resp = client.get(SVRS_URL)
 
         if resp.status_code == 403:

--- a/backend/tests/test_classtrib.py
+++ b/backend/tests/test_classtrib.py
@@ -232,3 +232,42 @@ class TestSyncClasstribSvrs:
 
         assert result["synced"] == 0
         assert "error" in result
+
+
+class TestSvrsAuthHeaders:
+    """#313 credential-ready: Authorization Bearer só quando CLASSTRIB_API_TOKEN setado."""
+
+    def test_sem_token_sem_authorization(self, monkeypatch):
+        from app.config import settings
+        from app.services.classtrib_service import svrs_auth_headers
+        monkeypatch.setattr(settings, "CLASSTRIB_API_TOKEN", "")
+        h = svrs_auth_headers()
+        assert "Authorization" not in h
+        assert h["Accept"] == "application/json"
+        assert "Tribultz" in h["User-Agent"]
+
+    def test_com_token_envia_bearer(self, monkeypatch):
+        from app.config import settings
+        from app.services.classtrib_service import svrs_auth_headers
+        monkeypatch.setattr(settings, "CLASSTRIB_API_TOKEN", "  tok-abc  ")
+        h = svrs_auth_headers()
+        assert h["Authorization"] == "Bearer tok-abc"  # trim aplicado
+
+    def test_sync_task_envia_authorization_quando_token(self, monkeypatch):
+        """O sync task injeta o header Authorization quando o token está configurado."""
+        from app.config import settings
+        from app.tasks.task_i_compliance import sync_classtrib_svrs
+        monkeypatch.setattr(settings, "CLASSTRIB_API_TOKEN", "tok-xyz")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+            sync_classtrib_svrs()
+
+        _, kwargs = mock_client_cls.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer tok-xyz"


### PR DESCRIPTION
## Contexto

A API SVRS Conformidade Fácil (`cff.svrs.rs.gov.br/api/v1/consultas/classTrib`) exige **credencial institucional** — retorna **403 sem autenticação**, e o host bloqueia IPs fora da allowlist. Investigação confirmou que **não há rota pública** (testado curl + proxy; as 4 APIs do CFF vivem todas no host bloqueado). O código já antecipava isso no TODO do task: *"adicionar o header Authorization"*.

Este PR **fia o mecanismo de auth** para que, ao obter o token, a sincronização funcione sem mais alterações de código.

## O que muda

- **config:** novo `CLASSTRIB_API_TOKEN` (de env/secret; vazio por padrão → mantém o comportamento atual de 403 + dados locais da migration 0018).
- **classtrib_service:** helper `svrs_auth_headers()` injeta `Authorization: Bearer <token>` quando configurado.
- **task `classtrib.sync_svrs`:** usa o helper compartilhado + `settings.CLASSTRIB_API_URL` (remove URL/headers hardcoded).
- **Testes:** +3 (sem token → sem Authorization; com token → Bearer com trim; task injeta o header). Os testes de 403/rede graceful seguem passando.

## ⚠️ NÃO fecha #313

A atualização **efetiva** da tabela cClassTrib ainda depende de uma destas entradas externas:
1. **Token SVRS institucional** (cadastro no Conformidade Fácil) → seta o secret e o sync semanal popula sozinho; **ou**
2. **Planilha oficial do anexo cClassTrib da NT v1.40** (Portal Nacional NF-e) → parse determinístico + diff vs os 74 atuais + PR.

Este PR remove a lacuna de config e deixa o sync **"pronto: falta o token"**.

## Verificação

Backend **118 passed** (classtrib + validação + cross + public) + `ruff` + `pyright` limpos. Mudança só backend.

Refs #313 · parte do EPIC #309