### PR TITLE
feat(data): Part 2 #313 — re-seed cclass_trib_items 6-díg + reconcilia /classtrib

### DIFF
--- a/backend/app/alembic/versions/2026_06_23_0020_reseed_cclasstrib_6dig.py
+++ b/backend/app/alembic/versions/2026_06_23_0020_reseed_cclasstrib_6dig.py
@@ -1,0 +1,82 @@
+"""reseed_cclasstrib_6dig — Part 2 do #313
+
+Re-seed de cclass_trib_items com os 156 cClassTrib de 6 dígitos (app/data/classtrib.json,
+fonte pública SVRS / NT 2025.002-RTC v1.40), substituindo a taxonomia de produto antiga
+(formato "01.01.001", da migration 0018). A partir daqui o /classtrib/{codigo} e o
+validate_classtrib operam sobre o cClassTrib real da NF-e.
+
+p_cbs/p_ibs = redução × alíquota de REFERÊNCIA PLENA (CBS 8,8% / IBS 17,7%, carga cheia
+da Reforma — consistente com uf_rates.py); isenção (CST 400) / imunidade (CST 410) → 0.
+NÃO são as alíquotas reduzidas da fase de teste de 2026 (CBS 0,9% / IBS 0,1% — ver #315).
+
+Revision ID: 2026_06_23_0020
+Revises: 2026_05_31_0019
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "2026_06_23_0020"
+down_revision = "2026_05_31_0019"
+branch_labels = None
+depends_on = None
+
+_CBS_PLENA = 8.8
+_IBS_PLENA = 17.7
+_ZERO_CSTS = {"400", "410"}  # isenção, imunidade/não incidência
+
+
+def _regime(cst: str, red_cbs: float, red_ibs: float) -> str:
+    if cst == "400":
+        return "isencao"
+    if cst == "410":
+        return "imunidade"
+    r = max(red_cbs, red_ibs)
+    if r >= 100:
+        return "reducao_integral"
+    if r > 0:
+        return f"reducao_{int(r)}"
+    return "padrao"
+
+
+def upgrade() -> None:
+    data_path = Path(__file__).resolve().parents[2] / "data" / "classtrib.json"
+    by_code = json.loads(data_path.read_text(encoding="utf-8")).get("by_code", {})
+
+    rows = []
+    for code, it in by_code.items():
+        cst = str(it.get("cst", ""))
+        red_cbs = float(it.get("reduction_cbs_pct", 0) or 0)
+        red_ibs = float(it.get("reduction_ibs_pct", 0) or 0)
+        zero = cst in _ZERO_CSTS
+        rows.append({
+            "c": code,
+            "d": (it.get("description") or "").strip() or code,
+            "cbs": 0.0 if zero else round(_CBS_PLENA * (1 - red_cbs / 100), 4),
+            "ibs": 0.0 if zero else round(_IBS_PLENA * (1 - red_ibs / 100), 4),
+            "reg": _regime(cst, red_cbs, red_ibs),
+            "vi": (it.get("vigencia_ini") or "2026-01-01") or "2026-01-01",
+        })
+
+    conn = op.get_bind()
+    conn.execute(sa.text("DELETE FROM cclass_trib_items"))
+    if rows:
+        conn.execute(
+            sa.text("""
+                INSERT INTO cclass_trib_items
+                    (codigo, descricao, p_cbs, p_ibs, regime_especial, vigencia_ini, is_active)
+                VALUES (:c, :d, :cbs, :ibs, :reg, :vi, TRUE)
+            """),
+            rows,
+        )
+
+
+def downgrade() -> None:
+    # Re-seed de dados — não reversível automaticamente (a migration 0018 repovoaria a
+    # taxonomia de produto antiga). Mantido como no-op intencional.
+    pass

--- a/backend/app/routers/classtrib.py
+++ b/backend/app/routers/classtrib.py
@@ -16,6 +16,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.data.ncm_cclasstrib_table import ncm_candidatos
 from app.database import get_db
 from app.models.auth import User
 
@@ -132,28 +133,24 @@ def validate_classtrib(
 
     item = dict(item)
 
-    # Buscar sugestão pelo NCM (prefixo dos 2 primeiros dígitos → capítulo SH)
-    ncm_prefix = payload.ncm[:2] if len(payload.ncm) >= 2 else ""
-    sugestao = db.execute(
-        text("""
-            SELECT codigo FROM cclass_trib_items
-            WHERE codigo LIKE :prefix AND is_active = TRUE
-            ORDER BY codigo LIMIT 1
-        """),
-        {"prefix": f"{ncm_prefix}.%"},
-    ).scalar_one_or_none()
+    # Sugestão pelo mapeamento oficial NCM→cClassTrib (anexos SVRS) — NÃO mais por prefixo
+    # de capítulo na taxonomia de produto (#313 Part 2). A mesma NCM pode admitir vários
+    # cClassTrib: divergência só quando o informado NÃO consta entre os candidatos.
+    candidatos = [c["codigo"] for c in ncm_candidatos(payload.ncm)]
+    sugestao = candidatos[0] if candidatos else None
 
-    divergente = sugestao is not None and sugestao != payload.classtrib_informado
+    divergente = bool(candidatos) and payload.classtrib_informado not in candidatos
 
     finding = None
     if divergente:
+        opcoes = ", ".join(candidatos)
         finding = {
             "id":             f"classtrib-{payload.ncm}-{payload.classtrib_informado}",
             "severity":       "ERROR",
             "rule_id":        "CBS-011",
             "title":          "cClassTrib divergente do NCM informado",
             "where":          {"field": "cClassTrib", "snippet": payload.classtrib_informado},
-            "recommendation": f"Substituir '{payload.classtrib_informado}' por '{sugestao}' conforme mapeamento NCM × cClassTrib da LC 214.",
+            "recommendation": f"cClassTrib '{payload.classtrib_informado}' não consta entre os candidatos da NCM {payload.ncm} ({opcoes}), conforme os Anexos da LC 214. Validar a classificação.",
             "evidence_ids":   [],
         }
 

--- a/backend/tests/test_classtrib.py
+++ b/backend/tests/test_classtrib.py
@@ -54,141 +54,106 @@ def auth_client():
     app.dependency_overrides.pop(get_current_user, None)
 
 
-# ── Testes de dados — via API (migration 0018) ────────────────────────────────
+# ── Testes de dados — via API (migration 0020: 156 cClassTrib de 6 dígitos) ───
 
 class TestClassTribData:
-    """Verifica que a migration 0018 populou os códigos corretamente — via endpoint."""
+    """A migration 0020 re-seedou os 156 cClassTrib de 6 dígitos (fonte pública SVRS)."""
 
-    @pytest.mark.parametrize("codigo,expected_regime,zero_rated", [
-        ("01.01.001", "cesta_basica", True),
-        ("02.01.001", "cesta_basica", True),
-        ("04.01.001", "cesta_basica", True),
-        ("10.01.001", "cesta_basica", True),
-        ("30.01.001", "reduzido_60",  False),
-        ("99.01.002", "reduzido_60",  False),
-        ("48.01.002", "imune",        True),
-        ("84.01.002", "imune",        True),
-        ("99.01.001", "padrao",       False),
-        ("39.01.001", "padrao",       False),
-        ("85.17.001", "padrao",       False),
+    @pytest.mark.parametrize("codigo,regime,zero", [
+        ("000001", "padrao", False),
+        ("200001", "reducao_integral", True),
+        ("400001", "isencao", True),
+        ("410001", "imunidade", True),
+        ("011001", "reducao_60", False),
     ])
-    def test_regime_e_aliquota(self, codigo, expected_regime, zero_rated):
+    def test_regime_e_aliquota(self, codigo, regime, zero):
         resp = client.get(f"/api/v1/public/classtrib/{codigo}")
-        assert resp.status_code == 200, f"Código {codigo} não encontrado (migration 0018?)"
+        assert resp.status_code == 200, f"{codigo} não encontrado (migration 0020?)"
         data = resp.json()
-        assert data["regime_especial"] == expected_regime, (
-            f"{codigo}: regime esperado={expected_regime}, obtido={data['regime_especial']}"
-        )
-        if zero_rated:
-            assert float(data["p_cbs"]) == 0.0, f"{codigo}: p_cbs deveria ser 0"
-            assert float(data["p_ibs"]) == 0.0, f"{codigo}: p_ibs deveria ser 0"
+        assert data["regime_especial"] == regime
+        if zero:
+            assert float(data["p_cbs"]) == 0.0 and float(data["p_ibs"]) == 0.0
         else:
-            assert float(data["p_cbs"]) > 0.0, f"{codigo}: p_cbs deveria ser > 0"
+            assert float(data["p_cbs"]) > 0.0
 
-    def test_capitulos_representados(self):
-        """Verifica que os principais capítulos NCM respondem via search."""
-        amostras = {
-            "bovino":      "01.",  # matches "bovinos"
-            "arroz":       "10.",  # matches "Cereais — arroz"
-            "medicamento": "30.",  # matches "Medicamentos"
-            "televisore":  "85.",  # matches "Televisores"
-        }
-        for termo, prefixo in amostras.items():
-            resp = client.get(f"/api/v1/public/classtrib/search?q={termo}")
-            assert resp.status_code == 200
-            results = resp.json()
-            assert any(r["codigo"].startswith(prefixo) for r in results), (
-                f"Termo '{termo}' não retornou código do capítulo {prefixo}"
-            )
+    def test_padrao_usa_aliquota_de_referencia_plena(self):
+        """000001 (padrão) → alíquota de REFERÊNCIA PLENA (8,8 / 17,7), não a de teste 2026."""
+        data = client.get("/api/v1/public/classtrib/000001").json()
+        assert float(data["p_cbs"]) == 8.8
+        assert float(data["p_ibs"]) == 17.7
+
+    def test_search_por_termo_da_descricao(self):
+        resp = client.get("/api/v1/public/classtrib/search?q=serviços")
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
 
 
 # ── Testes de endpoint público ────────────────────────────────────────────────
 
 class TestClassTribEndpoint:
-    def test_lookup_cesta_basica(self):
-        resp = client.get("/api/v1/public/classtrib/10.01.001")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["codigo"] == "10.01.001"
+    def test_lookup_isencao(self):
+        data = client.get("/api/v1/public/classtrib/400001").json()
+        assert data["codigo"] == "400001"
         assert float(data["p_cbs"]) == 0.0
-        assert float(data["p_ibs"]) == 0.0
-        assert data["regime_especial"] == "cesta_basica"
+        assert data["regime_especial"] == "isencao"
 
-    def test_lookup_servico_padrao(self):
-        resp = client.get("/api/v1/public/classtrib/99.01.001")
-        assert resp.status_code == 200
-        data = resp.json()
+    def test_lookup_padrao(self):
+        data = client.get("/api/v1/public/classtrib/000001").json()
         assert float(data["p_cbs"]) > 0
         assert data["regime_especial"] == "padrao"
 
     def test_lookup_retorna_last_synced_at(self):
         """Acceptance criteria #264: endpoint deve retornar last_synced_at."""
