### PR TITLE
chore(data): re-sincronizar classtrib.json da fonte pública SVRS — 74→156 códigos (#313)

### DIFF
--- a/backend/app/data/classtrib.json
+++ b/backend/app/data/classtrib.json
@@ -1,18 +1,20 @@
 {
   "meta": {
-    "source": "NT 2025.002-RTC",
-    "date": "2026-04-10",
-    "total_codes": 74,
-    "total_cst_groups": 9
+    "source": "SVRS Conformidade Fácil — consulta pública classTrib (sem credencial)",
+    "source_url": "https://dfe-portal.svrs.rs.gov.br/CFF/ClassificacaoTributaria",
+    "extraction_method": "JSON embutido na página /CFF/ClassificacaoTributaria",
+    "date": "2026-06-20",
+    "total_codes": 156,
+    "total_cst_groups": 18
   },
   "by_code": {
-    "1": {
-      "cst": "0",
+    "000001": {
+      "cst": "000",
       "cst_description": "Tributação integral",
       "description": "Situações tributadas integralmente pelo IBS e CBS.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -24,838 +26,994 @@
         "NFCE",
         "NFCOM",
         "NFE",
-        "NFSE",
-        "NFGAS"
-      ]
+        "NFGAS",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art4"
     },
-    "2": {
-      "cst": "0",
+    "000002": {
+      "cst": "000",
       "cst_description": "Tributação integral",
-      "description": "Exploração de via",
+      "description": "Exploração de via, observado o art. 11 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSVIA"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art11"
     },
-    "3": {
-      "cst": "0",
+    "000003": {
+      "cst": "000",
       "cst_description": "Tributação integral",
-      "description": "Regime automotivo - projetos incentivados (art. 311)",
+      "description": "Regime automotivo - projetos incentivados, observado o art. 311 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art311"
     },
-    "4": {
-      "cst": "0",
+    "000004": {
+      "cst": "000",
       "cst_description": "Tributação integral",
-      "description": "Regime automotivo - projetos incentivados (art. 312)",
+      "description": "Regime automotivo - projetos incentivados, observado o art. 312 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art312"
     },
-    "10001": {
-      "cst": "10",
+    "000005": {
+      "cst": "000",
+      "cst_description": "Tributação integral",
+      "description": "Operação com EAC destinado à mistura com gasolina A, mas com saída do biocombustível com destinação diversa, observado o art. 179 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art179\r\n"
+    },
+    "010001": {
+      "cst": "010",
       "cst_description": "Tributação com alíquotas uniformes",
-      "description": "Operações do FGTS não realizadas pela Caixa Econômica Federal",
+      "description": "Operações do FGTS não realizadas pela Caixa Econômica Federal, observado o art. 212 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "5 - Uniforme Setorial",
+      "tipo_aliquota": 5,
       "dfe_allowed": [
-        "NFSE",
-        "DERE"
-      ]
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art212"
     },
-    "10002": {
-      "cst": "10",
+    "010002": {
+      "cst": "010",
       "cst_description": "Tributação com alíquotas uniformes",
       "description": "Operações do serviço financeiro",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "5 - Uniforme Setorial",
-      "dfe_allowed": [
-        "NFSE",
-        "DERE"
-      ]
-    },
-    "11001": {
-      "cst": "11",
-      "cst_description": "Tributação com alíquotas uniformes reduzidas",
-      "description": "Planos de assistência funerária.",
-      "reduction_ibs_pct": 60.0,
-      "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "4 - Uniforme Nacional",
-      "dfe_allowed": [
-        "DERE"
-      ]
-    },
-    "11002": {
-      "cst": "11",
-      "cst_description": "Tributação com alíquotas uniformes reduzidas",
-      "description": "Planos de assistência à saúde",
-      "reduction_ibs_pct": 60.0,
-      "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "4 - Uniforme Nacional",
-      "dfe_allowed": [
-        "DERE"
-      ]
-    },
-    "11003": {
-      "cst": "11",
-      "cst_description": "Tributação com alíquotas uniformes reduzidas",
-      "description": "Intermediação de planos de assistência à saúde",
-      "reduction_ibs_pct": 60.0,
-      "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "4 - Uniforme Nacional",
+      "tipo_aliquota": 5,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art233\r\n"
     },
-    "11004": {
-      "cst": "11",
+    "011001": {
+      "cst": "011",
       "cst_description": "Tributação com alíquotas uniformes reduzidas",
-      "description": "Concursos e prognósticos",
+      "description": "Planos de assistência funerária, observado o art. 236 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 60.0,
+      "reduction_cbs_pct": 60.0,
+      "tipo_aliquota": 4,
+      "dfe_allowed": [],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art236"
+    },
+    "011002": {
+      "cst": "011",
+      "cst_description": "Tributação com alíquotas uniformes reduzidas",
+      "description": "Planos de assistência à saúde, observado o art. 237 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 60.0,
+      "reduction_cbs_pct": 60.0,
+      "tipo_aliquota": 4,
+      "dfe_allowed": [],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art237"
+    },
+    "011003": {
+      "cst": "011",
+      "cst_description": "Tributação com alíquotas uniformes reduzidas",
+      "description": "Intermediação de planos de assistência à saúde, observado o art. 240 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 60.0,
+      "reduction_cbs_pct": 60.0,
+      "tipo_aliquota": 4,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art240"
+    },
+    "011004": {
+      "cst": "011",
+      "cst_description": "Tributação com alíquotas uniformes reduzidas",
+      "description": "Concursos e prognósticos, observado o art. 246 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "4 - Uniforme Nacional",
-      "dfe_allowed": [
-        "DERE"
-      ]
+      "tipo_aliquota": 4,
+      "dfe_allowed": [],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art246"
     },
-    "11005": {
-      "cst": "11",
+    "011005": {
+      "cst": "011",
       "cst_description": "Tributação com alíquotas uniformes reduzidas",
-      "description": "Planos de assistência à saúde de animais domésticos",
+      "description": "Planos de assistência à saúde de animais domésticos, observado o art. 243 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 30.0,
       "reduction_cbs_pct": 30.0,
-      "tipo_aliquota": "4 - Uniforme Nacional",
-      "dfe_allowed": [
-        "DERE"
-      ]
+      "tipo_aliquota": 4,
+      "dfe_allowed": [],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art243"
     },
     "200001": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Serviços de transporte de bens até as zonas de processamento de exportação e bens exportados a partir das zonas de processamento de exportação",
+      "description": "Serviços de transporte de bens até as zonas de processamento de exportação e bens exportados a partir das zonas de processamento de exportação, observado o art. 103 da Lei Complementar n 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "CTE",
         "CTEOS",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art103"
     },
     "200002": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento ou importação para produtor rural não contribuinte ou TAC",
+      "description": "Fornecimento ou importação de tratores, máquinas e implementos agrícolas, destinados a produtor rural não contribuinte, e de veículos de transporte de carga destinados a transportador autônomo de carga pessoa física não contribuinte, observado o art. 110 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art110"
     },
     "200003": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Vendas de produtos destinados à alimentação humana (Anexo I)",
+      "description": "Vendas de produtos destinados à alimentação humana relacionados no Anexo I da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, que compõem a Cesta Básica Nacional de Alimentos, criada nos termos do art. 8º da Emenda Constitucional nº 132, de 20 de dezembro de 2023, observado o art. 125 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art125"
     },
     "200004": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de dispositivos médicos (Anexo XII)",
+      "description": "Fornecimento de dispositivos médicos com a especificação das respectivas classificações da NCM/SH previstas no Anexo XII da Lei Complementar nº 214, de 2025, observado o art. 144 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art144"
     },
     "200005": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de dispositivos médicos para órgãos da administração pública e entidades de saúde imunes (Anexo IV)",
+      "description": "Fornecimento de dispositivos médicos com a especificação das respectivas classificações da NCM/SH previstas no Anexo IV da Lei Complementar nº 214, de 2025, quando adquiridos por órgãos da administração pública direta, autarquias, fundações públicas e entidades de saúde imunes, observado o art. 144 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art144"
     },
     "200006": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Situação de emergência de saúde pública reconhecida pelo Poder público (Anexo XII)",
+      "description": "Situação de emergência de saúde pública reconhecida pelo Poder Legislativo federal, estadual, distrital ou municipal competente, ato conjunto do Ministro da Fazenda e do Comitê Gestor do IBS poderá ser editado, a qualquer momento, para incluir dispositivos não listados no Anexo XII da Lei Complementar nº 214, de 2025, limitada a vigência do benefício ao período e à localidade da emergência de saúde pública, observado o art. 144 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art144"
     },
     "200007": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos dispositivos de acessibilidade próprios para pessoas com deficiência (Anexo XIII)",
+      "description": "Fornecimento dos dispositivos de acessibilidade próprios para pessoas com deficiência relacionados no Anexo XIII da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, observado o art. 145 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art145"
     },
     "200008": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos dispositivos de acessibilidade próprios para pessoas com deficiência adquiridos por órgãos da administração pública (Anexo V)",
+      "description": "Fornecimento dos dispositivos de acessibilidade próprios para pessoas com deficiência relacionados no Anexo V da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, quando adquiridos por órgãos da administração pública direta, autarquias, fundações públicas e entidades imunes, observado o art. 145 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art145"
     },
     "200009": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos medicamentos registrados na Anvisa",
+      "description": "Fornecimento dos medicamentos registrados na Anvisa, observado o art. 146 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art146"
     },
     "200010": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos medicamentos registrados na Anvisa, adquiridos por órgãos da administração pública",
+      "description": "Fornecimento dos medicamentos registrados na Anvisa, quando adquiridos por órgãos da administração pública direta, autarquias, fundações públicas e entidades imunes, observado o art. 146 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art146"
     },
     "200011": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento das composições para nutrição enteral e parenteral quando adquiridas por órgãos da administração pública (Anexo VI)",
