### PR TITLE
feat(rules): #311 — CLASSTRIB_DOC_TYPE (cClassTrib aplicável ao modelo do documento)

### DIFF
--- a/backend/app/data/classtrib_table.py
+++ b/backend/app/data/classtrib_table.py
@@ -46,3 +46,16 @@ def classtrib_permite_cred_pres(code: str) -> bool | None:
     if item is None:
         return None
     return bool(item.get("permite_cred_pres", False))
+
+
+def classtrib_dfe_allowed(code: str) -> list[str] | None:
+    """Modelos de DFe em que o cClassTrib é aplicável (ex.: ['NFE','NFCE']) — #311.
+
+    Retorna a lista (fonte SVRS: IndNfe/IndNfce/IndNfse/…) ou None se o código for
+    desconhecido. Usar um cClassTrib fora dos seus modelos publicados tende à rejeição
+    (cClassTrib inválido para o modelo — família 1106/960).
+    """
+    item = CLASSTRIB_BY_CODE.get(code)
+    if item is None:
+        return None
+    return list(item.get("dfe_allowed") or [])

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -29,7 +29,11 @@ from app.tools import s3_tool, postgres_tool
 from app.services.xml_correction_service import correct_xml
 from app.api.plan_gate import require_plan, check_usage_limit, increment_usage
 from app.data.ncm_codes import VALID_NCM_CODES
-from app.data.classtrib_table import classtrib_expected_zero, classtrib_permite_cred_pres
+from app.data.classtrib_table import (
+    classtrib_dfe_allowed,
+    classtrib_expected_zero,
+    classtrib_permite_cred_pres,
+)
 from app.data.cest_ncm import lookup_ncm_st
 
 logger = logging.getLogger(__name__)
@@ -825,6 +829,31 @@ def validate_xml(
                     evidence_ids=[ev_id],
                 ),
                 Evidence(id=ev_id, type="xml", label="cCredPres incoerente com cClassTrib", xpath=_xpath("cCredPres", doc_type), snippet=_ccp["snippet"] if _ccp else None),
+            )
+
+    # ── Rule 21: CLASSTRIB_DOC_TYPE — cClassTrib aplicável ao modelo do documento (#311) ──
+    # Fonte SVRS (dfe_allowed): cada cClassTrib é publicado para modelos específicos
+    # (NF-e/NFC-e/NFS-e/…). Usar um cClassTrib fora dos seus modelos tende à rejeição da
+    # SEFAZ (cClassTrib inválido para o modelo — família 1106/960). Confiança alta na tabela,
+    # mas o código de rejeição exato não é citável aqui → WARNING (não FATAL).
+    if doc_type and c_class_trib and re.match(r"^\d{6}$", c_class_trib["value"]):
+        _allowed = classtrib_dfe_allowed(c_class_trib["value"])
+        if _allowed and doc_type not in _allowed:
+            ev_id = "E_XML_CLASSTRIB_DOC_TYPE"
+            _modelos = ", ".join(_allowed)
+            _add(
+                Finding(
+                    id="F_CLASSTRIB_DOC_TYPE", severity="WARNING", rule_id="CLASSTRIB_DOC_TYPE",
+                    title=f'cClassTrib {c_class_trib["value"]} não é aplicável a {doc_type} (válido para: {_modelos})',
+                    where=FindingWhere(field="cClassTrib", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]),
+                    recommendation=(
+                        f'O cClassTrib {c_class_trib["value"]} é publicado apenas para {_modelos} (tabela oficial SVRS). '
+                        f"Usá-lo em {doc_type} tende à rejeição da SEFAZ (cClassTrib inválido para o modelo — família 1106/960). "
+                        "Revise o cClassTrib do item."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="cClassTrib — modelo de documento incompatível", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]),
             )
 
     # ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -537,3 +537,45 @@ class TestCredPres:
 
     def test_classtrib_desconhecido_sem_finding(self):
         assert self._find(self._nfe("999999")) == []
