### PR TITLE
feat(rules): #278 fase 2 — ALIQUOTA_CLASSTRIB comparação absoluta (pCBS/pIBS vs cClassTrib)

### DIFF
--- a/backend/app/data/classtrib_table.py
+++ b/backend/app/data/classtrib_table.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from app.data.uf_rates import CBS_TESTE_2026, IBS_TESTE_2026_TOTAL
+
 _DATA = json.loads((Path(__file__).parent / "classtrib.json").read_text(encoding="utf-8"))
 CLASSTRIB_BY_CODE: dict[str, dict] = _DATA.get("by_code", {})
 
@@ -59,3 +61,25 @@ def classtrib_dfe_allowed(code: str) -> list[str] | None:
     if item is None:
         return None
     return list(item.get("dfe_allowed") or [])
+
+
+def classtrib_expected_aliquota_2026(code: str) -> tuple[float, float] | None:
+    """(pCBS, pIBS_total) esperados para o cClassTrib na fase de teste 2026 — #278 fase 2.
+
+    Deriva da redução oficial × alíquota de referência de 2026 (CBS 0,9% / IBS 0,1%, #315):
+        esperado = base × (1 − redução/100).
+    Retorna None para códigos zero-rate (cobertos pela fase 1, que é FATAL) ou desconhecidos.
+    Nota: para regimes monofásico/específico a derivação ad-valorem não se aplica — por isso
+    a regra fase 2 emite ALERT (advisory), nunca FATAL.
+    """
+    item = CLASSTRIB_BY_CODE.get(code)
+    if item is None:
+        return None
+    cst = str(item.get("cst", ""))
+    red_cbs = float(item.get("reduction_cbs_pct", 0) or 0)
+    red_ibs = float(item.get("reduction_ibs_pct", 0) or 0)
+    if cst in _ZERO_CSTS or red_cbs >= 100 or red_ibs >= 100:
+        return None
+    exp_cbs = float(CBS_TESTE_2026) * (1 - red_cbs / 100)
+    exp_ibs = float(IBS_TESTE_2026_TOTAL) * (1 - red_ibs / 100)
+    return round(exp_cbs, 6), round(exp_ibs, 6)

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -31,6 +31,7 @@ from app.api.plan_gate import require_plan, check_usage_limit, increment_usage
 from app.data.ncm_codes import VALID_NCM_CODES
 from app.data.classtrib_table import (
     classtrib_dfe_allowed,
+    classtrib_expected_aliquota_2026,
     classtrib_expected_zero,
     classtrib_permite_cred_pres,
 )
@@ -785,6 +786,54 @@ def validate_xml(
                     ),
                     Evidence(id=ev_id, type="xml", label="IBS — alíquota-zero incoerente", xpath=_xpath("pIBSUF", doc_type), snippet=p_ibs_uf["snippet"] if p_ibs_uf else None),
                 )