+      "description": "Fornecimento das composições para nutrição enteral e parenteral, composições especiais e fórmulas nutricionais destinadas às pessoas com erros inatos do metabolismo relacionadas no Anexo VI da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, quando adquiridas por órgãos da administração pública direta, autarquias e fundações públicas, observado o art. 146 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art146"
     },
     "200012": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Situação de emergência de saúde pública reconhecida pelo Poder público",
+      "description": "Situação de emergência de saúde pública reconhecida pelo Poder Legislativo federal, estadual, distrital ou municipal competente, ato conjunto do Ministro da Fazenda e do Comitê Gestor do IBS poderá ser editado, a qualquer momento, limitada a vigência do benefício ao período e à localidade da emergência de saúde pública, observado o art. 146 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art146"
     },
     "200013": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de tampões higiênicos, absorventes higiênicos internos ou externos",
+      "description": "Fornecimento de tampões higiênicos, absorventes higiênicos internos ou externos, descartáveis ou reutilizáveis, calcinhas absorventes e coletores menstruais, observado o art. 147 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art147"
     },
     "200014": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos produtos hortícolas, frutas e ovos (Anexo XV)",
+      "description": "Fornecimento dos produtos hortícolas, frutas e ovos, relacionados no Anexo XV da Lei Complementar nº 214 , de 2025, com a especificação das respectivas classificações da NCM/SH e desde que não cozidos, observado o art. 148 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art148"
     },
     "200015": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Venda de automóveis de passageiros de fabricação nacional adquiridos por motoristas profissionais ou pessoas com deficiência",
+      "description": "Venda de automóveis de passageiros de fabricação nacional de, no mínimo, 4 (quatro) portas, inclusive a de acesso ao bagageiro, quando adquiridos por motoristas profissionais que exerçam, comprovadamente, em automóvel de sua propriedade, atividade de condutor autônomo de passageiros, na condição de titular de autorização, permissão ou concessão do poder público, e que destinem o automóvel à utilização na categoria de aluguel (táxi), ou por pessoas com deficiência física, visual, auditiva, deficiência mental severa ou profunda, transtorno do espectro autista, com prejuízos na comunicação social e em padrões restritos ou repetitivos de comportamento de nível moderado ou grave, nos termos da legislação relativa à matéria, observado o disposto no art. 149 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art149"
     },
     "200016": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Prestação de serviços de pesquisa e desenvolvimento por Instituição Científica, Tecnológica e de Inovação (ICT)",
+      "description": "Prestação de serviços de pesquisa e desenvolvimento por Instituição Científica, Tecnológica e de Inovação (ICT) sem fins lucrativos para a administração pública direta, autarquias e fundações públicas ou para o contribuinte sujeito ao regime regular do IBS e da CBS, observado o disposto no art. 156  da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art156"
     },
     "200017": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operações relacionadas ao FGTS",
+      "description": "Operações relacionadas ao FGTS, considerando aquelas necessárias à aplicação da Lei nº 8.036, de 1990, realizadas pelo Conselho Curador ou Secretaria Executiva do FGTS, observado o art. 212 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
-        "NFSE",
-        "DERE"
-      ]
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art212"
     },
     "200018": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operações de resseguro e retrocessão",
+      "description": "Operações de resseguro e retrocessão ficam sujeitas à incidência à alíquota zero, inclusive quando os prêmios de resseguro e retrocessão forem cedidos ao exterior, observado o art. 223 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
-      "dfe_allowed": [
-        "DERE"
-      ]
+      "tipo_aliquota": 2,
+      "dfe_allowed": [],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art223"
     },
     "200019": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Importador dos serviços financeiros contribuinte",
+      "description": "Importador dos serviços financeiros que seja contribuinte e tenha direito de apropriação de créditos na aquisição do mesmo serviço financeiro no País, observado o art. 231 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
-        "NFSE",
-        "DERE"
-      ]
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art231"
     },
     "200020": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operação praticada por sociedades cooperativas optantes por regime específico do IBS e CBS",
+      "description": "Operação praticada por sociedades cooperativas optantes por regime específico do IBS e CBS, quando o associado destinar bem ou serviço à cooperativa de que participa, e a cooperativa fornecer bem ou serviço ao associado sujeito ao regime regular do IBS e da CBS, observado o art. 271 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
+        "NF3E",
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art271"
     },
     "200021": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Serviços de transporte público coletivo de passageiros ferroviário e hidroviário",
+      "description": "Serviços de transporte público coletivo de passageiros ferroviário e hidroviário urbanos, semiurbanos e metropolitanos, observado o art. 285 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "BPETM",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art285"
     },
     "200022": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operação originada fora da ZFM que destine bem material industrializado a contribuinte estabelecido na ZFM",
+      "description": "Operação originada fora da Zona Franca de Manaus que destine bem material industrializado de origem nacional a contribuinte estabelecido na Zona Franca de Manaus que seja habilitado nos termos do art. 442 da Lei Complementar nº 214, de 2025, e sujeito ao regime regular do IBS e da CBS ou optante pelo regime do Simples Nacional de que trata o art. 12 da Lei Complementar nº 123, de 2006, observado o art. 445 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art445"
     },
     "200023": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operação realizada por indústria incentivada que destine bem material intermediário para outra indústria incentivada na ZFM",