+
+
+class TestClassTribDocType:
+    """#311 — cClassTrib deve ser aplicável ao modelo do documento (fonte SVRS dfe_allowed).
+    Usar um cClassTrib fora dos seus modelos publicados tende à rejeição (família 1106/960)."""
+
+    def _nfe(self, code, mod="55"):
+        return (
+            f'<nfeProc><NFe><infNFe><ide><mod>{mod}</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            '<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>{code}</cClassTrib>'
+            '<gIBSCBS><vBC>1000.00</vBC>'
+            '<gIBSUF><pIBSUF>0</pIBSUF><vIBSUF>0.00</vIBSUF></gIBSUF>'
+            '<gIBSMun><pIBSMun>0</pIBSMun><vIBSMun>0.00</vIBSMun></gIBSMun>'
+            '<vIBS>0.00</vIBS><gCBS><pCBS>0</pCBS><vCBS>0.00</vCBS></gCBS>'
+            '</gIBSCBS></IBSCBS></imposto></det>'
+            '<total><IBSCBSTot><vIBS>0.00</vIBS><vCBS>0.00</vCBS></IBSCBSTot></total>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, dt):
+        return [f for f in validate_xml(xml, dt).findings if f.rule_id == "CLASSTRIB_DOC_TYPE"]
+
+    def test_classtrib_de_outro_modelo_em_nfe_warning(self):
+        # 000002 só vale p/ NFSVIA → em NF-e gera WARNING
+        f = self._find(self._nfe("000002"), "NFE")
+        assert any(x.id == "F_CLASSTRIB_DOC_TYPE" and x.severity == "WARNING" for x in f)
+
+    def test_classtrib_universal_em_nfe_sem_finding(self):
+        # 000001 vale p/ NFE e NFCE → sem finding
+        assert self._find(self._nfe("000001"), "NFE") == []
+
+    def test_classtrib_nfe_only_em_nfce_warning(self):
+        # 000003 só vale p/ NFE → em NFC-e gera WARNING
+        assert any(x.id == "F_CLASSTRIB_DOC_TYPE" for x in self._find(self._nfe("000003", mod="65"), "NFCE"))
+
+    def test_classtrib_nfe_only_em_nfe_sem_finding(self):
+        assert self._find(self._nfe("000003"), "NFE") == []
+
+    def test_desconhecido_sem_finding(self):
+        assert self._find(self._nfe("999999"), "NFE") == []


### PR DESCRIPTION
## #311 — cClassTrib × modelo do documento (família 1106/960)

Avança o **catálogo de rejeições da v1.40** do #311 com um slice **autoritativo e de alto valor**, destravado pelo #313.

> ⚠️ **PR empilhado** sobre #340 (#339) — base `feat/339-ccredpres` (compartilham `classtrib_table.py`/`validate_xml.py`). Após o merge do #340, o GitHub re-aponta a base para `main`.

### Valor
A consulta pública SVRS publica, por cClassTrib, em quais **modelos de DFe** ele é válido (`dfe_allowed`). **60** cClassTrib **não** se aplicam a NF-e e **116** não se aplicam a NFC-e (ex.: códigos NFSE-only, NFSVIA-only). Usar um cClassTrib fora do seu modelo → **rejeição da SEFAZ** (cClassTrib inválido — família 1106/960).

### Mudanças
- **Loader:** `classtrib_dfe_allowed(code)`.
- **Regra `CLASSTRIB_DOC_TYPE`:** cClassTrib conhecido cujo `dfe_allowed` não inclui o modelo (NFE/NFCE/NFSE) → **WARNING** citando os modelos válidos + a família 1106/960.

### Decisões
- **Severidade WARNING** (não FATAL): confiança alta na tabela, mas o código de rejeição exato não é citável com segurança → princípio "só FATAL com confiança".
- **Backend-only** (enrichment), como `CRED_PRES`/`ALIQUOTA_CLASSTRIB` — não altera `RULES_COUNT` do mock.
- As demais famílias do catálogo (B25d/BB05/C22-SUFRAMA/UB66) seguem **deferidas** — dependem do pacote de schemas oficial + tabelas externas (SUFRAMA/municípios), conforme registrado na issue.

### QA
`TestClassTribDocType` (5 casos) + regressão `validate_xml` **58** verdes; `ruff` + `pyright` limpos.

Avança #311 (mantém aberta para o restante do catálogo). Refs #309. Reusa #313.