### PR TITLE
fix(s8): #315 — calculadora com modo de período (default emissão 2026) + docs de alíquotas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,10 @@ cd backend && source .venv/bin/activate && python -m pytest tests/ -q && ruff ch
 
 ## Regras de domínio
 
-- **CBS**: Contribuição sobre Bens e Serviços (federal) — alíquota referência 0,10%
-- **IBS**: Imposto sobre Bens e Serviços (estadual/municipal) — alíquota referência 0,90%
+- **CBS**: Contribuição sobre Bens e Serviços (federal) — fase de teste 2026: **0,9%**; referência plena (regime cheio, ~2033): **8,8%**
+- **IBS**: Imposto sobre Bens e Serviços (estadual/municipal) — fase de teste 2026: **0,1%**; referência plena (regime cheio, ~2033): **17,7%** (UF + Município)
 - **Base legal**: LC 214 (reforma tributária) + LC 227 (regulamentação)
-- **10 regras determinísticas** com evidência auditável no formato Findings/Evidence v1.1
+- **20 regras determinísticas** no engine (`frontend/src/lib/validation/xmlRules.ts`, fonte canônica `RULES_COUNT`; 22 ruleIds − 2 placeholders) com evidência auditável no formato Findings/Evidence v1.1
 - **Vocabulário fiscal**: CEST, ClassTrib, IBS, CBS, Nota Nacional, ISS, ICMS, Split Payment, Cashback
 
 ## Validação

--- a/backend/app/data/uf_rates.py
+++ b/backend/app/data/uf_rates.py
@@ -15,11 +15,19 @@ IBS Mun (municipal): varies by municipality — uses state average as default.
 
 from decimal import Decimal
 
-# National reference rates (LC 214 Art. 9)
+# Reference (plena / regime cheio, ~2033) rates (LC 214 Art. 9)
 CBS_NATIONAL_RATE = Decimal("0.0880")       # 8.80% CBS federal
 IBS_NATIONAL_RATE = Decimal("0.1770")       # 17.70% IBS total (UF + Mun)
 IBS_UF_DEFAULT = Decimal("0.1130")          # ~11.30% state share (avg)
 IBS_MUN_DEFAULT = Decimal("0.0640")         # ~6.40% municipal share (avg)