+      "description": "Operação realizada por indústria incentivada que destine bem material intermediário para outra indústria incentivada na Zona Franca de Manaus, desde que a entrega ou disponibilização dos bens ocorra dentro da referida área, observado o art. 448 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art448"
     },
     "200024": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operação originada fora das Áreas de Livre Comércio destinadas a contribuinte estabelecido nas Áreas de Livre Comércio",
+      "description": "Operação originada fora das Áreas de Livre Comércio que destine bem material industrializado de origem nacional a contribuinte estabelecido nas Áreas de Livre Comércio que seja habilitado nos termos do art. 456 da Lei Complementar nº 214, de 2025, e sujeito ao regime regular do IBS e da CBS ou optante pelo regime do Simples Nacional de que trata o art. 12 da Lei Complementar nº 123, de 2006, observado o art. 463 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art463"
     },
     "200025": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos serviços de educação relacionados ao Programa Universidade para Todos (Prouni)",
+      "description": "Fornecimento dos serviços de educação relacionados ao Programa Universidade para Todos (Prouni), instituído pela Lei nº 11.096, de 13 de janeiro de 2005, observado o art. 308 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art308"
     },
     "200026": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Locação de imóveis localizados nas zonas reabilitadas",
+      "description": "Locação de imóveis localizados nas zonas reabilitadas, pelo prazo de 5 (cinco) anos, contado da data de expedição do habite-se, e relacionados a projetos de reabilitação urbana de zonas históricas e de áreas críticas de recuperação e reconversão urbanística dos Municípios ou do Distrito Federal, a serem delimitadas por lei municipal ou distrital, observado o art. 158 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 80.0,
       "reduction_cbs_pct": 80.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art158"
     },
     "200027": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operações de locação, cessão onerosa e arrendamento de bens imóveis",
+      "description": "Operações de locação, cessão onerosa e arrendamento de bens imóveis, observado o art. 261 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 70.0,
       "reduction_cbs_pct": 70.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
-        "NFABI",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art261"
     },
     "200028": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos serviços de educação (Anexo II)",
+      "description": "Fornecimento dos serviços de educação relacionados no Anexo II da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da Nomenclatura Brasileira de Serviços, Intangíveis e Outras Operações que Produzam Variações no Patrimônio (NBS), observado o art. 129 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art129"
     },
     "200029": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos serviços de saúde humana (Anexo III)",
+      "description": "Fornecimento dos serviços de saúde humana relacionados no Anexo III da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NBS, observado o art. 130 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art130"
     },
     "200030": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Venda dos dispositivos médicos (Anexo IV)",
+      "description": "Venda dos dispositivos médicos relacionados no Anexo IV da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, observado o art. 131 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art131"
     },
     "200031": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos dispositivos de acessibilidade próprios para pessoas com deficiência (Anexo V)",
+      "description": "Fornecimento dos dispositivos de acessibilidade próprios para pessoas com deficiência relacionados no Anexo V da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, observado o art. 132 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art132"
     },
     "200032": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos medicamentos registrados na Anvisa ou produzidos por farmácias de manipulação, ressalvados os medicamentos sujeitos à alíquota zero",
+      "description": "Fornecimento dos medicamentos registrados na Anvisa ou produzidos por farmácias de manipulação, ressalvados os medicamentos sujeitos à alíquota zero de que trata o art. 146 da Lei Complementar nº 214, de 2025, observado o art. 133 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art133"
     },
     "200033": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento das composições para nutrição enteral e parenteral (Anexo VI)",
+      "description": "Fornecimento das composições para nutrição enteral e parenteral, composições especiais e fórmulas nutricionais destinadas às pessoas com erros inatos do metabolismo relacionadas no Anexo VI da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, observado o art. 133 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art133"
     },
     "200034": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos alimentos destinados ao consumo humano (Anexo VII)",
+      "description": "Fornecimento dos alimentos destinados ao consumo humano relacionados no Anexo VII da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, observado o art. 135 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art135"
     },
     "200035": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos produtos de higiene pessoal e limpeza (Anexo VIII)",
+      "description": "Fornecimento dos produtos de higiene pessoal e limpeza relacionados no Anexo VIII da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH, observado o art. 136 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art136"
     },
     "200036": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de produtos agropecuários, aquícolas, pesqueiros, florestais e extrativistas vegetais in natura",
+      "description": "Fornecimento de produtos agropecuários, aquícolas, pesqueiros, florestais e extrativistas vegetais in natura, observado o art. 137 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art137"
     },
     "200037": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de serviços ambientais de conservação ou recuperação da vegetação nativa",
+      "description": "Fornecimento de serviços ambientais de conservação ou recuperação da vegetação nativa, mesmo que fornecidos sob a forma de manejo sustentável de sistemas agrícolas, agroflorestais e agrossilvopastoris, em conformidade com as definições e requisitos da legislação específica, observado o art. 137 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art137"
     },
     "200038": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos insumos agropecuários e aquícolas (Anexo IX)",
+      "description": "Fornecimento dos insumos agropecuários e aquícolas relacionados no Anexo IX da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH e da NBS, observado o art. 138 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art138"
     },
     "200039": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento dos bens e serviços relacionados com produções nacionais artísticas, culturais, de eventos, jornalísticas e audiovisuais (Anexo X)",
+      "description": "Fornecimento dos bens e serviços listados no Anexo X da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NCM/SH e NBS, nos casos relacionados com produções nacionais artísticas, culturais, de eventos, jornalísticas e audiovisuais, observado o art. 139 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art139"
     },
     "200040": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de serviços de comunicação institucional à administração pública",
+      "description": "Fornec dos seguintes serv de comunic instit à admin púb direta, autarq e fund púb: serviços direcionados ao planej, criação, programação e manutenção de páginas eletrônicas da admin pública, ao monitor e gestão de suas redes sociais e à otimização de páginas e canais digitais para mecanismos de buscas e produção de mensagens, infográficos, painéis interativos e conteúdo institucional, serviços de relações com a imprensa, que reúnem estrat org para promover e reforçar a comunicação dos órgãos e das entidades contratantes com seus públicos de interesse, por meio da interação com prof da imprensa, e serviços de relações públicas, que compreendem o esforço de comunic planej, coeso e contínuo que tem por obj estab adequada percepção da atuação e dos obj instituc, a partir do estímulo à compreensão mútua e da manut de padrões de relac e fluxos de inf entre os órgãos e as entidades contrat e seus públicos de interesse, no País e no exterior, obs o art. 140 da Lei Compl nº 214, de 2025",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art140"
     },
     "200041": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de serviço de educação desportiva (art. 141. I)",
+      "description": "Operações relacionadas às seguintes atividades desportivas: fornecimento de serviço de educação desportiva, classificado no código 1.2205.12.00 da NBS, e gestão e exploração do desporto por associações e clubes esportivos filiados ao órgão estadual ou federal responsável pela coordenação dos desportos, inclusive por meio de venda de ingressos para eventos desportivos, fornecimento oneroso ou não de bens e serviços, inclusive ingressos, por meio de programas de sócio-torcedor, cessão dos direitos desportivos dos atletas e transferência de atletas para outra entidade desportiva ou seu retorno à atividade em outra entidade desportiva, observado o art. 141 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art141"
     },
     "200042": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de serviço de gestão e exploração do desporto (art. 141. II)",