+
+        # Fase 2 (#278): comparação ABSOLUTA — pCBS/pIBS vs referência 2026 × (1−redução).
+        # ALERT advisory (não FATAL): há regimes monofásico/específico onde a derivação
+        # ad-valorem não vale; não bloquear nota legítima (incerto → ALERT honesto). Só
+        # emissão 2026 (a fase de transição 2027+ tem alíquotas em rampa — fora de escopo).
+        _em2 = emission_date["value"][:10] if emission_date else ""
+        if re.match(r"^2026-\d{2}-\d{2}$", _em2):
+            _expa = classtrib_expected_aliquota_2026(c_class_trib["value"])
+            if _expa is not None:
+                _exp_cbs, _exp_ibs = _expa
+                _TOL2 = 0.0001  # ±0,01 ponto percentual
+                _pcbs2 = _to_float(p_cbs["value"]) if p_cbs else None
+                _pibs2 = (
+                    (_to_float(p_ibs_uf["value"]) if p_ibs_uf else 0.0)
+                    + (_to_float(p_ibs_mun["value"]) if p_ibs_mun else 0.0)
+                ) if (p_ibs_uf or p_ibs_mun) else None
+                if _pcbs2 is not None and abs(_pcbs2 - _exp_cbs) > _TOL2:
+                    ev_id = "E_XML_ALIQUOTA_CLASSTRIB_ABS_CBS"
+                    _add(
+                        Finding(
+                            id="F_ALIQUOTA_CLASSTRIB_ABS_CBS", severity="ALERT", rule_id="ALIQUOTA_CLASSTRIB",
+                            title=f'pCBS {_pcbs2} diverge do esperado ({round(_exp_cbs, 4)}) para o cClassTrib {c_class_trib["value"]} em 2026',
+                            where=FindingWhere(field="pCBS", xpath=_xpath("pCBS", doc_type), snippet=p_cbs["snippet"] if p_cbs else None),
+                            recommendation=(
+                                f'Para o cClassTrib {c_class_trib["value"]}, a CBS esperada em 2026 é '
+                                f'{round(_exp_cbs * 100, 4)}% (0,9% × (1 − redução oficial SVRS)). Verifique a alíquota '
+                                "declarada — exceto em regime monofásico/específico, onde a derivação não se aplica."
+                            ),
+                            evidence_ids=[ev_id],
+                        ),
+                        Evidence(id=ev_id, type="xml", label="CBS — alíquota diverge do cClassTrib (2026)", xpath=_xpath("pCBS", doc_type), snippet=p_cbs["snippet"] if p_cbs else None),
+                    )
+                if _pibs2 is not None and abs(_pibs2 - _exp_ibs) > _TOL2:
+                    ev_id = "E_XML_ALIQUOTA_CLASSTRIB_ABS_IBS"
+                    _add(
+                        Finding(
+                            id="F_ALIQUOTA_CLASSTRIB_ABS_IBS", severity="ALERT", rule_id="ALIQUOTA_CLASSTRIB",
+                            title=f'pIBSUF+pIBSMun ({round(_pibs2, 6)}) diverge do esperado ({round(_exp_ibs, 4)}) para o cClassTrib {c_class_trib["value"]} em 2026',
+                            where=FindingWhere(field="pIBS", xpath=_xpath("pIBSUF", doc_type), snippet=p_ibs_uf["snippet"] if p_ibs_uf else None),
+                            recommendation=(
+                                f'Para o cClassTrib {c_class_trib["value"]}, o IBS total esperado em 2026 é '
+                                f'{round(_exp_ibs * 100, 4)}% (0,1% × (1 − redução oficial SVRS)). Verifique a alíquota '
+                                "declarada — exceto em regime monofásico/específico, onde a derivação não se aplica."
+                            ),
+                            evidence_ids=[ev_id],
+                        ),
+                        Evidence(id=ev_id, type="xml", label="IBS — alíquota diverge do cClassTrib (2026)", xpath=_xpath("pIBSUF", doc_type), snippet=p_ibs_uf["snippet"] if p_ibs_uf else None),
+                    )
 
     # ── Rule 20: CRED_PRES — crédito presumido coerente com o cClassTrib (#339) ──
     # Fonte SVRS (IndPermiteCredPres): só alguns cClassTrib admitem crédito presumido.

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -492,6 +492,59 @@ class TestAliquotaClasstrib:
         assert self._find(self._nfe("999999", pcbs="0.009")) == []
 
 
