### PR TITLE
feat(admin): dashboard administrativo completo (leitura top-down) + fluxo de acesso

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.database import get_db
+from app.models.api_key import ApiKey
 from app.models.auth import User, Tenant
 from app.models.billing import Payment, Plan, Subscription
 
@@ -307,4 +308,102 @@ def admin_dashboard(
         },
         "support": _support_stats(db),
         "feedback": _feedback_stats(db, month_start),
+    }
+
+
+# ── Drill-down (leitura) — visão top-down completa (superadmin) ──────────────
+
+@router.get("/me")
+def admin_me(_admin: Annotated[User, Depends(_require_superadmin)]) -> dict[str, Any]:
+    """Ping de autorização: 200 só para superadmin (usado pelo guard do layout /admin)."""
+    return {"email": cast(str, _admin.email), "role": cast(str, _admin.role), "is_superadmin": True}
+
+
+@router.get("/tenants")
+def admin_tenants(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    limit: int = 50,
+    offset: int = 0,
+    q: str | None = None,
+) -> dict[str, Any]:
+    stmt = select(Tenant)
+    if q:
+        stmt = stmt.where(Tenant.name.ilike(f"%{q}%"))
+    total = _safe_count(db, select(func.count()).select_from(stmt.subquery()))
+    rows = db.execute(
+        stmt.order_by(Tenant.created_at.desc()).limit(min(limit, 200)).offset(max(offset, 0))
+    ).scalars().all()
+    items = [
+        {
+            "id": str(t.id),
+            "name": cast(str, t.name),
+            "is_active": bool(t.is_active),
+            "users": _safe_count(db, select(func.count(User.id)).where(User.tenant_id == t.id)),
+            "created_at": cast(datetime, t.created_at).isoformat(),
+        }
+        for t in rows
+    ]
+    return {"total": total, "limit": limit, "offset": offset, "items": items}
+
+
+@router.get("/users")
+def admin_users(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    limit: int = 50,
+    offset: int = 0,
+    q: str | None = None,
+) -> dict[str, Any]:
+    stmt = select(User)
+    if q:
+        stmt = stmt.where(User.email.ilike(f"%{q}%") | User.full_name.ilike(f"%{q}%"))
+    total = _safe_count(db, select(func.count()).select_from(stmt.subquery()))
+    rows = db.execute(
+        stmt.order_by(User.created_at.desc()).limit(min(limit, 200)).offset(max(offset, 0))
+    ).scalars().all()
+    items = [
+        {
+            "id": str(u.id),
+            "email": cast(str, u.email),
+            "full_name": cast(str, u.full_name),
+            "role": cast(str, u.role),
+            "is_active": bool(u.is_active),
+            "created_at": cast(datetime, u.created_at).isoformat(),
+        }
+        for u in rows
+    ]
+    return {"total": total, "limit": limit, "offset": offset, "items": items}
+
+
+@router.get("/usage")
+def admin_usage(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    def _jobs_since(start: datetime | None) -> int:
+        try:
+            if start is None:
+                return db.scalar(text("SELECT COUNT(*) FROM jobs")) or 0
+            return db.scalar(text("SELECT COUNT(*) FROM jobs WHERE created_at >= :s"), {"s": start}) or 0
+        except Exception:
+            return 0
+
+    credits = db.execute(
+        select(func.coalesce(func.sum(ApiKey.credits_balance), 0)).where(ApiKey.is_active == True)  # noqa: E712
+    ).scalar() or 0
+
+    return {
+        "generated_at": now.isoformat(),
+        "jobs": {"today": _jobs_since(today_start), "month": _jobs_since(month_start), "total": _jobs_since(None)},
+        "api_keys": {
+            "total": _safe_count(db, select(func.count(ApiKey.id))),
+            "active": _safe_count(db, select(func.count(ApiKey.id)).where(ApiKey.is_active == True)),  # noqa: E712
+            "credits_balance": int(credits),
+            "used_today": _safe_count(db, select(func.count(ApiKey.id)).where(ApiKey.last_used_at >= today_start)),
+        },
     }

--- a/backend/tests/test_admin_access.py
+++ b/backend/tests/test_admin_access.py
@@ -1,0 +1,29 @@
+"""Gate de acesso do admin BFF — endpoints exigem autenticação superadmin."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+# Endpoints de leitura do painel admin (visão top-down). Todos atrás de _require_superadmin.
+ADMIN_ENDPOINTS = [
+    "/api/v1/admin/me",
+    "/api/v1/admin/dashboard",
+    "/api/v1/admin/tenants",
+    "/api/v1/admin/users",
+    "/api/v1/admin/usage",
+]
+
+
+def test_admin_endpoints_exigem_autenticacao():
+    """Sem token → 401/403 (nunca 200). Não vaza dado de plataforma a anônimo."""
+    for path in ADMIN_ENDPOINTS:
+        resp = client.get(path)
+        assert resp.status_code in (401, 403), f"{path} deveria bloquear anônimo, veio {resp.status_code}"
+
+
+def test_admin_endpoints_registrados():
+    """As rotas existem (não 404) — o gate responde com 401/403, não com rota inexistente."""
+    for path in ADMIN_ENDPOINTS:
+        assert client.get(path).status_code != 404, f"{path} não registrado"

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import Link from "next/link";
+import { API_BASE } from "@/lib/api";
+import { getToken } from "@/lib/storage";
+
+const NAV = [
+  { href: "/admin", label: "Visão geral" },
+  { href: "/admin/tenants", label: "Tenants" },
+  { href: "/admin/users", label: "Usuários" },
+  { href: "/admin/usage", label: "Uso & Operações" },
+  { href: "/admin/system", label: "Saúde do sistema" },
+];
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [state, setState] = useState<"checking" | "ok" | "denied">("checking");
+
+  useEffect(() => {
+    // Guard server-side (fonte da verdade): /admin/me só responde 200 a superadmin.
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/v1/admin/me`, {
+          headers: { Authorization: `Bearer ${getToken()}` },
+        });
+        if (!alive) return;
+        if (res.ok) {
+          setState("ok");
+        } else {
+          setState("denied");
+          router.replace("/dashboard");
+        }
+      } catch {
+        if (alive) {
+          setState("denied");
+          router.replace("/dashboard");
+        }
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [router]);
+
+  if (state !== "ok") {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-slate-500">
+        {state === "checking" ? "Verificando acesso…" : "Acesso restrito. Redirecionando…"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-7xl gap-6 px-4 py-6 md:px-6">
+      <aside className="hidden w-52 shrink-0 md:block">
+        <div className="sticky top-6 space-y-1">
+          <p className="px-3 pb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">Admin</p>
+          {NAV.map((item) => {
+            const active = item.href === "/admin" ? pathname === "/admin" : pathname.startsWith(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`block rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  active ? "bg-[#2956E3] text-white" : "text-slate-600 hover:bg-slate-100"
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </div>
+      </aside>
+      <main className="min-w-0 flex-1">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/system/page.tsx
+++ b/frontend/src/app/admin/system/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { API_BASE } from "@/lib/api";
+
+type Health = {
+  status: string;
+  db: string;
+  redis: string;
+  asaas_api: string;
+  ai_engine: string;
+  hubspot: string;
+  email: string;
+  latency_ms: number;
+};
+
+const LABELS: Record<string, string> = {
+  db: "PostgreSQL",
+  redis: "Redis",
+  asaas_api: "Asaas (pagamentos)",
+  ai_engine: "AI engine (OpenRouter)",
+  hubspot: "HubSpot (CRM)",
+  email: "E-mail (Resend/SMTP)",
+};
+
+export default function AdminSystemPage() {
+  const [data, setData] = useState<Health | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch(`${API_BASE}/health/ready`)
+      .then((r) => r.json())
+      .then((d) => alive && setData(d))
+      .catch(() => alive && setError("Não foi possível obter a saúde do sistema."));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const ok = (s: string | undefined) => s === "ok";
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Saúde do sistema</h1>
+      <p className="mb-5 text-sm text-slate-500">Probe profundo (/health/ready) das dependências de produção.</p>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {!data && !error && <p className="text-sm text-slate-500">Carregando…</p>}
+
+      {data && (
+        <>
+          <div className={`mb-4 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold ${ok(data.status) ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
+            <span className={`h-2 w-2 rounded-full ${ok(data.status) ? "bg-green-500" : "bg-red-500"}`} />
+            {ok(data.status) ? "Operacional" : "Degradado"} · {data.latency_ms} ms
+          </div>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Object.entries(LABELS).map(([key, label]) => {
+              const status = (data as unknown as Record<string, string>)[key];
+              return (
+                <div key={key} className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3">
+                  <span className="text-sm font-medium text-slate-700">{label}</span>
+                  <span className={`inline-flex items-center gap-1.5 text-xs font-semibold ${ok(status) ? "text-green-600" : "text-red-600"}`}>
+                    <span className={`h-2 w-2 rounded-full ${ok(status) ? "bg-green-500" : "bg-red-500"}`} />
+                    {ok(status) ? "ok" : status ?? "?"}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/tenants/page.tsx
+++ b/frontend/src/app/admin/tenants/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useAdminData } from "@/lib/useAdminData";
+
+type Tenant = { id: string; name: string; is_active: boolean; users: number; created_at: string };
+type Resp = { total: number; items: Tenant[] };
+
+export default function AdminTenantsPage() {
+  const { data, error, loading } = useAdminData<Resp>("/api/v1/admin/tenants?limit=100");
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Tenants</h1>
+      <p className="mb-5 text-sm text-slate-500">
+        {data ? `${data.total} tenant(s)` : "Organizações cadastradas na plataforma."}
+      </p>
+
+      {loading && <p className="text-sm text-slate-500">Carregando…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Nome</th>
+                <th className="px-4 py-3">Usuários</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Criado em</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.items.map((t) => (
+                <tr key={t.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 font-medium text-slate-900">{t.name}</td>
+                  <td className="px-4 py-3 text-slate-700">{t.users}</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${t.is_active ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
+                      {t.is_active ? "Ativo" : "Inativo"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500">{new Date(t.created_at).toLocaleDateString("pt-BR")}</td>
+                </tr>
+              ))}
+              {data.items.length === 0 && (
+                <tr><td colSpan={4} className="px-4 py-8 text-center text-slate-400">Nenhum tenant.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/usage/page.tsx
+++ b/frontend/src/app/admin/usage/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useAdminData } from "@/lib/useAdminData";
+
+type Usage = {
+  generated_at: string;
+  jobs: { today: number; month: number; total: number };
+  api_keys: { total: number; active: number; credits_balance: number; used_today: number };
+};
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <p className="text-xs uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-slate-900">{value}</p>
+    </div>
+  );
+}
+
+export default function AdminUsagePage() {
+  const { data, error, loading } = useAdminData<Usage>("/api/v1/admin/usage");
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Uso &amp; Operações</h1>
+      <p className="mb-5 text-sm text-slate-500">Validações (jobs) e consumo da API pública.</p>
+
+      {loading && <p className="text-sm text-slate-500">Carregando…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="space-y-6">
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">Validações (jobs)</h2>
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+              <Stat label="Hoje" value={data.jobs.today} />
+              <Stat label="Mês" value={data.jobs.month} />
+              <Stat label="Total" value={data.jobs.total} />
+            </div>
+          </section>
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">API pública (pay-per-call)</h2>
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+              <Stat label="API Keys" value={data.api_keys.total} />
+              <Stat label="Ativas" value={data.api_keys.active} />
+              <Stat label="Créditos (ativos)" value={data.api_keys.credits_balance} />
+              <Stat label="Usadas hoje" value={data.api_keys.used_today} />
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useAdminData } from "@/lib/useAdminData";
+
+type AdminUser = {
+  id: string;
+  email: string;
+  full_name: string;
+  role: string;
+  is_active: boolean;
+  created_at: string;
+};
+type Resp = { total: number; items: AdminUser[] };
+
+export default function AdminUsersPage() {
+  const { data, error, loading } = useAdminData<Resp>("/api/v1/admin/users?limit=100");
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Usuários</h1>
+      <p className="mb-5 text-sm text-slate-500">
+        {data ? `${data.total} usuário(s)` : "Usuários cadastrados na plataforma."}
+      </p>
+
+      {loading && <p className="text-sm text-slate-500">Carregando…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Nome</th>
+                <th className="px-4 py-3">E-mail</th>
+                <th className="px-4 py-3">Papel</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Criado em</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.items.map((u) => (
+                <tr key={u.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 font-medium text-slate-900">{u.full_name}</td>
+                  <td className="px-4 py-3 text-slate-700">{u.email}</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${u.role === "superadmin" ? "bg-purple-100 text-purple-700" : "bg-slate-100 text-slate-600"}`}>
+                      {u.role}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${u.is_active ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
+                      {u.is_active ? "Ativo" : "Inativo"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500">{new Date(u.created_at).toLocaleDateString("pt-BR")}</td>
+                </tr>
+              ))}
+              {data.items.length === 0 && (
+                <tr><td colSpan={5} className="px-4 py-8 text-center text-slate-400">Nenhum usuário.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { Toast } from "@/components/common/Toast";
 import { loginWithApi, resendVerificationEmail } from "@/lib/api";
-import { setAccountType, setTenantId, setTenants, setToken } from "@/lib/storage";
+import { setAccountType, setRole, setTenantId, setTenants, setToken } from "@/lib/storage";
 
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
@@ -68,6 +68,7 @@ function LoginForm() {
       setTenantId(login.tenant_id ?? "");
       setToken(login.access_token);
       setAccountType(login.account_type ?? "empresa");
+      setRole(login.role ?? "user");
       setTenants(login.tenants ?? []);
       window.dispatchEvent(new Event("tribultz-settings-updated"));
       // Superadmins go to plan/mode selector before entering the app

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,8 +1,9 @@
 ﻿"use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { clearSession } from "@/lib/storage";
+import { clearSession, getRole } from "@/lib/storage";
 
 const links = [
   { href: "/dashboard", label: "Painel" },
@@ -24,6 +25,14 @@ export function Sidebar({ mobile = false, onNavigate }: { mobile?: boolean; onNa
   const pathname = usePathname();
   const router = useRouter();
 
+  // Link de Admin só para superadmin (UX). A autorização real é no backend (/admin/me + guard).
+  // useEffect evita mismatch de hidratação (localStorage só existe no cliente).
+  const [isAdmin, setIsAdmin] = useState(false);
+  useEffect(() => {
+    setIsAdmin(getRole() === "superadmin");
+  }, [pathname]);
+  const navLinks = isAdmin ? [...links, { href: "/admin", label: "Admin" }] : links;
+
   function handleLogout(): void {
     clearSession();
     window.dispatchEvent(new Event("tribultz-settings-updated"));
@@ -44,7 +53,7 @@ export function Sidebar({ mobile = false, onNavigate }: { mobile?: boolean; onNa
       </div>
       <nav className="flex-1 p-3" aria-label="Navegação principal">
         <ul className="space-y-1">
-          {links.map((item) => {
+          {navLinks.map((item) => {
             const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
             return (
               <li key={item.href}>

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -2,6 +2,7 @@ const KEY_TENANT = "tribultz.tenant";
 const KEY_TOKEN = "tribultz.token";
 const KEY_ACCOUNT_TYPE = "tribultz.account_type";
 const KEY_TENANTS = "tribultz.tenants";
+const KEY_ROLE = "tribultz.role";
 
 function safeLocalStorage(): Storage | null {
   if (typeof window === "undefined") return null;
@@ -44,6 +45,18 @@ export function setAccountType(value: string): void {
   store.setItem(KEY_ACCOUNT_TYPE, value);
 }
 
+export function getRole(): string {
+  const store = safeLocalStorage();
+  if (!store) return "";
+  return store.getItem(KEY_ROLE) ?? "";
+}
+
+export function setRole(value: string): void {
+  const store = safeLocalStorage();
+  if (!store) return;
+  store.setItem(KEY_ROLE, value);
+}
+
 export type StoredTenant = { id: string; name: string; slug: string; is_default: boolean };
 
 export function getTenants(): StoredTenant[] {
@@ -69,4 +82,5 @@ export function clearSession(): void {
   store.removeItem(KEY_ACCOUNT_TYPE);
   store.removeItem(KEY_TENANTS);
   store.removeItem(KEY_TENANT);
+  store.removeItem(KEY_ROLE);
 }

--- a/frontend/src/lib/useAdminData.ts
+++ b/frontend/src/lib/useAdminData.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { API_BASE } from "@/lib/api";
+import { getToken } from "@/lib/storage";
+
+/** Busca autenticada de dados do admin BFF. O acesso é garantido pelo guard do layout /admin. */
+export function useAdminData<T>(path: string) {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await fetch(`${API_BASE}${path}`, {
+          headers: { Authorization: `Bearer ${getToken()}` },
+        });
+        if (!alive) return;
+        if (!res.ok) setError(`Erro ${res.status}`);
+        else setData((await res.json()) as T);
+      } catch {
+        if (alive) setError("Erro de conexão.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [path]);
+
+  return { data, error, loading };
+}


### PR DESCRIPTION
## Dashboard admin completo — visão top-down (leitura) + fluxo de acesso

Evolui o admin (Fase 1 = só overview) para a visão **top-down completa**, com **RBAC defense-in-depth**. Escopo desta entrega: **leitura completa + acesso** (sem ações destrutivas — conforme decidido).

### 🔐 Fluxo de acesso (best practices)
- **Backend = fonte da verdade:** todo `/api/v1/admin/*` atrás de `_require_superadmin` (403).
- **Guard no frontend:** `app/admin/layout.tsx` chama `/admin/me`; **não-superadmin → redirect** `/dashboard`.
- **Nav role-based:** link "Admin" no Sidebar só para superadmin (role persistido no login); **área /admin separada** com nav própria.

### 🗂️ Seções (BFF superadmin)
| Endpoint | Página |
|---|---|
| `/admin/me` | guard de acesso |
| `/admin/tenants` | **Tenants** (nome, nº usuários, status, criado) |
| `/admin/users` | **Usuários** (email/nome, papel, status) |
| `/admin/usage` | **Uso & Operações** (jobs hoje/mês/total + API keys) |
| (`/health/ready`) | **Saúde do sistema** (db/redis/asaas/ai/hubspot/email + latência) |
| `/admin/dashboard` | **Visão geral** (Fase 1, mantida) |

### Decisão de escopo
**Somente leitura.** Ações administrativas (suspender usuário, ajustar créditos, marcar pagamento) são sensíveis/irreversíveis → **fase própria**, com confirmação + `admin_audit_log`.

### QA
Gating (anônimo → 401/403; rotas registradas) **2 verdes**; `ruff`+`pyright` limpos; frontend **124** testes + build (5 rotas `/admin` compiladas).