### PR TITLE
feat(admin): Fase 2 — ações administrativas auditadas (suspender/reativar) + audit log

### DIFF
--- a/backend/app/alembic/versions/2026_06_26_0021_add_admin_audit_log.py
+++ b/backend/app/alembic/versions/2026_06_26_0021_add_admin_audit_log.py
@@ -1,0 +1,40 @@
+"""add_admin_audit_log — Fase 2 do admin (ações auditadas)
+
+Trilha de auditoria de TODA ação administrativa (mutação) feita por superadmin:
+quem (actor), o quê (action), alvo (target), detalhe (before/after) e quando.
+Exigência de mercado para SaaS — nenhuma ação privilegiada sem rastro.
+
+Revision ID: 2026_06_26_0021
+Revises: 2026_06_23_0020
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_06_26_0021"
+down_revision = "2026_06_23_0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_audit_log",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("actor_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_email", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("target_type", sa.Text(), nullable=False),
+        sa.Column("target_id", sa.Text(), nullable=True),
+        sa.Column("detail", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_admin_audit_log_created_at", "admin_audit_log", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_admin_audit_log_created_at", table_name="admin_audit_log")
+    op.drop_table("admin_audit_log")

--- a/backend/app/models/admin_audit.py
+++ b/backend/app/models/admin_audit.py
@@ -1,0 +1,20 @@
+"""AdminAuditLog — trilha de auditoria de ações administrativas (Fase 2 do admin)."""
+
+from sqlalchemy import Column, DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class AdminAuditLog(Base):
+    __tablename__ = "admin_audit_log"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    actor_user_id = Column(UUID(as_uuid=True), nullable=True)
+    actor_email = Column(Text, nullable=False)
+    action = Column(Text, nullable=False)
+    target_type = Column(Text, nullable=False)
+    target_id = Column(Text, nullable=True)
+    detail = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -3,13 +3,16 @@
 import logging
 from datetime import datetime, timezone
 from typing import Annotated, Any, cast
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
 from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.database import get_db
+from app.models.admin_audit import AdminAuditLog
 from app.models.api_key import ApiKey
 from app.models.auth import User, Tenant
 from app.models.billing import Payment, Plan, Subscription
@@ -407,3 +410,97 @@ def admin_usage(
             "used_today": _safe_count(db, select(func.count(ApiKey.id)).where(ApiKey.last_used_at >= today_start)),
         },
     }
+
+
+# ── Fase 2 — ações administrativas (auditadas) + audit log (superadmin) ──────
+
+def _audit(
+    db: Session, actor: User, action: str, target_type: str, target_id: Any, detail: dict[str, Any]
+) -> None:
+    """Registra a ação na trilha de auditoria (mesma transação da mutação)."""
+    db.add(
+        AdminAuditLog(
+            actor_user_id=actor.id,
+            actor_email=cast(str, actor.email),
+            action=action,
+            target_type=target_type,
+            target_id=str(target_id),
+            detail=detail,
+        )
+    )
+
+
+class SetActiveBody(BaseModel):
+    is_active: bool
+
+
+@router.post("/users/{user_id}/active")
+def admin_set_user_active(
+    user_id: UUID,
+    body: SetActiveBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado.")
+    if str(user.id) == str(_admin.id) and not body.is_active:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Você não pode desativar a si mesmo.")
+    before = bool(user.is_active)
+    user.is_active = body.is_active  # type: ignore[assignment]
+    _audit(
+        db, _admin,
+        "user.activate" if body.is_active else "user.deactivate",
+        "user", user.id,
+        {"before": before, "after": body.is_active, "email": cast(str, user.email)},
+    )
+    db.commit()
+    return {"id": str(user.id), "is_active": body.is_active}
+
+
+@router.post("/tenants/{tenant_id}/active")
+def admin_set_tenant_active(
+    tenant_id: UUID,
+    body: SetActiveBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    tenant = db.get(Tenant, tenant_id)
+    if tenant is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant não encontrado.")
+    before = bool(tenant.is_active)
+    tenant.is_active = body.is_active  # type: ignore[assignment]
+    _audit(
+        db, _admin,
+        "tenant.activate" if body.is_active else "tenant.deactivate",
+        "tenant", tenant.id,
+        {"before": before, "after": body.is_active, "name": cast(str, tenant.name)},
+    )
+    db.commit()
+    return {"id": str(tenant.id), "is_active": body.is_active}
+
+
+@router.get("/audit-log")
+def admin_audit_log_list(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    total = _safe_count(db, select(func.count(AdminAuditLog.id)))
+    rows = db.execute(
+        select(AdminAuditLog).order_by(AdminAuditLog.created_at.desc()).limit(min(limit, 200)).offset(max(offset, 0))
+    ).scalars().all()
+    items = [
+        {
+            "id": str(r.id),
+            "actor_email": cast(str, r.actor_email),
+            "action": cast(str, r.action),
+            "target_type": cast(str, r.target_type),
+            "target_id": r.target_id,
+            "detail": r.detail,
+            "created_at": cast(datetime, r.created_at).isoformat(),
+        }
+        for r in rows
+    ]
+    return {"total": total, "limit": limit, "offset": offset, "items": items}

--- a/backend/tests/test_admin_access.py
+++ b/backend/tests/test_admin_access.py
@@ -6,13 +6,21 @@ from app.main import app
 
 client = TestClient(app)
 
-# Endpoints de leitura do painel admin (visão top-down). Todos atrás de _require_superadmin.
+# Endpoints de leitura do painel admin (visão top-down) + audit log. Todos superadmin-only.
 ADMIN_ENDPOINTS = [
     "/api/v1/admin/me",
     "/api/v1/admin/dashboard",
     "/api/v1/admin/tenants",
     "/api/v1/admin/users",
     "/api/v1/admin/usage",
+    "/api/v1/admin/audit-log",
+]
+
+# Ações administrativas (mutações) — Fase 2. UUID fictício; o gate barra antes de tudo.
+_UUID = "00000000-0000-0000-0000-000000000000"
+ADMIN_ACTIONS = [
+    f"/api/v1/admin/users/{_UUID}/active",
+    f"/api/v1/admin/tenants/{_UUID}/active",
 ]
 
 
@@ -27,3 +35,10 @@ def test_admin_endpoints_registrados():
     """As rotas existem (não 404) — o gate responde com 401/403, não com rota inexistente."""
     for path in ADMIN_ENDPOINTS:
         assert client.get(path).status_code != 404, f"{path} não registrado"
+
+
+def test_admin_acoes_exigem_autenticacao():
+    """Mutações (suspender/reativar) bloqueadas para anônimo — nunca executam sem superadmin."""
+    for path in ADMIN_ACTIONS:
+        resp = client.post(path, json={"is_active": False})
+        assert resp.status_code in (401, 403), f"{path} deveria bloquear anônimo, veio {resp.status_code}"

--- a/frontend/src/app/admin/audit/page.tsx
+++ b/frontend/src/app/admin/audit/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useAdminData } from "@/lib/useAdminData";
+
+type AuditEntry = {
+  id: string;
+  actor_email: string;
+  action: string;
+  target_type: string;
+  target_id: string | null;
+  detail: Record<string, unknown>;
+  created_at: string;
+};
+type Resp = { total: number; items: AuditEntry[] };
+
+const ACTION_LABEL: Record<string, string> = {
+  "user.activate": "Reativou usuário",
+  "user.deactivate": "Suspendeu usuário",
+  "tenant.activate": "Reativou tenant",
+  "tenant.deactivate": "Suspendeu tenant",
+};
+
+export default function AdminAuditPage() {
+  const { data, error, loading } = useAdminData<Resp>("/api/v1/admin/audit-log?limit=100");
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Audit log</h1>
+      <p className="mb-5 text-sm text-slate-500">
+        Trilha de auditoria de todas as ações administrativas. {data ? `${data.total} registro(s).` : ""}
+      </p>
+
+      {loading && <p className="text-sm text-slate-500">Carregando…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Quando</th>
+                <th className="px-4 py-3">Quem</th>
+                <th className="px-4 py-3">Ação</th>
+                <th className="px-4 py-3">Alvo</th>
+                <th className="px-4 py-3">Detalhe</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.items.map((e) => (
+                <tr key={e.id} className="hover:bg-slate-50">
+                  <td className="whitespace-nowrap px-4 py-3 text-slate-500">{new Date(e.created_at).toLocaleString("pt-BR")}</td>
+                  <td className="px-4 py-3 text-slate-700">{e.actor_email}</td>
+                  <td className="px-4 py-3 font-medium text-slate-900">{ACTION_LABEL[e.action] ?? e.action}</td>
+                  <td className="px-4 py-3 text-slate-600">
+                    {String(e.detail.email ?? e.detail.name ?? e.target_id ?? "—")}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-slate-400">
+                    {typeof e.detail.before !== "undefined" ? `${e.detail.before} → ${e.detail.after}` : ""}
+                  </td>
+                </tr>
+              ))}
+              {data.items.length === 0 && (
+                <tr><td colSpan={5} className="px-4 py-8 text-center text-slate-400">Nenhuma ação registrada ainda.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -12,6 +12,7 @@ const NAV = [
   { href: "/admin/users", label: "Usuários" },
   { href: "/admin/usage", label: "Uso & Operações" },
   { href: "/admin/system", label: "Saúde do sistema" },
+  { href: "/admin/audit", label: "Audit log" },
 ];
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/admin/tenants/page.tsx
+++ b/frontend/src/app/admin/tenants/page.tsx
@@ -1,12 +1,28 @@
 "use client";
 
-import { useAdminData } from "@/lib/useAdminData";
+import { useState } from "react";
+import { useAdminData, adminPost } from "@/lib/useAdminData";
 
 type Tenant = { id: string; name: string; is_active: boolean; users: number; created_at: string };
 type Resp = { total: number; items: Tenant[] };
 
 export default function AdminTenantsPage() {
-  const { data, error, loading } = useAdminData<Resp>("/api/v1/admin/tenants?limit=100");
+  const { data, error, loading, reload } = useAdminData<Resp>("/api/v1/admin/tenants?limit=100");
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function toggleActive(t: Tenant) {
+    const verb = t.is_active ? "suspender" : "reativar";
+    if (!window.confirm(`Confirma ${verb} o tenant "${t.name}"? A ação fica registrada na auditoria.`)) return;
+    setBusy(t.id);
+    try {
+      await adminPost(`/api/v1/admin/tenants/${t.id}/active`, { is_active: !t.is_active });
+      reload();
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : "Falha na ação.");
+    } finally {
+      setBusy(null);
+    }
+  }
 
   return (
     <div>
@@ -27,6 +43,7 @@ export default function AdminTenantsPage() {
                 <th className="px-4 py-3">Usuários</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Criado em</th>
+                <th className="px-4 py-3 text-right">Ações</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
@@ -40,10 +57,19 @@ export default function AdminTenantsPage() {
                     </span>
                   </td>
                   <td className="px-4 py-3 text-slate-500">{new Date(t.created_at).toLocaleDateString("pt-BR")}</td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => toggleActive(t)}
+                      disabled={busy === t.id}
+                      className={`rounded-lg px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${t.is_active ? "border border-red-200 text-red-600 hover:bg-red-50" : "border border-green-200 text-green-700 hover:bg-green-50"}`}
+                    >
+                      {busy === t.id ? "…" : t.is_active ? "Suspender" : "Reativar"}
+                    </button>
+                  </td>
                 </tr>
               ))}
               {data.items.length === 0 && (
-                <tr><td colSpan={4} className="px-4 py-8 text-center text-slate-400">Nenhum tenant.</td></tr>
+                <tr><td colSpan={5} className="px-4 py-8 text-center text-slate-400">Nenhum tenant.</td></tr>
               )}
             </tbody>
           </table>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useAdminData } from "@/lib/useAdminData";
+import { useState } from "react";
+import { useAdminData, adminPost } from "@/lib/useAdminData";
 
 type AdminUser = {
   id: string;
@@ -13,7 +14,22 @@ type AdminUser = {
 type Resp = { total: number; items: AdminUser[] };
 
 export default function AdminUsersPage() {
-  const { data, error, loading } = useAdminData<Resp>("/api/v1/admin/users?limit=100");
+  const { data, error, loading, reload } = useAdminData<Resp>("/api/v1/admin/users?limit=100");
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function toggleActive(u: AdminUser) {
+    const verb = u.is_active ? "suspender" : "reativar";
+    if (!window.confirm(`Confirma ${verb} o usuário ${u.email}? A ação fica registrada na auditoria.`)) return;
+    setBusy(u.id);
+    try {
+      await adminPost(`/api/v1/admin/users/${u.id}/active`, { is_active: !u.is_active });
+      reload();
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : "Falha na ação.");
+    } finally {
+      setBusy(null);
+    }
+  }
 
   return (
     <div>
@@ -35,6 +51,7 @@ export default function AdminUsersPage() {
                 <th className="px-4 py-3">Papel</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Criado em</th>
+                <th className="px-4 py-3 text-right">Ações</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
@@ -53,10 +70,19 @@ export default function AdminUsersPage() {
                     </span>
                   </td>
                   <td className="px-4 py-3 text-slate-500">{new Date(u.created_at).toLocaleDateString("pt-BR")}</td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => toggleActive(u)}
+                      disabled={busy === u.id}
+                      className={`rounded-lg px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${u.is_active ? "border border-red-200 text-red-600 hover:bg-red-50" : "border border-green-200 text-green-700 hover:bg-green-50"}`}
+                    >
+                      {busy === u.id ? "…" : u.is_active ? "Suspender" : "Reativar"}
+                    </button>
+                  </td>
                 </tr>
               ))}
               {data.items.length === 0 && (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-slate-400">Nenhum usuário.</td></tr>
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">Nenhum usuário.</td></tr>
               )}
             </tbody>
           </table>

--- a/frontend/src/lib/useAdminData.ts
+++ b/frontend/src/lib/useAdminData.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { API_BASE } from "@/lib/api";
 import { getToken } from "@/lib/storage";
 
@@ -9,9 +9,13 @@ export function useAdminData<T>(path: string) {
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [tick, setTick] = useState(0);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
 
   useEffect(() => {
     let alive = true;
+    setLoading(true);
     (async () => {
       try {
         const res = await fetch(`${API_BASE}${path}`, {
@@ -19,7 +23,10 @@ export function useAdminData<T>(path: string) {
         });
         if (!alive) return;
         if (!res.ok) setError(`Erro ${res.status}`);
-        else setData((await res.json()) as T);
+        else {
+          setError(null);
+          setData((await res.json()) as T);
+        }
       } catch {
         if (alive) setError("Erro de conexão.");
       } finally {
@@ -29,7 +36,20 @@ export function useAdminData<T>(path: string) {
     return () => {
       alive = false;
     };
-  }, [path]);
+  }, [path, tick]);
 
-  return { data, error, loading };
+  return { data, error, loading, reload };
+}
+
+/** Mutação autenticada (ação administrativa). Lança em erro para o chamador tratar. */
+export async function adminPost(path: string, body: unknown): Promise<void> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail ?? `Erro ${res.status}`);
+  }
 }


### PR DESCRIPTION
## Admin Fase 2 — ações auditadas + audit log

Adiciona **ações de gestão** ao painel admin, todas com **trilha de auditoria** (best practice: nenhuma ação privilegiada sem rastro).

### Backend
- **Migration 0021 + modelo `AdminAuditLog`** (actor, action, target, `detail` JSONB, created_at).
- **`_audit()`** — registra na **mesma transação** da mutação.
- **`POST /admin/users/{id}/active`** e **`/admin/tenants/{id}/active`** — suspender/reativar (superadmin), audita `before/after`; **bloqueia auto-desativação** do próprio superadmin.
- **`GET /admin/audit-log`** — leitura paginada.

### Frontend
- `useAdminData` ganha `reload()`; helper `adminPost()`.
- **Usuários** e **Tenants**: botão **Suspender/Reativar** com **confirmação** + reload.
- Nova página **`/admin/audit`** (quem · quando · ação · alvo · before→after) + item no nav.

### Segurança / escopo
- Ações **reversíveis e de baixo risco** (toggle ativo). Confirmação no front + gate superadmin no back + auditoria.
- Créditos/reembolso seguem o mesmo padrão em iteração futura.

### QA
Backend `ruff`+`pyright` limpos; gating (leitura + ações + audit-log → 401/403 anônimo) **3 verdes**; alembic head único (0021). Frontend **124** testes + build (`/admin/audit` compilada).