+      "description": "Operações relacionadas às seguintes atividades desportivas: gestão e exploração do desporto por associações e clubes esportivos filiados ao órgão estadual ou federal responsável pela coordenação dos desportos, observado o art. 141 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art141"
     },
     "200043": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento à administração pública dos serviços e dos bens relativos à soberania (Anexo XI)",
+      "description": "Fornecimento à administração pública direta, autarquias e fundações púbicas dos serviços e dos bens relativos à soberania e à segurança nacional, à segurança da informação e à segurança cibernética relacionados no Anexo XI da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NBS e da NCM/SH, observado o art. 142 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCOM",
         "NFE",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art142"
     },
     "200044": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operações e prestações de serviços de segurança da informação e segurança cibernética desenv por sociedade que tenha sócio brasileiro (Anexo XI)",
+      "description": "Operações e prestações de serviços de segurança da informação e segurança cibernética desenvolvidos por sociedade que tenha sócio brasileiro com o mínimo de 20% (vinte por cento) do seu capital social, relacionados no Anexo XI da Lei Complementar nº 214, de 2025, com a especificação das respectivas classificações da NBS e da NCM/SH, observado o art. 142 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCOM",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art142"
     },
     "200045": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operações relacionadas a projetos de reabilitação urbana de zonas históricas e de áreas críticas de recuperação e reconversão urbanística",
+      "description": "Operações relacionadas a projetos de reabilitação urbana de zonas históricas e de áreas críticas de recuperação e reconversão urbanística dos Municípios ou do Distrito Federal, a serem delimitadas por lei municipal ou distrital, observado o art. 158 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFABI",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art158"
     },
     "200046": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Operações com bens imóveis",
+      "description": "Operações com bens imóveis, observado o art. 261 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 50.0,
       "reduction_cbs_pct": 50.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFABI",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art261"
     },
     "200047": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Bares e Restaurantes",
+      "description": "Bares e Restaurantes, observado o art. 275 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art275"
     },
     "200048": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Hotelaria, Parques de Diversão e Parques Temáticos",
+      "description": "Hotelaria, Parques de Diversão e Parques Temáticos, observado o art. 281 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art281"
     },
     "200049": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Transporte coletivo de passageiros rodoviário, ferroviário e hidroviário",
+      "description": "Transporte coletivo de passageiros rodoviário, ferroviário e hidroviário intermunicipais e interestaduais, observado o art. 286 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "BPE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art286"
     },
     "200050": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Serviços de transporte aéreo regional coletivo de passageiros ou de carga",
+      "description": "Serviços de transporte aéreo regional coletivo de passageiros ou de carga, observado o art. 287 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "BPETA",
         "CTE",
         "CTEOS"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art287"
     },
     "200051": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Agências de Turismo",
+      "description": "Agências de Turismo, observado o art. 289 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art289"
     },
     "200052": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Prestação de serviços de profissões intelectuais",
