### PR TITLE
fix(api): /public-api/classify (pago) — cClassTrib inválido + cobrança no fallback

### DIFF
--- a/backend/app/routers/public_api.py
+++ b/backend/app/routers/public_api.py
@@ -17,7 +17,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import text
 
 from app.api.deps import get_current_user
 from app.data.ncm_codes import is_valid_ncm
@@ -79,7 +78,11 @@ class ClassifyRequest(BaseModel):
 
 class ClassifyResponse(BaseModel):
     ncm: str
-    cClassTrib: Optional[str]
+    # cClassTrib: NUNCA taxonomia de produto (RF-A1). null + status até o mapeamento
+    # oficial NCM→cClassTrib existir (#313); candidatos populados quando houver.
+    cClassTrib: Optional[str] = None
+    cclasstrib_candidatos: list = []
+    cclasstrib_status: str = "requer_validacao"
     cest: None = None
     cst: str
     vBC: str
@@ -153,18 +156,10 @@ def classify(
     api_key: ApiKey = Depends(_resolve_api_key),
     db: Session = Depends(get_db),
 ) -> ClassifyResponse:
-    # 1. Buscar cClassTrib pelo capítulo NCM (2 primeiros dígitos)
-    ncm_prefix = payload.ncm[:2]
-    row = db.execute(
-        text("""
-            SELECT codigo FROM cclass_trib_items
-            WHERE codigo LIKE :prefix AND is_active = TRUE
-            ORDER BY codigo
-            LIMIT 1
-        """),
-        {"prefix": f"{ncm_prefix}.%"},
-    ).mappings().fetchone()
-    classtrib_codigo: str | None = dict(row)["codigo"] if row else None
+    # 1. cClassTrib: NÃO derivar do DB cclass_trib_items (taxonomia de produto, defasada
+    #    — #313). Sem mapeamento NCM→cClassTrib 6-díg, retorna fallback honesto (RF-A1/A3):
+    #    nunca código inválido. Candidatos serão populados quando o mapeamento existir (#313).
+    classtrib_codigo: str | None = None
 
     # 2. Calcular CBS/IBS
     result = calculate_full(
@@ -174,8 +169,11 @@ def classify(
         cst=payload.cst,
     )
 
-    # 3. Debitar 1 crédito e registrar last_used_at
-    new_balance = cast(int, api_key.credits_balance) - 1
+    # 3. Debitar 1 crédito SOMENTE quando há classificação entregue (cClassTrib != None).
+    #    Enquanto o mapeamento não existe, cClassTrib é sempre None → NÃO cobra (o cliente
+    #    não paga por classificação que ainda não acende). last_used_at é registrado.
+    charge = classtrib_codigo is not None
+    new_balance = cast(int, api_key.credits_balance) - (1 if charge else 0)
     db.execute(
         update(ApiKey)
         .where(ApiKey.id == api_key.id)
@@ -196,7 +194,7 @@ def classify(
         total_tributos=str(result.total_tributos),
         aliquota_efetiva_pct=str((result.aliquota_efetiva * 100).quantize(Decimal("0.01"))),
         xml_snippet=result.xml_snippet,
-        credits_used=1,
+        credits_used=1 if charge else 0,
         credits_remaining=new_balance,
     )
 

--- a/backend/tests/test_public_api_classify.py
+++ b/backend/tests/test_public_api_classify.py
@@ -1,0 +1,70 @@
+"""POST /api/v1/public-api/classify (pago) — nunca taxonomia de produto + não debita no fallback."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.database import get_db
+from app.routers.public_api import _resolve_api_key
+
+client = TestClient(app)
+PRODUCT_TAX = re.compile(r"\d{2}\.\d{2}\.\d{3}")
+
+
+def _fake_key(balance=100):
+    k = MagicMock()
+    k.id = "key-1"
+    k.credits_balance = balance
+    return k
+
+
+def _fake_result():
+    r = MagicMock()
+    r.cst = "000"
+    r.vBC = Decimal("100.00")
+    r.vCBS = Decimal("8.80")
+    r.vIBS = Decimal("17.70")
+    r.total_tributos = Decimal("26.50")
+    r.aliquota_efetiva = Decimal("0.2650")
+    r.xml_snippet = "<IBSCBS><CST>000</CST></IBSCBS>"
+    return r
+
+
+class TestClassifyPagoCClassTrib:
+    def setup_method(self):
+        app.dependency_overrides[_resolve_api_key] = lambda: _fake_key(100)
+        app.dependency_overrides[get_db] = lambda: MagicMock()
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    def _post(self):
+        with patch("app.routers.public_api.calculate_full", return_value=_fake_result()):
+            return client.post(
+                "/api/v1/public-api/classify",
+                headers={"X-API-Key": "x"},
+                json={"ncm": "01012100", "uf_destino": "SP", "cst": "000", "base_value": "100.00"},
+            )
+
+    def test_cclasstrib_null_fallback(self):
+        body = self._post().json()
+        assert body["cClassTrib"] is None
+        assert body["cclasstrib_status"] == "requer_validacao"
+        assert body["cclasstrib_candidatos"] == []
+
+    def test_nunca_taxonomia_de_produto(self):
+        assert not PRODUCT_TAX.search(self._post().text)
+
+    def test_nao_debita_credito_no_fallback(self):
+        body = self._post().json()
+        assert body["credits_used"] == 0
+        assert body["credits_remaining"] == 100  # saldo intacto
+
+    def test_calculo_cbs_ibs_ainda_entregue(self):
+        body = self._post().json()
+        assert body["vCBS"] == "8.80" and body["vIBS"] == "17.70"


### PR DESCRIPTION
## 🔴 Defeito vivo em prod afetando clientes PAGANTES

O endpoint pago `POST /api/v1/public-api/classify` (X-API-Key, 1 crédito) tinha o **mesmo bug** que o `ncm/suggest` tinha: derivava o `cClassTrib` de `cclass_trib_items` via `LIKE '{capítulo}.%'` → **código de produto inválido** (`01.01.001`) — **e debitava 1 crédito**. O #333 corrigiu **só o freemium**; este endpoint pago continuou quebrado.

## Correção
- **RF-A1/A3:** removida a leitura do DB defasado → `cClassTrib=null` + `cclasstrib_status="requer_validacao"` + `cclasstrib_candidatos=[]` (mesmo contrato do #333). Nunca taxonomia de produto.
- **Billing (sua decisão):** **não debita** crédito quando `cClassTrib` é null. Hoje é sempre null (sem mapeamento — #313) → não cobra até a classificação "acender" (Order A). O **cálculo CBS/IBS segue entregue**; `last_used_at` registrado.
- Forward-compatible: quando o mapeamento (#313) existir, `charge = classtrib is not None` volta a cobrar automaticamente.

## Testes & verificação
+4 testes (null+fallback; regex anti-`NN.NN.NNN`; não debita; cálculo entregue). Backend **77 passed**, ruff + pyright limpos. Sem migration.

Relacionada: **#313** (o mapeamento habilita candidatos reais + retoma a cobrança).