### PR TITLE
feat(rules): #339 — cCredPres (crédito presumido IBS/CBS) coerente com o cClassTrib

### DIFF
--- a/backend/app/data/classtrib.json
+++ b/backend/app/data/classtrib.json
@@ -3,7 +3,7 @@
     "source": "SVRS Conformidade Fácil — consulta pública classTrib (sem credencial)",
     "source_url": "https://dfe-portal.svrs.rs.gov.br/CFF/ClassificacaoTributaria",
     "extraction_method": "JSON embutido na página /CFF/ClassificacaoTributaria",
-    "date": "2026-06-20",
+    "date": "2026-06-24",
     "total_codes": 156,
     "total_cst_groups": 18
   },
@@ -15,6 +15,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -39,6 +40,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSVIA"
       ],
@@ -52,6 +54,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": true,
       "dfe_allowed": [
         "NFE"
       ],
@@ -65,6 +68,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": true,
       "dfe_allowed": [
         "NFE"
       ],
@@ -78,6 +82,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -91,6 +96,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 5,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -104,6 +110,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 5,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -117,6 +124,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 4,
+      "permite_cred_pres": false,
       "dfe_allowed": [],
       "vigencia_ini": "2025-05-05",
       "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art236"
@@ -128,6 +136,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 4,
+      "permite_cred_pres": false,
       "dfe_allowed": [],
       "vigencia_ini": "2025-05-05",
       "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art237"
@@ -139,6 +148,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 4,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -152,6 +162,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 4,
+      "permite_cred_pres": false,
       "dfe_allowed": [],
       "vigencia_ini": "2025-05-05",
       "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art246"
@@ -163,6 +174,7 @@
       "reduction_ibs_pct": 30.0,
       "reduction_cbs_pct": 30.0,
       "tipo_aliquota": 4,
+      "permite_cred_pres": false,
       "dfe_allowed": [],
       "vigencia_ini": "2025-05-05",
       "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art243"
@@ -174,6 +186,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "CTE",
         "CTEOS",
@@ -189,6 +202,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -203,6 +217,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -217,6 +232,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -232,6 +248,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -246,6 +263,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -261,6 +279,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -276,6 +295,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -290,6 +310,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -304,6 +325,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -318,6 +340,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -331,6 +354,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -345,6 +369,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -359,6 +384,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -373,6 +399,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -387,6 +414,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -400,6 +428,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -413,6 +442,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [],
       "vigencia_ini": "2025-05-05",
       "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art223"
@@ -424,6 +454,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -437,6 +468,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E",
         "NFCE",
@@ -453,6 +485,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPETM",
         "NFSE"
@@ -467,6 +500,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -480,6 +514,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -493,6 +528,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -506,6 +542,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -519,6 +556,7 @@
       "reduction_ibs_pct": 80.0,
       "reduction_cbs_pct": 80.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -532,6 +570,7 @@
       "reduction_ibs_pct": 70.0,
       "reduction_cbs_pct": 70.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -545,6 +584,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -558,6 +598,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -571,6 +612,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -586,6 +628,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -601,6 +644,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -615,6 +659,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -629,6 +674,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -643,6 +689,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -657,6 +704,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -671,6 +719,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -684,6 +733,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -699,6 +749,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -713,6 +764,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -726,6 +778,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -739,6 +792,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -752,6 +806,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCOM",
         "NFE",
@@ -767,6 +822,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCOM",
         "NFSE"
@@ -781,6 +837,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI",
         "NFSE"
@@ -795,6 +852,7 @@
       "reduction_ibs_pct": 50.0,
       "reduction_cbs_pct": 50.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI",
         "NFSE"
@@ -809,6 +867,7 @@
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -823,6 +882,7 @@
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -836,6 +896,7 @@
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE"
       ],
@@ -849,6 +910,7 @@
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPETA",
         "CTE",