+
+# Fase de teste 2026 (LC 214 — transição). Alíquotas EFETIVAS de emissão em 2026:
+# CBS 0,9% (federal, uniforme) e IBS 0,1% (total UF+Mun). O split UF/Mun de 2026 é
+# obtido escalando o split plena por-UF proporcionalmente ao total de 2026 (preserva
+# a estrutura estadual/municipal). Estas são as alíquotas que vão na NF-e em 2026.
+CBS_TESTE_2026 = Decimal("0.0090")          # 0,9% CBS federal (teste 2026)
+IBS_TESTE_2026_TOTAL = Decimal("0.0010")    # 0,1% IBS total (teste 2026)
+IBS_2026_FACTOR = IBS_TESTE_2026_TOTAL / IBS_NATIONAL_RATE  # escala plena → 2026
 
 
 UF_RATES: dict[str, dict] = {

--- a/backend/app/routers/calculadora.py
+++ b/backend/app/routers/calculadora.py
@@ -50,6 +50,17 @@ class CalculadoraRequest(BaseModel):
     base_value: Decimal
     quantity: Decimal = Decimal("1")
     cst: str = "000"
+    # "teste_2026" (default): alíquotas reduzidas de emissão de 2026 (CBS 0,9% / IBS 0,1%)
+    # — o que vai na NF-e agora. "regime_cheio": carga plena (8,8 / 17,7) p/ projeção.
+    periodo: str = "teste_2026"
+
+    @field_validator("periodo")
+    @classmethod
+    def validate_periodo(cls, v: str) -> str:
+        v = v.strip()
+        if v not in ("teste_2026", "regime_cheio"):
+            raise ValueError("periodo deve ser 'teste_2026' ou 'regime_cheio'")
+        return v
 
     @field_validator("uf_destino")
     @classmethod
@@ -116,6 +127,7 @@ class CalculadoraResponse(BaseModel):
     rate_source: str
     cst: str
     cst_desc: str
+    periodo: str
     xml_snippet: str
     data_policy: str
     upgrade_cta: str
@@ -128,7 +140,7 @@ DATA_POLICY = (
 
 UPGRADE_CTA = (
     "Crie sua conta gratuita para salvar cálculos, gerar relatórios PDF "
-    "e validar XMLs completos com 18 regras de conformidade."
+    "e validar XMLs completos com 20 regras de conformidade."
 )
 
 
@@ -156,6 +168,7 @@ async def public_calculadora(request: Request, body: CalculadoraRequest):
         ncm=body.ncm_code,
         uf=body.uf_destino,
         cst=body.cst,
+        periodo=body.periodo,
     )
 
     return CalculadoraResponse(
@@ -169,6 +182,7 @@ async def public_calculadora(request: Request, body: CalculadoraRequest):
         rate_source=result.rate_source,
         cst=result.cst,
         cst_desc=result.cst_desc,
+        periodo=body.periodo,
         xml_snippet=result.xml_snippet,
         data_policy=DATA_POLICY,
         upgrade_cta=UPGRADE_CTA,

--- a/backend/app/services/tax_rate_resolver.py
+++ b/backend/app/services/tax_rate_resolver.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 
 from app.data.uf_rates import (
     UF_RATES, CBS_NATIONAL_RATE, IBS_UF_DEFAULT, IBS_MUN_DEFAULT,
+    CBS_TESTE_2026, IBS_2026_FACTOR,
 )
 from app.data.cst_regimes import get_rate_modifier, get_cst_regime, generates_tax
 from app.data.ncm_rates import get_ncm_modifier
@@ -64,6 +65,7 @@ def resolve_rates(
     ncm: str | None = None,
     uf: str | None = None,
     cst: str = "000",
+    periodo: str = "regime_cheio",
 ) -> TaxRateResult:
     """Resolve CBS/IBS rates from the hierarchy: NCM → UF → National.
 
@@ -88,6 +90,15 @@ def resolve_rates(
             ibs_uf_rate = uf_data["ibs_uf_rate"]
             ibs_mun_rate = uf_data["ibs_mun_rate"]
             rate_source = "uf_default"
+
+    # Período de emissão: "teste_2026" (default) aplica as alíquotas reduzidas de 2026
+    # (CBS 0,9% / IBS 0,1% total — o que vai na NF-e agora); "regime_cheio" mantém as
+    # plenas resolvidas acima (projeção). O split IBS UF/Mun de 2026 escala o split plena.
+    if periodo == "teste_2026":
+        cbs_rate = CBS_TESTE_2026
+        ibs_uf_rate = ibs_uf_rate * IBS_2026_FACTOR
+        ibs_mun_rate = ibs_mun_rate * IBS_2026_FACTOR
+        rate_source = f"{rate_source}_2026"
 
     # Step 2: NCM modifier (chapter-based overrides)
     ncm_mod = get_ncm_modifier(ncm or "")
@@ -184,6 +195,7 @@ def calculate_full(
     ncm: str | None = None,
     uf: str | None = None,
     cst: str = "000",
+    periodo: str = "regime_cheio",
 ) -> CalculationResult:
     """Convenience: resolve rates + calculate in one call.
 
@@ -197,7 +209,7 @@ def calculate_full(
     Returns:
         Full CalculationResult.
     """
-    rates = resolve_rates(ncm=ncm, uf=uf, cst=cst)
+    rates = resolve_rates(ncm=ncm, uf=uf, cst=cst, periodo=periodo)
     result = calculate(vBC, quantity, rates)
 
     # Override CST in the result

--- a/backend/tests/test_calculadora.py
+++ b/backend/tests/test_calculadora.py
@@ -38,6 +38,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "1000.00",
+                "periodo": "regime_cheio",
             },
         )
         assert resp.status_code == 200
@@ -56,6 +57,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "RJ",
                 "base_value": "500.00",
+                "periodo": "regime_cheio",
                 "ncm_code": "84713012",
             },
         )
@@ -70,6 +72,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "100.00",
+                "periodo": "regime_cheio",
                 "ncm_code": "02011000",  # Meat — cesta básica
             },
         )
@@ -85,6 +88,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "MG",
                 "base_value": "1000.00",
+                "periodo": "regime_cheio",
                 "cst": "070",
             },
         )
@@ -100,6 +104,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "1000.00",
+                "periodo": "regime_cheio",
                 "cst": "001",
             },
         )
@@ -114,6 +119,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "200.00",
+                "periodo": "regime_cheio",
                 "quantity": "3",
             },
         )
@@ -127,6 +133,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "XX",
                 "base_value": "1000.00",
+                "periodo": "regime_cheio",
             },
         )
         assert resp.status_code == 422
@@ -137,6 +144,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "-100.00",
+                "periodo": "regime_cheio",
             },
         )
         assert resp.status_code == 422
@@ -147,6 +155,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "100.00",
+                "periodo": "regime_cheio",
                 "ncm_code": "1234",
             },
         )
@@ -158,6 +167,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": "SP",
                 "base_value": "100.00",
+                "periodo": "regime_cheio",
                 "cst": "999",
             },
         )
@@ -192,6 +202,7 @@ class TestPublicCalculadora:
             json={
                 "uf_destino": uf,
                 "base_value": "1000.00",
+                "periodo": "regime_cheio",
                 "quantity": "1",
                 "cst": "000",
             },
@@ -250,3 +261,36 @@ class TestCstListEndpoint:
         codes = {item["code"] for item in data}
         assert "000" in codes
         assert "070" in codes
+
+
+class TestCalculadoraPeriodo:
+    """#315 lado-valor: período de emissão (default 2026) vs regime cheio (projeção)."""
+
+    def _post(self, **extra):
+        body = {"uf_destino": "SP", "base_value": "1000.00", **extra}
+        return client.post("/api/v1/public/calculadora/regime-geral", json=body)
+
+    def test_default_e_emissao_2026(self):
+        """Sem 'periodo' → default emissão 2026: CBS 0,9% / IBS 0,1% (1% efetivo)."""
+        data = self._post().json()
+        assert data["periodo"] == "teste_2026"
+        assert float(data["pCBS"]) == 0.0090
+        assert float(data["vCBS"]) == 9.00          # 1000 × 0,009
+        assert float(data["aliquota_efetiva"]) == 0.0100  # CBS 0,9% + IBS 0,1%
+        assert float(data["vIBS"]) == 1.00          # 1000 × 0,001
+
+    def test_regime_cheio_e_plena(self):
+        """'periodo'=regime_cheio → carga plena: CBS 8,8% / IBS 17,7% (26,5%)."""
+        data = self._post(periodo="regime_cheio").json()
+        assert data["periodo"] == "regime_cheio"
+        assert float(data["pCBS"]) == 0.0880
+        assert float(data["vCBS"]) == 88.00
+        assert float(data["aliquota_efetiva"]) == 0.2650
+
+    def test_periodo_invalido_422(self):
+        assert self._post(periodo="2025").status_code == 422
+
+    def test_xml_snippet_reflete_periodo_2026(self):
+        """O XML snippet de 2026 traz a alíquota reduzida (não a plena)."""
+        data = self._post().json()
+        assert "0.0090" in data["xml_snippet"] or "0.009" in data["xml_snippet"]

--- a/frontend/src/app/calculadora/Calculator.tsx
+++ b/frontend/src/app/calculadora/Calculator.tsx
@@ -31,6 +31,7 @@ type CalculadoraResult = {
   rate_source: string;
   cst: string;
   cst_desc: string;
+  periodo: string;
   xml_snippet: string;
   data_policy: string;
   upgrade_cta: string;
@@ -50,6 +51,7 @@ function CalculadoraInner() {
   const [ncm, setNcm] = useState(searchParams.get("ncm") ?? "");
   const [cst, setCst] = useState(searchParams.get("cst") ?? "000");
   const [quantity, setQuantity] = useState(searchParams.get("qty") ?? "1");
+  const [periodo, setPeriodo] = useState(searchParams.get("periodo") ?? "teste_2026");
 
   const [state, setState] = useState<CalcState>("idle");
   const [result, setResult] = useState<CalculadoraResult | null>(null);
@@ -73,6 +75,7 @@ function CalculadoraInner() {
         base_value: baseValue,
         quantity,
         cst,
+        periodo,
       };
       if (ncm.trim()) body.ncm_code = ncm.trim();
 
@@ -124,12 +127,13 @@ function CalculadoraInner() {
       if (ncm.trim()) params.set("ncm", ncm.trim());
       if (cst !== "000") params.set("cst", cst);
       if (quantity !== "1") params.set("qty", quantity);
+      if (periodo !== "teste_2026") params.set("periodo", periodo);
       router.replace(`/calculadora?${params.toString()}`, { scroll: false });
     } catch {
       setError("Erro de conexão. Verifique se o servidor está acessível.");
       setState("error");
     }
-  }, [uf, baseValue, ncm, cst, quantity, router]);
+  }, [uf, baseValue, ncm, cst, quantity, periodo, router]);
 
   const handleSuggestNcm = useCallback(async () => {
     if (!suggestDesc.trim()) return;
@@ -331,6 +335,21 @@ function CalculadoraInner() {
               </select>
             </div>
 
+            {/* Período */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">
+                Período
+              </label>
+              <select
+                value={periodo}
+                onChange={(e) => setPeriodo(e.target.value)}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-tribultz-500 focus:outline-none focus:ring-1 focus:ring-tribultz-500"
+              >
+                <option value="teste_2026">Emissão 2026 (CBS 0,9% / IBS 0,1%)</option>
+                <option value="regime_cheio">Regime cheio — projeção (CBS 8,8% / IBS 17,7%)</option>
+              </select>
+            </div>
+
             {/* Quantity */}
             <div>
               <label className="mb-1 block text-sm font-medium text-slate-700">
@@ -430,9 +449,15 @@ function CalculadoraInner() {
                   <span className="font-mono text-lg font-bold text-slate-900">{brlFmt(result.total_tributos)}</span>
                 </div>
 
-                <p className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-                  Alíquota de <strong>referência plena</strong> (regime cheio da Reforma). Na <strong>fase de teste de 2026</strong> as alíquotas de emissão são reduzidas — CBS 0,9% / IBS 0,1%. Use este resultado para projeção; confira a tabela de 2026 antes de emitir.
-                </p>
+                {result.periodo === "regime_cheio" ? (
+                  <p className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                    Alíquota de <strong>referência plena</strong> (regime cheio da Reforma) — use para <strong>projeção</strong>. Na <strong>emissão de 2026</strong> as alíquotas são reduzidas (CBS 0,9% / IBS 0,1%): selecione <strong>“Emissão 2026”</strong> para o valor que vai na NF-e.
+                  </p>
+                ) : (
+                  <p className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+                    Alíquotas de <strong>emissão de 2026</strong> (CBS 0,9% / IBS 0,1%) — o XML abaixo já reflete a fase de teste. Para projetar a <strong>carga cheia</strong> da Reforma, selecione <strong>“Regime cheio”</strong>.
+                  </p>
+                )}
               </div>
 
               {/* Visual bar */}
@@ -542,11 +567,12 @@ function CalculadoraInner() {
         <div className="mx-auto max-w-4xl rounded-xl border border-tribultz-100 bg-tribultz-50 p-5">
           <h3 className="text-base font-semibold text-slate-900">Como funciona a calculadora</h3>
           <p className="mt-2 text-sm text-slate-700">
-            A calculadora aplica as alíquotas de <strong>referência plena</strong> (regime cheio) da
-            LC 214/2025 — não as alíquotas reduzidas da fase de teste de 2026 (CBS 0,9% / IBS 0,1%) — para
-            CBS (federal) e IBS (estadual + municipal). Para NCMs de alimentos da Cesta Básica Nacional,
-            farmacêuticos e educação, aplica automaticamente as reduções previstas nos Anexos da lei.
-            O XML gerado segue o leiaute da NT 2025.002-RTC.
+            Por padrão, a calculadora usa as alíquotas de <strong>emissão de 2026</strong> (CBS 0,9% /
+            IBS 0,1%) — o que efetivamente vai na NF-e na fase de teste. Selecione <strong>“Regime cheio”</strong>
+            no campo Período para projetar a <strong>carga plena</strong> da Reforma (CBS 8,8% / IBS 17,7%),
+            da LC 214/2025. Para NCMs de alimentos da Cesta Básica Nacional, farmacêuticos e educação, aplica
+            automaticamente as reduções previstas nos Anexos da lei. O XML gerado segue o leiaute da NT
+            2025.002-RTC e reflete o período selecionado.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## #315 — alíquotas de referência + lado-valor da calculadora

Resolve as duas faces do #315.

### (a) Docs (CLAUDE.md)
- Alíquotas de referência **corrigidas** — estavam invertidas e em magnitude errada (`0,10%/0,90%`). Agora: **teste 2026** CBS 0,9% / IBS 0,1%; **referência plena** CBS 8,8% / IBS 17,7%.
- "10 regras" → **20** (`RULES_COUNT`); `UPGRADE_CTA` "18"→"20".

### (b) Lado-valor — modo de período na calculadora
A calculadora gerava "XML pronto p/ NF-e" com a alíquota **plena** (8,8/17,7), mas a emissão 2026 usa **0,9/0,1** → snippet impreciso.

- **`uf_rates.py`:** constantes de 2026 (`CBS_TESTE_2026`, `IBS_2026_FACTOR` escalando o split UF/Mun plena → 0,1% total).
- **`tax_rate_resolver`:** param `periodo` (`teste_2026` ⟷ `regime_cheio`).
- **Endpoint `/calculadora/regime-geral`:** `periodo` no request/response, **default `teste_2026`** — o XML reflete o período. `/classify` (API paga) **inalterado** (plena), fora de escopo.
- **Frontend:** seletor de **Período** (Emissão 2026 ⟷ Regime cheio/projeção) + ressalva dinâmica + copy atualizada.

### Decisão de produto
Conforme acordado: **default = emissão 2026** (o que vai na nota agora); regime cheio disponível para projeção. Verificação: teste 2026 → **1,0% efetivo** (CBS 0,9 + IBS 0,1); regime cheio → **26,5%**.

### QA
Backend `ruff`+`pyright` limpos, **169** testes sem-DB (novos: default 2026, regime_cheio, período inválido 422, XML reflete 2026). Frontend **103** testes + build OK.

Fecha #315.