### PR TITLE
feat(content): corretor de conformidade fiscal (contentLint) + runbook — re-land

### DIFF
--- a/docs/content/publicacao-diaria.md
+++ b/docs/content/publicacao-diaria.md
@@ -1,0 +1,52 @@
+# Runbook — Publicação diária de conteúdo (Soro → Blog + Social)
+
+Fluxo de publicação com **gate de revisão fiscal** e **corretor automático** (#349/#350).
+Princípio: nada que cite alíquota/código/prazo vai ao ar sem revisão. O corretor por código
+(`contentLint`) reduz o trabalho — auto-corrige o determinístico e sinaliza o resto.
+
+## Visão geral dos canais
+
+| Canal | Como publica | Gate |
+|-------|--------------|------|
+| **Blog** (tribultz.com.br/blog) | GitHub Action lê o RSS do Soro → abre **PR `needs-review`** (com auto-fixes aplicados) | PR review + merge |
+| **Instagram / Facebook** | **Publish manual no Soro** (autoshare **DESLIGADO**) | revisão do draft no Soro |
+| **LinkedIn** | (pendente #351) RSS do blog → agendador | herda o gate do blog |
+
+## Rotina diária (≈10 min)
+
+1. **Soro — revisar o draft**
+   - Abrir o Soro → ler o artigo do dia.
+   - Checklist fiscal (o que o `Topics to Avoid` cobre):
+     - [ ] Alíquota cita a **fase**? (2026 = CBS 0,9% / IBS 0,1%; pleno = 8,8% / 17,7%)
+     - [ ] Sem código/rejeição/artigo/prazo **inventado**.
+     - [ ] Sem **promessa** ("garante", "100%", "zero rejeição", "sem multa").
+   - Corrigir no editor do Soro o que precisar (principalmente a linha da alíquota).
+
+2. **Soro — publicar** (com autoshare OFF) → posta no **IG/FB** a versão revisada e
+   coloca o item no feed RSS.
+
+3. **Blog — revisar o PR** (a Action abre sozinha, diária; ou rode `workflow_dispatch`)
+   - O PR já vem com **auto-fixes** do `contentLint` (ex.: nota de vigência da alíquota).
+   - No PR: ler o **preview da Vercel**, conferir `frontend-build` verde.
+   - Preencher `tags`, ajustar `category` e **`legalRefs`** (base legal).
+   - **Merge** → Vercel publica no blog.
+
+## Corretor de conteúdo (mecanismo por código)
+
+- **Automático:** roda na geração (pipeline Soro) e aplica auto-fixes seguros.
+- **Sob demanda / posts existentes:**
+  ```bash
+  cd frontend
+  npm run content:lint        # checa e reporta (falha se houver correção fiscal pendente)
+  npm run content:lint:fix    # aplica os auto-fixes nos .mdx
+  ```
+- Regras: `ALIQUOTA_PLENA_SEM_CONTEXTO` (auto-fix), `PROMESSA` (warn), `LEGALREFS_VAZIO`/`TAGS_VAZIO` (warn).
+
+## Não fazer
+- ❌ **Habilitar autoshare IG/FB** — conteúdo fiscal iria ao ar sem revisão.
+- ❌ **Mergear PR de blog** sem ler o conteúdo e conferir o build.
+- ❌ Publicar no Soro um draft com alíquota sem contexto de fase.
+
+## Ativação (uma vez)
+- Secret **`SORO_RSS_URL`** no repo (feed habilitado no Soro). `?include=drafts` permite revisar antes do social.
+- Autoshare IG/FB **desligado** no Soro.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,10 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
+    "content:lint": "tsx scripts/content-lint.ts",
+    "content:lint:fix": "tsx scripts/content-lint.ts --fix",
     "test:e2e": "tsx --test tests/calculadora.e2e.test.ts tests/auth.e2e.test.ts tests/validate-xml.e2e.test.ts"
   },
   "dependencies": {

--- a/frontend/scripts/content-lint.ts
+++ b/frontend/scripts/content-lint.ts
@@ -1,0 +1,47 @@
+/**
+ * Corretor de conformidade do blog (#349) — modo CLI, para posts existentes.
+ *
+ *   npx tsx scripts/content-lint.ts          # checa e reporta (exit≠0 se houver auto-fix pendente)
+ *   npx tsx scripts/content-lint.ts --fix     # aplica os auto-fixes nos arquivos
+ *
+ * Use no CI (sem --fix) como gate: falha se algum post tiver correção fiscal pendente.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { lintMdx } from "../src/lib/contentLint";
+
+const CONTENT_DIR = path.join(process.cwd(), "content", "blog");
+const FIX = process.argv.includes("--fix");
+
+const files = fs.existsSync(CONTENT_DIR)
+  ? fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".mdx"))
+  : [];
+
+let pendingFixes = 0;
+let warns = 0;
+
+for (const file of files) {
+  const full = path.join(CONTENT_DIR, file);
+  const original = fs.readFileSync(full, "utf-8");
+  const { mdx, findings } = lintMdx(original);
+  if (findings.length === 0) continue;
+
+  console.log(`\n${file}`);
+  for (const f of findings) {
+    console.log(`  [${f.severity === "fix" ? "FIX" : "warn"}] ${f.rule}: ${f.message}`);
+    if (f.severity === "fix") pendingFixes++;
+    else warns++;
+  }
+  if (FIX && mdx !== original) {
+    fs.writeFileSync(full, mdx, "utf-8");
+    console.log("  → corrigido.");
+  }
+}
+
+console.log(`\nResumo: ${files.length} posts | auto-fix ${FIX ? "aplicados" : "pendentes"}: ${pendingFixes} | warnings: ${warns}`);
+
+// Sem --fix, falha se houver correção fiscal pendente (gate de CI). Warnings não bloqueiam.
+if (!FIX && pendingFixes > 0) {
+  console.error("\n✖ Há correções fiscais pendentes. Rode `npm run content:lint:fix` ou ajuste manualmente.");
+  process.exit(1);
+}

--- a/frontend/scripts/soro-sync.ts
+++ b/frontend/scripts/soro-sync.ts
@@ -9,6 +9,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { parseFeedToPosts, postToMdx } from "../src/lib/soroSync";
+import { lintMdx } from "../src/lib/contentLint";
 
 const FEED_URL = process.env.SORO_RSS_URL;
 const CONTENT_DIR = path.join(process.cwd(), "content", "blog");
@@ -28,14 +29,20 @@ async function main() {
 
   let created = 0;
   for (const p of posts) {
-    const { filename, mdx } = postToMdx(p);
-    const dest = path.join(CONTENT_DIR, filename);
+    const built = postToMdx(p);
+    const dest = path.join(CONTENT_DIR, built.filename);
     if (fs.existsSync(dest)) {
-      console.log(`skip (já existe): ${filename}`);
+      console.log(`skip (já existe): ${built.filename}`);
       continue;
     }
+    // Corretor de conformidade: auto-fix do determinístico (ex.: alíquota plena sem
+    // contexto de 2026) + flags para a revisão humana do PR.
+    const { mdx, findings } = lintMdx(built.mdx);
     fs.writeFileSync(dest, mdx, "utf-8");
-    console.log(`novo: ${filename}`);
+    console.log(`novo: ${built.filename}`);
+    for (const f of findings) {
+      console.log(`   [${f.severity === "fix" ? "auto-fix" : "REVISAR"}] ${f.rule}: ${f.message}`);
+    }
     created++;
   }
   console.log(`Itens no feed: ${posts.length} | novos gravados: ${created}`);

--- a/frontend/src/lib/contentLint.test.ts
+++ b/frontend/src/lib/contentLint.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { lintMdx } from "./contentLint";
+
+const FM = '---\ntitle: "X"\nlegalRefs: []\ntags: []\n---\n';
+
+test("#349 lint: alíquota plena SEM contexto → auto-fix (nota de vigência)", () => {
+  const { mdx, findings } = lintMdx(`${FM}<p>Sujeita a 8,8% de CBS e 17,7% de IBS.</p>`);
+  assert.ok(mdx.includes("CBS 0,9% e IBS 0,1%"), "nota de vigência inserida");
+  assert.ok(findings.some((f) => f.rule === "ALIQUOTA_PLENA_SEM_CONTEXTO" && f.severity === "fix"));
+});
+
+test("#349 lint: alíquota plena COM contexto → não duplica", () => {
+  const body = "<p>8,8% e 17,7% são a referência do regime pleno; em 2026 usa-se 0,9% e 0,1%.</p>";
+  const { mdx, findings } = lintMdx(`${FM}${body}`);
+  assert.ok(!findings.some((f) => f.rule === "ALIQUOTA_PLENA_SEM_CONTEXTO"));
+  // idempotência: o corpo não ganha uma segunda nota
+  assert.equal((mdx.match(/Aplique o percentual do período correto/g) ?? []).length, 0);
+});
+
+test("#349 lint: idempotente (rodar 2x não muda)", () => {
+  const first = lintMdx(`${FM}<p>8,8% de CBS.</p>`).mdx;
+  const second = lintMdx(first).mdx;
+  assert.equal(first, second);
+});
+
+test("#349 lint: linguagem de promessa → warn", () => {
+  const { findings } = lintMdx(`${FM}<p>Garante zero rejeição e elimina multas.</p>`);
+  assert.ok(findings.some((f) => f.rule === "PROMESSA" && f.severity === "warn"));
+});
+
+test("#349 lint: frontmatter incompleto (legalRefs/tags vazios) → warn", () => {
+  const { findings } = lintMdx(`${FM}<p>texto neutro</p>`);
+  assert.ok(findings.some((f) => f.rule === "LEGALREFS_VAZIO"));
+  assert.ok(findings.some((f) => f.rule === "TAGS_VAZIO"));
+});

--- a/frontend/src/lib/contentLint.ts
+++ b/frontend/src/lib/contentLint.ts
@@ -1,0 +1,79 @@
+/**
+ * Corretor de conformidade de conteúdo do blog (#349). Aplica, por CÓDIGO, os guardrails
+ * fiscais que antes eram só checklist humano — auto-corrige o determinístico e sinaliza o
+ * resto. Usado pelo pipeline do Soro (na geração) e pelo CLI `content:lint` (posts existentes).
+ *
+ * Filosofia: somos uma empresa de validação determinística — dogfood no nosso próprio conteúdo.
+ * Auto-fix só em correções SEGURAS (anexar disclaimer); tom/afirmações ficam como WARN p/ humano.
+ */
+
+export type LintFinding = {
+  rule: string;
+  severity: "fix" | "warn";
+  message: string;
+};
+
+export type LintResult = { mdx: string; findings: LintFinding[] };
+
+// Alíquotas de referência plena (carga cheia) — 8,8% CBS / 17,7% IBS.
+const PLENA_RX = /8[.,]8\s*%|17[.,]7\s*%/;
+// Contexto que torna o uso da plena seguro. O sinal CONFIÁVEL é citar as alíquotas de
+// TESTE de 2026 (0,9% / 0,1%) ou "fase de teste" — não basta dizer "referência"/"2026"
+// genéricos (um artigo pode falar "alíquota de referência" sem esclarecer a fase).
+const CONTEXT_RX = /fase de teste|0[.,]9\s*%|0[.,]1\s*%/i;
+
+const VIGENCIA_NOTE =
+  "<p><strong>Atenção à vigência:</strong> 8,8% (CBS) e 17,7% (IBS) são as alíquotas de " +
+  "<strong>referência do regime pleno</strong> (carga cheia da Reforma). Na " +
+  "<strong>fase de teste de 2026</strong>, a emissão usa alíquotas reduzidas — " +
+  "<strong>CBS 0,9% e IBS 0,1%</strong>. Aplique o percentual do período correto.</p>";
+
+// Linguagem de promessa/garantia — não auto-corrige (tom), só sinaliza.
+const PROMISE_RX =
+  /\b(garant\w+|100\s*%\s*de\s*conformidade|zero\s+rejei\w+|sem\s+multas?|isen[çc][ãa]o\s+garantida|elimina\s+(as\s+)?multas)\b/gi;
+
+function splitFrontmatter(mdx: string): { front: string; body: string } {
+  const m = mdx.match(/^(---\n[\s\S]*?\n---\n)([\s\S]*)$/);
+  return m ? { front: m[1], body: m[2] } : { front: "", body: mdx };
+}
+
+/**
+ * Aplica os guardrails ao MDX. Retorna o MDX corrigido (auto-fixes seguros) + os achados.
+ * Idempotente: rodar de novo não duplica correções.
+ */
+export function lintMdx(mdx: string): LintResult {
+  const { front, body } = splitFrontmatter(mdx);
+  const findings: LintFinding[] = [];
+  let fixedBody = body;
+
+  // R1 — alíquota plena sem contexto de fase → AUTO-FIX (anexa nota de vigência).
+  if (PLENA_RX.test(fixedBody) && !CONTEXT_RX.test(fixedBody)) {
+    fixedBody = `${fixedBody.trimEnd()}\n\n${VIGENCIA_NOTE}\n`;
+    findings.push({
+      rule: "ALIQUOTA_PLENA_SEM_CONTEXTO",
+      severity: "fix",
+      message: "Alíquota plena (8,8/17,7) sem contexto de 2026 — nota de vigência inserida automaticamente.",
+    });
+  }
+
+  // R2 — linguagem de promessa/garantia → WARN (revisão humana decide o tom).
+  const promises = fixedBody.match(PROMISE_RX);
+  if (promises) {
+    const uniq = [...new Set(promises.map((p) => p.toLowerCase()))];
+    findings.push({
+      rule: "PROMESSA",
+      severity: "warn",
+      message: `Linguagem de promessa: "${uniq.join('", "')}". Suavizar (ex.: "reduz o risco").`,
+    });
+  }
+
+  // R3 — frontmatter incompleto p/ publicação (base legal / tags) → WARN.
+  if (/legalRefs:\s*\[\s*\]/.test(front)) {
+    findings.push({ rule: "LEGALREFS_VAZIO", severity: "warn", message: "legalRefs vazio — adicionar base legal antes de publicar." });
+  }
+  if (/tags:\s*\[\s*\]/.test(front)) {
+    findings.push({ rule: "TAGS_VAZIO", severity: "warn", message: "tags vazias — adicionar tags." });
+  }
+
+  return { mdx: front + fixedBody, findings };
+}


### PR DESCRIPTION
## Re-land do corretor de conteúdo

O commit do **corretor `contentLint` + runbook** foi pushado para a branch do #350, mas o **#350 foi mergeado antes** desse commit entrar (squash pegou só o commit do pipeline). Resultado: o corretor ficou **órfão**, fora do `main`. Este PR re-landa o **mesmo commit** (cherry-pick `e691e31` → `b212aab`) sobre o `main` atual.

### Conteúdo (idêntico ao já validado)
- `src/lib/contentLint.ts` — `lintMdx()`: auto-fix `ALIQUOTA_PLENA_SEM_CONTEXTO` (nota de vigência quando cita 8,8/17,7 sem a fase 2026), warns `PROMESSA`/`LEGALREFS_VAZIO`/`TAGS_VAZIO`. Idempotente.
- `scripts/soro-sync.ts` — aplica o corretor na geração (auto-fix + flags no log).
- `scripts/content-lint.ts` + `npm run content:lint[/:fix]` — corrige/checa posts existentes (exit≠0 em correção pendente).
- `docs/content/publicacao-diaria.md` — runbook diário.
- `contentLint.test.ts` (5 casos).

### QA
124 testes frontend verdes; `npm run build` OK; cherry-pick sem conflito (6 arquivos). O `content:lint` já flagra 1 post existente (`classtrib-2026-ncm-mapeamento-completo`) — deixado p/ revisão humana.

Fecha a lacuna de merge do #350. Refs #349.