### PR TITLE
content(blog): primeiro post — Como calcular alíquota CBS IBS (revisado)

### DIFF
--- a/frontend/content/blog/como-calcular-aliquota-cbs-ibs.mdx
+++ b/frontend/content/blog/como-calcular-aliquota-cbs-ibs.mdx
@@ -1,0 +1,58 @@
+---
+title: "tribultz.com.br"
+description: "Latest articles from tribultz.com.br"
+slug: "como-calcular-aliquota-cbs-ibs"
+category: "Reforma Tributária"
+author:
+  name: "Equipe Tribultz"
+  jobTitle: "Conteúdo Fiscal"
+  url: "https://tribultz.com.br/sobre"
+publishedAt: "2026-06-25T14:13:01.000Z"
+tags: ["CBS", "IBS", "alíquota", "Reforma Tributária", "cClassTrib"]
+coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/4aa3737a-e38b-4624-a082-2472b7b92a70.webp"
+legalRefs: []
+soroGuid: "4aa3737a-e38b-4624-a082-2472b7b92a70"
+---
+
+<p>Se a sua operação ainda trata a pergunta sobre como calcular alíquota CBS IBS como uma conta simples de percentual, o risco já começou. Na prática, a alíquota correta depende de enquadramento tributário, classificação do item, natureza da operação, destino e regras da LC 214. O problema não é só pagar a mais ou a menos. É emitir NF-e com inconsistência, gerar rejeição, abrir passivo e deixar rastros frágeis para auditoria.</p>
+<h2>Como calcular alíquota CBS IBS na prática</h2>
+<p>O ponto de partida não é a fórmula. É a regra aplicável ao item e à operação. CBS e IBS surgem dentro da lógica da Reforma Tributária com incidência orientada por novos critérios de classificação e compatibilidade de campos fiscais. Isso muda a rotina de quem mantém cadastro, parametriza ERP e valida XML antes da emissão.</p>
+<p>Na prática, calcular a alíquota exige cruzar pelo menos quatro camadas. Primeiro, identificar corretamente o produto ou serviço. Depois, verificar a classificação tributária aplicável, incluindo o <a href="https://tribultz.com.br/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs">cClassTrib</a> e demais atributos exigidos. Em seguida, validar o tipo de operação, o perfil do contribuinte e eventuais tratamentos específicos, como redução, alíquota diferenciada, isenção ou suspensão. Só então faz sentido falar em percentual.</p>
+<p>Quando uma dessas camadas falha, a conta final fica errada mesmo que a matemática esteja certa. É por isso que equipes fiscais experientes tratam o cálculo como resultado de validação, não como simples parametrização de imposto.</p>
+<h3>A lógica básica do cálculo</h3>
+<p>Em termos operacionais, o cálculo parte da base tributável multiplicada pela alíquota aplicável de CBS e pela alíquota aplicável de IBS. Parece direto, mas o ponto crítico está justamente em definir qual alíquota usar em cada documento fiscal.</p>
+<p>A estrutura geral é esta: valor da base de cálculo x alíquota CBS = valor de CBS. Depois, valor da base de cálculo x alíquota IBS = valor de IBS. O desafio é que a base pode variar conforme a regra da operação e a alíquota pode não ser a alíquota padrão cheia.</p>
+<p>Em alguns cenários, o item segue regime favorecido ou possui tratamento específico previsto na legislação complementar. Em outros, a natureza da saída ou da entrada altera o comportamento esperado do documento. Há também casos em que o erro não está no percentual, mas na combinação entre CST, cClassTrib, NCM e finalidade da operação. Esse tipo de incompatibilidade tende a aparecer tarde, geralmente quando a nota já está prestes a sair.</p>
+<h2>O que precisa ser validado antes do cálculo</h2>
+<p>Para calcular com segurança, a empresa precisa ter domínio sobre o cadastro fiscal e sobre o contexto da operação. Sem isso, qualquer percentual vira aposta.</p>
+<h3>1. Classificação correta do item</h3>
+<p>O primeiro filtro é o cadastro. <a href="https://tribultz.com.br/blog/como-classificar-ncm-corretamente-2026">NCM incorreto</a>, descrição genérica, ausência de atributos fiscais e cClassTrib mal mapeado contaminam todo o restante. A LC 214 exige uma leitura mais estruturada do item, porque o enquadramento tributário deixa de ser apenas uma decisão de tabela interna e passa a ter impacto direto na consistência da NF-e e do SPED.</p>
+<p>Se o produto está classificado de forma incompleta, a alíquota apurada pode até parecer coerente no ERP, mas não estará sustentada juridicamente nem tecnicamente.</p>
+<h3>2. Natureza da operação</h3>
+<p>Venda interna, interestadual, devolução, bonificação, remessa, industrialização, transferência e outras naturezas operacionais não podem ser tratadas como detalhe. Elas influenciam a leitura fiscal do documento e podem alterar o tratamento de CBS e IBS.</p>
+<p>Esse é um ponto em que muitas empresas erram por replicar regra antiga em operação nova. A Reforma Tributária não perdoa reaproveitamento preguiçoso de parametrização.</p>
+<h3>3. Regime e tratamento tributário aplicável</h3>
+<p>Nem toda operação seguirá a alíquota de referência. Dependendo do setor, do item ou da hipótese legal, pode haver alíquota reduzida, alíquota zero, imunidade, suspensão ou outro tratamento específico. O cálculo só fecha quando esse enquadramento é reconhecido de forma consistente no documento e no cadastro.</p>
+<h3>4. Coerência entre campos fiscais</h3>
+<p>Aqui mora boa parte do retrabalho. Não basta o percentual estar correto isoladamente. Ele precisa conversar com CST, CFOP, cClassTrib, códigos do item, base de cálculo e demais tags do XML. Quando essa coerência não existe, o problema aparece em forma de rejeição, divergência de escrituração ou apontamento de auditoria.</p>
+<h2>Exemplo objetivo de como calcular alíquota CBS IBS</h2>
+<p>Imagine uma venda de mercadoria com base de cálculo de R$ 10.000, em uma operação que, após análise do cadastro e da regra aplicável, esteja sujeita a 8,8% de CBS e 17,7% de IBS. O cálculo nominal seria simples: CBS de R$ 880 e IBS de R$ 1.770.</p><p><strong>Atenção à vigência:</strong> 8,8% (CBS) e 17,7% (IBS) são as alíquotas de <strong>referência do regime pleno</strong> (carga cheia da Reforma). Na <strong>fase de teste de 2026</strong>, a emissão usa alíquotas reduzidas — <strong>CBS 0,9% e IBS 0,1%</strong>. Sempre aplique o percentual do período correto.</p>
+<p>Mas esse exemplo só é válido se o item estiver classificado corretamente, se não houver benefício fiscal aplicável, se a operação não estiver em hipótese de tratamento específico e se os campos fiscais da NF-e estiverem coerentes com esse enquadramento. Se houver redução legal, por exemplo, a alíquota efetiva muda. Se a operação exigir outro tratamento, o cálculo inteiro precisa ser revisto.</p>
+<p>Esse é o ponto central: o percentual não nasce da planilha. Ele nasce da regra fiscal validada.</p>
+<h2>Onde as empresas mais erram ao calcular CBS e IBS</h2>
+<p>O erro mais comum é confiar em cadastro legado. Empresas com grande volume de SKUs e múltiplos ERPs costumam carregar classificações históricas que funcionavam de forma tolerável antes, mas deixam de sustentar a nova lógica de validação. O segundo erro é tratar exceção legal como ajuste manual de última hora. Isso até resolve uma nota, mas destrói governança.</p>
+<p>Também é frequente ver times fiscais e times de TI trabalhando em paralelo, sem uma camada comum de validação. O fiscal conhece a regra, o ERP aplica a parametrização, mas ninguém garante que o XML final respeita a combinação certa entre classificação, base e alíquota. É nesse vácuo que surgem <a href="https://tribultz.com.br/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir">rejeições como a 1024</a>, divergências no SPED e exposição desnecessária a penalidades.</p>
+<p>Outro ponto sensível é a ausência de evidência. Mesmo quando a empresa calcula certo, muitas vezes não consegue provar por que calculou daquele jeito. Em ambiente de fiscalização e auditoria, isso custa caro.</p>
+<h2>Como estruturar um processo confiável</h2>
+<p>Quem quer acertar o cálculo de CBS e IBS em escala precisa sair do modo reativo. O processo confiável começa na governança do cadastro e termina na validação pré-emissão.</p>
+<p>Primeiro, vale sanear a base de produtos e revisar a relação entre NCM, descrição, unidade, atributos fiscais e cClassTrib. Depois, é necessário parametrizar as regras por tipo de operação dentro do ERP, sem depender de exceções manuais recorrentes. Em seguida, o ideal é validar XML e arquivos fiscais com uma camada automatizada que confronte o documento com as regras legais e operacionais antes da nota sair.</p>
+<p>Esse modelo reduz retrabalho porque ataca o problema na origem. Em vez de descobrir erro no fechamento, a empresa barra inconsistência no momento em que ela ainda é barata de corrigir.</p>
+<h3>O papel da automação nesse cálculo</h3>
+<p>Calcular corretamente em uma operação pequena já exige cuidado. Em empresas com alto volume de NF-e, múltiplas filiais e catálogos extensos, fazer isso manualmente não é controle. É exposição.</p>
+<p>Automação faz diferença porque traduz a legislação em regra verificável. Em vez de depender da memória de quem parametrizou o sistema ou da conferência visual do analista, a empresa passa a rodar validações objetivas sobre cadastro, classificação e documento fiscal. Isso é especialmente relevante no contexto da CBS e do IBS, em que a consistência entre campos será tão importante quanto o percentual em si.</p>
+<p>Uma plataforma especializada como a Tribultz ajuda justamente nesse ponto: valida catálogo, cruza regras fiscais, calcula alíquotas de CBS e IBS e gera evidência auditável em PDF e JSON. Para times que operam com TOTVS, SAP, Omie ou Linx, esse tipo de camada reduz o risco onde ele realmente nasce - antes da emissão.</p>
+<h2>Como calcular alíquota CBS IBS sem criar passivo oculto</h2>
+<p>A resposta curta é esta: com regra, contexto e prova. Regra para definir o enquadramento correto. Contexto para entender a operação real. Prova para sustentar o cálculo em auditoria, fiscalização e reconciliação interna.</p>
+<p>Se a sua empresa ainda depende de planilhas paralelas, ajustes manuais no ERP ou interpretação descentralizada por filial, o cálculo pode até sair, mas a conformidade não acompanha. E quando a conformidade falha, o custo não aparece só no tributo. Aparece em nota rejeitada, atraso operacional, multa, reprocessamento e desgaste entre fiscal, controladoria e TI.</p>
+<p>A melhor abordagem é tratar CBS e IBS como tema de engenharia fiscal operacional. Isso significa combinar base legal, classificação confiável, validação sistêmica e rastreabilidade. Não existe atalho maduro fora disso.</p>
+<p>No fim, calcular alíquota corretamente não é apenas fechar a conta do imposto. É garantir que a empresa emita, escriture e comprove cada operação com menos retrabalho e menos exposição a multas. Quem ajustar isso agora vai trabalhar com muito menos surpresa quando a cobrança apertar de verdade.</p>


### PR DESCRIPTION
## Primeiro post do blog — revisado e pronto para publicar

Artigo gerado pelo Soro ("Como calcular alíquota CBS IBS sem erro"), publicado **manualmente** (estava atrasado; antes do pipeline #350). **Passou pelo gate de revisão fiscal.**

### Correções aplicadas na revisão
- 🔴 **Obrigatória (precisão fiscal):** o exemplo usava **8,8% / 17,7%** sem contexto de fase → inserida nota: *regime pleno* vs *fase de teste 2026 (CBS 0,9% / IBS 0,1%)*. Era o item nº 1 do nosso `Topics to Avoid`.
- 🟡 Suavizada promessa: "sem multa, sem susto" → "menos retrabalho e menos exposição a multas".
- Frontmatter: `author`=Equipe Tribultz, `tags` preenchidas, `legalRefs: []`, `soroGuid` p/ proveniência.

### QA
`npm run build` valida o MDX e renderiza a página do post. Revisado por techlead.

**Ao mergear → Vercel publica.** Para o IG/FB: ajuste a mesma linha (vigência) no draft do Soro **antes** de clicar publish, para o social sair correto.

Relacionada: #349 (pipeline), #347 (link do blog).