### PR TITLE
fix(site): copy interina (classificação a validar) + moldura da alíquota plena vs teste 2026 (Order B)

### DIFF
--- a/backend/app/data/uf_rates.py
+++ b/backend/app/data/uf_rates.py
@@ -1,14 +1,16 @@
 """
 Reference CBS/IBS tax rates by Brazilian state (UF).
 
-Rates based on LC 214/2025 (Reforma Tributária) reference values.
-The IBS rate is split between state (UF) and municipality (Mun) components.
+Estes são os valores de REFERÊNCIA PLENA (carga cheia da Reforma, LC 214/2025),
+usados para projeção/planejamento de longo prazo. NÃO são as alíquotas reduzidas
+da fase de teste de 2026 (CBS 0,9% / IBS 0,1%): durante a transição 2026-2032 as
+alíquotas efetivas de emissão são frações destas. Os valores abaixo NÃO devem ser
+lidos como a alíquota vigente de emissão em 2026 (ver #315).
 
+The IBS rate is split between state (UF) and municipality (Mun) components.
 CBS (federal): uniform national rate.
 IBS UF (state): varies by state — transition period 2026-2032.
 IBS Mun (municipal): varies by municipality — uses state average as default.
-
-Reference period: 2026 (first year of dual system).
 """
 
 from decimal import Decimal