-        resp = client.get("/api/v1/public/classtrib/99.01.001")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "last_synced_at" in data, "Campo last_synced_at ausente na resposta"
-        assert data["last_synced_at"] is not None
+        data = client.get("/api/v1/public/classtrib/000001").json()
+        assert "last_synced_at" in data and data["last_synced_at"] is not None
 
     def test_lookup_nao_encontrado(self):
-        resp = client.get("/api/v1/public/classtrib/99.99.999")
-        assert resp.status_code == 404
+        assert client.get("/api/v1/public/classtrib/999999").status_code == 404
 
-    def test_search_cereais(self):
-        resp = client.get("/api/v1/public/classtrib/search?q=arroz")
-        assert resp.status_code == 200
-        results = resp.json()
-        assert len(results) >= 1
-        codigos = [r["codigo"] for r in results]
-        assert any(c.startswith("10.") for c in codigos)
-
-    def test_search_medicamento(self):
-        resp = client.get("/api/v1/public/classtrib/search?q=medicamento")
-        assert resp.status_code == 200
-        results = resp.json()
-        assert len(results) >= 1
+    def test_taxonomia_de_produto_aposentada(self):
+        """Código no formato antigo de produto (01.01.001) não deve mais existir."""
+        assert client.get("/api/v1/public/classtrib/10.01.001").status_code == 404
 
     def test_search_min_length(self):
