### PR TITLE
feat(rules): #314 — Imposto Seletivo (IS_CALC + IS_EXPECTED)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -955,6 +955,60 @@ def validate_xml(
                     Evidence(id=ev_id, type="xml", label="Devolução sem DFeReferenciado por item", xpath=_xpath("DFeReferenciado", doc_type), snippet=_fin["snippet"]),
                 )
 
+    # ── Rule 23: IS_CALC — coerência do Imposto Seletivo declarado (#314) ──────
+    # vIS = vBCIS × pIS (ad valorem) + qTrib × pISEspec (específico). Incoerência → FATAL
+    # (erro de cálculo é alta confiança). Tags exclusivas do IS (vIS/vBCIS/pIS), sem colisão
+    # com o PIS legado (vPIS/pPIS). O IS só é cobrado a partir de 2027, mas a coerência do
+    # grupo, quando declarado, é validável já.
+    _is_match = re.search(r"<IS\b[^>]*>(.*?)</IS>", xml, re.DOTALL)
+    if is_nfe and _is_match:
+        _isblk = _is_match.group(1)
+
+        def _isf(tag: str) -> float:
+            t = _first_tag(_isblk, [tag])
+            return _to_float(t["value"]) if t else 0.0
+
+        _vis_tag = _first_tag(_isblk, ["vIS"])
+        if _vis_tag:
+            _expected_is = round(_isf("vBCIS") * _isf("pIS") + _isf("qTrib") * _isf("pISEspec"), 2)
+            _vis_decl = _to_float(_vis_tag["value"])
+            if abs(_vis_decl - _expected_is) > 0.01:
+                ev_id = "E_XML_IS_CALC"
+                _add(
+                    Finding(
+                        id="F_IS_CALC", severity="FATAL", rule_id="IS_CALC",
+                        title=f"Imposto Seletivo incoerente: vIS={_vis_decl} declarado, esperado {_expected_is}",
+                        where=FindingWhere(field="vIS", xpath=_xpath("vIS", doc_type), snippet=_vis_tag["snippet"]),
+                        recommendation=(
+                            "vIS deve ser vBCIS × pIS (ad valorem) + qTrib × pISEspec (específico), "
+                            "conforme NT 2025.002-RTC. Ajuste a base, a alíquota ou o valor do IS."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="IS — cálculo incoerente", xpath=_xpath("vIS", doc_type), snippet=_vis_tag["snippet"]),
+                )
+
+    # ── Rule 24: IS_EXPECTED — NCM de capítulo sujeito ao IS sem grupo IS (#314) ──
+    # Núcleo inequívoco do IS na LC 214: bebidas (cap. 22) e produtos fumígenos (cap. 24).
+    # ALERT informativo (não FATAL): o IS só passa a ser cobrado em 2027 e há exceções.
+    if is_nfe and ncm and re.match(r"^\d{8}$", ncm["value"]) and not _is_match:
+        if ncm["value"][:2] in {"22", "24"}:
+            ev_id = "E_XML_IS_EXPECTED"
+            _add(
+                Finding(
+                    id="F_IS_EXPECTED", severity="ALERT", rule_id="IS_EXPECTED",
+                    title=f'NCM {ncm["value"]} pode estar sujeito ao Imposto Seletivo — grupo IS ausente',
+                    where=FindingWhere(field="IS", xpath=_xpath("IS", doc_type), snippet=ncm["snippet"]),
+                    recommendation=(
+                        "Produtos dos capítulos 22 (bebidas) e 24 (fumo) são, em regra, sujeitos ao "
+                        "Imposto Seletivo (LC 214 art. 409). A cobrança do IS inicia em 2027; verifique "
+                        "o enquadramento e, quando aplicável, informe o grupo IS na NF-e."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="IS — NCM possivelmente sujeito, grupo ausente", xpath=_xpath("IS", doc_type), snippet=ncm["snippet"]),
+            )
+
     # ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────
     # Apenas NF-e/NFC-e (rejeições da SEFAZ NF-e; NFS-e tem regras próprias).
     if is_nfe:

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -626,3 +626,58 @@ class TestDevolucaoDFeRef:
     def test_pedagogical_mantem_warning(self):
         f = self._find(self._nfe(dhemi="2026-09-15", n_ref=0), pedagogical_mode=True)
         assert f and all(x.severity == "WARNING" for x in f)
+
+
+class TestImpostoSeletivo:
+    """#314 — Imposto Seletivo: coerência do grupo IS (IS_CALC) + advertência de NCM
+    sujeito sem grupo IS (IS_EXPECTED, cap. 22 bebidas / 24 fumo, vigência 2027)."""
+
+    def _nfe(self, ncm="22030000", vbcis=None, pis=None, vis=None, pespec=None, qtrib=None):
+        is_grp = ""
+        if vis is not None:
+            fields = ""
+            if vbcis is not None:
+                fields += f"<vBCIS>{vbcis}</vBCIS>"
+            if pis is not None:
+                fields += f"<pIS>{pis}</pIS>"
+            if pespec is not None:
+                fields += f"<pISEspec>{pespec}</pISEspec>"
+            if qtrib is not None:
+                fields += f"<qTrib>{qtrib}</qTrib>"
+            fields += f"<vIS>{vis}</vIS>"
+            is_grp = f"<IS><CSTIS>01</CSTIS><cClassTribIS>000001</cClassTribIS><gIS>{fields}</gIS></IS>"
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            f'<det nItem="1"><prod><NCM>{ncm}</NCM><vProd>1000.00</vProd></prod>'
+            f'<imposto>{is_grp}</imposto></det>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, rule):
+        return [f for f in validate_xml(xml, "NFE").findings if f.rule_id == rule]
+
+    def test_is_advalorem_coerente_sem_finding(self):
+        assert self._find(self._nfe(vbcis="1000.00", pis="0.1000", vis="100.00"), "IS_CALC") == []
+
+    def test_is_advalorem_incoerente_fatal(self):
+        f = self._find(self._nfe(vbcis="1000.00", pis="0.1000", vis="50.00"), "IS_CALC")
+        assert any(x.id == "F_IS_CALC" and x.severity == "FATAL" for x in f)
+
+    def test_is_especifico_coerente_sem_finding(self):
+        # vIS = qTrib × pISEspec = 100 × 0,50 = 50,00
+        assert self._find(self._nfe(qtrib="100", pespec="0.50", vis="50.00"), "IS_CALC") == []
+
+    def test_ncm_bebida_sem_is_alerta(self):
+        f = self._find(self._nfe(ncm="22030000"), "IS_EXPECTED")
+        assert any(x.id == "F_IS_EXPECTED" and x.severity == "ALERT" for x in f)
+
+    def test_ncm_fumo_sem_is_alerta(self):
+        assert any(x.id == "F_IS_EXPECTED" for x in self._find(self._nfe(ncm="24022000"), "IS_EXPECTED"))
+
+    def test_ncm_nao_sujeito_sem_finding(self):
+        assert self._find(self._nfe(ncm="84713012"), "IS_EXPECTED") == []
+
+    def test_ncm_sujeito_com_is_nao_alerta(self):
+        # grupo IS presente → IS_EXPECTED não dispara
+        assert self._find(self._nfe(ncm="22030000", vbcis="1000.00", pis="0.1000", vis="100.00"), "IS_EXPECTED") == []

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -4,7 +4,7 @@
  * Fonte única reutilizada por copy, blog e metadados (SEO/OG/Twitter), para que o
  * site nunca divirja do engine. Conta as regras de validação ATIVAS do
  * `xmlRules.ts`, excluindo os placeholders (lembretes que só emitem ALERT e não
- * validam nada). Hoje: 23 ruleIds distintos − 2 placeholders = 21.
+ * validam nada). Hoje: 25 ruleIds distintos − 2 placeholders = 23.
  *
  * Anti-drift: `rulesMeta.test.ts` extrai os ruleIds reais do `xmlRules.ts` e falha
  * se esta contagem sair de sincronia com o engine. Ao adicionar/remover uma regra,
@@ -15,7 +15,7 @@
 export const PLACEHOLDER_RULE_IDS: readonly string[] = ["BENEFITS_PLACEHOLDER", "NCM_PLACEHOLDER"];
 
 /** Quantidade canônica de regras determinísticas ativas. */
-export const RULES_COUNT = 21;
+export const RULES_COUNT = 23;
 
 /** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
 export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -969,3 +969,50 @@ test("#312 pedagogicalMode mantém WARNING após vigência", () => {
   const f = devFindings(devNfe("4", "2026-09-15", 1, 0), true);
   assert.ok(f.length > 0 && f.every((x) => x.severity === "WARNING"));
 });
+
+// ── #314 — Imposto Seletivo (IS_CALC + IS_EXPECTED) ──────────────────────────
+function isNfe(ncm: string, opts: { vbcis?: string; pis?: string; vis?: string; pespec?: string; qtrib?: string } = {}): string {
+  let grp = "";
+  if (opts.vis !== undefined) {
+    let f = "";
+    if (opts.vbcis !== undefined) f += `<vBCIS>${opts.vbcis}</vBCIS>`;
+    if (opts.pis !== undefined) f += `<pIS>${opts.pis}</pIS>`;
+    if (opts.pespec !== undefined) f += `<pISEspec>${opts.pespec}</pISEspec>`;
+    if (opts.qtrib !== undefined) f += `<qTrib>${opts.qtrib}</qTrib>`;
+    f += `<vIS>${opts.vis}</vIS>`;
+    grp = `<IS><CSTIS>01</CSTIS><cClassTribIS>000001</cClassTribIS><gIS>${f}</gIS></IS>`;
+  }
+  return `<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>` +
+    `<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>` +
+    `<det nItem="1"><prod><NCM>${ncm}</NCM><vProd>1000.00</vProd></prod>` +
+    `<imposto>${grp}</imposto></det></infNFe></NFe></nfeProc>`;
+}
+function isFindings(xml: string, rule: string) {
+  return validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml }).findings.filter((f) => f.rule_id === rule);
+}
+
+test("#314 IS ad valorem coerente → sem IS_CALC", () => {
+  assert.equal(isFindings(isNfe("22030000", { vbcis: "1000.00", pis: "0.1000", vis: "100.00" }), "IS_CALC").length, 0);
+});
+
+test("#314 IS incoerente → IS_CALC FATAL", () => {
+  const f = isFindings(isNfe("22030000", { vbcis: "1000.00", pis: "0.1000", vis: "50.00" }), "IS_CALC");
+  assert.ok(f.some((x) => x.id === "F_IS_CALC" && x.severity === "FATAL"));
+});
+
+test("#314 IS específico coerente → sem IS_CALC", () => {
+  assert.equal(isFindings(isNfe("24022000", { qtrib: "100", pespec: "0.50", vis: "50.00" }), "IS_CALC").length, 0);
+});
+
+test("#314 NCM bebida/fumo sem grupo IS → IS_EXPECTED ALERT", () => {
+  const f = isFindings(isNfe("22030000"), "IS_EXPECTED");
+  assert.ok(f.some((x) => x.id === "F_IS_EXPECTED" && x.severity === "ALERT"));
+});
+
+test("#314 NCM não sujeito → sem IS_EXPECTED", () => {
+  assert.equal(isFindings(isNfe("84713012"), "IS_EXPECTED").length, 0);
+});
+
+test("#314 NCM sujeito com grupo IS → sem IS_EXPECTED", () => {
+  assert.equal(isFindings(isNfe("22030000", { vbcis: "1000.00", pis: "0.1000", vis: "100.00" }), "IS_EXPECTED").length, 0);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -931,6 +931,67 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
     }
   }
 
+  // ── Rule: IS_CALC — coerência do Imposto Seletivo declarado (#314) ──────
+  // vIS = vBCIS × pIS (ad valorem) + qTrib × pISEspec (específico). Tags exclusivas do IS
+  // (sem colisão com o PIS legado vPIS/pPIS). O IS só é cobrado a partir de 2027, mas a
+  // coerência do grupo, quando declarado, é validável já.
+  const isMatch = xml.match(/<IS\b[^>]*>([\s\S]*?)<\/IS>/);
+  if (isNfe && isMatch) {
+    const isblk = isMatch[1];
+    const isf = (tag: string): number => parseFloat(firstTag(isblk, [tag])?.value ?? "0") || 0;
+    const visTag = firstTag(isblk, ["vIS"]);
+    if (visTag) {
+      const expected = Math.round((isf("vBCIS") * isf("pIS") + isf("qTrib") * isf("pISEspec")) * 100) / 100;
+      const declared = parseFloat(visTag.value) || 0;
+      if (Math.abs(declared - expected) > 0.01) {
+        const evId = makeEvidenceId("IS_CALC");
+        pushFindingAndEvidence(findings, evidences, evidenceById,
+          makeFinding({
+            id: "F_IS_CALC",
+            severity: "FATAL",
+            ruleId: "IS_CALC",
+            title: `Imposto Seletivo incoerente: vIS=${declared} declarado, esperado ${expected}`,
+            field: "vIS",
+            xpath: inferXpath("vIS", docType),
+            snippet: visTag.snippet,
+            evidenceId: evId,
+            recommendation:
+              "vIS deve ser vBCIS × pIS (ad valorem) + qTrib × pISEspec (específico), " +
+              "conforme NT 2025.002-RTC. Ajuste a base, a alíquota ou o valor do IS.",
+          }),
+          makeEvidence({ id: evId, type: "xml", label: "IS — cálculo incoerente", xpath: inferXpath("vIS", docType), snippet: visTag.snippet }),
+        );
+      }
+    }
+  }
+
+  // ── Rule: IS_EXPECTED — NCM de capítulo sujeito ao IS sem grupo IS (#314) ──
+  // Núcleo inequívoco do IS na LC 214: bebidas (cap. 22) e fumo (cap. 24). ALERT informativo
+  // (não FATAL): o IS só passa a ser cobrado em 2027 e há exceções.
+  if (isNfe && ncm && /^\d{8}$/.test(ncm.value) && !isMatch) {
+    const cap = ncm.value.slice(0, 2);
+    if (cap === "22" || cap === "24") {
+      const evId = makeEvidenceId("IS_EXPECTED");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_IS_EXPECTED",
+          severity: "ALERT",
+          ruleId: "IS_EXPECTED",
+          title: `NCM ${ncm.value} pode estar sujeito ao Imposto Seletivo — grupo IS ausente`,
+          field: "IS",
+          xpath: inferXpath("IS", docType),
+          snippet: ncm.snippet,
+          evidenceId: evId,
+          recommendation:
+            "Produtos dos capítulos 22 (bebidas) e 24 (fumo) são, em regra, sujeitos ao " +
+            "Imposto Seletivo (LC 214 art. 409). A cobrança do IS inicia em 2027; verifique " +
+            "o enquadramento e, quando aplicável, informe o grupo IS na NF-e.",
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "IS — NCM possivelmente sujeito, grupo ausente", xpath: inferXpath("IS", docType), snippet: ncm.snippet }),
+      );
+    }
+  }
+
   // ── Rule 9: CEST_FORMAT — CEST must be exactly 7 digits ──────────────────
 
   if (cest && !/^\d{7}$/.test(cest.value)) {


### PR DESCRIPTION
## #314 — Imposto Seletivo no motor

Concretiza o IS (antes só vocabulário). Tags do grupo IS confirmadas na NT 2025.002-RTC (`CSTIS/cClassTribIS/vBCIS/pIS/pISEspec/uTrib/qTrib/vIS` — exclusivas do IS, sem colisão com o PIS legado).

### Mudanças (dois motores)
- **`IS_CALC`** (FATAL): `vIS = vBCIS×pIS` (ad valorem) `+ qTrib×pISEspec` (específico); incoerência > R$0,01 → erro de cálculo. Valida o grupo IS quando declarado.
- **`IS_EXPECTED`** (ALERT): NCM cap. **22** (bebidas) / **24** (fumo) — núcleo inequívoco do IS (LC 214 art. 409) — sem grupo IS → adverte. Não-FATAL: IS só é cobrado em **2027** e há exceções.
- **`RULES_COUNT` 21 → 23** (anti-drift verde).

### Decisões
- **Severidades honestas:** coerência matemática = FATAL (alta confiança); presença = ALERT (IS ainda não vigora, exceções existem) — princípio "só FATAL com confiança".
- **Escopo P2 consciente:** lista completa de NCMs sujeitos (veículos, minerais, exceções) depende do regulamento/v1.50 → **follow-up**. Entregue o núcleo inequívoco + a coerência. Coluna dedicada de IS no relatório tabular = follow-up (os findings já entram no relatório auditável).

### QA
Backend: `TestImpostoSeletivo` (7) + regressão **71**; ruff. Frontend: 6 + anti-drift, **115** + build.

Fecha o núcleo do #314. Refs #309, #168, #277.