### PR TITLE
feat(rules): #312 — DEVOLUCAO_DFEREF (devolução referencia a nota original por item)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -300,6 +300,11 @@ def _within_no_penalty_window(emission_date: dict | None) -> bool:
 # contribuinte não é verificável do XML → ALERT informativo (verificar enquadramento).
 _PF_CNPJ_REQUIRED_DATE = "2026-07-01"
 
+# ── NF-e de devolução: referência à nota original por item via DFeReferenciado ──
+# v1.40: a partir de 01/09/2026, a devolução (finNFe=4) referencia a nota original
+# exclusivamente por item, via grupo DFeReferenciado (Rejeição 321 — VC02-14/VC03-20).
+_DEVOLUCAO_DFEREF_DATE = "2026-09-01"
+
 
 def validate_xml(
     xml: str,
@@ -919,6 +924,35 @@ def validate_xml(
                         evidence_ids=[ev_id],
                     ),
                     Evidence(id=ev_id, type="xml", label="Emitente PF (CPF) — verificar CNPJ", xpath=_xpath("CPF", doc_type), snippet=emit_cpf["snippet"]),
+                )
+
+    # ── Rule 22: DEVOLUCAO_DFEREF — devolução referencia a nota original por item (#312) ──
+    # v1.40: NF-e de devolução (finNFe=4) deve referenciar a nota original POR ITEM,
+    # exclusivamente via grupo DFeReferenciado. Antes de 01/09/2026 → WARNING (antecipação);
+    # a partir da vigência → FATAL. pedagogical_mode mantém WARNING.
+    if is_nfe:
+        _fin = _first_tag(xml, ["finNFe"])
+        if _fin and _fin["value"].strip() == "4":
+            _n_items = len(re.findall(r"<det\b", xml))
+            _n_ref = len(re.findall(r"<DFeReferenciado\b", xml))
+            if _n_ref < max(_n_items, 1):
+                _vigente = bool(re.match(r"^\d{4}-\d{2}-\d{2}$", em_date)) and em_date >= _DEVOLUCAO_DFEREF_DATE
+                _sev = "FATAL" if (_vigente and not pedagogical_mode) else "WARNING"
+                _falta = "nenhum item referencia" if _n_ref == 0 else f"só {_n_ref} de {_n_items} itens referenciam"
+                ev_id = "E_XML_DEVOLUCAO_DFEREF"
+                _add(
+                    Finding(
+                        id="F_DEVOLUCAO_DFEREF", severity=_sev, rule_id="DEVOLUCAO_DFEREF",
+                        title=f"NF-e de devolução sem DFeReferenciado por item ({_falta} a nota original)",
+                        where=FindingWhere(field="DFeReferenciado", xpath=_xpath("DFeReferenciado", doc_type), snippet=_fin["snippet"]),
+                        recommendation=(
+                            "NF-e de devolução (finNFe=4) deve referenciar a nota original POR ITEM, "
+                            "exclusivamente via grupo DFeReferenciado (NT 2025.002-RTC v1.40, vigência 01/09/2026). "
+                            "Inclua um DFeReferenciado para cada item devolvido. SEFAZ: Rejeição 321 (regras VC02-14 / VC03-20)."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="Devolução sem DFeReferenciado por item", xpath=_xpath("DFeReferenciado", doc_type), snippet=_fin["snippet"]),
                 )
 
     # ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -579,3 +579,50 @@ class TestClassTribDocType:
 
     def test_desconhecido_sem_finding(self):
         assert self._find(self._nfe("999999"), "NFE") == []
+
+
+class TestDevolucaoDFeRef:
+    """#312 — NF-e de devolução (finNFe=4) referencia a nota original por item via
+    DFeReferenciado. WARNING até 31/08/2026; FATAL a partir de 01/09/2026 (Rej. 321)."""
+
+    def _nfe(self, fin="4", dhemi="2026-09-15", n_items=1, n_ref=0):
+        dets = "".join(
+            f'<det nItem="{i + 1}"><prod><NCM>84713012</NCM><vProd>10.00</vProd></prod></det>'
+            for i in range(n_items)
+        )
+        refs = "".join(
+            '<DFeReferenciado><refNFe>35260612345678000195550010000000011000000017</refNFe></DFeReferenciado>'
+            for _ in range(n_ref)
+        )
+        return (
+            f'<nfeProc><NFe><infNFe><ide><mod>55</mod><finNFe>{fin}</finNFe>'
+            f'<dhEmi>{dhemi}T10:00:00-03:00</dhEmi></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            f'{refs}{dets}'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, **kw):
+        return [f for f in validate_xml(xml, "NFE", **kw).findings if f.rule_id == "DEVOLUCAO_DFEREF"]
+
+    def test_sem_ref_apos_vigencia_fatal(self):
+        f = self._find(self._nfe(dhemi="2026-09-15", n_ref=0))
+        assert any(x.id == "F_DEVOLUCAO_DFEREF" and x.severity == "FATAL" for x in f)
+
+    def test_sem_ref_antes_vigencia_warning(self):
+        f = self._find(self._nfe(dhemi="2026-08-15", n_ref=0))
+        assert f and all(x.severity == "WARNING" for x in f)
+
+    def test_com_ref_por_item_sem_finding(self):
+        assert self._find(self._nfe(n_items=2, n_ref=2)) == []
+
+    def test_ref_parcial_gera_finding(self):
+        f = self._find(self._nfe(n_items=2, n_ref=1))
+        assert any(x.id == "F_DEVOLUCAO_DFEREF" for x in f)
+
+    def test_nao_devolucao_sem_finding(self):
+        assert self._find(self._nfe(fin="1", n_ref=0)) == []
+
+    def test_pedagogical_mantem_warning(self):
+        f = self._find(self._nfe(dhemi="2026-09-15", n_ref=0), pedagogical_mode=True)
+        assert f and all(x.severity == "WARNING" for x in f)

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -4,7 +4,7 @@
  * Fonte única reutilizada por copy, blog e metadados (SEO/OG/Twitter), para que o
  * site nunca divirja do engine. Conta as regras de validação ATIVAS do
  * `xmlRules.ts`, excluindo os placeholders (lembretes que só emitem ALERT e não
- * validam nada). Hoje: 22 ruleIds distintos − 2 placeholders = 20.
+ * validam nada). Hoje: 23 ruleIds distintos − 2 placeholders = 21.
  *
  * Anti-drift: `rulesMeta.test.ts` extrai os ruleIds reais do `xmlRules.ts` e falha
  * se esta contagem sair de sincronia com o engine. Ao adicionar/remover uma regra,
@@ -15,7 +15,7 @@
 export const PLACEHOLDER_RULE_IDS: readonly string[] = ["BENEFITS_PLACEHOLDER", "NCM_PLACEHOLDER"];
 
 /** Quantidade canônica de regras determinísticas ativas. */
-export const RULES_COUNT = 20;
+export const RULES_COUNT = 21;
 
 /** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
 export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -926,3 +926,46 @@ test("#311: NFS-e NÃO recebe código de rejeição NF-e (1106)", () => {
   assert.ok(f, "CCLASSTRIB_6_DIGITS esperado em NFS-e");
   assert.doesNotMatch(f!.recommendation ?? "", /1106/);
 });
+
+// ── #312 — DEVOLUCAO_DFEREF (devolução referencia nota original por item) ─────
+function devNfe(fin: string, dhEmi: string, nItems: number, nRef: number): string {
+  const dets = Array.from({ length: nItems }, (_, i) =>
+    `<det nItem="${i + 1}"><prod><NCM>84713012</NCM><vProd>10.00</vProd></prod></det>`).join("");
+  const refs = Array.from({ length: nRef }, () =>
+    "<DFeReferenciado><refNFe>35260612345678000195550010000000011000000017</refNFe></DFeReferenciado>").join("");
+  return `<nfeProc><NFe><infNFe><ide><mod>55</mod><finNFe>${fin}</finNFe>` +
+    `<dhEmi>${dhEmi}T10:00:00-03:00</dhEmi></ide>` +
+    `<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>${refs}${dets}` +
+    `</infNFe></NFe></nfeProc>`;
+}
+function devFindings(xml: string, pedagogicalMode = false) {
+  return validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml, pedagogicalMode })
+    .findings.filter((f) => f.rule_id === "DEVOLUCAO_DFEREF");
+}
+
+test("#312 devolução sem DFeReferenciado após 01/09 → FATAL", () => {
+  const f = devFindings(devNfe("4", "2026-09-15", 1, 0));
+  assert.ok(f.some((x) => x.id === "F_DEVOLUCAO_DFEREF" && x.severity === "FATAL"));
+});
+
+test("#312 devolução sem DFeReferenciado antes da vigência → WARNING", () => {
+  const f = devFindings(devNfe("4", "2026-08-15", 1, 0));
+  assert.ok(f.length > 0 && f.every((x) => x.severity === "WARNING"));
+});
+
+test("#312 devolução com DFeReferenciado por item → sem finding", () => {
+  assert.equal(devFindings(devNfe("4", "2026-09-15", 2, 2)).length, 0);
+});
+
+test("#312 referência parcial → finding", () => {
+  assert.ok(devFindings(devNfe("4", "2026-09-15", 2, 1)).length > 0);
+});
+
+test("#312 não-devolução (finNFe=1) → sem finding", () => {
+  assert.equal(devFindings(devNfe("1", "2026-09-15", 1, 0)).length, 0);
+});
+
+test("#312 pedagogicalMode mantém WARNING após vigência", () => {
+  const f = devFindings(devNfe("4", "2026-09-15", 1, 0), true);
+  assert.ok(f.length > 0 && f.every((x) => x.severity === "WARNING"));
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -86,6 +86,10 @@ function isWithinNoPenaltyWindow(emissionDate: string | undefined): boolean {
 // não é verificável do XML — por isso a regra é ALERT informativo (verificar enquadramento).
 const PF_CNPJ_REQUIRED_DATE = "2026-07-01";
 
+// NF-e de devolução (finNFe=4): a partir de 01/09/2026 referencia a nota original por item,
+// exclusivamente via grupo DFeReferenciado (v1.40, Rejeição 321 — VC02-14/VC03-20).
+const DEVOLUCAO_DFEREF_DATE = "2026-09-01";
+
 // ── CST table (NT 2025.002-RTC) ────────────────────────────────────────────
 export const CST_TABLE: Record<string, { group: string | null; description: string }> = {
   "000": { group: "gIBSCBS", description: "Tributação normal (ad valorem)" },
@@ -886,6 +890,42 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
               `caso, providencie a inscrição no CNPJ. A inscrição não transforma a PF em PJ.`,
           }),
           makeEvidence({ id: evId, type: "xml", label: "Emitente PF (CPF) — verificar CNPJ", xpath: inferXpath("CPF", docType), snippet: emitCpf.snippet }),
+        );
+      }
+    }
+  }
+
+  // ── Rule: DEVOLUCAO_DFEREF — devolução referencia a nota original por item (#312) ──
+  // v1.40: NF-e de devolução (finNFe=4) deve referenciar a nota original POR ITEM,
+  // exclusivamente via grupo DFeReferenciado. Antes de 01/09/2026 → WARNING (antecipação);
+  // a partir da vigência → FATAL. pedagogicalMode mantém WARNING.
+  if (isNfe) {
+    const fin = firstTag(xml, ["finNFe"]);
+    if (fin && fin.value.trim() === "4") {
+      const nItems = (xml.match(/<det\b/g) ?? []).length;
+      const nRef = (xml.match(/<DFeReferenciado\b/g) ?? []).length;
+      if (nRef < Math.max(nItems, 1)) {
+        const emDate = emissionDate?.value?.slice(0, 10) ?? "";
+        const vigente = /^\d{4}-\d{2}-\d{2}$/.test(emDate) && emDate >= DEVOLUCAO_DFEREF_DATE;
+        const sev: FindingSeverity = vigente && !pedMode ? "FATAL" : "WARNING";
+        const falta = nRef === 0 ? "nenhum item referencia" : `só ${nRef} de ${nItems} itens referenciam`;
+        const evId = makeEvidenceId("DEVOLUCAO_DFEREF");
+        pushFindingAndEvidence(findings, evidences, evidenceById,
+          makeFinding({
+            id: "F_DEVOLUCAO_DFEREF",
+            severity: sev,
+            ruleId: "DEVOLUCAO_DFEREF",
+            title: `NF-e de devolução sem DFeReferenciado por item (${falta} a nota original)`,
+            field: "DFeReferenciado",
+            xpath: inferXpath("DFeReferenciado", docType),
+            snippet: fin.snippet,
+            evidenceId: evId,
+            recommendation:
+              "NF-e de devolução (finNFe=4) deve referenciar a nota original POR ITEM, " +
+              "exclusivamente via grupo DFeReferenciado (NT 2025.002-RTC v1.40, vigência 01/09/2026). " +
+              "Inclua um DFeReferenciado para cada item devolvido. SEFAZ: Rejeição 321 (regras VC02-14 / VC03-20).",
+          }),
+          makeEvidence({ id: evId, type: "xml", label: "Devolução sem DFeReferenciado por item", xpath: inferXpath("DFeReferenciado", docType), snippet: fin.snippet }),
         );
       }
     }


### PR DESCRIPTION
## #312 — Devolução referencia a nota original por item (`DFeReferenciado`)

A partir de **01/09/2026** (v1.40), NF-e de devolução (`finNFe=4`) deve referenciar a nota original **por item, exclusivamente via grupo `DFeReferenciado`** (Rejeição 321 — VC02-14/VC03-20). O parser não validava.

### Mudanças
- **Regra `DEVOLUCAO_DFEREF`** nos **dois motores** (backend `validate_xml.py` + frontend `xmlRules.ts`): se `finNFe=4` e nº de `DFeReferenciado` < nº de itens (`det`) → Finding. Cobre o caso claro (zero referências) e a referência parcial (proxy de "por item").
- **Severidade ciente da vigência** (por `dhEmi`): **WARNING** até 31/08/2026 (antecipação) → **FATAL** a partir de 01/09/2026. `pedagogicalMode` mantém WARNING. Evidência cita a Rejeição 321.
- **`RULES_COUNT` 20 → 21** (23 ruleIds − 2 placeholders); teste anti-drift verde.

### Decisões
- **Regra estrutural** (só depende do XML) → mirrorada nos **dois motores**, ao contrário de `CRED_PRES` (#339)/`CLASSTRIB_DOC_TYPE` (#311), que dependem da tabela SVRS (backend-only).
- Detecção por **contagem** `det` × `DFeReferenciado` (parser é regex, não DOM) — proxy robusto de "por item", baixo falso-positivo (gatilho em `finNFe=4`).

### QA
Backend: `TestDevolucaoDFeRef` (6) + regressão `validate_xml` **64**; `ruff` limpo. Frontend: 6 casos + anti-drift, **109** testes + build OK.

Fecha #312. Refs #309. (Aberto direto contra `main`.)