-        resp = client.get("/api/v1/public/classtrib/search?q=a")
-        assert resp.status_code == 422
+        assert client.get("/api/v1/public/classtrib/search?q=a").status_code == 422
 
 
-# ── Testes de validação autenticada ───────────────────────────────────────────
+# ── Testes de validação autenticada (NCM × cClassTrib via mapeamento) ──────────
 
 class TestClassTribValidate:
-    def test_validate_ok(self, auth_client):
+    def test_validate_ok_candidato_oficial(self, auth_client):
+        # NCM 0201.10.00 → candidato oficial 200003 (mapeamento de anexos SVRS)
         resp = auth_client.post(
             "/api/v1/classtrib/validate",
-            json={"ncm": "1001000", "classtrib_informado": "10.01.001"},
+            json={"ncm": "02011000", "classtrib_informado": "200003"},
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["status"] in ("OK", "DIVERGENTE", "NAO_ENCONTRADO")
+        assert data["status"] == "OK" and not data["divergencia"]
+
+    def test_validate_divergente(self, auth_client):
+        # 000001 existe mas NÃO é candidato da NCM 0201.10.00 → DIVERGENTE
+        resp = auth_client.post(
+            "/api/v1/classtrib/validate",
+            json={"ncm": "02011000", "classtrib_informado": "000001"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "DIVERGENTE" and data["divergencia"]
+        assert data["classtrib_sugerido"] == "200003"
 
     def test_validate_nao_encontrado(self, auth_client):
         resp = auth_client.post(
             "/api/v1/classtrib/validate",
-            json={"ncm": "9999999", "classtrib_informado": "99.99.999"},
+            json={"ncm": "02011000", "classtrib_informado": "999999"},
         )
         assert resp.status_code == 200
         assert resp.json()["status"] == "NAO_ENCONTRADO"
 
-    def test_validate_cesta_basica_correto(self, auth_client):
-        """NCM 01 (bovinos) com cClassTrib 01.01.001 — deve ser OK e alíquotas zero."""
-        resp = auth_client.post(
-            "/api/v1/classtrib/validate",
-            json={"ncm": "0102900000", "classtrib_informado": "01.01.001"},
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "OK"
-        assert not data["divergencia"]
-        assert data["p_cbs_correto"] == 0.0
-        assert data["p_ibs_correto"] == 0.0
-
     def test_validate_sem_auth(self):
         resp = client.post(
             "/api/v1/classtrib/validate",
-            json={"ncm": "1001000", "classtrib_informado": "10.01.001"},
+            json={"ncm": "02011000", "classtrib_informado": "200003"},
         )
         assert resp.status_code == 401
 


### PR DESCRIPTION
## Part 2 do #313 — lado-dado do DB

Completa o #313: `cclass_trib_items` deixa de guardar a **taxonomia de produto placeholder** (`01.01.001`, da migration 0018) e passa aos **156 cClassTrib de 6 dígitos** reais. `/classtrib/{codigo}` e `validate_classtrib` agora operam sobre o cClassTrib da NF-e.

### Mudanças
- **Migration 0020:** `DELETE` + re-seed dos 156 códigos (lê `classtrib.json`). `p_cbs/p_ibs` = redução × **referência PLENA** (CBS 8,8% / IBS 17,7%, decisão acordada — consistente com `uf_rates.py`); isenção/imunidade → 0. `regime_especial` derivado.
- **validate_classtrib:** sugestão via **mapeamento oficial NCM→cClassTrib** (não mais `LIKE` na taxonomia de produto). Divergência só quando o informado não está entre os candidatos da NCM.
- **test_classtrib reescrito** para 6-díg + plena + validação por mapeamento.

### ⚠️ Validação
Os testes de `classtrib` **dependem de Postgres** → rodam no **CI** (`backend-gates`); o sandbox local não tem DB. Localmente: suítes sem-DB **77 passed**, `ruff`+`pyright` limpos, alembic **head único** (0020). Seed validado standalone (padrão→8,8/17,7; redução/isenção/imunidade→0).

### Semântica
O seed antigo (produto, descrições tipo "arroz") era placeholder (a 0018 admite). Os 156 cClassTrib são classificações tributárias — search por nome de produto deixa de aplicar; lookup/validate passam a ser por cClassTrib real.

Fecha o lado-dado do #313. Relacionada: #336 (Part 1), #278/#315.