+class TestAliquotaAbsoluta:
+    """#278 fase 2 — pCBS/pIBS declarados vs referência 2026 × (1−redução). ALERT advisory
+    (não FATAL): regimes monofásico/específico não derivam ad-valorem. Só emissão 2026."""
+
+    def _nfe(self, code, pcbs="0", pibsuf="0", pibsmun="0", dhemi="2026-06-15"):
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod>'
+            f'<dhEmi>{dhemi}T10:00:00-03:00</dhEmi></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            '<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>{code}</cClassTrib>'
+            '<gIBSCBS><vBC>1000.00</vBC>'
+            f'<gIBSUF><pIBSUF>{pibsuf}</pIBSUF><vIBSUF>0.00</vIBSUF></gIBSUF>'
+            f'<gIBSMun><pIBSMun>{pibsmun}</pIBSMun><vIBSMun>0.00</vIBSMun></gIBSMun>'
+            f'<vIBS>0.00</vIBS><gCBS><pCBS>{pcbs}</pCBS><vCBS>0.00</vCBS></gCBS>'
+            '</gIBSCBS></IBSCBS></imposto></det>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _abs(self, xml):
+        return [f for f in validate_xml(xml, "NFE").findings
+                if f.rule_id == "ALIQUOTA_CLASSTRIB" and "ABS" in f.id]
+
+    def test_aliquotas_corretas_sem_alerta(self):
+        # 000001 (sem redução): CBS 0,9% / IBS total 0,1%
+        assert self._abs(self._nfe("000001", pcbs="0.009", pibsuf="0.0005", pibsmun="0.0005")) == []
+
+    def test_cbs_divergente_alerta(self):
+        # exemplo da issue: padrão 0,9% declarado como 0,1%
+        f = self._abs(self._nfe("000001", pcbs="0.001", pibsuf="0.0005", pibsmun="0.0005"))
+        assert any(x.id == "F_ALIQUOTA_CLASSTRIB_ABS_CBS" and x.severity == "ALERT" for x in f)
+
+    def test_ibs_divergente_alerta(self):
+        f = self._abs(self._nfe("000001", pcbs="0.009", pibsuf="0", pibsmun="0"))
+        assert any(x.id == "F_ALIQUOTA_CLASSTRIB_ABS_IBS" and x.severity == "ALERT" for x in f)
+
+    def test_reducao_60_correta_sem_alerta(self):
+        # 011001 (redução 60%): CBS 0,36% / IBS total 0,04%
+        assert self._abs(self._nfe("011001", pcbs="0.0036", pibsuf="0.0002", pibsmun="0.0002")) == []
+
+    def test_reducao_60_ignorada_alerta(self):
+        # declarou a alíquota cheia ignorando a redução → diverge
+        f = self._abs(self._nfe("011001", pcbs="0.009", pibsuf="0.0002", pibsmun="0.0002"))
+        assert any(x.id == "F_ALIQUOTA_CLASSTRIB_ABS_CBS" for x in f)
+
+    def test_fora_de_2026_nao_dispara(self):
+        assert self._abs(self._nfe("000001", pcbs="0.001", pibsuf="0", pibsmun="0", dhemi="2027-01-15")) == []
+
+    def test_zero_rate_nao_emite_absoluto(self):
+        # 400001 (isento) é tratado pela fase 1 (zero), não pela comparação absoluta
+        assert self._abs(self._nfe("400001", pcbs="0.009", pibsuf="0.0005", pibsmun="0.0005")) == []
+
+
 class TestCredPres:
     """#339 — crédito presumido (cCredPres) coerente com o cClassTrib (fonte SVRS).
     Só alguns cClassTrib admitem (IndPermiteCredPres): 000003/000004/410014/410016."""


### PR DESCRIPTION
## #278 fase 2 — comparação absoluta de alíquota

Fecha a fase 2, **destravada por #315** (alíquotas de referência) e **#313** (reduções SVRS). A fase 1 (slice alíquota-zero, FATAL) já existia.

### Mudanças
- **`classtrib_expected_aliquota_2026(code)`:** deriva `(pCBS, pIBS_total)` esperados em 2026 = referência (CBS 0,9% / IBS 0,1%) × (1 − redução oficial SVRS). `None` para zero-rate (fase 1) e desconhecidos.
- **`ALIQUOTA_CLASSTRIB` fase 2:** `pCBS` e `pIBSUF+pIBSMun` declarados vs esperado (±0,01 p.p.). Pega o exemplo da issue (padrão 0,9% declarado como **0,1%**).

### Decisão de severidade — **ALERT**, não FATAL
Honra o princípio do projeto ("incerto → ALERT, nunca bloquear nota legítima"):
- **Regimes monofásico/específico:** `TipoAliq` tem 5 valores **sem semântica oficial confirmada** — a derivação ad-valorem não vale para todos → risco de falso-positivo fiscal.
- **2027+ em rampa:** restrito a **emissão 2026** (gate por `dhEmi`).

Entrega o valor (flagra a alíquota errada) sem o risco de travar faturamento. **Caminho para FATAL** documentado (semântica de TipoAliq + validação em campo).

### QA
`TestAliquotaAbsoluta` (7) + regressão `validate_xml` **78**; `ruff` + `pyright` limpos. Backend-only (como a fase 1).

Fecha #278. Refs #309, #265.