### PR TITLE
feat(health): probe de e-mail/Resend (SMTP) em /health/ready — observabilidade (#293)

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -8,6 +8,7 @@ GET /health/deep     → alias de /health/ready (convenção Magalu Cloud)
 from __future__ import annotations
 
 import logging
+import smtplib
 import time
 from typing import Literal
 
@@ -37,6 +38,7 @@ class DeepHealthResponse(BaseModel):
     asaas_api: ServiceStatus
     ai_engine: ServiceStatus
     hubspot: ServiceStatus
+    email: ServiceStatus
     latency_ms: int
 
 
@@ -121,6 +123,24 @@ def _probe_hubspot() -> ServiceStatus:
         return "unreachable"
 
 
+def _probe_email() -> ServiceStatus:
+    """Conecta no relay SMTP (Resend em produção) e faz EHLO (timeout 3s).
+
+    Mesma condição de no-op do email_service: 'unconfigured' quando
+    EMAIL_VERIFICATION_ENABLED=false ou SMTP_HOST vazio. Não autentica nem
+    envia — apenas valida que o gateway SMTP está alcançável.
+    """
+    if not settings.EMAIL_VERIFICATION_ENABLED or not settings.SMTP_HOST:
+        return "unconfigured"
+    try:
+        with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT, timeout=3.0) as server:
+            server.ehlo()
+        return "ok"
+    except Exception as exc:
+        logger.warning("Health: SMTP/email probe failed — %s", exc)
+        return "unreachable"
+
+
 def _probe_ai_engine() -> ServiceStatus:
     """GET OpenRouter /models (timeout 3s).
 
@@ -176,6 +196,7 @@ def readiness() -> DeepHealthResponse:
     asaas_status   = _probe_asaas()
     ai_status      = _probe_ai_engine()
     hubspot_status = _probe_hubspot()
+    email_status   = _probe_email()
 
     latency_ms = int((time.monotonic() - t0) * 1000)
 
@@ -183,7 +204,8 @@ def readiness() -> DeepHealthResponse:
     optional_ok = (
         asaas_status   in ("ok", "unconfigured") and
         ai_status      in ("ok", "unconfigured") and
-        hubspot_status in ("ok", "unconfigured")
+        hubspot_status in ("ok", "unconfigured") and
+        email_status   in ("ok", "unconfigured")
     )
 
     if not critical_ok:
@@ -200,6 +222,7 @@ def readiness() -> DeepHealthResponse:
         asaas_api=asaas_status,
         ai_engine=ai_status,
         hubspot=hubspot_status,
+        email=email_status,
         latency_ms=latency_ms,
     )
 

--- a/backend/tests/test_health_deep.py
+++ b/backend/tests/test_health_deep.py
@@ -17,14 +17,15 @@ client = TestClient(app)
 
 # ── Helper ────────────────────────────────────────────────────────────────────
 
-def _patch_probes(db="ok", redis="ok", asaas="unconfigured", ai="unconfigured", hubspot="unconfigured"):
-    """Context manager that patches all five probe functions."""
+def _patch_probes(db="ok", redis="ok", asaas="unconfigured", ai="unconfigured", hubspot="unconfigured", email="unconfigured"):
+    """Context manager that patches all six probe functions."""
     return (
         patch("app.routers.health._probe_db",         return_value=db),
         patch("app.routers.health._probe_redis",       return_value=redis),
         patch("app.routers.health._probe_asaas",       return_value=asaas),
         patch("app.routers.health._probe_ai_engine",   return_value=ai),
         patch("app.routers.health._probe_hubspot",     return_value=hubspot),
+        patch("app.routers.health._probe_email",       return_value=email),
     )
 
 
@@ -54,6 +55,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="ok"),
             patch("app.routers.health._probe_ai_engine",   return_value="ok"),
             patch("app.routers.health._probe_hubspot",     return_value="ok"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.status_code == 200
@@ -73,6 +75,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",     return_value="unreachable"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.json()["status"] == "degraded"
@@ -86,6 +89,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="ok"),
             patch("app.routers.health._probe_ai_engine",   return_value="ok"),
             patch("app.routers.health._probe_hubspot",     return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.json()["status"] == "ok"
@@ -99,6 +103,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",   return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.status_code == 200
@@ -111,6 +116,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",   return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.status_code == 200  # HTTP always 200 — status field signals health
@@ -124,6 +130,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",   return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.json()["status"] == "error"
@@ -137,6 +144,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="unreachable"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",   return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         assert r.json()["status"] == "degraded"
@@ -149,6 +157,7 @@ class TestReadiness:
             patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",   return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r = client.get("/health/ready")
         body = r.json()
@@ -168,6 +177,7 @@ class TestDeepAlias:
             patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
             patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
             patch("app.routers.health._probe_hubspot",   return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
         ):
             r_ready = client.get("/health/ready")
             r_deep  = client.get("/health/deep")
@@ -372,3 +382,78 @@ class TestProbeHubspot:
             mock_cfg.HUBSPOT_API_BASE_URL = "https://api.hubapi.com"
             from app.routers.health import _probe_hubspot
             assert _probe_hubspot() == "unreachable"
+
+
+# ── Email/Resend readiness (#293) ─────────────────────────────────────────────
+
+class TestEmailReadiness:
+    def test_email_unreachable_returns_degraded(self):
+        with (
+            patch("app.routers.health._probe_db",         return_value="ok"),
+            patch("app.routers.health._probe_redis",       return_value="ok"),
+            patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
+            patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
+            patch("app.routers.health._probe_hubspot",     return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unreachable"),
+        ):
+            r = client.get("/health/ready")
+        assert r.json()["status"] == "degraded"
+        assert r.json()["email"] == "unreachable"
+
+    def test_email_unconfigured_stays_ok(self):
+        with (
+            patch("app.routers.health._probe_db",         return_value="ok"),
+            patch("app.routers.health._probe_redis",       return_value="ok"),
+            patch("app.routers.health._probe_asaas",       return_value="ok"),
+            patch("app.routers.health._probe_ai_engine",   return_value="ok"),
+            patch("app.routers.health._probe_hubspot",     return_value="ok"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
+        ):
+            r = client.get("/health/ready")
+        assert r.json()["status"] == "ok"
+        assert r.json()["email"] == "unconfigured"
+
+
+# ── Email probe unit (#293) ───────────────────────────────────────────────────
+
+class TestProbeEmail:
+    def test_disabled_returns_unconfigured(self):
+        with patch("app.routers.health.settings") as cfg:
+            cfg.EMAIL_VERIFICATION_ENABLED = False
+            cfg.SMTP_HOST = "smtp.resend.com"
+            from app.routers.health import _probe_email
+            assert _probe_email() == "unconfigured"
+
+    def test_no_host_returns_unconfigured(self):
+        with patch("app.routers.health.settings") as cfg:
+            cfg.EMAIL_VERIFICATION_ENABLED = True
+            cfg.SMTP_HOST = ""
+            from app.routers.health import _probe_email
+            assert _probe_email() == "unconfigured"
+
+    def test_ehlo_ok_returns_ok(self):
+        mock_server = MagicMock()
+        mock_smtp = MagicMock()
+        mock_smtp.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp.__exit__ = MagicMock(return_value=False)
+        with (
+            patch("app.routers.health.settings") as cfg,
+            patch("app.routers.health.smtplib.SMTP", return_value=mock_smtp),
+        ):
+            cfg.EMAIL_VERIFICATION_ENABLED = True
+            cfg.SMTP_HOST = "smtp.resend.com"
+            cfg.SMTP_PORT = 587
+            from app.routers.health import _probe_email
+            assert _probe_email() == "ok"
+        mock_server.ehlo.assert_called_once()
+
+    def test_connection_error_returns_unreachable(self):
+        with (
+            patch("app.routers.health.settings") as cfg,
+            patch("app.routers.health.smtplib.SMTP", side_effect=OSError("connection refused")),
+        ):
+            cfg.EMAIL_VERIFICATION_ENABLED = True
+            cfg.SMTP_HOST = "smtp.resend.com"
+            cfg.SMTP_PORT = 587
+            from app.routers.health import _probe_email
+            assert _probe_email() == "unreachable"


### PR DESCRIPTION
## Contexto

O `/health/ready` (alias `/health/deep`, convenção Magalu) já probava **db, redis, asaas, ai_engine, hubspot**, mas o **relay de e-mail** (SMTP — **Resend** em produção) ficava **cego**. Se o SMTP cair ou a credencial expirar, os e-mails de verificação/recuperação falham **em silêncio** — exatamente o tipo de falha invisível que a #293 quer eliminar.

## O que muda

- **`_probe_email()`**: conecta no `SMTP_HOST:SMTP_PORT` e faz `EHLO` (timeout 3s, **sem autenticar nem enviar**). 
  - `unconfigured` quando `EMAIL_VERIFICATION_ENABLED=false` ou `SMTP_HOST` vazio (mesma condição de no-op do `email_service`)
  - `ok` quando o gateway SMTP responde
  - `unreachable` em falha/timeout
- Campo **`email`** adicionado ao `DeepHealthResponse`, como serviço **opcional**: `unreachable → degraded` (nunca `error`); `unconfigured → ok`.
- **Testes:** +6 (2 readiness + 4 unidade do probe, mockando `smtplib.SMTP`).

## Nota sobre o escopo do #293

O probe de **HubSpot** pedido no título do #293 **já existia e funciona** (`hubspot:ok` em produção, validado hoje). Este PR estende a mesma observabilidade ao **e-mail/Resend**, que era a lacuna remanescente — fechando o objetivo da issue (eliminar falhas silenciosas de integrações externas).

## Verificação

`pytest` health **36 passed** · `ruff` + `pyright` limpos. Backend-only (sem migration).

Closes #293