### PR TITLE
feat(obs): error tracking de aplicação via Sentry (no-op sem DSN)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,6 +43,12 @@ MAGALU_S3_REGION=br-se1                      # região brasileira
 ALLOWED_ORIGINS=http://localhost:3000
 ENVIRONMENT=development  # development | staging | production
 FRONTEND_URL=http://localhost:3000
+
+# Observabilidade / Sentry (error tracking). Vazio = desativado (no-op).
+# Em produção: definir SENTRY_DSN no /opt/tribultz/.env da VM (lido via env_file).
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.0   # 0.0 = só erros; ex.: 0.1 p/ 10% de tracing de performance
+SENTRY_RELEASE=                 # opcional (ex.: git sha do deploy)
 # Production: FRONTEND_URL=https://www.tribultz.com.br
 # (used to build email links: /verify-email, /reset-password, /dashboard)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,13 @@ class Settings(BaseSettings):
     ALLOWED_ORIGINS: str = "http://localhost:3000,https://tribultz.com.br,https://*.vercel.app"
     ENVIRONMENT: str = "development"  # development | staging | production
 
+    # ── Observabilidade / Sentry (error tracking) ───────────
+    # Sem DSN → init é no-op (zero impacto em dev/CI). traces_sample_rate controla apenas o
+    # tracing de performance; erros são sempre capturados quando o DSN está presente.
+    SENTRY_DSN: str = ""
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.0
+    SENTRY_RELEASE: str = ""
+
     # ── Turnstile (CAPTCHA) ─────────────────────────────────
     TURNSTILE_SECRET_KEY: str = ""
     CAPTCHA_ENABLED: bool = False

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,0 +1,44 @@
+"""Error tracking de aplicação via Sentry.
+
+Inicialização defensiva e opcional: sem `SENTRY_DSN` configurado, `init_sentry()` é
+no-op (zero impacto em desenvolvimento, testes e CI). Falhas na própria inicialização
+nunca derrubam o boot da aplicação — observabilidade não pode ser ponto único de falha.
+
+Privacidade (LGPD): `send_default_pii=False` — não enviamos cabeçalhos/corpo da requisição
+ao Sentry. O conteúdo do XML fiscal (CNPJ/CPF/itens) não é capturado automaticamente.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def init_sentry() -> bool:
+    """Inicializa o Sentry se `SENTRY_DSN` estiver configurado. Retorna True se ativo."""
+    dsn = (settings.SENTRY_DSN or "").strip()
+    if not dsn:
+        return False
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.fastapi import FastApiIntegration
+        from sentry_sdk.integrations.starlette import StarletteIntegration
+
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=settings.ENVIRONMENT,
+            release=(settings.SENTRY_RELEASE or None),
+            traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+            # Não enviar PII (cabeçalhos/corpo) — dados fiscais são sensíveis (LGPD).
+            send_default_pii=False,
+            integrations=[StarletteIntegration(), FastApiIntegration()],
+        )
+        logger.info("Sentry inicializado (environment=%s)", settings.ENVIRONMENT)
+        return True
+    except Exception as exc:  # pragma: no cover — observabilidade nunca derruba o boot
+        logger.warning("Falha ao inicializar Sentry — seguindo sem error tracking: %s", exc)
+        return False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,10 +9,12 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.core.logging import configure_logging
+from app.core.observability import init_sentry
 from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, simulator, sped, split_payment, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry
 
 configure_logging()
+init_sentry()  # no-op sem SENTRY_DSN — deve vir antes da criação do app FastAPI
 
 
 @asynccontextmanager

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ redis==5.2.1
 httpx==0.28.1
 celery==5.4.0
 gunicorn==23.0.0
+sentry-sdk[fastapi]==2.63.0
 weasyprint==63.1
 jinja2==3.1.6
 pytest>=8.0.0

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,29 @@
+"""Testes do init de error tracking (Sentry) — comportamento no-op e ativo."""
+
+from app.config import settings
+from app.core import observability
+
+
+def test_init_sentry_noop_sem_dsn(monkeypatch):
+    """Sem SENTRY_DSN → no-op (não inicializa, não lança)."""
+    monkeypatch.setattr(settings, "SENTRY_DSN", "")
+    assert observability.init_sentry() is False
+
+
+def test_init_sentry_noop_dsn_em_branco(monkeypatch):
+    """DSN só com espaços → tratado como ausente."""
+    monkeypatch.setattr(settings, "SENTRY_DSN", "   ")
+    assert observability.init_sentry() is False
+
+
+def test_init_sentry_ativo_com_dsn(monkeypatch):
+    """Com DSN válido → inicializa e retorna True, sem lançar."""
+    monkeypatch.setattr(settings, "SENTRY_DSN", "https://abc123@o0.ingest.sentry.io/0")
+    monkeypatch.setattr(settings, "SENTRY_TRACES_SAMPLE_RATE", 0.0)
+    assert observability.init_sentry() is True
+
+
+def test_init_sentry_dsn_invalido_nao_derruba(monkeypatch):
+    """DSN malformado → captura a exceção e segue sem error tracking (retorna False)."""
+    monkeypatch.setattr(settings, "SENTRY_DSN", "isto-nao-e-um-dsn")
+    assert observability.init_sentry() is False


### PR DESCRIPTION
## Observabilidade — error tracking de aplicação (Sentry)

Fecha o ponto cego identificado na revisão de infra: o **uptime monitor** cobre **infra** (`/health/deep`), mas **exceções de aplicação** (um 5xx num XML específico) eram **invisíveis** — só via `docker logs` na VM. É a falha mais provável rumo ao 03/08 (as 5 regras novas processam regex sobre XML do mundo real).

### Mudanças
- **`app/core/observability.py` → `init_sentry()`**: inicializa **apenas** com `SENTRY_DSN`; **no-op** em dev/CI; falha de init **nunca derruba o boot** (try/except defensivo).
- **`send_default_pii=False`** (LGPD): não envia cabeçalhos/corpo; o conteúdo do XML fiscal (CNPJ/CPF/itens) não é capturado.
- **`main.py`**: `init_sentry()` antes do FastAPI (integrações Starlette+FastAPI).
- **`config.py`**: `SENTRY_DSN` / `SENTRY_TRACES_SAMPLE_RATE` (default **0.0**, só erros) / `SENTRY_RELEASE`. `.env.example` documenta.
- **`requirements`**: `sentry-sdk[fastapi]==2.63.0`.

### Segurança / footprint
- **Zero impacto** onde `SENTRY_DSN` não está setado (no-op) — inclusive CI/testes.
- **Sem mudança no compose**: `env_file` já lê `/opt/tribultz/.env`.

### Ativação em produção (você)
1. Criar projeto Sentry → obter o **DSN**.
2. Adicionar `SENTRY_DSN=...` ao `/opt/tribultz/.env` da VM → redeploy.

### QA
`test_observability` (4: no-op sem DSN, DSN em branco, ativo, DSN inválido não derruba) + regressão **78** + `ruff`/`pyright` limpos.

Follow-up: Sentry no frontend (Next.js/Vercel) + scrubbing adicional se necessário.