### PR TITLE
feat(rules): #311 — SUFRAMA_DV (C22-20) + ALCZFM_NPROC (UB66c-10)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -126,6 +126,20 @@ def _first_tag(xml: str, tags: list[str]) -> dict[str, Any] | None:
     return None
 
 
+def _suframa_dv_ok(inscricao: str) -> bool:
+    """Valida o DV da Inscrição SUFRAMA (9 díg: 8 base + DV; módulo 11, pesos 2–9 da
+    direita p/ esquerda; resto 0 ou 1 → DV 0). Usado pela regra SUFRAMA_DV (C22-20, #311)."""
+    digits = "".join(c for c in (inscricao or "") if c.isdigit())
+    if len(digits) != 9:
+        return False
+    weights = [9, 8, 7, 6, 5, 4, 3, 2]  # pesos 2–9 da direita p/ esquerda = 9..2 da esquerda
+    total = sum(int(d) * w for d, w in zip(digits[:8], weights))
+    calc = 11 - (total % 11)
+    if calc >= 10:
+        calc = 0
+    return calc == int(digits[8])
+
+
 def _to_float(value: str | None) -> float:
     """Parse a numeric string to float; returns 0.0 on missing/invalid input."""
     try:
@@ -1057,6 +1071,49 @@ def validate_xml(
                 ),
                 Evidence(id=ev_id, type="xml", label="IS — NCM possivelmente sujeito, grupo ausente", xpath=_xpath("IS", doc_type), snippet=ncm["snippet"]),
             )