@@ -864,6 +926,7 @@
       "reduction_ibs_pct": 40.0,
       "reduction_cbs_pct": 40.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -877,6 +940,7 @@
       "reduction_ibs_pct": 30.0,
       "reduction_cbs_pct": 30.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -890,6 +954,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -904,6 +969,7 @@
       "reduction_ibs_pct": 100.0,
       "reduction_cbs_pct": 100.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -919,6 +985,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 1,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -932,6 +999,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 1,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -945,6 +1013,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 1,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -958,6 +1027,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 1,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -971,6 +1041,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -986,6 +1057,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETM",
@@ -1001,6 +1073,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "CTEOS"
       ],
@@ -1014,6 +1087,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -1039,6 +1113,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1052,6 +1127,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -1078,6 +1154,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -1098,6 +1175,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFAG",
         "NFCE",
@@ -1114,6 +1192,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -1129,6 +1208,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -1144,6 +1224,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFCOM",
@@ -1160,6 +1241,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFCOM",
@@ -1176,6 +1258,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCOM",
         "NFSE"
@@ -1190,6 +1273,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [],
       "vigencia_ini": "2025-05-05",
       "legislacao": "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm#art9"
@@ -1201,6 +1285,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -1216,6 +1301,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1229,6 +1315,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": true,
       "dfe_allowed": [
         "NFCE",
         "NFE",
@@ -1244,6 +1331,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "CTE",
         "NFSE"
@@ -1258,6 +1346,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": true,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1271,6 +1360,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1284,6 +1374,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -1297,6 +1388,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -1311,6 +1403,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -1325,6 +1418,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E"
       ],
@@ -1338,6 +1432,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -1351,6 +1446,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -1364,6 +1460,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -1377,6 +1474,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -1390,6 +1488,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -1416,6 +1515,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "CTE",
         "CTEOS",
@@ -1432,6 +1532,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI",
         "NFSE"
@@ -1446,6 +1547,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -1460,6 +1562,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1473,6 +1576,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E",
         "NFAG",
@@ -1490,6 +1594,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E",
         "NFAG",
@@ -1506,6 +1611,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI",
         "NFSE"
@@ -1520,6 +1626,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -1533,6 +1640,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "CTE",
         "CTEOS",
@@ -1550,6 +1658,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "BPE",
         "BPETA",
@@ -1575,6 +1684,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E",
         "NFE"
@@ -1589,6 +1699,7 @@
       "reduction_ibs_pct": 60.0,
       "reduction_cbs_pct": 60.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -1603,6 +1714,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1616,6 +1728,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1629,6 +1742,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1642,6 +1756,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1655,6 +1770,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1668,6 +1784,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1681,6 +1798,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1694,6 +1812,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1707,6 +1826,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1720,6 +1840,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1733,6 +1854,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1746,6 +1868,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1759,6 +1882,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1772,6 +1896,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1785,6 +1910,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1798,6 +1924,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -1812,6 +1939,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1825,6 +1953,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1838,6 +1967,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1851,6 +1981,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1864,6 +1995,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1877,6 +2009,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -1891,6 +2024,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1904,6 +2038,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1917,6 +2052,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1930,6 +2066,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1943,6 +2080,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1956,6 +2094,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -1969,6 +2108,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFCE",
         "NFE"
@@ -1983,6 +2123,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -1997,6 +2138,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -2011,6 +2153,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE"
       ],
@@ -2024,6 +2167,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -2038,6 +2182,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -2052,6 +2197,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFE",
         "NFSE"
@@ -2066,6 +2212,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -2079,6 +2226,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -2092,6 +2240,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -2105,6 +2254,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -2118,6 +2268,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFABI"
       ],
@@ -2131,6 +2282,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -2144,6 +2296,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NFSE"
       ],
@@ -2157,6 +2310,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E",
         "NFAG",
@@ -2173,6 +2327,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 3,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "CTEOS",
         "NF3E",
@@ -2191,6 +2346,7 @@
       "reduction_ibs_pct": 0.0,
       "reduction_cbs_pct": 0.0,
       "tipo_aliquota": 2,