--- a/frontend/src/app/calculadora/Calculator.tsx
+++ b/frontend/src/app/calculadora/Calculator.tsx
@@ -429,6 +429,10 @@ function CalculadoraInner() {
                   </div>
                   <span className="font-mono text-lg font-bold text-slate-900">{brlFmt(result.total_tributos)}</span>
                 </div>
+
+                <p className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                  Alíquota de <strong>referência plena</strong> (regime cheio da Reforma). Na <strong>fase de teste de 2026</strong> as alíquotas de emissão são reduzidas — CBS 0,9% / IBS 0,1%. Use este resultado para projeção; confira a tabela de 2026 antes de emitir.
+                </p>
               </div>
 
               {/* Visual bar */}
@@ -538,7 +542,8 @@ function CalculadoraInner() {
         <div className="mx-auto max-w-4xl rounded-xl border border-tribultz-100 bg-tribultz-50 p-5">
           <h3 className="text-base font-semibold text-slate-900">Como funciona a calculadora</h3>
           <p className="mt-2 text-sm text-slate-700">
-            A calculadora aplica as alíquotas de referência da LC 214/2025 (Reforma Tributária) para
+            A calculadora aplica as alíquotas de <strong>referência plena</strong> (regime cheio) da
+            LC 214/2025 — não as alíquotas reduzidas da fase de teste de 2026 (CBS 0,9% / IBS 0,1%) — para
             CBS (federal) e IBS (estadual + municipal). Para NCMs de alimentos da Cesta Básica Nacional,
             farmacêuticos e educação, aplica automaticamente as reduções previstas nos Anexos da lei.
             O XML gerado segue o leiaute da NT 2025.002-RTC.

--- a/frontend/src/app/calculadora/page.tsx
+++ b/frontend/src/app/calculadora/page.tsx
@@ -39,7 +39,7 @@ const LEGAL_REFS = [
   {
     instrumento: "LC 214/2025",
     artigo: "arts. 8º a 22, 156-A",
-    descricao: "Base legal da CBS e IBS, definição de base de cálculo, alíquotas referência (CBS 0,9% / IBS 0,1% em 2026).",
+    descricao: "Base legal da CBS e IBS e definição de base de cálculo. Alíquotas de referência do regime cheio: CBS ~8,8% / IBS ~17,7%; fase de teste de 2026: CBS 0,9% / IBS 0,1%.",
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm",
   },
   {
@@ -78,7 +78,7 @@ export default function CalculadoraPage() {
         <div className="mx-auto max-w-3xl">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1.5">
             <span className="h-2 w-2 rounded-full bg-emerald-500" />
-            <span className="text-xs font-semibold text-emerald-700">Alíquotas LC 214 atualizadas — 2026</span>
+            <span className="text-xs font-semibold text-emerald-700">Alíquota de referência (regime cheio · LC 214)</span>
           </div>
           <h1 className="text-3xl font-extrabold leading-tight text-slate-900 md:text-4xl">
             Calculadora CBS/IBS<br />

--- a/frontend/src/app/classificacao/layout.tsx
+++ b/frontend/src/app/classificacao/layout.tsx
@@ -8,7 +8,7 @@ import { CLASSIFICACAO_SCHEMA } from "@/components/seo/schemas";
 export const metadata: Metadata = {
   title: "Classificar NCM → cClassTrib CBS/IBS — Evite a Rejeição 1024",
   description:
-    "Classifique o NCM correto para o cClassTrib da Reforma Tributária automaticamente. " +
+    "Classifique o NCM e entenda o cClassTrib aplicável na Reforma Tributária (sugestão a validar). " +
     "Evite a Rejeição 1024 em NF-e antes das penalidades CBS/IBS de agosto/2026. " +
     "Ferramenta gratuita — 10 classificações por dia.",
   keywords: [
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Classificar NCM → cClassTrib | Tribultz",
     description:
-      "Evite a Rejeição 1024 — classifique NCM → cClassTrib automaticamente e calcule CBS/IBS antes das penalidades de agosto/2026.",
+      "Evite a Rejeição 1024 — classifique o NCM, entenda o cClassTrib aplicável (a validar) e calcule CBS/IBS antes das penalidades de agosto/2026.",
     type: "website",
   },
 };

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -26,7 +26,7 @@ const robotoMono = Roboto_Mono({
 const SITE_URL = "https://tribultz.com.br";
 const SITE_NAME = "Tribultz";
 const DEFAULT_DESCRIPTION =
-  `Evite Rejeição 1024 e penalidades CBS/IBS. Classifique NCM → cClassTrib, valide ${RULES_COUNT} regras LC 214 e exporte para TOTVS, SAP, Omie e Linx. Compliance auditável para a Reforma Tributária.`;
+  `Evite a Rejeição 1024 e penalidades CBS/IBS: valide CST × cClassTrib e ${RULES_COUNT} regras LC 214, calcule CBS/IBS e exporte para TOTVS, SAP, Omie e Linx. Compliance auditável para a Reforma Tributária.`;
 
 export const metadata: Metadata = {
   title: {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,7 +7,7 @@ import { RULES_COUNT, CLASSTRIB_COUNT } from "@/lib/validation/rulesMeta";
 
 export const metadata: Metadata = {
   title: "IBS e CBS sem Rejeição de NF-e — Compliance LC 214",
-  description: `Rejeição 1024 por cClassTrib errado? Penalidades CBS/IBS a partir de agosto/2026. Classifique NCM → cClassTrib, valide ${RULES_COUNT} regras da Reforma e exporte para TOTVS/SAP/Omie/Linx. 100 créditos API grátis.`,
+  description: `Rejeição 1024 por cClassTrib errado? Penalidades CBS/IBS a partir de agosto/2026. Valide CST × cClassTrib e ${RULES_COUNT} regras da Reforma, calcule CBS/IBS e exporte para TOTVS/SAP/Omie/Linx. 100 créditos API grátis.`,
   keywords: [
     "Rejeição 1024 NF-e", "cClassTrib CBS IBS", "NCM cClassTrib LC 214",
     "penalidades CBS IBS 2026", "validação NF-e reform tributária",
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "IBS e CBS sem Rejeição de NF-e | Tribultz",
-    description: "Evite a Rejeição 1024. Classifique NCM → cClassTrib e valide CBS/IBS antes das penalidades de agosto/2026.",
+    description: "Evite a Rejeição 1024. Valide CST × cClassTrib e calcule CBS/IBS antes das penalidades de agosto/2026.",
   },
 };
 
@@ -42,7 +42,7 @@ const JSON_LD = {
       "applicationCategory": "BusinessApplication",
       "operatingSystem": "Web",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL", "description": "100 créditos API grátis" },
-      "description": "Plataforma de validação CBS/IBS, classificação NCM → cClassTrib e compliance para a Reforma Tributária brasileira (LC 214).",
+      "description": "Plataforma de validação CBS/IBS e compliance para a Reforma Tributária brasileira (LC 214): cálculo CBS/IBS e validação de CST × cClassTrib.",
     },
     {
       "@type": "FAQPage",
@@ -60,7 +60,7 @@ const JSON_LD = {
         {
           "@type": "Question",
           "name": "Como classificar o NCM correto para o cClassTrib na Reforma Tributária?",
-          "acceptedAnswer": { "@type": "Answer", "text": "O cClassTrib é determinado pelo capítulo NCM e pelo regime tributário aplicável (padrão, reduzido, cesta básica, imune, etc). A Tribultz oferece classificação automática NCM → cClassTrib via API pay-per-call ou pelo validador gratuito, com evidência auditável da base legal." },
+          "acceptedAnswer": { "@type": "Answer", "text": "O cClassTrib é determinado pelo capítulo NCM e pelo regime tributário aplicável (padrão, reduzido, cesta básica, imune, etc). A Tribultz valida a compatibilidade CST × cClassTrib (a fonte da Rejeição 1024) e calcula CBS/IBS com evidência auditável da base legal; a sugestão automática de cClassTrib a partir do NCM está em ativação e deve ser validada." },
         },
         {
           "@type": "Question",
@@ -244,7 +244,7 @@ export default function HomePage() {
           <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-10 px-4 md:px-6">
             {[
               { icon: "🛡", label: "Tabela oficial SVRS" },
-              { icon: "🔌", label: "API NCM → cClassTrib" },
+              { icon: "🔌", label: "API de cálculo CBS/IBS" },
               { icon: "✅", label: `${RULES_COUNT} regras CBS/IBS LC 214` },
               { icon: "🔗", label: "TOTVS · SAP · Omie · Linx" },
               { icon: "📄", label: "Auditável (PDF + JSON)" },
@@ -356,12 +356,12 @@ export default function HomePage() {
                 {
                   badge: "API · PAY-PER-CALL",
                   preview: [
-                    { l: "POST /classify", r: "NCM → cClassTrib", ok: true },
-                    { l: "CBS 8,80% + IBS 17,70%", r: "26,50%", ok: true },
+                    { l: "POST /classify", r: "CBS/IBS calculado", ok: true },
+                    { l: "CBS 8,80% + IBS 17,70% (ref. plena)", r: "26,50%", ok: true },
                     { l: "1 crédito / chamada", r: "100 grátis", ok: false },
                   ],
                   title: "API Classify",
-                  body: "Classifique NCM e calcule CBS/IBS direto no seu ERP via API. 100 créditos grátis. Sem contrato — pague só o que usar.",
+                  body: "Calcule CBS/IBS direto no seu ERP via API. Classificação NCM→cClassTrib em ativação (sugestão a validar). 100 créditos grátis. Sem contrato — pague só o que usar.",
                   meta: "X-API-Key · REST · JSON",
                 },
               ].map((f) => (

--- a/frontend/src/app/settings/api/page.tsx
+++ b/frontend/src/app/settings/api/page.tsx
@@ -102,6 +102,7 @@ export default function ApiSettingsPage() {
         <p className="text-sm text-slate-500 mt-1">
           Autentique integrações ERP e sistemas externos com a API pay-per-call.
           Cada chamada a <code className="bg-slate-100 px-1 rounded text-xs">/classify</code> consome 1 crédito.
+          O cálculo CBS/IBS é completo; a classificação NCM→cClassTrib está em ativação e é retornada como sugestão a validar.
         </p>
       </header>
 


### PR DESCRIPTION
## Order B — copy interina + verificação da alíquota (B3)

Alinha a vitrine ao estado real pós-#332/#333. **Interina:** revisada quando a Order A (mapeamento NCM→cClassTrib) entrar.

### RB-1 — claims de classificação honestos
Metadados (layout, page desc/OG/JSON-LD), FAQ, pill, **card "API Classify"**, `/classificacao` metadata e doc `settings/api` deixam de prometer classificação NCM→cClassTrib **automática**. Passam a: **cálculo CBS/IBS + validação CST×cClassTrib (Rejeição 1024) funcionam**; sugestão de cClassTrib a partir do NCM está **"em ativação / a validar"**. Gancho 1024 mantido (validação é real).

### RB-2 (B3) — cenário (2) confirmado, moldura corrigida (valores intactos)
A calculadora **computa a alíquota plena** (8,8%/17,7%, `uf_rates.py`) mas a exibia sob badge/contexto **"2026"** (teste real = 0,9%/0,1%). Corrigido **só o rótulo/contexto**:
- badge → "referência (regime cheio)"; ref-legal reconciliada; **ressalva no resultado do widget**; nota "Como funciona"; comentário enganoso do `uf_rates.py` corrigido. **Nenhum valor alterado.**

### Housekeeping (recon C)
- **#313** P1 → **P0** (gancho freemium / GTM)
- **#296** **fechada** (`/classificacao` e `/calculadora` já server-rendered)
- **#315** P3 → **P0** + escopo expandido (a calc usa plena onde a **emissão 2026** precisa de 0,9/0,1; o **XML snippet ficaria errado p/ 2026** — fix de valor, fora do escopo de copy)

### ⚠️ Achado para follow-up (fora do escopo desta ordem)
Existe um **2º endpoint pago** `POST /api/v1/public-api/classify` (X-API-Key, 1 crédito), marketado no card e em `settings/api`. O **#333 corrigiu apenas o `ncm/suggest`** — o `/classify` pago pode ter o **mesmo bug de taxonomia de produto**. Recomendo verificar/ordem dedicada (clientes pagantes).

### Verificação
frontend **103** testes + build OK; `ruff` (uf_rates) limpo. Não toca valores de alíquota, engine, billing, auth.