### PR TITLE
fix(api): /public/ncm/suggest deixa de servir cClassTrib em taxonomia de produto (RF-A1/A3/A4)

### DIFF
--- a/backend/app/routers/ncm_suggest.py
+++ b/backend/app/routers/ncm_suggest.py
@@ -17,13 +17,10 @@ from typing import Optional, cast
 
 import litellm
 from litellm.types.utils import Choices as LiteLLMChoices
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, field_validator
-from sqlalchemy.orm import Session
-from sqlalchemy.sql import text
 
 from app.data.ncm_codes import is_valid_ncm
-from app.database import get_db
 
 logger = logging.getLogger(__name__)
 
@@ -83,11 +80,24 @@ class SuggestRequest(BaseModel):
         return v
 
 
+class CClassTribCandidato(BaseModel):
+    """Candidato de cClassTrib (6 dígitos) para uma NCM, com base legal (RF-A2)."""
+    codigo: str          # 6 dígitos, tabela oficial SVRS
+    descricao: str
+    base_legal: str      # Anexo/artigo da LC 214/2025
+
+
 class SuggestResponse(BaseModel):
     ncm: str
     ncm_descricao: str
     confidence: float
-    cClassTrib: Optional[str]
+    # cClassTrib: NUNCA taxonomia de produto (RF-A1). null quando não há mapeamento
+    # 6-díg confiável — usar candidatos/status em vez de palpite único (RF-A2/A3).
+    cClassTrib: Optional[str] = None
+    cclasstrib_candidatos: list[CClassTribCandidato] = []
+    # "requer_validacao" (sem mapeamento confiável) | "multiplos" (NCM admite vários)
+    # | "unico" (1:1). Resposta de cClassTrib é sempre SUGESTÃO a validar, não veredito.
+    cclasstrib_status: str = "requer_validacao"
     cest: None = None
     rate_source: str = "ncm_ai"
     aviso: Optional[str] = None
@@ -192,14 +202,13 @@ def _llm_classify(descricao: str) -> dict:
 def suggest_ncm(
     payload: SuggestRequest,
     request: Request,
-    db: Session = Depends(get_db),
 ) -> SuggestResponse:
     client_ip = (request.client.host if request.client else "unknown")
     _rate_check(client_ip)
 
     # Cache key: SHA-256 de descrição normalizada (case-insensitive, espaços colapsados)
     normalized = " ".join(payload.descricao.lower().split())
-    cache_key = f"ncm_suggest:{hashlib.sha256(normalized.encode()).hexdigest()[:24]}"
+    cache_key = f"ncm_suggest:v2:{hashlib.sha256(normalized.encode()).hexdigest()[:24]}"
 
     cached = _cache_get(cache_key)
     if cached:
@@ -217,19 +226,11 @@ def suggest_ncm(
         confidence = min(confidence, 0.50)
         logger.warning("ncm_suggest: NCM %s not in TIPI table — confidence capped at 0.50", ncm)
 
-    # Buscar cClassTrib pelo capítulo (2 primeiros dígitos)
-    ncm_prefix = ncm[:2]
-    row = db.execute(
-        text("""
-            SELECT codigo FROM cclass_trib_items
-            WHERE codigo LIKE :prefix AND is_active = TRUE
-            ORDER BY codigo
-            LIMIT 1
-        """),
-        {"prefix": f"{ncm_prefix}.%"},
-    ).mappings().fetchone()
-    classtrib: str | None = dict(row)["codigo"] if row else None
-
+    # cClassTrib: NÃO derivar do DB cclass_trib_items (taxonomia de produto, defasada — #313).
+    # Sem mapeamento NCM→cClassTrib 6-díg confiável no repo, retornamos fallback honesto
+    # (RF-A1/A3): nunca um código inválido nem palpite único confiante (que gera Rejeição
+    # 1024). Os candidatos (RF-A2) serão populados quando o mapeamento oficial estiver
+    # disponível (lado dado — #313).
     aviso: str | None = None
     if confidence < 0.70:
         aviso = "Confiança baixa — confirme o NCM com seu contador antes de usar em NF-e."
@@ -238,7 +239,9 @@ def suggest_ncm(
         "ncm": ncm,
         "ncm_descricao": ncm_descricao,
         "confidence": round(confidence, 2),
-        "cClassTrib": classtrib,
+        "cClassTrib": None,
+        "cclasstrib_candidatos": [],
+        "cclasstrib_status": "requer_validacao",
         "cest": None,
         "rate_source": "ncm_ai",
         "aviso": aviso,

--- a/backend/tests/test_ncm_suggest.py
+++ b/backend/tests/test_ncm_suggest.py
@@ -1,0 +1,65 @@
+"""POST /api/v1/public/ncm/suggest — cClassTrib nunca em taxonomia de produto (ORDER fix)."""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+PRODUCT_TAX = re.compile(r"\d{2}\.\d{2}\.\d{3}")  # ex.: 01.01.001 (taxonomia antiga, proibida)
+
+
+def _patches(ncm="84713012", conf=0.9):
+    return [
+        patch("app.routers.ncm_suggest._rate_check", return_value=None),
+        patch("app.routers.ncm_suggest._cache_get", return_value=None),
+        patch("app.routers.ncm_suggest._cache_set", return_value=None),
+        patch(
+            "app.routers.ncm_suggest._llm_classify",
+            return_value={"ncm": ncm, "ncm_descricao": "Produto X", "confidence": conf},
+        ),
+    ]
+
+
+def _post(desc="Notebook 16GB", ncm="84713012", conf=0.9):
+    with contextlib.ExitStack() as stack:
+        for p in _patches(ncm=ncm, conf=conf):
+            stack.enter_context(p)
+        return client.post("/api/v1/public/ncm/suggest", json={"descricao": desc})
+
+
+class TestNcmSuggestCClassTrib:
+    def test_nunca_retorna_taxonomia_de_produto(self):
+        """RF-A1: nenhum valor da resposta no formato NN.NN.NNN."""
+        r = _post()
+        assert r.status_code == 200
+        assert not PRODUCT_TAX.search(r.text), f"taxonomia de produto vazou: {r.text}"
+
+    def test_cclasstrib_null_com_fallback_honesto(self):
+        """RF-A1/A3: cClassTrib null + status 'requer_validacao' (sem palpite confiante)."""
+        body = _post().json()
+        assert body["cClassTrib"] is None
+        assert body["cclasstrib_status"] == "requer_validacao"
+        assert body["cclasstrib_candidatos"] == []
+
+    def test_ncm_multi_mapeada_tambem_fallback_ate_mapeamento(self):
+        """RF-A2: NCM multi (ex. 9619.00.00) ainda em fallback até o mapeamento (#313) — sem veredito."""
+        body = _post(desc="Absorvente higiênico", ncm="96190000").json()
+        assert body["cClassTrib"] is None
+        assert body["cclasstrib_status"] == "requer_validacao"
+
+    def test_contrato_ncm_preservado(self):
+        """RF-A4: campos do contrato público preservados (ncm, confidence, aviso)."""
+        body = _post().json()
+        assert body["ncm"] == "84713012"
+        assert "confidence" in body and "aviso" in body and "rate_source" in body
+
+    def test_baixa_confianca_mantem_aviso(self):
+        body = _post(conf=0.4).json()
+        assert body["aviso"] is not None


### PR DESCRIPTION
## Bloqueador de GTM (🔴) — endpoint público servia cClassTrib inválido

`POST /api/v1/public/ncm/suggest` (gancho freemium) derivava o `cClassTrib` de `cclass_trib_items` via `LIKE '{capítulo}.%'` → retornava **código de produto** (`01.01.001`), não o cClassTrib **6-díg** da NF-e (`000001`). Avaliador técnico recebia dado inválido na 1ª chamada.

### Fase 0 (investigação)
- `ncm/suggest` lia o cClassTrib do **DB defasado** (taxonomia de produto).
- Repo tem os **156 códigos 6-díg** (`classtrib.json`) mas **não** o mapeamento NCM→cClassTrib (lado dado — #313).
- **Gate não dispara:** não depende 100% do #313 → corrigimos o comportamento agora.

### Correção
| RF | O quê |
|---|---|
| **A1** | Removida a leitura do DB → cClassTrib **nunca** em taxonomia de produto |
| **A3** | Fallback honesto: `cClassTrib=null` + `cclasstrib_status="requer_validacao"` (sem palpite único confiante, que é o que gera a Rejeição 1024) |
| **A2** | Contrato preparado (`cclasstrib_candidatos[]` + `cclasstrib_status`) p/ candidatos + base legal quando o mapeamento oficial existir (#313) |
| **A4** | Contrato preservado (cClassTrib já Optional; campos novos aditivos); rate-limit/freemium intactos; **cache key v2** (não serve cache antigo com o código de produto) |

### Antes / depois (3 NCMs)
| NCM | Antes | Depois |
|---|---|---|
| 8471.30.12 (notebook) | `cClassTrib: "84.xx.xxx"` (produto, inválido) | `cClassTrib: null`, `status: "requer_validacao"` |
| 9619.00.00 (absorvente/fralda, multi) | código único de produto | `null` + `status` (candidatos virão via #313, sem veredito) |
| NCM sem mapeamento | `null` silencioso | `null` + `status` honesto |

### Testes & verificação
+5 testes (incl. regex anti-`NN.NN.NNN`); backend **101 passed**, ruff + pyright limpos. Sem migration. **Créditos/rate-limit (10/IP/dia) preservados.**

Relacionada: **#313** (re-seed = cobertura plena do RF-A2). Backend autorizado só neste endpoint.
