### PR TITLE
fix(site): números canônicos — regras/cClassTrib/SPED alinhados ao código (SPEC Fase 1, RF-1/2/3)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "test:e2e": "tsx --test tests/calculadora.e2e.test.ts tests/auth.e2e.test.ts tests/validate-xml.e2e.test.ts"
   },

--- a/frontend/src/app/classificacao/page.tsx
+++ b/frontend/src/app/classificacao/page.tsx
@@ -9,11 +9,12 @@
 
 import { Classifier } from "./Classifier";
 import { FundamentacaoLegal } from "@/components/seo/FundamentacaoLegal";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 const FAQ = [
   {
     q: "O que é cClassTrib e por que ele causa rejeições de NF-e?",
-    a: "O cClassTrib é um código de 7 dígitos da LC 214/2025 que define o regime tributário de CBS e IBS de cada produto. Quando ele é incompatível com o CST informado no XML, a SEFAZ rejeita a nota com o código 1024. A classificação correta exige mapear o NCM do produto para o regime aplicável (padrão, reduzido, cesta básica, monofásico, imune, etc).",
+    a: "O cClassTrib é um código de 6 dígitos da LC 214/2025 que define o regime tributário de CBS e IBS de cada produto. Quando ele é incompatível com o CST informado no XML, a SEFAZ rejeita a nota com o código 1024. A classificação correta exige mapear o NCM do produto para o regime aplicável (padrão, reduzido, cesta básica, monofásico, imune, etc).",
   },
   {
     q: "Quando começam as penalidades por cClassTrib incorreto?",
@@ -21,15 +22,15 @@ const FAQ = [
   },
   {
     q: "Como funciona a classificação automática NCM → cClassTrib?",
-    a: "Nossa IA analisa a descrição do produto e sugere o NCM mais adequado conforme a TIPI (Decreto 11.158/2022). A partir do capítulo NCM, mapeamos o cClassTrib disponível na tabela oficial SVRS atualizada em 15/abr/2026. O resultado inclui um indicador de confiança — valores abaixo de 70% devem ser confirmados com o contador.",
+    a: "Nossa IA analisa a descrição do produto e sugere o NCM mais adequado conforme a TIPI (Decreto 11.158/2022). A partir do capítulo NCM, mapeamos o cClassTrib conforme a tabela oficial da SVRS (NT 2025.002-RTC v1.40). O resultado inclui um indicador de confiança — valores abaixo de 70% devem ser confirmados com o contador.",
   },
   {
     q: "Posso usar o NCM sugerido diretamente na NF-e?",
-    a: "O NCM sugerido é referência baseada em IA para agilizar a classificação. Confiança acima de 85% indica alta probabilidade de acerto, mas recomendamos sempre validar com o contador responsável pelo SPED antes de usar em produção. A Tribultz oferece validação completa das 18 regras CBS/IBS para confirmação.",
+    a: `O NCM sugerido é referência baseada em IA para agilizar a classificação. Confiança acima de 85% indica alta probabilidade de acerto, mas recomendamos sempre validar com o contador responsável pelo SPED antes de usar em produção. A Tribultz oferece validação completa das ${RULES_COUNT} regras CBS/IBS para confirmação.`,
   },
   {
     q: "Qual a diferença entre NCM e cClassTrib?",
-    a: "NCM é o código de 8 dígitos que identifica o produto na Nomenclatura Comum do Mercosul (tabela TIPI). cClassTrib é o código de 7 dígitos da LC 214 que define como esse produto é tributado pelo IBS e CBS na Reforma Tributária. Um mesmo NCM pode ter diferentes cClassTrib dependendo do regime fiscal aplicável (padrão, reduzido, cesta básica, monofásico, imune).",
+    a: "NCM é o código de 8 dígitos que identifica o produto na Nomenclatura Comum do Mercosul (tabela TIPI). cClassTrib é o código de 6 dígitos da LC 214 que define como esse produto é tributado pelo IBS e CBS na Reforma Tributária. Um mesmo NCM pode ter diferentes cClassTrib dependendo do regime fiscal aplicável (padrão, reduzido, cesta básica, monofásico, imune).",
   },
   {
     q: "O cClassTrib muda com base no destinatário ou na operação?",
@@ -112,7 +113,7 @@ export default function ClassificacaoPage() {
             <h2 className="mb-3 text-2xl font-bold text-slate-900">O que é o cClassTrib</h2>
             <p className="text-slate-700">
               O <strong>cClassTrib</strong> (Código de Classificação Tributária) é um código numérico
-              de 7 dígitos introduzido pela <strong>Lei Complementar 214/2025</strong> e detalhado pela
+              de 6 dígitos introduzido pela <strong>Lei Complementar 214/2025</strong> e detalhado pela
               <strong> Nota Técnica 2025.002-RTC</strong>. Ele define o regime tributário de IBS e CBS
               aplicável a cada item da NF-e — informa à SEFAZ se o produto é normalmente tributado,
               tem alíquota reduzida, integra a cesta básica, está sujeito a monofásico, é imune ou
@@ -129,7 +130,7 @@ export default function ClassificacaoPage() {
           <div>
             <h2 className="mb-3 text-2xl font-bold text-slate-900">Estrutura do código cClassTrib</h2>
             <p className="text-slate-700">
-              Os 7 dígitos do cClassTrib têm semântica posicional. Os três primeiros dígitos batem
+              Os 6 dígitos do cClassTrib têm semântica posicional. Os três primeiros dígitos batem
               obrigatoriamente com o CST informado — esta é a fonte mais comum de Rejeição 1024:
             </p>
             <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200">
@@ -215,7 +216,7 @@ export default function ClassificacaoPage() {
               A Tribultz combina três fontes para sugerir o cClassTrib correto:
             </p>
             <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-700">
-              <li>Base oficial cClassTrib SVRS (atualização 15/abr/2026, ~1.500 códigos vigentes)</li>
+              <li>Base oficial cClassTrib da SVRS (tabela da NT 2025.002-RTC v1.40)</li>
               <li>Anexos da LC 214 com regime, alíquota referência e vigência por NCM</li>
               <li>Modelo de IA treinado sobre descrições reais de NF-e para resolver ambiguidade do NCM a partir da descrição em linguagem natural</li>
             </ul>

--- a/frontend/src/app/diagnostico/layout.tsx
+++ b/frontend/src/app/diagnostico/layout.tsx
@@ -4,11 +4,12 @@ import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { DIAGNOSTICO_SCHEMA } from "@/components/seo/schemas";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 export const metadata: Metadata = {
   title: "Diagnóstico Gratuito NF-e — Conformidade IBS/CBS 2026 | Tribultz",
   description:
-    "Valide sua NF-e, NFC-e ou NFS-e gratuitamente contra as 18 regras da NT 2025.002-RTC. " +
+    `Valide sua NF-e, NFC-e ou NFS-e gratuitamente contra as ${RULES_COUNT} regras da NT 2025.002-RTC. ` +
     "Evite multas de 18% por não destacar IBS e CBS. Diagnóstico instantâneo.",
   openGraph: {
     title: "Diagnóstico Gratuito NF-e — Conformidade IBS/CBS 2026",

--- a/frontend/src/app/diagnostico/page.tsx
+++ b/frontend/src/app/diagnostico/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 import Link from "next/link";
 import { API_BASE, createTransactionId } from "@/lib/api";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -120,7 +121,7 @@ export default function DiagnosticoPage() {
           Faça o diagnóstico gratuito agora.
         </p>
         <div className="mx-auto mt-2 flex items-center justify-center gap-4 text-sm text-slate-500">
-          <span>18 regras verificadas</span>
+          <span>{RULES_COUNT} regras verificadas</span>
           <span>NF-e, NFC-e e NFS-e</span>
           <span>NT 2025.002-RTC</span>
         </div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import { Montserrat, Source_Sans_3, Roboto_Mono } from "next/font/google";
 import Script from "next/script";
 import { AppShell } from "@/components/layout/AppShell";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 import "./globals.css";
 
 const montserrat = Montserrat({
@@ -25,7 +26,7 @@ const robotoMono = Roboto_Mono({
 const SITE_URL = "https://tribultz.com.br";
 const SITE_NAME = "Tribultz";
 const DEFAULT_DESCRIPTION =
-  "Evite Rejeição 1024 e penalidades CBS/IBS. Classifique NCM → cClassTrib, valide 18 regras LC 214 e exporte para TOTVS, SAP, Omie e Linx. Compliance auditável para a Reforma Tributária.";
+  `Evite Rejeição 1024 e penalidades CBS/IBS. Classifique NCM → cClassTrib, valide ${RULES_COUNT} regras LC 214 e exporte para TOTVS, SAP, Omie e Linx. Compliance auditável para a Reforma Tributária.`;
 
 export const metadata: Metadata = {
   title: {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,10 +3,11 @@ import Link from "next/link";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
 import { NewsFeed } from "@/components/public/NewsFeed";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 export const metadata: Metadata = {
   title: "IBS e CBS sem Rejeição de NF-e — Compliance LC 214",
-  description: "Rejeição 1024 por cClassTrib errado? Penalidades CBS/IBS a partir de agosto/2026. Classifique NCM → cClassTrib, valide 18 regras da Reforma e exporte para TOTVS/SAP/Omie/Linx. 100 créditos API grátis.",
+  description: `Rejeição 1024 por cClassTrib errado? Penalidades CBS/IBS a partir de agosto/2026. Classifique NCM → cClassTrib, valide ${RULES_COUNT} regras da Reforma e exporte para TOTVS/SAP/Omie/Linx. 100 créditos API grátis.`,
   keywords: [
     "Rejeição 1024 NF-e", "cClassTrib CBS IBS", "NCM cClassTrib LC 214",
     "penalidades CBS IBS 2026", "validação NF-e reform tributária",
@@ -119,7 +120,7 @@ function HeroVisual() {
         <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#E8F0FE] text-[#2956E3]">
           <Check color="#2956E3" />
         </span>
-        18 regras validadas
+        {RULES_COUNT} regras validadas
       </div>
 
       <div className="rounded-2xl border border-slate-200 bg-white p-6" style={{ boxShadow: "0 24px 60px -20px rgba(41,86,227,0.18), 0 4px 12px rgba(36,41,46,0.04)" }}>
@@ -244,7 +245,7 @@ export default function HomePage() {
             {[
               { icon: "🛡", label: "Tabela oficial SVRS" },
               { icon: "🔌", label: "API NCM → cClassTrib" },
-              { icon: "✅", label: "18 regras CBS/IBS LC 214" },
+              { icon: "✅", label: `${RULES_COUNT} regras CBS/IBS LC 214` },
               { icon: "🔗", label: "TOTVS · SAP · Omie · Linx" },
               { icon: "📄", label: "Auditável (PDF + JSON)" },
               { icon: "🔔", label: "Trial gerenciado · avisos D-3 e D-1" },
@@ -269,7 +270,7 @@ export default function HomePage() {
                 </h2>
               </div>
               <p className="text-base leading-relaxed text-[#334155]">
-                Seu ERP envia o XML, nosso motor valida contra as 18 regras da LC 214, você emite com a evidência auditável.
+                Seu ERP envia o XML, nosso motor valida contra as {RULES_COUNT} regras da LC 214, você emite com a evidência auditável.
               </p>
             </div>
 
@@ -322,7 +323,7 @@ export default function HomePage() {
                 {
                   badge: "SPED FISCAL",
                   preview: [
-                    { l: "EFD-ICMS/IPI · 12.430 itens", r: "✓", ok: true },
+                    { l: "EFD-ICMS/IPI · catálogo completo", r: "✓", ok: true },
                     { l: "Catálogo CBS/IBS", r: "100%", ok: true },
                     { l: "Export TOTVS / SAP / Omie", r: "↓", ok: false },
                   ],
@@ -338,8 +339,8 @@ export default function HomePage() {
                     { l: "0030005 · Cesta básica", r: "0%", ok: true },
                   ],
                   title: "cClassTrib LC 214",
-                  body: "Valide a nova classificação tributária da Reforma. Alíquotas CBS/IBS sincronizadas com a tabela oficial SVRS.",
-                  meta: "Sincronização semanal · 1.247 códigos",
+                  body: "Valide a nova classificação tributária da Reforma. Alíquotas CBS/IBS conforme a tabela oficial SVRS.",
+                  meta: "Tabela oficial SVRS · NT 2025.002-RTC v1.40",
                 },
                 {
                   badge: "COMPLIANCE SCORE",
@@ -445,7 +446,7 @@ export default function HomePage() {
                   Reforma chega em 2026.
                 </h2>
                 <p className="mb-8 text-lg leading-relaxed" style={{ color: "rgba(255,255,255,0.8)" }}>
-                  5 validações de cortesia, 18 regras CBS/IBS, diagnóstico imediato. Sem cartão de crédito.
+                  5 validações de cortesia, {RULES_COUNT} regras CBS/IBS, diagnóstico imediato. Sem cartão de crédito.
                 </p>
                 <div className="flex flex-wrap items-center gap-4">
                   <Link
@@ -464,8 +465,8 @@ export default function HomePage() {
 
               <div className="grid grid-cols-2 gap-4">
                 {[
-                  { n: "18", l: "Regras CBS/IBS validadas" },
-                  { n: "1.247", l: "Códigos cClassTrib ativos" },
+                  { n: String(RULES_COUNT), l: "Regras CBS/IBS validadas" },
+                  { n: "156", l: "Classificações cClassTrib (SVRS)" },
                   { n: "100", l: "Créditos API grátis" },
                   { n: "5 min", l: "Monitoramento contínuo" },
                 ].map((s) => (

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/storage";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 // ── Plan definitions ────────────────────────────────────────────
 
@@ -29,7 +30,7 @@ const PLANS: Plan[] = [
     tagline: "Comece agora, sem cartão",
     features: [
       "5 validações XML por mês",
-      "18 regras CBS/IBS",
+      `${RULES_COUNT} regras CBS/IBS`,
       "Diagnóstico gratuito",
       "Calculadora CBS/IBS",
     ],
@@ -45,7 +46,7 @@ const PLANS: Plan[] = [
     tagline: "Para autônomos e MEIs",
     features: [
       "10 validações XML por mês",
-      "18 regras CBS/IBS",
+      `${RULES_COUNT} regras CBS/IBS`,
       "Dashboard de conformidade",
       "Histórico de validações",
     ],
@@ -428,7 +429,7 @@ export default function PricingPage() {
                     values: [false, false, true, true, true],
                   },
                   {
-                    label: "18 regras CBS/IBS",
+                    label: `${RULES_COUNT} regras CBS/IBS`,
                     values: [true, true, true, true, true],
                   },
                   {
@@ -520,7 +521,7 @@ export default function PricingPage() {
         <section className="border-t border-slate-200 bg-tribultz-700 py-16 text-center text-white">
           <h2 className="mb-4 text-3xl font-extrabold">Pronto para estar em conformidade?</h2>
           <p className="mb-8 text-tribultz-200">
-            18 regras determinísticas. Evidências auditáveis. Reforma tributária descomplicada.
+            {RULES_COUNT} regras determinísticas. Evidências auditáveis. Reforma tributária descomplicada.
           </p>
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link

--- a/frontend/src/components/seo/schemas.ts
+++ b/frontend/src/components/seo/schemas.ts
@@ -10,6 +10,7 @@
  */
 
 import type { SchemaObject } from "./JsonLd";
+import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 const SITE_URL = "https://tribultz.com.br";
 const ORG_ID = `${SITE_URL}/#org`;
@@ -157,14 +158,14 @@ export const DIAGNOSTICO_SCHEMA: SchemaObject[] = [
     "isAccessibleForFree": true,
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL" },
     "description":
-      "Valide sua NF-e, NFC-e ou NFS-e contra as 18 regras da NT 2025.002-RTC. " +
+      `Valide sua NF-e, NFC-e ou NFS-e contra as ${RULES_COUNT} regras da NT 2025.002-RTC. ` +
       "Diagnóstico instantâneo, sem cadastro, evidência auditável.",
   },
   faqPage(DIAGNOSTICO_URL, [
     {
       q: "O que é validado no diagnóstico gratuito?",
       a:
-        "São aplicadas 18 regras determinísticas: formato CST/cClassTrib/NCM, " +
+        `São aplicadas ${RULES_COUNT} regras determinísticas: formato CST/cClassTrib/NCM, ` +
         "compatibilidade CST × cClassTrib (Rejeição 1024), cálculo CBS/IBS, " +
         "totais, CEST × ST (Convênio 142/2018), split payment indPag e estrutura XML.",
     },

--- a/frontend/src/lib/validation/rulesMeta.test.ts
+++ b/frontend/src/lib/validation/rulesMeta.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RULES_COUNT, PLACEHOLDER_RULE_IDS } from "./rulesMeta";
+
+// Guarda anti-drift (RF-1): RULES_COUNT deve igualar a contagem real de regras de
+// validação ativas no engine (ruleIds distintos do xmlRules.ts menos os placeholders).
+// Se uma regra for adicionada/removida no engine, este teste falha até RULES_COUNT
+// ser atualizado — garantindo que site/blog/metadados nunca divirjam do código.
+test("RULES_COUNT == regras ativas no engine (xmlRules.ts)", () => {
+  const src = readFileSync(join(process.cwd(), "src/lib/validation/xmlRules.ts"), "utf-8");
+  const ids = new Set<string>();
+  for (const m of src.matchAll(/ruleId:\s*"([A-Z_]+)"/g)) {
+    ids.add(m[1]);
+  }
+  const placeholders = new Set(PLACEHOLDER_RULE_IDS);
+  const active = [...ids].filter((id) => !placeholders.has(id));
+  assert.equal(
+    active.length,
+    RULES_COUNT,
+    `RULES_COUNT (${RULES_COUNT}) ≠ regras ativas no engine (${active.length}). ` +
+      `ruleIds ativos: ${active.sort().join(", ")}. Atualize RULES_COUNT em rulesMeta.ts.`,
+  );
+});
+
+test("placeholders existem no engine (evita exclusão obsoleta)", () => {
+  const src = readFileSync(join(process.cwd(), "src/lib/validation/xmlRules.ts"), "utf-8");
+  for (const ph of PLACEHOLDER_RULE_IDS) {
+    assert.ok(src.includes(`"${ph}"`), `placeholder ${ph} não encontrado no engine — remover de PLACEHOLDER_RULE_IDS`);
+  }
+});

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -1,0 +1,21 @@
+/**
+ * Número canônico de regras determinísticas do motor (RF-1 — SPEC site).
+ *
+ * Fonte única reutilizada por copy, blog e metadados (SEO/OG/Twitter), para que o
+ * site nunca divirja do engine. Conta as regras de validação ATIVAS do
+ * `xmlRules.ts`, excluindo os placeholders (lembretes que só emitem ALERT e não
+ * validam nada). Hoje: 22 ruleIds distintos − 2 placeholders = 20.
+ *
+ * Anti-drift: `rulesMeta.test.ts` extrai os ruleIds reais do `xmlRules.ts` e falha
+ * se esta contagem sair de sincronia com o engine. Ao adicionar/remover uma regra,
+ * o teste aponta a atualização necessária aqui.
+ */
+
+/** ruleIds que NÃO contam como "regra de validação" (lembretes informativos ALERT). */
+export const PLACEHOLDER_RULE_IDS: readonly string[] = ["BENEFITS_PLACEHOLDER", "NCM_PLACEHOLDER"];
+
+/** Quantidade canônica de regras determinísticas ativas. */
+export const RULES_COUNT = 20;
+
+/** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
+export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;


### PR DESCRIPTION
## SPEC site-realign — Fase 1 (FATAL: RF-1/2/3)

Elimina as inconsistências numéricas entre site e código (Fase 0 confirmou as divergências).

### RF-1 — número de regras único
- Constante canônica **`RULES_COUNT`** (`lib/validation/rulesMeta.ts`) = **20** (22 ruleIds do `xmlRules.ts` − 2 placeholders ALERT que não validam).
- **Teste-guarda anti-drift** (`rulesMeta.test.ts`): extrai os ruleIds reais do engine e falha se a contagem divergir. Adicionado ao `npm test`.
- 16 literais **"18 regras"** → `${RULES_COUNT}` em page/layout/pricing/classificacao/diagnostico/schemas. Site agora exibe **20 = engine**.

### RF-2 — cClassTrib rastreável
- Removidos os fabricados **"1.247"** e **"1.500 códigos"** + a claim **"Sincronização semanal"** (o sync via API SVRS exige credencial ainda não provisionada).
- Passa a exibir o real (**156**, tabela oficial SVRS) com fonte citada; copy → "tabela oficial SVRS — NT 2025.002-RTC v1.40".
- Corrigido comprimento do cClassTrib: **7 → 6 dígitos** (o engine valida `CCLASSTRIB_6_DIGITS`; SVRS usa 6).

### RF-3 — produto ativo = anunciado
- **SPED permanece ativo** (rota `/validate-sped` + backend `/api/v1/sped` existem/registrados — contrariando a premissa da spec). Removido o número sem lastro **"12.430 itens"** → "catálogo completo".

### Verificação
`npm test` **103** (incl. guarda) + `npm run build` ✓.

### Fora de escopo (flag de produto)
Cobertura cClassTrib (**156 carregados vs total oficial maior**) é lacuna de **produto** (re-seed/expansão), não de copy — sugiro issue separada.

Parte da SPEC `site-realign-intelligence-positioning`. Fase 2 (RF-4/5/6) em PR separado.