+      "permite_cred_pres": false,
       "dfe_allowed": [
         "NF3E",
         "NFE"

--- a/backend/app/data/classtrib_table.py
+++ b/backend/app/data/classtrib_table.py
@@ -33,3 +33,16 @@ def classtrib_expected_zero(code: str) -> tuple[bool, bool] | None:
     cbs_zero = is_exempt or float(item.get("reduction_cbs_pct", 0) or 0) >= 100
     ibs_zero = is_exempt or float(item.get("reduction_ibs_pct", 0) or 0) >= 100
     return cbs_zero, ibs_zero
+
+
+def classtrib_permite_cred_pres(code: str) -> bool | None:
+    """Indica se o cClassTrib permite crédito presumido (tag cCredPres) — #339.
+
+    Retorna True/False (fonte SVRS: IndPermiteCredPres) ou None se o código for desconhecido.
+    Apenas alguns cClassTrib permitem; quando permitem, a ausência de cCredPres na operação
+    pode levar à rejeição da NF-e e à perda do crédito.
+    """
+    item = CLASSTRIB_BY_CODE.get(code)
+    if item is None:
+        return None
+    return bool(item.get("permite_cred_pres", False))

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -29,7 +29,7 @@ from app.tools import s3_tool, postgres_tool
 from app.services.xml_correction_service import correct_xml
 from app.api.plan_gate import require_plan, check_usage_limit, increment_usage
 from app.data.ncm_codes import VALID_NCM_CODES
-from app.data.classtrib_table import classtrib_expected_zero
+from app.data.classtrib_table import classtrib_expected_zero, classtrib_permite_cred_pres
 from app.data.cest_ncm import lookup_ncm_st
 
 logger = logging.getLogger(__name__)
@@ -776,6 +776,56 @@ def validate_xml(
                     ),
                     Evidence(id=ev_id, type="xml", label="IBS — alíquota-zero incoerente", xpath=_xpath("pIBSUF", doc_type), snippet=p_ibs_uf["snippet"] if p_ibs_uf else None),
                 )
