### PR TITLE
feat(content): #349 — automação do blog via Soro RSS → PR (gate de revisão)

### DIFF
--- a/.github/workflows/soro-blog-sync.yml
+++ b/.github/workflows/soro-blog-sync.yml
@@ -1,0 +1,56 @@
+name: Soro Blog Sync
+
+# Importa artigos do feed RSS do Soro como MDX e abre um PR draft (needs-review).
+# Gate de revisão (#349): nada vai ao ar sem revisão humana + merge.
+
+on:
+  schedule:
+    - cron: "0 9 * * *"   # diário, 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: soro-blog-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install deps (tsx)
+        working-directory: frontend
+        run: npm ci
+
+      - name: Soro RSS → MDX
+        working-directory: frontend
+        env:
+          SORO_RSS_URL: ${{ secrets.SORO_RSS_URL }}
+        run: npx tsx scripts/soro-sync.ts
+
+      - name: Abrir PR de revisão
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: soro-sync/auto
+          title: "chore(blog): novos artigos do Soro para revisão"
+          commit-message: "chore(blog): import de artigos do Soro (RSS)"
+          labels: "blog-automation,needs-review"
+          draft: true
+          add-paths: frontend/content/blog/*.mdx
+          body: |
+            Artigos importados do feed RSS do Soro para **revisão humana** (gate do #349).
+
+            ⚠️ **Antes do merge:**
+            - Revisar a **precisão fiscal** (alíquotas, códigos, prazos) — conteúdo gerado por IA.
+            - Preencher `legalRefs`, `tags` e ajustar `category`.
+            - Confirmar que o `frontend-build` passou (valida o MDX).
+
+            Nada vai ao ar até o merge. Gerado por `.github/workflows/soro-blog-sync.yml`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "test:e2e": "tsx --test tests/calculadora.e2e.test.ts tests/auth.e2e.test.ts tests/validate-xml.e2e.test.ts"
   },

--- a/frontend/scripts/soro-sync.ts
+++ b/frontend/scripts/soro-sync.ts
@@ -1,0 +1,47 @@
+/**
+ * Soro RSS → MDX (#349). Executado pela GitHub Action `soro-blog-sync.yml`.
+ * Lê o feed (SORO_RSS_URL), gera .mdx para itens novos (dedup por slug) e os grava
+ * em content/blog/. A Action abre um PR draft (needs-review) com os arquivos — nada
+ * vai ao ar sem revisão + merge humano.
+ *
+ * Rodar local: SORO_RSS_URL="..." npx tsx scripts/soro-sync.ts   (a partir de frontend/)
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { parseFeedToPosts, postToMdx } from "../src/lib/soroSync";
+
+const FEED_URL = process.env.SORO_RSS_URL;
+const CONTENT_DIR = path.join(process.cwd(), "content", "blog");
+
+async function main() {
+  if (!FEED_URL) {
+    console.error("SORO_RSS_URL não definido.");
+    process.exit(1);
+  }
+  const res = await fetch(FEED_URL);
+  if (!res.ok) {
+    console.error(`Feed indisponível: HTTP ${res.status}`);
+    process.exit(1);
+  }
+  const posts = parseFeedToPosts(await res.text());
+  fs.mkdirSync(CONTENT_DIR, { recursive: true });
+
+  let created = 0;
+  for (const p of posts) {
+    const { filename, mdx } = postToMdx(p);
+    const dest = path.join(CONTENT_DIR, filename);
+    if (fs.existsSync(dest)) {
+      console.log(`skip (já existe): ${filename}`);
+      continue;
+    }
+    fs.writeFileSync(dest, mdx, "utf-8");
+    console.log(`novo: ${filename}`);
+    created++;
+  }
+  console.log(`Itens no feed: ${posts.length} | novos gravados: ${created}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/frontend/src/lib/soroSync.test.ts
+++ b/frontend/src/lib/soroSync.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseFeedToPosts, postToMdx, slugify } from "./soroSync";
+
+// Item real do feed Soro (estrutura capturada de app.trysoro.com/api/rss/...).
+const FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>tribultz.com.br</title>
+    <item>
+      <title>Como calcular alíquota CBS IBS sem erro</title>
+      <link>https://tribultz.com.br/como-calcular-aliquota-cbs-ibs</link>
+      <guid>4aa3737a-e38b-4624-a082-2472b7b92a70</guid>
+      <pubDate>Thu, 25 Jun 2026 14:13:01 GMT</pubDate>
+      <description>Veja como calcular alíquota CBS IBS com base legal.</description>
+      <content:encoded><![CDATA[<p>Texto do artigo com <a href="https://x">link</a>.</p>]]></content:encoded>
+      <enclosure url="https://cdn.example/img.webp" type="image/webp" />
+      <media:content url="https://cdn.example/img.webp" medium="image" />
+    </item>
+  </channel>
+</rss>`;
+
+test("#349 parseFeedToPosts extrai os campos do item Soro", () => {
+  const [p] = parseFeedToPosts(FEED);
+  assert.equal(p.title, "Como calcular alíquota CBS IBS sem erro");
+  assert.equal(p.slug, "como-calcular-aliquota-cbs-ibs"); // derivado do <link>
+  assert.equal(p.guid, "4aa3737a-e38b-4624-a082-2472b7b92a70");
+  assert.equal(p.coverImage, "https://cdn.example/img.webp");
+  assert.equal(p.publishedAt, "2026-06-25T14:13:01.000Z"); // RFC822 → ISO
+  assert.ok(p.contentHtml.includes("<p>Texto do artigo"));
+  assert.ok(!p.contentHtml.includes("CDATA"));
+});
+
+test("#349 postToMdx gera frontmatter válido + corpo, com legalRefs/tags vazios para revisão", () => {
+  const [p] = parseFeedToPosts(FEED);
+  const { filename, mdx } = postToMdx(p);
+  assert.equal(filename, "como-calcular-aliquota-cbs-ibs.mdx");
+  assert.ok(mdx.startsWith("---\n"));
+  assert.ok(mdx.includes(`title: "Como calcular alíquota CBS IBS sem erro"`));
+  assert.ok(mdx.includes(`slug: "como-calcular-aliquota-cbs-ibs"`));
+  assert.ok(mdx.includes(`coverImage: "https://cdn.example/img.webp"`));
+  assert.ok(mdx.includes(`soroGuid: "4aa3737a-e38b-4624-a082-2472b7b92a70"`));
+  assert.ok(mdx.includes("legalRefs: []"));
+  assert.ok(mdx.includes("tags: []"));
+  assert.ok(mdx.includes("REVISAR antes do merge"));
+  assert.ok(mdx.includes("<p>Texto do artigo"));
+});
+
+test("#349 feed vazio (só publicados, nenhum) → nenhum post", () => {
+  assert.equal(parseFeedToPosts("<rss><channel></channel></rss>").length, 0);
+});
+
+test("#349 slugify normaliza acentos e símbolos", () => {
+  assert.equal(slugify("Reforma Tributária: CBS & IBS!"), "reforma-tributaria-cbs-ibs");
+});

--- a/frontend/src/lib/soroSync.ts
+++ b/frontend/src/lib/soroSync.ts
@@ -1,0 +1,123 @@
+/**
+ * Soro RSS → MDX (#349). Converte o feed RSS do Soro em posts MDX do nosso blog,
+ * para entrarem via PR com revisão humana (gate). Fonte controlada (feed do Soro,
+ * RSS 2.0 + content:encoded + media:content); parsing direcionado às tags conhecidas.
+ *
+ * Importante: NADA aqui publica — só gera o conteúdo do arquivo. A publicação acontece
+ * apenas quando o PR (needs-review) é mergeado por um humano.
+ */
+
+export type SoroPost = {
+  guid: string;
+  title: string;
+  description: string;
+  slug: string;
+  link: string;
+  publishedAt: string; // ISO 8601
+  coverImage?: string;
+  contentHtml: string;
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function tagValue(item: string, name: string): string | undefined {
+  const re = new RegExp(`<${name}(?:\\s[^>]*)?>([\\s\\S]*?)</${name}>`);
+  const m = item.match(re);
+  if (!m) return undefined;
+  const raw = m[1].trim();
+  const cdata = raw.match(/^<!\[CDATA\[([\s\S]*?)\]\]>$/);
+  return cdata ? cdata[1] : decodeEntities(raw);
+}
+
+function tagAttr(item: string, name: string, attr: string): string | undefined {
+  const re = new RegExp(`<${name}[^>]*\\b${attr}="([^"]*)"`);
+  return item.match(re)?.[1];
+}
+
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function slugFromLink(link: string, title: string): string {
+  try {
+    const last = new URL(link).pathname.replace(/\/+$/, "").split("/").filter(Boolean).pop();
+    if (last) return last;
+  } catch {
+    /* link inválido → cai no slug do título */
+  }
+  return slugify(title);
+}
+
+function toIso(rfc822: string | undefined): string {
+  const d = new Date(rfc822 ?? "");
+  return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
+}
+
+export function parseFeedToPosts(xml: string): SoroPost[] {
+  const items = xml.match(/<item>[\s\S]*?<\/item>/g) ?? [];
+  return items.map((item) => {
+    const title = tagValue(item, "title") ?? "Sem título";
+    const link = tagValue(item, "link") ?? "";
+    const description = tagValue(item, "description") ?? "";
+    return {
+      guid: tagValue(item, "guid") ?? link ?? title,
+      title,
+      description,
+      slug: slugFromLink(link, title),
+      link,
+      publishedAt: toIso(tagValue(item, "pubDate")),
+      coverImage: tagAttr(item, "media:content", "url") ?? tagAttr(item, "enclosure", "url"),
+      contentHtml: tagValue(item, "content:encoded") ?? description,
+    };
+  });
+}
+
+const EDITORIAL_AUTHOR = {
+  name: "Equipe Tribultz",
+  jobTitle: "Conteúdo Fiscal",
+  url: "https://tribultz.com.br/sobre",
+};
+
+const yamlStr = (s: string) => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+
+/** Escapa chaves para não quebrar a compilação MDX (artigos raramente usam `{`/`}`). */
+const mdxSafe = (html: string) => html.replace(/{/g, "&#123;").replace(/}/g, "&#125;");
+
+export function postToMdx(p: SoroPost): { filename: string; mdx: string } {
+  const lines = [
+    "---",
+    `title: ${yamlStr(p.title)}`,
+    `description: ${yamlStr(p.description)}`,
+    `slug: ${yamlStr(p.slug)}`,
+    `category: "Reforma Tributária"`,
+    "author:",
+    `  name: ${yamlStr(EDITORIAL_AUTHOR.name)}`,
+    `  jobTitle: ${yamlStr(EDITORIAL_AUTHOR.jobTitle)}`,
+    `  url: ${yamlStr(EDITORIAL_AUTHOR.url)}`,
+    `publishedAt: ${yamlStr(p.publishedAt)}`,
+    "tags: []",
+    ...(p.coverImage ? [`coverImage: ${yamlStr(p.coverImage)}`] : []),
+    "legalRefs: []",
+    `soroGuid: ${yamlStr(p.guid)}`,
+    "---",
+    "",
+    "{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}",
+    "",
+    mdxSafe(p.contentHtml).trim(),
+    "",
+  ];
+  return { filename: `${p.slug}.mdx`, mdx: lines.join("\n") };
+}


### PR DESCRIPTION
## #349 — Soro RSS → PR (gate de revisão)

Pipeline **RSS-pull** que protege a marca: o Soro gera conteúdo, mas **nada vai ao ar sem revisão humana**.

### Como funciona
1. **GitHub Action** (cron diário + manual) lê o feed RSS do Soro (`SORO_RSS_URL`).
2. Gera `.mdx` para itens novos (dedup por slug) com nosso frontmatter — `author`=time editorial, `legalRefs`/`tags` **vazios**, `soroGuid` para dedup.
3. Abre **PR draft** com labels `blog-automation` + `needs-review` (via `GITHUB_TOKEN`, sem endpoint/secret de app).
4. Revisor valida o fiscal → merge → Vercel publica.

### Por que esta arquitetura
- **Zero endpoint inbound** + **zero backend novo**; RSS é padrão.
- Mantém MDX/SEO/git **+ gate de revisão**.
- Escapa `{`/`}` no corpo p/ não quebrar a compilação MDX; o `frontend-build` do PR valida cada post.

### ✅ Validação end-to-end (contra o feed REAL)
- 119 testes frontend; `soroSync.test.ts` cobre a estrutura real do item Soro.
- Dry-run contra o feed real **gerou o MDX** e o **`npm run build` compilou** — fluxo confirmado. (O `.mdx` gerado **não** foi commitado — ele só deve entrar via PR revisado.)

### Ativação (você)
- Definir secret **`SORO_RSS_URL`** (feed habilitado no Soro). Itens publicados aparecem no feed; `?include=drafts` permite revisar antes de expor o social.

### Escopo
- **LinkedIn:** trilha separada (issue à parte) — nosso RSS `/blog/feed.xml` → agendador.

Fecha #349. Relacionada #347.