### PR TITLE
feat(rules): ALIQUOTA_CLASSTRIB — slice alíquota-zero coerente com o cClassTrib (#278)

### DIFF
--- a/backend/app/data/classtrib_table.py
+++ b/backend/app/data/classtrib_table.py
@@ -1,0 +1,35 @@
+"""Tabela cClassTrib (6 dígitos) carregada de classtrib.json — fonte oficial SVRS (#313/#328).
+
+Usada pela regra ALIQUOTA_CLASSTRIB (#278) para o slice de alíquota-zero: determinar,
+de forma independente das alíquotas de referência, se um cClassTrib deve ter IBS/CBS = 0.
+
+Um cClassTrib é "alíquota-zero" para um tributo quando:
+  - o CST é 400 (isenção) ou 410 (imunidade/não incidência), OU
+  - a redução daquele tributo é >= 100% (ex.: cesta básica).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_DATA = json.loads((Path(__file__).parent / "classtrib.json").read_text(encoding="utf-8"))
+CLASSTRIB_BY_CODE: dict[str, dict] = _DATA.get("by_code", {})
+
+# CSTs do cClassTrib que zeram o tributo independentemente de redução.
+_ZERO_CSTS = {"400", "410"}
+
+
+def classtrib_expected_zero(code: str) -> tuple[bool, bool] | None:
+    """Retorna (cbs_zero, ibs_zero) para o cClassTrib, ou None se o código for desconhecido.
+
+    cbs_zero/ibs_zero = True quando aquele tributo deve ser 0% para este cClassTrib.
+    """
+    item = CLASSTRIB_BY_CODE.get(code)
+    if item is None:
+        return None
+    cst = str(item.get("cst", ""))
+    is_exempt = cst in _ZERO_CSTS
+    cbs_zero = is_exempt or float(item.get("reduction_cbs_pct", 0) or 0) >= 100
+    ibs_zero = is_exempt or float(item.get("reduction_ibs_pct", 0) or 0) >= 100
+    return cbs_zero, ibs_zero

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -29,6 +29,7 @@ from app.tools import s3_tool, postgres_tool
 from app.services.xml_correction_service import correct_xml
 from app.api.plan_gate import require_plan, check_usage_limit, increment_usage
 from app.data.ncm_codes import VALID_NCM_CODES
+from app.data.classtrib_table import classtrib_expected_zero
 from app.data.cest_ncm import lookup_ncm_st
 
 logger = logging.getLogger(__name__)
@@ -728,6 +729,53 @@ def validate_xml(
                 Finding(id="F_CNPJ_UNAVAIL", severity="ALERT", rule_id="CNPJ_ACTIVE", title="Verificação de CNPJ indisponível — API fora do ar", where=FindingWhere(field="CNPJ", xpath=_xpath("CNPJ", doc_type)), recommendation="APIs de consulta CNPJ temporariamente indisponíveis. Verifique manualmente.", evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="CNPJ — API indisponível", xpath=_xpath("CNPJ", doc_type)),
             )
+
+    # ── Rule 19: ALIQUOTA_CLASSTRIB — alíquota-zero coerente com o cClassTrib (#278) ──
+    # Slice de alíquota-zero (independente das alíquotas de referência 2026, que ainda
+    # têm ambiguidade — #315): se o cClassTrib é isento/imune (CST 400/410) ou tem
+    # redução ≥ 100% (ex.: cesta básica), o IBS/CBS declarado DEVE ser 0. pCBS/pIBS > 0
+    # nesse caso é FATAL. Dados da tabela oficial SVRS (classtrib.json, #328).
+    # A comparação absoluta (alíquota não-zero vs esperada) fica para fase 2 (depende #315).
+    if has_ibscbs and c_class_trib and re.match(r"^\d{6}$", c_class_trib["value"]):
+        _exp = classtrib_expected_zero(c_class_trib["value"])
+        if _exp is not None:
+            _cbs_zero, _ibs_zero = _exp
+            _TOL = 0.0001  # 0,01%
+            _pcbs = _to_float(p_cbs["value"]) if p_cbs else 0.0
+            _pibs_total = (
+                (_to_float(p_ibs_uf["value"]) if p_ibs_uf else 0.0)
+                + (_to_float(p_ibs_mun["value"]) if p_ibs_mun else 0.0)
+            )
+            if _cbs_zero and _pcbs > _TOL:
+                ev_id = "E_XML_ALIQUOTA_CLASSTRIB_CBS"
+                _add(
+                    Finding(
+                        id="F_ALIQUOTA_CLASSTRIB_CBS", severity="FATAL", rule_id="ALIQUOTA_CLASSTRIB",
+                        title=f'cClassTrib {c_class_trib["value"]} é alíquota-zero de CBS, mas pCBS={_pcbs} foi declarado',
+                        where=FindingWhere(field="pCBS", xpath=_xpath("pCBS", doc_type), snippet=p_cbs["snippet"] if p_cbs else None),
+                        recommendation=(
+                            f'O cClassTrib {c_class_trib["value"]} é isento/imune ou tem redução de 100% — '
+                            "a CBS deve ser zero. Ajuste pCBS para 0 ou corrija o cClassTrib (tabela oficial SVRS)."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="CBS — alíquota-zero incoerente", xpath=_xpath("pCBS", doc_type), snippet=p_cbs["snippet"] if p_cbs else None),
+                )
+            if _ibs_zero and _pibs_total > _TOL:
+                ev_id = "E_XML_ALIQUOTA_CLASSTRIB_IBS"
+                _add(
+                    Finding(
+                        id="F_ALIQUOTA_CLASSTRIB_IBS", severity="FATAL", rule_id="ALIQUOTA_CLASSTRIB",
+                        title=f'cClassTrib {c_class_trib["value"]} é alíquota-zero de IBS, mas pIBSUF+pIBSMun={_pibs_total} foi declarado',
+                        where=FindingWhere(field="pIBS", xpath=_xpath("pIBSUF", doc_type), snippet=p_ibs_uf["snippet"] if p_ibs_uf else None),
+                        recommendation=(
+                            f'O cClassTrib {c_class_trib["value"]} é isento/imune ou tem redução de 100% — '
+                            "o IBS deve ser zero. Ajuste pIBSUF/pIBSMun para 0 ou corrija o cClassTrib (tabela oficial SVRS)."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="IBS — alíquota-zero incoerente", xpath=_xpath("pIBSUF", doc_type), snippet=p_ibs_uf["snippet"] if p_ibs_uf else None),
+                )
 
     # ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────
     # Decreto 12.955/2026 art. 65 (LC 214 art. 63): IBS/CBS incidem sobre a importação

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -442,3 +442,51 @@ class TestRejectionCodesV140:
         r = validate_xml(xml, "NFSE")
         f = [x for x in r.findings if x.rule_id == "CCLASSTRIB_6_DIGITS"]
         assert f and "1106" not in f[0].recommendation
+
+
+# ── Item #278: ALIQUOTA_CLASSTRIB — slice alíquota-zero ──────────────────────
+
+
+class TestAliquotaClasstrib:
+    """cClassTrib isento/imune (CST 400/410) ou redução ≥100% deve ter IBS/CBS = 0.
+    pCBS/pIBS > 0 nesse caso → FATAL. Independente das alíquotas de referência."""
+
+    def _nfe(self, code, pcbs="0", pibsuf="0", pibsmun="0"):
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            '<det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>{code}</cClassTrib>'
+            '<gIBSCBS><vBC>1000.00</vBC>'
+            f'<gIBSUF><pIBSUF>{pibsuf}</pIBSUF><vIBSUF>0.00</vIBSUF></gIBSUF>'
+            f'<gIBSMun><pIBSMun>{pibsmun}</pIBSMun><vIBSMun>0.00</vIBSMun></gIBSMun>'
+            f'<vIBS>0.00</vIBS><gCBS><pCBS>{pcbs}</pCBS><vCBS>0.00</vCBS></gCBS>'
+            '</gIBSCBS></IBSCBS></imposto></det>'
+            '<total><IBSCBSTot><vIBS>0.00</vIBS><vCBS>0.00</vCBS></IBSCBSTot></total>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml):
+        return [f for f in validate_xml(xml, "NFE").findings if f.rule_id == "ALIQUOTA_CLASSTRIB"]
+
+    def test_isento_400_com_cbs_declarado_fatal(self):
+        f = self._find(self._nfe("400001", pcbs="0.009"))
+        assert any(x.id == "F_ALIQUOTA_CLASSTRIB_CBS" for x in f)
+        assert all(x.severity == "FATAL" for x in f)
+
+    def test_isento_zerado_sem_finding(self):
+        assert self._find(self._nfe("400001")) == []
+
+    def test_tributado_000_com_cbs_sem_finding(self):
+        assert self._find(self._nfe("000001", pcbs="0.009")) == []
+
+    def test_imune_410_com_ibs_declarado_fatal(self):
+        f = self._find(self._nfe("410001", pibsuf="0.0005"))
+        assert any(x.id == "F_ALIQUOTA_CLASSTRIB_IBS" for x in f)
+
+    def test_reducao_100_com_cbs_fatal(self):
+        f = self._find(self._nfe("200001", pcbs="0.009"))
+        assert any(x.id == "F_ALIQUOTA_CLASSTRIB_CBS" for x in f)
+
+    def test_codigo_desconhecido_sem_finding(self):
+        assert self._find(self._nfe("999999", pcbs="0.009")) == []


### PR DESCRIPTION
## Contexto

Hoje validamos `vCBS = vBC × pCBS` e o formato do `cClassTrib`, mas **não** se a alíquota declarada é coerente com o `cClassTrib`. Ex. que passa: cesta básica (alíquota 0%) emitida com `pCBS = 0,88%` → aprovado incorretamente.

## O que muda — slice **alíquota-zero**

Nova regra **`ALIQUOTA_CLASSTRIB`** (NF-e, backend): se o `cClassTrib` é **isento/imune** (CST 400/410) ou tem **redução ≥ 100%** (cesta básica), o IBS/CBS declarado **deve ser 0**. `pCBS` ou `pIBSUF+pIBSMun` > 0 (tolerância 0,01%) → **FATAL**.

- **Fonte oficial direto:** novo `app/data/classtrib_table.py` lê o `classtrib.json` (156 códigos 6-díg + reduções, do #328) — padrão `ncm_codes`. **Sem re-seed do DB** e **sem o mismatch de taxonomia** (`cclass_trib_items` é keyed por código de produto, não pelo cClassTrib de 6 dígitos da NF-e).
- **Backend-only**, como as outras regras de enrichment (`CLASSTRIB_VALID`, `CNPJ_ACTIVE`).

## Escopo deliberado (fase 1) e follow-up

A comparação **absoluta** (`pCBS` vs referência 2026 × (1−redução)) **fica para fase 2** — depende de resolver a **ambiguidade das alíquotas de referência** (#315: 0,9%/0,1% vs migration 0018: 0,88%/0,176%). Codar agora arriscaria **falso-positivo fiscal**. O slice alíquota-zero é **independente de referência** e alta confiança.

Também deferido: **re-seed do DB `cclass_trib_items`** com os 156 códigos 6-díg (para o endpoint público `/classtrib/{codigo}` servir a taxonomia certa).

## Verificação

Backend **124 passed** (+6) · `ruff` + `pyright` limpos · backend-only (sem migration).

Refs #278 · parte do EPIC #309