+
+    # ── Rule 25: SUFRAMA_DV — DV da Inscrição SUFRAMA do emitente (#311, C22-20) ──
+    # WARNING (não FATAL): catch determinístico do DV, mas mantemos advisory para não
+    # bloquear nota por nuance do algoritmo; cita o código oficial de rejeição.
+    if is_nfe:
+        _isuf = _first_tag(xml, ["ISUFemit", "ISUF"])
+        if _isuf and _isuf["value"].strip() and not _suframa_dv_ok(_isuf["value"]):
+            ev_id = "E_XML_SUFRAMA_DV"
+            _add(
+                Finding(
+                    id="F_SUFRAMA_DV", severity="WARNING", rule_id="SUFRAMA_DV",
+                    title=f'Inscrição SUFRAMA "{_isuf["value"].strip()}" — dígito verificador inválido',
+                    where=FindingWhere(field="ISUFemit", xpath=_xpath("ISUFemit", doc_type), snippet=_isuf["snippet"]),
+                    recommendation=(
+                        "A Inscrição SUFRAMA do emitente deve ter 9 dígitos com DV válido (módulo 11). "
+                        "Verifique a inscrição. SEFAZ: Rejeição C22-20 (DV da Inscrição SUFRAMA do emitente inválido)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="SUFRAMA — DV inválido", xpath=_xpath("ISUFemit", doc_type), snippet=_isuf["snippet"]),
+            )
+
+    # ── Rule 26: ALCZFM_NPROC — grupo gALCZFMCBS exige nProcSuframa (#311, UB66c-10) ──
+    if is_nfe:
+        _alc = re.search(r"<gALCZFMCBS\b[^>]*>([\s\S]*?)</gALCZFMCBS>", xml, re.IGNORECASE)
+        if _alc:
+            _nproc = _first_tag(_alc.group(1), ["nProcSuframa"])
+            if not (_nproc and _nproc["value"].strip()):
+                ev_id = "E_XML_ALCZFM_NPROC"
+                _add(
+                    Finding(
+                        id="F_ALCZFM_NPROC", severity="WARNING", rule_id="ALCZFM_NPROC",
+                        title="Grupo ALC/ZFM (gALCZFMCBS) sem nProcSuframa",
+                        where=FindingWhere(field="nProcSuframa", xpath=_xpath("nProcSuframa", doc_type), snippet=_alc.group(0)[:200]),
+                        recommendation=(
+                            "Operações com benefício de ALC/Zona Franca (grupo gALCZFMCBS) exigem o número do "
+                            "processo na SUFRAMA (nProcSuframa) do processo produtivo aprovado. Informe o nProcSuframa. "
+                            "SEFAZ: Rejeição UB66c-10 (Número do processo na SUFRAMA não informado)."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="ALC/ZFM — nProcSuframa ausente", xpath=_xpath("nProcSuframa", doc_type), snippet=_alc.group(0)[:200]),
+                )
 
     # ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────
     # Apenas NF-e/NFC-e (rejeições da SEFAZ NF-e; NFS-e tem regras próprias).

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -734,3 +734,47 @@ class TestImpostoSeletivo:
     def test_ncm_sujeito_com_is_nao_alerta(self):
         # grupo IS presente → IS_EXPECTED não dispara
         assert self._find(self._nfe(ncm="22030000", vbcis="1000.00", pis="0.1000", vis="100.00"), "IS_EXPECTED") == []
+
+
+class TestSuframaAlczfm:
+    """#311 — SUFRAMA_DV (C22-20: DV da Inscrição SUFRAMA do emitente) +
+    ALCZFM_NPROC (UB66c-10: grupo gALCZFMCBS exige nProcSuframa)."""
+
+    def _nfe(self, isuf=None, alczfm=None):
+        emit_extra = f"<ISUFemit>{isuf}</ISUFemit>" if isuf is not None else ""
+        imp = alczfm if alczfm is not None else ""
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>'
+            f'<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT>{emit_extra}</emit>'
+            '<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib>{imp}</IBSCBS></imposto></det>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, rule):
+        return [f for f in validate_xml(xml, "NFE").findings if f.rule_id == rule]
+
+    def test_suframa_dv_valido_sem_finding(self):
+        assert self._find(self._nfe(isuf="100123457"), "SUFRAMA_DV") == []
+
+    def test_suframa_dv_invalido_warning(self):
+        f = self._find(self._nfe(isuf="100123450"), "SUFRAMA_DV")
+        assert any(x.id == "F_SUFRAMA_DV" and x.severity == "WARNING" for x in f)
+
+    def test_suframa_malformado_warning(self):
+        assert any(x.id == "F_SUFRAMA_DV" for x in self._find(self._nfe(isuf="12345"), "SUFRAMA_DV"))
+
+    def test_sem_suframa_sem_finding(self):
+        assert self._find(self._nfe(), "SUFRAMA_DV") == []
+
+    def test_alczfm_com_nproc_sem_finding(self):
+        xml = self._nfe(alczfm="<gALCZFMCBS><nProcSuframa>1234567890</nProcSuframa></gALCZFMCBS>")
+        assert self._find(xml, "ALCZFM_NPROC") == []
+
+    def test_alczfm_sem_nproc_warning(self):
+        xml = self._nfe(alczfm="<gALCZFMCBS><vCBS>0.00</vCBS></gALCZFMCBS>")
+        f = self._find(xml, "ALCZFM_NPROC")
+        assert any(x.id == "F_ALCZFM_NPROC" and x.severity == "WARNING" for x in f)
+
+    def test_sem_grupo_alczfm_sem_finding(self):
+        assert self._find(self._nfe(), "ALCZFM_NPROC") == []

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -4,7 +4,7 @@
  * Fonte única reutilizada por copy, blog e metadados (SEO/OG/Twitter), para que o
  * site nunca divirja do engine. Conta as regras de validação ATIVAS do
  * `xmlRules.ts`, excluindo os placeholders (lembretes que só emitem ALERT e não
- * validam nada). Hoje: 25 ruleIds distintos − 2 placeholders = 23.
+ * validam nada). Hoje: 27 ruleIds distintos − 2 placeholders = 25.
  *
  * Anti-drift: `rulesMeta.test.ts` extrai os ruleIds reais do `xmlRules.ts` e falha
  * se esta contagem sair de sincronia com o engine. Ao adicionar/remover uma regra,
@@ -15,7 +15,7 @@
 export const PLACEHOLDER_RULE_IDS: readonly string[] = ["BENEFITS_PLACEHOLDER", "NCM_PLACEHOLDER"];
 
 /** Quantidade canônica de regras determinísticas ativas. */
-export const RULES_COUNT = 23;
+export const RULES_COUNT = 25;
 
 /** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
 export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -1016,3 +1016,44 @@ test("#314 NCM não sujeito → sem IS_EXPECTED", () => {
 test("#314 NCM sujeito com grupo IS → sem IS_EXPECTED", () => {
   assert.equal(isFindings(isNfe("22030000", { vbcis: "1000.00", pis: "0.1000", vis: "100.00" }), "IS_EXPECTED").length, 0);
 });
+
+// ── #311 — SUFRAMA_DV (C22-20) + ALCZFM_NPROC (UB66c-10) ─────────────────────
+function sufNfe(opts: { isuf?: string; alczfm?: string } = {}): string {
+  const isuf = opts.isuf !== undefined ? `<ISUFemit>${opts.isuf}</ISUFemit>` : "";
+  const alc = opts.alczfm ?? "";
+  return `<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>` +
+    `<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT>${isuf}</emit>` +
+    `<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>` +
+    `<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib>${alc}</IBSCBS></imposto></det>` +
+    `</infNFe></NFe></nfeProc>`;
+}
+function sufFindings(xml: string, rule: string) {
+  return validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml }).findings.filter((f) => f.rule_id === rule);
+}
+
+test("#311 SUFRAMA_DV: DV válido (100123457) → sem finding", () => {
+  assert.equal(sufFindings(sufNfe({ isuf: "100123457" }), "SUFRAMA_DV").length, 0);
+});
+
+test("#311 SUFRAMA_DV: DV inválido → WARNING (C22-20)", () => {
+  const f = sufFindings(sufNfe({ isuf: "100123450" }), "SUFRAMA_DV");
+  assert.ok(f.some((x) => x.id === "F_SUFRAMA_DV" && x.severity === "WARNING"));
+});
+
+test("#311 SUFRAMA_DV: sem ISUFemit → sem finding", () => {
+  assert.equal(sufFindings(sufNfe(), "SUFRAMA_DV").length, 0);
+});
+
+test("#311 ALCZFM_NPROC: grupo com nProcSuframa → sem finding", () => {
+  const xml = sufNfe({ alczfm: "<gALCZFMCBS><nProcSuframa>1234567890</nProcSuframa></gALCZFMCBS>" });
+  assert.equal(sufFindings(xml, "ALCZFM_NPROC").length, 0);
+});
+
+test("#311 ALCZFM_NPROC: grupo sem nProcSuframa → WARNING (UB66c-10)", () => {
+  const f = sufFindings(sufNfe({ alczfm: "<gALCZFMCBS><vCBS>0.00</vCBS></gALCZFMCBS>" }), "ALCZFM_NPROC");
+  assert.ok(f.some((x) => x.id === "F_ALCZFM_NPROC" && x.severity === "WARNING"));
+});
+
+test("#311 ALCZFM_NPROC: sem grupo → sem finding", () => {
+  assert.equal(sufFindings(sufNfe(), "ALCZFM_NPROC").length, 0);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -142,6 +142,19 @@ function firstTag(xml: string, tags: string[]): { tag: string; value: string; sn
   return null;
 }
 
+/** Valida o DV da Inscrição SUFRAMA (9 díg; módulo 11, pesos 2–9 da direita p/ esquerda;
+ * resto 0/1 → DV 0). Regra SUFRAMA_DV (C22-20, #311). */
+function suframaDvOk(inscricao: string): boolean {
+  const digits = (inscricao.match(/\d/g) ?? []).join("");
+  if (digits.length !== 9) return false;
+  const weights = [9, 8, 7, 6, 5, 4, 3, 2];
+  let total = 0;
+  for (let i = 0; i < 8; i++) total += Number(digits[i]) * weights[i];
+  let calc = 11 - (total % 11);
+  if (calc >= 10) calc = 0;
+  return calc === Number(digits[8]);
+}
+
 /** Returns ALL matches for a tag (useful for multi-item NF-e). */
 function allTags(xml: string, tag: string): { value: string; snippet: string; index: number }[] {
   const re = new RegExp(`<${tag}(?=[\\s>/])([^>]*)>([\\s\\S]*?)<\\/${tag}>`, "gi");
@@ -989,6 +1002,57 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
         }),
         makeEvidence({ id: evId, type: "xml", label: "IS — NCM possivelmente sujeito, grupo ausente", xpath: inferXpath("IS", docType), snippet: ncm.snippet }),
       );