+      "description": "Prestação de serviços das seguintes profissões intelectuais de natureza científica, literária ou artística, submetidas à fiscalização por conselho profissional: administradores, advogados, arquitetos e urbanistas, assistentes sociais, bibliotecários, biólogos, contabilistas, economistas, economistas domésticos, profissionais de educação física, engenheiros e agrônomos, estatísticos, médicos veterinários e zootecnistas, museólogos, químicos, profissionais de relações públicas, técnicos industriais e técnicos agrícolas, observado o art. 127 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 30.0,
       "reduction_cbs_pct": 30.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art127"
     },
     "200053": {
       "cst": "200",
       "cst_description": "Alíquota reduzida",
-      "description": "Fornecimento de medicamentos registrados na Anvisa, quando classificados como soros ou vacinas",
+      "description": "Fornecimento de medicamentos registrados na Anvisa, quando  classificados como soros ou vacinas, observado o art. 146 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "NFCE",
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art146"
+    },
+    "200054": {
+      "cst": "200",
+      "cst_description": "Alíquota reduzida",
+      "description": "Fornecimento de bem material pela cooperativa de produção agropecuária a associado não sujeito ao regime regular do IBS e da CBS com anulação de créditos referentes ao bem fornecido, observado o art. 271 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 100.0,
+      "reduction_cbs_pct": 100.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art271\r\n"
     },
     "220001": {
       "cst": "220",
       "cst_description": "Alíquota fixa",
-      "description": "Incorporação imobiliária submetida ao regime especial de tributação",
+      "description": "Incorporação imobiliária submetida ao regime especial de tributação, observado o art. 485 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "1 - Fixa",
+      "tipo_aliquota": 1,
       "dfe_allowed": [
         "NFABI"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art485"
     },
     "220002": {
       "cst": "220",
       "cst_description": "Alíquota fixa",
-      "description": "Incorporação imobiliária submetida ao regime especial de tributação",
+      "description": "Incorporação imobiliária submetida ao regime especial de tributação, observado o art. 485 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "1 - Fixa",
+      "tipo_aliquota": 1,
       "dfe_allowed": [
         "NFABI"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art485"
     },
     "220003": {
       "cst": "220",
       "cst_description": "Alíquota fixa",
-      "description": "Alienação de imóvel decorrente de parcelamento do solo",
+      "description": "Alienação de imóvel decorrente de parcelamento do solo, observado o art. 486 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "1 - Fixa",
+      "tipo_aliquota": 1,
       "dfe_allowed": [
         "NFABI"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art486"
     },
     "221001": {
       "cst": "221",
       "cst_description": "Alíquota fixa proporcional",
-      "description": "Locação, cessão onerosa ou arrendamento de bem imóvel com alíquota sobre a receita bruta",
+      "description": "Locação, cessão onerosa ou arrendamento de bem imóvel com alíquota sobre a receita bruta, observado o art. 487 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "1 - Fixa",
+      "tipo_aliquota": 1,
       "dfe_allowed": [
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art484\r\n"
     },
     "222001": {
       "cst": "222",
       "cst_description": "Redução de Base de Cálculo",
-      "description": "Transporte internacional de passageiros, caso os trechos de ida e volta sejam vendidos em conjunto",
+      "description": "Transporte internacional de passageiros, caso os trechos de ida e volta sejam vendidos em conjunto, a base de cálculo será a metade do valor cobrado, observado o Art. 12 § 8º da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "BPE",
         "BPETA",
         "CTEOS"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art12"
     },
     "400001": {
       "cst": "400",
       "cst_description": "Isenção",
-      "description": "Fornecimento de serviços de transporte público coletivo de passageiros rodoviário e metroviário",
+      "description": "Fornecimento de serviços de transporte público coletivo de passageiros rodoviário e metroviário de caráter urbano, semiurbano e metropolitano, sob regime de autorização, permissão ou concessão pública, observado o art. 157 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "2 - Padrão",
+      "tipo_aliquota": 2,
       "dfe_allowed": [
         "BPE",
         "BPETM",
         "NFSE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art157"
     },
     "400002": {
       "cst": "400",
       "cst_description": "Isenção",
-      "description": "Fornecimento de serviços de transporte público coletivo de passageiros rodoviário e metroviário com medição por quilômetro rodado",
+      "description": "Fornecimento de serviços de transporte público coletivo de passageiros rodoviário e metroviário de caráter urbano, semiurbano e metropolitano, sob regime de autorização, permissão ou concessão pública, com medição por quilômetro rodado, observado o art. 157 da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "3 - Sem aliquota",
+      "tipo_aliquota": 3,
       "dfe_allowed": [
         "CTEOS"
-      ]
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art157"
     },
     "410001": {
       "cst": "410",
       "cst_description": "Imunidade e não incidência",
-      "description": "Fornecimento de bonificações quando constem no documento fiscal e que não dependam de evento posterior",
+      "description": "Fornecimento de bonificações quando constem do respectivo documento fiscal e que não dependam de evento posterior, observado o art. 5º da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "3 - Sem aliquota",
+      "tipo_aliquota": 3,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -868,28 +1026,32 @@
         "NFCE",
         "NFCOM",
         "NFE",
-        "NFSE",
-        "NFGAS"
-      ]
+        "NFGAS",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art5"
     },
     "410002": {
       "cst": "410",
       "cst_description": "Imunidade e não incidência",
-      "description": "Transferências entre estabelecimentos pertencentes ao mesmo contribuinte",
+      "description": "Transferências entre estabelecimentos pertencentes ao mesmo contribuinte, observado o art. 6º da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "3 - Sem aliquota",
+      "tipo_aliquota": 3,
       "dfe_allowed": [
         "NFE"
-      ]
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art6"
     },
     "410003": {
       "cst": "410",
       "cst_description": "Imunidade e não incidência",
-      "description": "Doações sem contraprestação em benefício do doador",
+      "description": "Doações que não tenham por objeto bens ou serviços que tenham permitido a apropriação de créditos pelo doador, observado o art. 6º da Lei Complementar nº 214, de 2025.",
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
-      "tipo_aliquota": "3 - Sem aliquota",
+      "tipo_aliquota": 3,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -902,30 +1064,1159 @@
         "NFCE",
         "NFCOM",
         "NFE",
-        "NFSE",
-        "NFSVIA",
         "NFGAS",
-        "DERE"
-      ]
+        "NFSE",
+        "NFSVIA"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art6"
+    },
+    "410004": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Exportações de bens e serviços, observado o art. 8º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "BPE",
+        "BPETA",
+        "CTE",
+        "CTEOS",
+        "NF3E",
+        "NFCOM",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art8"
+    },
+    "410005": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos realizados pela União, pelos Estados, pelo Distrito Federal e pelos Municípios, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFAG",
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410006": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos realizados por entidades religiosas e templos de qualquer culto, inclusive suas organizações assistenciais e beneficentes, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410007": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos realizados por partidos políticos, inclusive suas fundações, entidades sindicais dos trabalhadores e instituições de educação e de assistência social, sem fins lucrativos, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410008": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos de livros, jornais, periódicos e do papel destinado a sua impressão, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFCOM",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410009": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos de fonogramas e videofonogramas musicais produzidos no Brasil contendo obras musicais ou literomusicais de autores brasileiros e/ou obras em geral interpretadas por artistas brasileiros, bem como os suportes materiais ou arquivos digitais que os contenham, salvo na etapa de replicação industrial de mídias ópticas de leitura a laser, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFCOM",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410010": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos de serviço de comunicação nas modalidades de radiodifusão sonora e de sons e imagens de recepção livre e gratuita, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCOM",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410011": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimentos de ouro, quando definido em lei como ativo financeiro ou instrumento cambial, observado o art. 9º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
+    },
+    "410012": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento de condomínio edilício não optante pelo regime regular, observado o art. 26 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art26"
+    },
+    "410013": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Exportações de combustíveis, observado o art. 98 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art98"
+    },
+    "410014": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento de produtor rural não contribuinte, observado o art. 164 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art164"
+    },
+    "410015": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento por transportador autônomo não contribuinte, observado o art. 169 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "CTE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art169"
+    },
+    "410016": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento ou aquisição de resíduos sólidos, observado o art. 170 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art170"
+    },
+    "410017": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Aquisição de bem móvel com crédito presumido sob condição de revenda realizada, observado o art. 171 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art171"
+    },
+    "410018": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Operações relacionadas aos fundos garantidores e executores de políticas públicas, inclusive de habitação, previstos em lei, assim entendidas os serviços prestados ao fundo pelo seu agente operador e por entidade encarregada da sua administração, observado o art. 213 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art213"
+    },
+    "410019": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Exclusão da gorjeta na base de cálculo no fornecimento de alimentação, observado o art. 274 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art274"
+    },
+    "410020": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Exclusão do valor de intermediação na base de cálculo no fornecimento de alimentação, observado o art. 274 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art274"
+    },
+    "410021": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Contribuição de que trata o art. 149-A da Constituição Federal, observado o art. 12 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NF3E"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art12"
+    },
+    "410022": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Consolidação da propriedade pelo credor de bens móveis ou imóveis que tenham sido objeto de garantia, observado o art. 200 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art200"
+    },
+    "410023": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Alienação de bens móveis ou imóveis que tenham sido objeto de garantia constituída em favor de credor em que o prestador da garantia não seja contribuinte, observado o art. 200 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art200"
+    },
+    "410024": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Consolidação da propriedade pelo grupo de consórcio de bem que tenha sido objeto de garantia, observado o art. 204 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art204"
+    },
+    "410025": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Alienação de bem que tenha sido objeto de garantia constituída em favor do grupo de consórcio em que o prestador da garantia não seja contribuinte, observado o art. 204 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art204"
+    },
+    "410026": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Doações sem contraprestação em benefício do doador, com anulação de crédito apropriados pelo doador referente ao fornecimento doado, observado o art. 6º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "BPE",
+        "BPETA",
+        "BPETM",
+        "CTE",
+        "CTEOS",
+        "NF3E",
+        "NFABI",
+        "NFAG",
+        "NFCE",
+        "NFCOM",
+        "NFE",
+        "NFGAS",
+        "NFSE",
+        "NFSVIA"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art6\r\n"
+    },
+    "410027": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento de bens e serviços, desde que vinculados direta e exclusivamente à exportação de bens materiais ou associados à entrega no exterior de bens materiais, observado o art. 6º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "CTE",
+        "CTEOS",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art80"
+    },
+    "410028": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Operações com bens imóveis realizadas por pessoas físicas não consideradas contribuintes do regime regular do IBS e da CBS, observado o art. 251 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art251"
+    },
+    "410029": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Operações não sujeitas à incidência de IBS e de CBS, alcançadas apenas por obrigação acessória do ICMS, observado o art. 4º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art4"
+    },
+    "410030": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Estorno de crédito apropriado de bens adquiridos e venham a perecer, deteriorar-se ou ser objeto de roubo, furto ou extravio, observado o art. 47 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art47"
+    },
+    "410031": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento em período anterior ao início de vigência de incidências de CBS e IBS, observado o art. 544 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NF3E",
+        "NFAG",
+        "NFCOM",
+        "NFE",
+        "NFGAS"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art544"
+    },
+    "410032": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Tributos incidentes na operação que não integram a base de cálculo do IBS e da CBS, observado o art. 12 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NF3E",
+        "NFAG",
+        "NFCOM",
+        "NFGAS"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art12"
+    },
+    "410033": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Operações com bens imóveis, inclusive operações com direitos reais sobre bens imóveis, realizadas por Fundos de Investimento Imobiliário (FII) e Fundos de Investimento nas Cadeias Produtivas do Agronegócio (Fiagro), observado o art. 26 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI",
+        "NFSE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art26"
+    },
+    "410034": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fundos de investimento cujo patrimônio seja constituído exclusivamente por aplicações em participações societárias, certificados, direitos, títulos, valores mobiliários e demais ativos financeiros permitidos pela Comissão de Valores Mobiliários, observado o art. 26 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art26"
+    },
+    "410035": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Fornecimento realizado por nanoempreendedor, observado o art. 226 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "CTE",
+        "CTEOS",
+        "NFCE",
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art26"
+    },
+    "410999": {
+      "cst": "410",
+      "cst_description": "Imunidade e não incidência",
+      "description": "Operações não onerosas sem previsão de tributação, não especificadas anteriormente, observado o art. 4º da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "BPE",
+        "BPETA",
+        "BPETM",
+        "CTE",
+        "CTEOS",
+        "NF3E",
+        "NFABI",
+        "NFAG",
+        "NFCE",
+        "NFCOM",
+        "NFE",
+        "NFGAS",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art4"
+    },
+    "510001": {
+      "cst": "510",
+      "cst_description": "Diferimento",
+      "description": "Operações, sujeitas a diferimento, com energia elétrica ou com direitos a ela relacionados, relativas à importação, geração, comercialização, distribuição e transmissão, observado o art. 28 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NF3E",
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art28"
+    },
+    "515001": {
+      "cst": "515",
+      "cst_description": "Diferimento com redução de alíquota",
+      "description": "Operações, sujeitas a diferimento, com insumos agropecuários e aquícolas, observado o art. 138 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 60.0,
+      "reduction_cbs_pct": 60.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art138\r\n"
+    },
+    "550001": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Exportações de bens materiais, observado o art. 82 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art82"
+    },
+    "550002": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regime de Trânsito, observado o art. 84 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art84"
+    },
+    "550003": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regimes de Depósito, observado o art. 85 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art85"
+    },
+    "550004": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regimes de Depósito, observado o art. 87 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art87"
+    },
+    "550005": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regimes de Depósito, observado o art. 87 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art87"
+    },
+    "550006": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regimes de Permanência Temporária, observado o art. 88 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art88"
+    },
+    "550007": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regimes de Aperfeiçoamento, observado o art. 90 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art90"
+    },
+    "550008": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Importação de bens para o Regime de Repetro-Temporário, de que tratam o inciso I do art. 93 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art93"
+    },
+    "550009": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "GNL-Temporário, de que trata o inciso II do art. 93 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art93"
+    },
+    "550010": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Repetro-Permanente, de que trata o inciso III do art. 93 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art93"
+    },
+    "550011": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Repetro-Industrialização, de que trata o inciso IV do art. 93 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art93"
+    },
+    "550012": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Repetro-Nacional, de que trata o inciso V do art. 93 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art93"
+    },
+    "550013": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Repetro-Entreposto, de que trata o inciso VI do art. 93 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art93"
+    },
+    "550014": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Zona de Processamento de Exportação, observado os arts. 99, 100 e 102 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art99"
+    },
+    "550015": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regime Tributário para Incentivo à Modernização e à Ampliação da Estrutura Portuária - Reporto, observado o art. 105 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art105"
+    },
+    "550016": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regime Especial de Incentivos para o Desenvolvimento da Infraestrutura - Reidi, observado o art. 106 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art106"
+    },
+    "550017": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regime Tributário para Incentivo à Atividade Econômica Naval – Renaval, observado o art. 107 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art107"
+    },
+    "550018": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Desoneração da aquisição de bens de capital, observado o art. 109 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art109"
+    },
+    "550019": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Importação de bem material por indústria incentivada para utilização na Zona Franca de Manaus, observado o art. 443 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art443"
+    },
+    "550020": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Áreas de livre comércio, observado o art. 461 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art461"
+    },
+    "550021": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Fornecimento de produtos agropecuários in natura para contribuinte do regime regular que promova industrialização destinada a exportação, observado o art. 82 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art82\r\n"
+    },
+    "550022": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Regime Especial de Incentivos para a Produção de Hidrogênio de Baixa Emissão de Carbono (Rehidro),  observado o art. 106 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art106"
+    },
+    "550023": {
+      "cst": "550",
+      "cst_description": "Suspensão",
+      "description": "Operações com hidrocarbonetos líquidos derivados de petróleo não combustíveis ou de gás natural, inclusive nafta, observado o art. 172 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art172"
+    },
+    "620001": {
+      "cst": "620",
+      "cst_description": "Tributação Monofásica",
+      "description": "Tributação monofásica sobre combustíveis, observados os art. 172 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art172"
+    },
+    "620002": {
+      "cst": "620",
+      "cst_description": "Tributação Monofásica",
+      "description": "Tributação monofásica com responsabilidade pela retenção sobre combustíveis, observado o art. 178 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art178"
+    },
+    "620003": {
+      "cst": "620",
+      "cst_description": "Tributação Monofásica",
+      "description": "Tributação monofásica com responsabilidade de retenção de tributos por terceiros, observado o art. 178 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art178"
+    },
+    "620004": {
+      "cst": "620",
+      "cst_description": "Tributação Monofásica",
+      "description": "Tributação monofásica sobre mistura de EAC com gasolina A em percentual superior ou inferior ao obrigatório, observado o art. 179 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art179"
+    },
+    "620005": {
+      "cst": "620",
+      "cst_description": "Tributação Monofásica",
+      "description": "Tributação monofásica sobre mistura de EAC com gasolina A em percentual superior ou inferior ao obrigatório, observado o art. 179 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art179"
+    },
+    "620006": {
+      "cst": "620",
+      "cst_description": "Tributação Monofásica",
+      "description": "Tributação monofásica sobre combustíveis cobrada anteriormente, observador o art. 180 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NFCE",
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art180"
+    },
+    "800001": {
+      "cst": "800",
+      "cst_description": "Transferência de crédito",
+      "description": "Fusão, cisão ou incorporação, observado o art. 55 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art55"
+    },
+    "800002": {
+      "cst": "800",
+      "cst_description": "Transferência de crédito",
+      "description": "Transferência de crédito do associado, inclusive as cooperativas singulares, para cooperativa de que participa das operações antecedentes às operações em que fornece bens e serviços e os créditos presumidos, observado o art. 272 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art272"
+    },
+    "810001": {
+      "cst": "810",
+      "cst_description": "Ajuste de IBS na ZFM",
+      "description": "Crédito presumido sobre o valor apurado nos fornecimentos a partir da Zona Franca de Manaus, observado o art. 450 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art450"
+    },
+    "811001": {
+      "cst": "811",
+      "cst_description": "Ajustes",
+      "description": "Anulação de crédito proporcional ao valor das operações imunes e isentas, observado o art. 51 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art51\r\n"
+    },
+    "811002": {
+      "cst": "811",
+      "cst_description": "Ajustes",
+      "description": "Débitos de notas fiscais não processadas na apuração, observado o art. 45 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art45\r\n"
+    },
+    "811003": {
+      "cst": "811",
+      "cst_description": "Ajustes",
+      "description": "Débitos apurados após o desenquadramento do regime Simples Nacional, observado o art. 41 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFE",
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art41\r\n"
+    },
+    "820001": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de fornecimento de serviços de planos de assistência à saúde elencados no art. 234 da Lei Complementar nº 214, de 2025, mas com tributação realizada por outro meio",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art234"
+    },
+    "820002": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de fornecimento de serviços de planos de assinstência funerária, mas com tributação realizada por outro meio, observado o art. 236 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art236"
+    },
+    "820003": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de fornecimento de serviços de planos de assinstência à saúde de animais domésticos, mas com tributação realizada por outro meio, observado o art. 243 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art243"
+    },
+    "820004": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de prestação de serviços de consursos de prognósticos, mas com tributação realizada por outro meio, observado o art. 248 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art248"
+    },
+    "820005": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de alienação de bens imóveis, mas com tributação realizada por outro meio,, observado o art. 254 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFABI"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art254"
+    },
+    "820006": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de fornecimento de serviços de exploração de via, mas com tributação realizada por outro meio, observado o art. 11 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-09-30",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art11\r\n"
+    },
+    "820007": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de fornecimento de serviços financeiros, mas com tributação realizada por outro meio, observado o art. 181 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NFSE"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art181"
+    },
+    "820008": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Documento com informações de fornecimento, mas com tributação realizada em fatura anterior, observado o art. 10 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "NF3E",
+        "NFAG",
+        "NFCOM",
+        "NFGAS"
+      ],
+      "vigencia_ini": "2025-11-19",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art10"
+    },
+    "820009": {
+      "cst": "820",
+      "cst_description": "Tributação em documento específico",
+      "description": "Cobrança relativa a fornecimentos declarados em outro documento, observado o art. 60 da Lei Complementar nº 214, de 2025.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 3,
+      "dfe_allowed": [
+        "CTEOS",
+        "NF3E",
+        "NFAG",
+        "NFCOM",
+        "NFGAS",
+        "NFSE"
+      ],
+      "vigencia_ini": "2026-01-01",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art60"
+    },
+    "830001": {
+      "cst": "830",
+      "cst_description": "Exclusão da Base de Cálculo",
+      "description": "Documento com  exclusão da base de cálculo da CBS e do IBS refrente à energia elétrica fornecida pela distribuidora à unidade consumidora, conforme  Art 28, parágrafos 3° e 4°.",
+      "reduction_ibs_pct": 0.0,
+      "reduction_cbs_pct": 0.0,
+      "tipo_aliquota": 2,
+      "dfe_allowed": [
+        "NF3E",
+        "NFE"
+      ],
+      "vigencia_ini": "2025-05-05",
+      "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art28"
     }
   },
   "by_cst": {
-    "0": [
-      "1",
-      "2",
-      "3",
-      "4"
+    "000": [
+      "000001",
+      "000002",
+      "000003",
+      "000004",
+      "000005"
     ],
-    "10": [
-      "10001",
-      "10002"
+    "010": [
+      "010001",
+      "010002"
     ],
-    "11": [
-      "11001",
-      "11002",
-      "11003",
-      "11004",
-      "11005"
+    "011": [
+      "011001",
+      "011002",
+      "011003",
+      "011004",
+      "011005"
     ],
     "200": [
       "200001",
@@ -980,7 +2271,8 @@
       "200050",
       "200051",
       "200052",
-      "200053"
+      "200053",
+      "200054"
     ],
     "220": [
       "220001",
@@ -1000,18 +2292,125 @@
     "410": [
       "410001",
       "410002",
-      "410003"
+      "410003",
+      "410004",
+      "410005",
+      "410006",
+      "410007",
+      "410008",
+      "410009",
+      "410010",
+      "410011",
+      "410012",
+      "410013",
+      "410014",
+      "410015",
+      "410016",
+      "410017",
+      "410018",
+      "410019",
+      "410020",
+      "410021",
+      "410022",
+      "410023",
+      "410024",
+      "410025",
+      "410026",
+      "410027",
+      "410028",
+      "410029",
+      "410030",
+      "410031",
+      "410032",
+      "410033",
+      "410034",
+      "410035",
+      "410999"
+    ],
+    "510": [
+      "510001"
+    ],
+    "515": [
+      "515001"
+    ],
+    "550": [
+      "550001",
+      "550002",
+      "550003",
+      "550004",
+      "550005",
+      "550006",
+      "550007",
+      "550008",
+      "550009",
+      "550010",
+      "550011",
+      "550012",
+      "550013",
+      "550014",
+      "550015",
+      "550016",
+      "550017",
+      "550018",
+      "550019",
+      "550020",
+      "550021",
+      "550022",
+      "550023"
+    ],
+    "620": [
+      "620001",
+      "620002",
+      "620003",
+      "620004",
+      "620005",
+      "620006"
+    ],
+    "800": [
+      "800001",
+      "800002"
+    ],
+    "810": [
+      "810001"
+    ],
+    "811": [
+      "811001",
+      "811002",
+      "811003"
+    ],
+    "820": [
+      "820001",
+      "820002",
+      "820003",
+      "820004",
+      "820005",
+      "820006",
+      "820007",
+      "820008",
+      "820009"
+    ],
+    "830": [
+      "830001"
     ]
   },
   "cst_descriptions": {
-    "0": "Tributação integral",
-    "10": "Tributação com alíquotas uniformes",
-    "11": "Tributação com alíquotas uniformes reduzidas",
+    "000": "Tributação integral",
+    "010": "Tributação com alíquotas uniformes",
+    "011": "Tributação com alíquotas uniformes reduzidas",
     "200": "Alíquota reduzida",
     "220": "Alíquota fixa",
     "221": "Alíquota fixa proporcional",
     "222": "Redução de Base de Cálculo",
     "400": "Isenção",
-    "410": "Imunidade e não incidência"
+    "410": "Imunidade e não incidência",
+    "510": "Diferimento",
+    "515": "Diferimento com redução de alíquota",
+    "550": "Suspensão",
+    "620": "Tributação Monofásica",
+    "800": "Transferência de crédito",
+    "810": "Ajuste de IBS na ZFM",
+    "811": "Ajustes",
+    "820": "Tributação em documento específico",
+    "830": "Exclusão da Base de Cálculo"
   }
 }

--- a/backend/scripts/resync_classtrib.py
+++ b/backend/scripts/resync_classtrib.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Re-sincroniza backend/app/data/classtrib.json a partir da fonte oficial SVRS (#313).
+
+A API SVRS Conformidade Fácil (cff.svrs.rs.gov.br) exige credencial institucional
+e bloqueia IPs fora da allowlist. PORÉM, a *consulta pública web* em
+https://dfe-portal.svrs.rs.gov.br/CFF/ClassificacaoTributaria embute o registro
+completo do classTrib como JSON na própria página — fonte autoritativa e acessível
+sem credencial. Este script:
+
+  1. baixa a página pública (ou usa --html para um arquivo local),
+  2. extrai o maior blob JSON balanceado com os registros (campo CstNavigation/
+     ClassificacoesTributarias),
+  3. normaliza no schema do classtrib.json (by_code / by_cst / cst_descriptions / meta),
+  4. grava o arquivo e imprime um diff resumido vs a versão anterior.
+
+Uso:
+    python scripts/resync_classtrib.py [--html caminho.html] [--out caminho.json] [--dry-run]
+
+NÃO re-popula cclass_trib_items (DB): a tabela guarda alíquotas absolutas e a fonte
+SVRS fornece apenas reduções — a derivação redução→alíquota é tratada junto do #278.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+SOURCE_URL = "https://dfe-portal.svrs.rs.gov.br/CFF/ClassificacaoTributaria"
+DEFAULT_OUT = Path(__file__).resolve().parents[1] / "app" / "data" / "classtrib.json"
+
+# Indicadores por DFe na fonte SVRS → rótulo no classtrib.json.
+_DFE_INDICATORS = {
+    "IndNfe": "NFE", "IndNfce": "NFCE", "IndCte": "CTE", "IndCteos": "CTEOS",
+    "IndBpe": "BPE", "IndNf3e": "NF3E", "IndNfcom": "NFCOM", "IndNfse": "NFSE",
+    "IndBpetm": "BPETM", "IndBpeta": "BPETA", "IndNfag": "NFAG", "IndNfgas": "NFGAS",
+    "IndNfsvia": "NFSVIA", "IndNfabi": "NFABI",
+}
+
+
+def fetch_html() -> str:
+    import httpx
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                      "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124 Safari/537.36",
+        "Accept": "text/html,application/json,*/*",
+    }
+    with httpx.Client(timeout=60, headers=headers, follow_redirects=True) as client:
+        resp = client.get(SOURCE_URL)
+        resp.raise_for_status()
+        return resp.text
+
+
+def extract_groups(html: str) -> list[dict]:
+    """Extrai o maior blob JSON balanceado contendo os grupos de CST/classificações."""
+    decoder = json.JSONDecoder()
+    best: list | None = None
+    i, n = 0, len(html)
+    while i < n:
+        if html[i] in "[{":
+            try:
+                obj, end = decoder.raw_decode(html, i)
+            except ValueError:
+                i += 1
+                continue
+            chunk = html[i:end]
+            if (end - i) > 2000 and ("ClassificacoesTributarias" in chunk or '"Cst"' in chunk):
+                if best is None or (end - i) > len(json.dumps(best)):
+                    best = obj
+                i = end
+                continue
+        i += 1
+    if not isinstance(best, list):
+        raise SystemExit("ERRO: blob JSON de classTrib não encontrado na página.")
+    return best
+
+
+def normalize(groups: list[dict]) -> dict:
+    by_code: dict[str, dict] = {}
+    by_cst: dict[str, list[str]] = {}
+    cst_descriptions: dict[str, str] = {}
+
+    for grp in groups:
+        cst = str(grp.get("Cst", "")).strip()
+        nome_cst = (grp.get("NomeCst") or "").strip()
+        if cst:
+            cst_descriptions[cst] = nome_cst
+        for c in grp.get("ClassificacoesTributarias") or []:
+            code = str(c.get("CodClassTrib", "")).strip()
+            if not code:
+                continue
+            dfe = sorted(label for ind, label in _DFE_INDICATORS.items() if c.get(ind))
+            by_code[code] = {
+                "cst": cst,
+                "cst_description": nome_cst,
+                "description": (c.get("NomeClassTrib") or "").strip(),
+                "reduction_ibs_pct": float(c.get("PercRedIbs") or 0.0),
+                "reduction_cbs_pct": float(c.get("PercRedCbs") or 0.0),
+                "tipo_aliquota": c.get("TipoAliq"),
+                "dfe_allowed": dfe,
+                "vigencia_ini": (c.get("DthIniVig") or "")[:10],
+                "legislacao": c.get("TexUrlLegislacao") or "",
+            }
+            by_cst.setdefault(cst, []).append(code)
+
+    for cst in by_cst:
+        by_cst[cst].sort()
+
+    return {
+        "meta": {
+            "source": "SVRS Conformidade Fácil — consulta pública classTrib (sem credencial)",
+            "source_url": SOURCE_URL,
+            "extraction_method": "JSON embutido na página /CFF/ClassificacaoTributaria",
+            "date": dt.date.today().isoformat(),
+            "total_codes": len(by_code),
+            "total_cst_groups": len(cst_descriptions),
+        },
+        "by_code": dict(sorted(by_code.items())),
+        "by_cst": dict(sorted(by_cst.items())),
+        "cst_descriptions": dict(sorted(cst_descriptions.items())),
+    }
+
+
+def print_diff(old: dict, new: dict) -> None:
+    old_codes = set(old.get("by_code", {}))
+    new_codes = set(new["by_code"])
+    added = sorted(new_codes - old_codes)
+    removed = sorted(old_codes - new_codes)
+    print(f"\n── DIFF vs versão anterior ({old.get('meta', {}).get('date', '?')}) ──")
+    print(f"  total: {len(old_codes)} → {len(new_codes)}")
+    print(f"  + adicionados: {len(added)}")
+    print(f"  - removidos:   {len(removed)}")
+    if removed:
+        print(f"    removidos: {removed[:20]}{' …' if len(removed) > 20 else ''}")
+    print(f"  amostra adicionados: {added[:10]}")
+    # checagem de sanidade: códigos devem ser 6 dígitos
+    bad = [c for c in new_codes if not (c.isdigit() and len(c) == 6)]
+    if bad:
+        print(f"  ⚠️  códigos fora do formato 6 dígitos: {bad[:10]}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--html", help="arquivo HTML local (em vez de baixar)")
+    ap.add_argument("--out", default=str(DEFAULT_OUT))
+    ap.add_argument("--dry-run", action="store_true", help="não grava, só mostra o diff")
+    args = ap.parse_args()
+
+    html = Path(args.html).read_text(encoding="utf-8", errors="replace") if args.html else fetch_html()
+    groups = extract_groups(html)
+    new = normalize(groups)
+
+    if len(new["by_code"]) < 74:
+        raise SystemExit(f"ERRO: só {len(new['by_code'])} códigos extraídos (< 74) — abortando p/ não degradar dados.")
+
+    out_path = Path(args.out)
+    old = json.loads(out_path.read_text(encoding="utf-8")) if out_path.exists() else {}
+    print_diff(old, new)
+
+    if args.dry_run:
+        print("\n[dry-run] nada gravado.")
+        return 0
+
+    out_path.write_text(json.dumps(new, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"\n✓ gravado {out_path} ({len(new['by_code'])} códigos)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Descoberta: fonte autoritativa **sem credencial**

A API SVRS Conformidade Fácil (`cff.svrs`) exige credencial e bloqueia IPs externos (403). Mas a **consulta pública web** `dfe-portal.svrs.rs.gov.br/CFF/ClassificacaoTributaria` (host alcançável) **embute o registro completo do classTrib como JSON** — fonte autoritativa, acessível sem credencial.

## O que muda

- **`scripts/resync_classtrib.py`** (novo, reprodutível): baixa a página pública → extrai o JSON embutido → normaliza no schema → grava `classtrib.json` + imprime diff. **Fetch ao vivo validado** (funciona do CI/prod sem credencial). Aborta se extrair < 74 códigos (proteção).
- **`classtrib.json`: 74 → 156 códigos** (a v1.40 expandiu o registro), com `PercRedIbs/Cbs` oficiais, `tipo_aliquota`, `dfe_allowed`, `vigencia_ini`, `legislacao` por código; `meta` com fonte/URL/data.
- **Correção de qualidade:** o arquivo antigo tinha códigos malformados (sem zeros à esquerda: `"1"`, `"10001"`) que não batiam com o cClassTrib de 6 dígitos da NF-e. Agora todos têm 6 dígitos corretos.

## Revisão de dado fiscal

| | Antes | Depois |
|---|---|---|
| Total | 74 | 156 (+93) |
| Formato | malformado | 6 dígitos |
| Grupos CST | 9 | 18 |

Os "11 removidos" são os malformados corrigidos para 6 dígitos (não são perdas).

## Escopo / follow-up

- **NÃO altera `cclass_trib_items` (DB):** a tabela guarda **alíquotas absolutas**; a fonte SVRS dá **reduções**. A derivação redução→alíquota é o núcleo do **#278** — fica para lá.
- **Complementa o #327** (API credenciada para o sync automático futuro). Este PR é o refresh real a partir da tabela pública.

## Verificação

`ruff` + `pyright` limpos no script; `pytest` classtrib + validação **69 passed**. (Nenhum código do app lê o `classtrib.json` — é artefato de referência; mudança de baixo risco operacional.)

Refs #313 · parte do EPIC #309