+
+    # ── Rule 20: CRED_PRES — crédito presumido coerente com o cClassTrib (#339) ──
+    # Fonte SVRS (IndPermiteCredPres): só alguns cClassTrib admitem crédito presumido.
+    # Se o cClassTrib admite e a tag cCredPres não veio, a operação corre risco de rejeição
+    # e PERDA do crédito (prejuízo direto). Severidade conservadora (janela 2026, educativa):
+    # WARNING/ALERT, nunca FATAL — a geração efetiva do crédito depende de mais que o
+    # cClassTrib (princípio: só FATAL com confiança; incerto → ALERT/fallback honesto).
+    if has_ibscbs and ibscbs_block and c_class_trib and re.match(r"^\d{6}$", c_class_trib["value"]):
+        _permite = classtrib_permite_cred_pres(c_class_trib["value"])
+        _ccp = _first_tag(ibscbs_block["snippet"], ["cCredPres"])
+        _ccp_val = _ccp["value"].strip() if _ccp and _ccp["value"] else ""
+        if _permite is True and not _ccp_val:
+            ev_id = "E_XML_CREDPRES_MISSING"
+            _add(
+                Finding(
+                    id="F_CREDPRES_MISSING", severity="WARNING", rule_id="CRED_PRES",
+                    title=f'cClassTrib {c_class_trib["value"]} admite crédito presumido, mas cCredPres não foi informado',
+                    where=FindingWhere(field="cCredPres", xpath=_xpath("cCredPres", doc_type), snippet=c_class_trib["snippet"]),
+                    recommendation=(
+                        "Se a operação gera crédito presumido de IBS/CBS, informe o código cCredPres (6 dígitos) "
+                        "no grupo IBSCBS. A ausência pode causar rejeição da NF-e e a perda do crédito (Tabela cCredPres, IT 2025.002)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="cCredPres ausente — cClassTrib admite crédito presumido", xpath=_xpath("cCredPres", doc_type), snippet=c_class_trib["snippet"]),
+            )
+        elif _ccp_val and not re.match(r"^\d{6}$", _ccp_val):
+            ev_id = "E_XML_CREDPRES_INVALID"
+            _add(
+                Finding(
+                    id="F_CREDPRES_INVALID", severity="ALERT", rule_id="CRED_PRES",
+                    title=f'cCredPres "{_ccp_val}" com formato inválido (esperado 6 dígitos)',
+                    where=FindingWhere(field="cCredPres", xpath=_xpath("cCredPres", doc_type), snippet=_ccp["snippet"] if _ccp else None),
+                    recommendation="O código de crédito presumido (cCredPres) deve ter 6 dígitos numéricos (Tabela cCredPres, IT 2025.002).",
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="cCredPres — formato inválido", xpath=_xpath("cCredPres", doc_type), snippet=_ccp["snippet"] if _ccp else None),
+            )
+        elif _ccp_val and _permite is False:
+            ev_id = "E_XML_CREDPRES_INCONSISTENT"
+            _add(
+                Finding(
+                    id="F_CREDPRES_INCONSISTENT", severity="ALERT", rule_id="CRED_PRES",
+                    title=f'cCredPres informado, mas o cClassTrib {c_class_trib["value"]} não admite crédito presumido',
+                    where=FindingWhere(field="cCredPres", xpath=_xpath("cCredPres", doc_type), snippet=_ccp["snippet"] if _ccp else None),
+                    recommendation="Reveja a classificação: este cClassTrib não admite crédito presumido (fonte SVRS). Verifique o cClassTrib ou remova o cCredPres.",
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="cCredPres incoerente com cClassTrib", xpath=_xpath("cCredPres", doc_type), snippet=_ccp["snippet"] if _ccp else None),
+            )
 
     # ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────
     # Decreto 12.955/2026 art. 65 (LC 214 art. 63): IBS/CBS incidem sobre a importação

--- a/backend/scripts/resync_classtrib.py
+++ b/backend/scripts/resync_classtrib.py
@@ -100,6 +100,9 @@ def normalize(groups: list[dict]) -> dict:
                 "reduction_ibs_pct": float(c.get("PercRedIbs") or 0.0),
                 "reduction_cbs_pct": float(c.get("PercRedCbs") or 0.0),
                 "tipo_aliquota": c.get("TipoAliq"),
+                # Crédito presumido IBS/CBS: se True, a operação pode carregar a tag cCredPres
+                # (#339). Só alguns cClassTrib permitem — fonte SVRS: IndPermiteCredPres.
+                "permite_cred_pres": bool(c.get("IndPermiteCredPres")),
                 "dfe_allowed": dfe,
                 "vigencia_ini": (c.get("DthIniVig") or "")[:10],
                 "legislacao": c.get("TexUrlLegislacao") or "",

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -490,3 +490,50 @@ class TestAliquotaClasstrib:
 
     def test_codigo_desconhecido_sem_finding(self):
         assert self._find(self._nfe("999999", pcbs="0.009")) == []
+
+
+class TestCredPres:
+    """#339 — crédito presumido (cCredPres) coerente com o cClassTrib (fonte SVRS).
+    Só alguns cClassTrib admitem (IndPermiteCredPres): 000003/000004/410014/410016."""
+
+    def _nfe(self, code, ccredpres=None):
+        ccp = f"<cCredPres>{ccredpres}</cCredPres>" if ccredpres is not None else ""
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            '<det nItem="1"><prod><NCM>84713012</NCM><CEST>2104900</CEST><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>{code}</cClassTrib>{ccp}'
+            '<gIBSCBS><vBC>1000.00</vBC>'
+            '<gIBSUF><pIBSUF>0</pIBSUF><vIBSUF>0.00</vIBSUF></gIBSUF>'
+            '<gIBSMun><pIBSMun>0</pIBSMun><vIBSMun>0.00</vIBSMun></gIBSMun>'
+            '<vIBS>0.00</vIBS><gCBS><pCBS>0</pCBS><vCBS>0.00</vCBS></gCBS>'
+            '</gIBSCBS></IBSCBS></imposto></det>'
+            '<total><IBSCBSTot><vIBS>0.00</vIBS><vCBS>0.00</vCBS></IBSCBSTot></total>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml):
+        return [f for f in validate_xml(xml, "NFE").findings if f.rule_id == "CRED_PRES"]
+
+    def test_permite_sem_ccredpres_warning(self):
+        # 000003 admite crédito presumido; sem cCredPres → WARNING (risco de perda do crédito)
+        f = self._find(self._nfe("000003"))
+        assert any(x.id == "F_CREDPRES_MISSING" and x.severity == "WARNING" for x in f)
+
+    def test_permite_com_ccredpres_sem_finding(self):
+        assert self._find(self._nfe("000003", "100001")) == []
+
+    def test_ccredpres_formato_invalido_alert(self):
+        f = self._find(self._nfe("000003", "12"))
+        assert any(x.id == "F_CREDPRES_INVALID" and x.severity == "ALERT" for x in f)
+
+    def test_ccredpres_em_classtrib_que_nao_permite_alert(self):
+        # 000001 não admite crédito presumido; cCredPres informado → ALERT (inconsistência)
+        f = self._find(self._nfe("000001", "100001"))
+        assert any(x.id == "F_CREDPRES_INCONSISTENT" and x.severity == "ALERT" for x in f)
+
+    def test_nao_permite_sem_ccredpres_sem_finding(self):
+        assert self._find(self._nfe("000001")) == []
+
+    def test_classtrib_desconhecido_sem_finding(self):
+        assert self._find(self._nfe("999999")) == []


### PR DESCRIPTION
## #339 — Crédito presumido (cCredPres)

Endereça a tabela **cCredPres** do **IT 2025.002** (publicada 23/06/2026), via validação no motor backend.

### ROI / risco de negócio
Se o cClassTrib **admite** crédito presumido e a tag `cCredPres` **não** vem (ou vem errada), a SEFAZ pode **rejeitar** a NF-e e o cliente **perde o crédito** — prejuízo direto e frequentemente irrecuperável. A regra acende exatamente esse cenário.

### Mudanças
- **Dados:** `resync_classtrib.py` captura `IndPermiteCredPres` por cClassTrib → `classtrib.json` ganha `permite_cred_pres` (fonte **pública SVRS**, sem credencial). Hoje só **4** admitem: `000003, 000004, 410014, 410016`.
- **Loader:** `classtrib_permite_cred_pres(code)`.
- **Regra `CRED_PRES`** (severidade conservadora — janela 2026, nunca FATAL):
  - admite + `cCredPres` ausente → **WARNING** (risco de perda de crédito);
  - `cCredPres` com formato ≠ 6 díg → **ALERT**;
  - `cCredPres` em cClassTrib que não admite → **ALERT** (inconsistência).

### Decisão de arquitetura
Regra de **enrichment** dependente da tabela SVRS → **backend-only**, igual a `ALIQUOTA_CLASSTRIB` (#278) e `CLASSTRIB_VALID`. Não altera o `RULES_COUNT` do motor mock frontend. A conferência de pertencimento aos **13 códigos oficiais** cCredPres é **follow-up** (depende do PDF do Portal NF-e; não está na consulta pública SVRS) — coerente com o princípio "só FATAL com confiança; validar o que dá para validar com segurança".

### QA
`TestCredPres` (6 casos) + regressão `validate_xml` **53** verdes; `ruff` + `pyright` limpos; suítes do loader (ncm_suggest/classify/public_validate) **30** verdes.

Fecha #339. Refs #309. Reusa a infra de #313.