+    }
+  }
+
+  // ── Rule: SUFRAMA_DV — DV da Inscrição SUFRAMA do emitente (#311, C22-20) ──
+  if (isNfe) {
+    const isuf = firstTag(xml, ["ISUFemit", "ISUF"]);
+    if (isuf && isuf.value.trim() && !suframaDvOk(isuf.value)) {
+      const evId = makeEvidenceId("SUFRAMA_DV");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_SUFRAMA_DV",
+          severity: "WARNING",
+          ruleId: "SUFRAMA_DV",
+          title: `Inscrição SUFRAMA "${isuf.value.trim()}" — dígito verificador inválido`,
+          field: "ISUFemit",
+          xpath: inferXpath("ISUFemit", docType),
+          snippet: isuf.snippet,
+          evidenceId: evId,
+          recommendation:
+            "A Inscrição SUFRAMA do emitente deve ter 9 dígitos com DV válido (módulo 11). " +
+            "Verifique a inscrição. SEFAZ: Rejeição C22-20 (DV da Inscrição SUFRAMA do emitente inválido).",
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "SUFRAMA — DV inválido", xpath: inferXpath("ISUFemit", docType), snippet: isuf.snippet }),
+      );
+    }
+  }
+
+  // ── Rule: ALCZFM_NPROC — grupo gALCZFMCBS exige nProcSuframa (#311, UB66c-10) ──
+  if (isNfe) {
+    const alc = xml.match(/<gALCZFMCBS\b[^>]*>([\s\S]*?)<\/gALCZFMCBS>/i);
+    if (alc) {
+      const nproc = firstTag(alc[1], ["nProcSuframa"]);
+      if (!(nproc && nproc.value.trim())) {
+        const evId = makeEvidenceId("ALCZFM_NPROC");
+        pushFindingAndEvidence(findings, evidences, evidenceById,
+          makeFinding({
+            id: "F_ALCZFM_NPROC",
+            severity: "WARNING",
+            ruleId: "ALCZFM_NPROC",
+            title: "Grupo ALC/ZFM (gALCZFMCBS) sem nProcSuframa",
+            field: "nProcSuframa",
+            xpath: inferXpath("nProcSuframa", docType),
+            snippet: alc[0].slice(0, 200),
+            evidenceId: evId,
+            recommendation:
+              "Operações com benefício de ALC/Zona Franca (grupo gALCZFMCBS) exigem o número do processo na " +
+              "SUFRAMA (nProcSuframa) do processo produtivo aprovado. Informe o nProcSuframa. SEFAZ: Rejeição UB66c-10.",
+          }),
+          makeEvidence({ id: evId, type: "xml", label: "ALC/ZFM — nProcSuframa ausente", xpath: inferXpath("nProcSuframa", docType), snippet: alc[0].slice(0, 200) }),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## #311 — desbloqueado: SUFRAMA_DV + ALCZFM_NPROC

Avança o catálogo de rejeições da v1.40. **Insight que desbloqueou:** a NT v1.40 + XSD são **públicos** (Portal NF-e) e estas regras são **estruturais / de DV sobre grupos que o emitente declara** — **não** exigem tabela de municípios ZFM (o emitente declara `gALCZFMCBS`/`ISUFemit`); o **DV SUFRAMA é algoritmo público** (módulo 11). O bloqueio de "tabelas externas" praticamente não existe.

### Regras (nos dois motores)
- **`SUFRAMA_DV` (C22-20):** valida o DV da Inscrição SUFRAMA do emitente (`ISUFemit`) — módulo 11, pesos 2–9.
- **`ALCZFM_NPROC` (UB66c-10):** grupo `gALCZFMCBS` presente exige `nProcSuframa`.

### Decisão de severidade — **WARNING**
Compliance é a marca: um falso-FATAL bloqueia nota legítima. WARNING **com o código oficial de rejeição** entrega o valor (flagra pré-emissão) sem o risco. **Promovível a FATAL** quando validarmos o DV contra inscrição real.

### QA
Backend `TestSuframaAlczfm` (7) + regressão **85**; ruff + pyright limpos. Frontend 6 + anti-drift (**RULES_COUNT 23→25**), **130** testes + build.

Avança #311 (restam `B25d/cIndOp` e `UB66e-10`). Refs #309.