### PR TITLE
fix(site): hotfix Fase 1 — integridade cClassTrib, escopo e âncora NT (FIX-1..5)

### DIFF
--- a/frontend/src/app/classificacao/Classifier.tsx
+++ b/frontend/src/app/classificacao/Classifier.tsx
@@ -110,11 +110,12 @@ export function Classifier() {
                 <ConfidenceBadge value={result.confidence} />
               </div>
               <p className="mt-0.5 text-sm text-slate-600">{result.ncm_descricao}</p>
-              {result.cClassTrib && (
-                <p className="mt-1 text-xs font-mono text-blue-700">
-                  cClassTrib LC 214: <strong>{result.cClassTrib}</strong>
-                </p>
-              )}
+              {/* FIX-1 (#313): o cClassTrib do lookup ainda vem da taxonomia de produto
+                  do DB (em reconciliação para os códigos 6-díg da NT). Não exibir como
+                  autoritativo até o re-seed; apontar para a tabela oficial. */}
+              <p className="mt-1 text-xs text-slate-500">
+                cClassTrib: confira na tabela oficial SVRS (NT 2025.002-RTC v1.40).
+              </p>
             </div>
             <Link
               href={`/calculadora?ncm=${result.ncm}`}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
 import { NewsFeed } from "@/components/public/NewsFeed";
-import { RULES_COUNT } from "@/lib/validation/rulesMeta";
+import { RULES_COUNT, CLASSTRIB_COUNT } from "@/lib/validation/rulesMeta";
 
 export const metadata: Metadata = {
   title: "IBS e CBS sem Rejeição de NF-e — Compliance LC 214",
@@ -323,7 +323,7 @@ export default function HomePage() {
                 {
                   badge: "SPED FISCAL",
                   preview: [
-                    { l: "EFD-ICMS/IPI · catálogo completo", r: "✓", ok: true },
+                    { l: "EFD-ICMS/IPI · validação CBS/IBS", r: "✓", ok: true },
                     { l: "Catálogo CBS/IBS", r: "100%", ok: true },
                     { l: "Export TOTVS / SAP / Omie", r: "↓", ok: false },
                   ],
@@ -466,7 +466,7 @@ export default function HomePage() {
               <div className="grid grid-cols-2 gap-4">
                 {[
                   { n: String(RULES_COUNT), l: "Regras CBS/IBS validadas" },
-                  { n: "156", l: "Classificações cClassTrib (SVRS)" },
+                  { n: String(CLASSTRIB_COUNT), l: "Classificações cClassTrib mapeadas (SVRS)" },
                   { n: "100", l: "Créditos API grátis" },
                   { n: "5 min", l: "Monitoramento contínuo" },
                 ].map((s) => (

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/storage";
-import { RULES_COUNT } from "@/lib/validation/rulesMeta";
+import { RULES_COUNT, RULES_LABEL } from "@/lib/validation/rulesMeta";
 
 // ── Plan definitions ────────────────────────────────────────────
 
@@ -521,7 +521,7 @@ export default function PricingPage() {
         <section className="border-t border-slate-200 bg-tribultz-700 py-16 text-center text-white">
           <h2 className="mb-4 text-3xl font-extrabold">Pronto para estar em conformidade?</h2>
           <p className="mb-8 text-tribultz-200">
-            {RULES_COUNT} regras determinísticas. Evidências auditáveis. Reforma tributária descomplicada.
+            {RULES_LABEL}. Evidências auditáveis. Reforma tributária descomplicada.
           </p>
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -19,3 +19,12 @@ export const RULES_COUNT = 20;
 
 /** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
 export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;
+
+/**
+ * Quantidade de classificações cClassTrib carregadas da tabela oficial SVRS
+ * (backend/app/data/classtrib.json, sincronizada na NT 2025.002-RTC v1.40 — #328).
+ * Apresentar SEMPRE como escopo ("classificações mapeadas"), nunca como total/completo:
+ * a tabela oficial cobre múltiplos DF-e; este é o conjunto carregado. Não derivado
+ * automaticamente porque o arquivo-fonte vive no backend (fora do build do frontend).
+ */
+export const CLASSTRIB_COUNT = 156;


### PR DESCRIPTION
## Hotfix da Fase 1 (SPEC site-realign) — followup do #331

Padrão: verificar → agir só se necessário → reportar.

| FIX | Estado encontrado | Ação |
|---|---|---|
| **FIX-1** 🔴 | `/classificacao` exibia cClassTrib vindo de `ncm/suggest` → DB `cclass_trib_items` (taxonomia de produto `01.01.001`, **inválida** como cClassTrib) | Backend fora de escopo → Classifier **não apresenta mais** esse código como autoritativo; aponta para a tabela oficial SVRS. Re-seed do DB → #313 |
| **FIX-2** 🟡 | Nenhuma copy de cClassTrib dizia "completo/total" | **Já OK** — sem ação. Proveniência registrada como subtarefa na #313 |
| **FIX-3** 🟡 | "156" era número solto no stat-grid | Relabel **escopo** ("classificações cClassTrib mapeadas (SVRS)") + derivado de `CLASSTRIB_COUNT` (constante única) |
| **FIX-4** 🟡 | Número de regras aparecia como "20" sem versão da NT no destaque | CTA do pricing ancorado via `RULES_LABEL` ("20 regras determinísticas alinhadas à NT 2025.002-RTC v1.40") |
| **FIX-5** 🔴 | SPED é pipeline real (upload→S3→job→export), **não stub**; valida CBS/IBS do catálogo (escopo, não as 20 regras do XML) | Smoke test ao vivo **não factível** aqui (sem fixture EFD, backend não roda local) → copy honesta: "EFD-ICMS/IPI · **validação CBS/IBS**" (antes "catálogo completo") |

### Fonte de dado de `/classificacao`
Widget Classifier → `POST /api/v1/public/ncm/suggest` → o `cClassTrib` retornado vem de `cclass_trib_items` (DB, taxonomia de produto). Por isso foi neutralizado na exibição.

### Smoke test SPED
Não executável neste ambiente (sem EFD-ICMS/IPI de amostra; backend depende de DB/Redis/S3 não disponíveis localmente). Avaliação por código: pipeline real e registrado, escopo = validação CBS/IBS do catálogo. Copy ajustada ao escopo comprovável.

### Proveniência (subtarefa #313)
"Confirmar se 156 = total vigente de NF-e/NFC-e (vs superset de DF-e)" já registrado no #313.

Gate: `npm test` **103** + `npm run build` ✓.