### PR TITLE
feat(site): #347 — link "Blog" no header público

### DIFF
--- a/frontend/src/components/public/PublicNavbar.tsx
+++ b/frontend/src/components/public/PublicNavbar.tsx
@@ -35,6 +35,9 @@ export function PublicNavbar() {
           <Link href="/pricing" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
             Planos
           </Link>
+          <Link href="/blog" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
+            Blog
+          </Link>
           <Link href="/login" className="font-medium text-slate-500 transition-colors hover:text-slate-800">
             Entrar
           </Link>


### PR DESCRIPTION
## #347 — Link "Blog" no header

Adiciona acesso ao **blog** (tribultz.com.br/blog, já no ar) pelo header público — divulgação/descoberta de conteúdo.

### Mudança
- `<Link href="/blog">Blog</Link>` no `PublicNavbar.tsx`, entre **"Planos"** e **"Entrar"** (ao lado de Entrar, como solicitado), mesmo estilo dos demais links.

### Nota de escopo
A nav pública é **desktop-only** (`hidden md:flex`) — **não há menu mobile**. O link de Blog (como todos os atuais) **não aparece no mobile**. Um menu mobile é gap pré-existente → **follow-up** se priorizado.

### QA
`npm test` + `npm run build` verdes. Mudança de 1 link, sem lógica.

Fecha #347.