### PR TITLE
feat(rules): #311 — CINDOP_NFCE (B25d: cIndOp não permitido em NFC-e)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -1115,6 +1115,27 @@ def validate_xml(
                     Evidence(id=ev_id, type="xml", label="ALC/ZFM — nProcSuframa ausente", xpath=_xpath("nProcSuframa", doc_type), snippet=_alc.group(0)[:200]),
                 )
 
+    # ── Rule 27: CINDOP_NFCE — cIndOp não é permitido na NFC-e (#311, B25d) ──
+    # A NT v1.40 veda o campo cIndOp (Código Indicador do Local da Operação) no modelo 65.
+    # Restrição explícita e determinística → regra limpa. WARNING (advisory, cita B25d).
+    if doc_type == "NFCE":
+        _cindop = _first_tag(xml, ["cIndOp"])
+        if _cindop and _cindop["value"].strip():
+            ev_id = "E_XML_CINDOP_NFCE"
+            _add(
+                Finding(
+                    id="F_CINDOP_NFCE", severity="WARNING", rule_id="CINDOP_NFCE",
+                    title="cIndOp informado em NFC-e (modelo 65) — não permitido",
+                    where=FindingWhere(field="cIndOp", xpath=_xpath("cIndOp", doc_type), snippet=_cindop["snippet"]),
+                    recommendation=(
+                        "O campo cIndOp (Código Indicador do Local da Operação de Fornecimento) não é permitido "
+                        "na NFC-e (modelo 65) — remova-o. SEFAZ: regra B25d (NT 2025.002-RTC v1.40)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="cIndOp — não permitido em NFC-e", xpath=_xpath("cIndOp", doc_type), snippet=_cindop["snippet"]),
+            )
+
     # ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────
     # Apenas NF-e/NFC-e (rejeições da SEFAZ NF-e; NFS-e tem regras próprias).
     if is_nfe:

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -778,3 +778,30 @@ class TestSuframaAlczfm:
 
     def test_sem_grupo_alczfm_sem_finding(self):
         assert self._find(self._nfe(), "ALCZFM_NPROC") == []
+
+
+class TestCindopNfce:
+    """#311 — B25d: cIndOp (Código Indicador do Local da Operação) não é permitido em NFC-e."""
+
+    def _doc(self, mod, with_cindop):
+        c = "<cIndOp>010104</cIndOp>" if with_cindop else ""
+        return (
+            f'<nfeProc><NFe><infNFe><ide><mod>{mod}</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            f'<det nItem="1"><prod><NCM>84713012</NCM>{c}<vProd>10.00</vProd></prod>'
+            '<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib></IBSCBS></imposto></det>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, dt):
+        return [f for f in validate_xml(xml, dt).findings if f.rule_id == "CINDOP_NFCE"]
+
+    def test_cindop_em_nfce_warning(self):
+        f = self._find(self._doc("65", True), "NFCE")
+        assert any(x.id == "F_CINDOP_NFCE" and x.severity == "WARNING" for x in f)
+
+    def test_cindop_em_nfe_sem_finding(self):
+        assert self._find(self._doc("55", True), "NFE") == []
+
+    def test_nfce_sem_cindop_sem_finding(self):
+        assert self._find(self._doc("65", False), "NFCE") == []

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -4,7 +4,7 @@
  * Fonte única reutilizada por copy, blog e metadados (SEO/OG/Twitter), para que o
  * site nunca divirja do engine. Conta as regras de validação ATIVAS do
  * `xmlRules.ts`, excluindo os placeholders (lembretes que só emitem ALERT e não
- * validam nada). Hoje: 27 ruleIds distintos − 2 placeholders = 25.
+ * validam nada). Hoje: 28 ruleIds distintos − 2 placeholders = 26.
  *
  * Anti-drift: `rulesMeta.test.ts` extrai os ruleIds reais do `xmlRules.ts` e falha
  * se esta contagem sair de sincronia com o engine. Ao adicionar/remover uma regra,
@@ -15,7 +15,7 @@
 export const PLACEHOLDER_RULE_IDS: readonly string[] = ["BENEFITS_PLACEHOLDER", "NCM_PLACEHOLDER"];
 
 /** Quantidade canônica de regras determinísticas ativas. */
-export const RULES_COUNT = 25;
+export const RULES_COUNT = 26;
 
 /** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
 export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -1057,3 +1057,31 @@ test("#311 ALCZFM_NPROC: grupo sem nProcSuframa → WARNING (UB66c-10)", () => {
 test("#311 ALCZFM_NPROC: sem grupo → sem finding", () => {
   assert.equal(sufFindings(sufNfe(), "ALCZFM_NPROC").length, 0);
 });
+
+// ── #311 — CINDOP_NFCE (B25d: cIndOp não permitido em NFC-e) ──────────────────
+function cindopDoc(model: string, withCindop: boolean): string {
+  const c = withCindop ? "<cIndOp>010104</cIndOp>" : "";
+  return `<nfeProc><NFe><infNFe><ide><mod>${model}</mod></ide>` +
+    `<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>` +
+    `<det nItem="1"><prod><NCM>84713012</NCM>${c}<vProd>10.00</vProd></prod>` +
+    `<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib></IBSCBS></imposto></det>` +
+    `</infNFe></NFe></nfeProc>`;
+}
+
+test("#311 CINDOP_NFCE: cIndOp em NFC-e (mod 65) → WARNING", () => {
+  const f = validateXmlWithRules({ tenantId: "t", documentType: "NFCE", xml: cindopDoc("65", true) })
+    .findings.filter((x) => x.rule_id === "CINDOP_NFCE");
+  assert.ok(f.some((x) => x.id === "F_CINDOP_NFCE" && x.severity === "WARNING"));
+});
+
+test("#311 CINDOP_NFCE: cIndOp em NF-e (mod 55) → sem finding", () => {
+  const f = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: cindopDoc("55", true) })
+    .findings.filter((x) => x.rule_id === "CINDOP_NFCE");
+  assert.equal(f.length, 0);
+});
+
+test("#311 CINDOP_NFCE: NFC-e sem cIndOp → sem finding", () => {
+  const f = validateXmlWithRules({ tenantId: "t", documentType: "NFCE", xml: cindopDoc("65", false) })
+    .findings.filter((x) => x.rule_id === "CINDOP_NFCE");
+  assert.equal(f.length, 0);
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -1056,6 +1056,30 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
     }
   }
 
+  // ── Rule: CINDOP_NFCE — cIndOp não é permitido na NFC-e (#311, B25d) ──
+  if (docType === "NFCE") {
+    const cindop = firstTag(xml, ["cIndOp"]);
+    if (cindop && cindop.value.trim()) {
+      const evId = makeEvidenceId("CINDOP_NFCE");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_CINDOP_NFCE",
+          severity: "WARNING",
+          ruleId: "CINDOP_NFCE",
+          title: "cIndOp informado em NFC-e (modelo 65) — não permitido",
+          field: "cIndOp",
+          xpath: inferXpath("cIndOp", docType),
+          snippet: cindop.snippet,
+          evidenceId: evId,
+          recommendation:
+            "O campo cIndOp (Código Indicador do Local da Operação de Fornecimento) não é permitido na " +
+            "NFC-e (modelo 65) — remova-o. SEFAZ: regra B25d (NT 2025.002-RTC v1.40).",
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "cIndOp — não permitido em NFC-e", xpath: inferXpath("cIndOp", docType), snippet: cindop.snippet }),
+      );
+    }
+  }
+
   // ── Rule 9: CEST_FORMAT — CEST must be exactly 7 digits ──────────────────
 
   if (cest && !/^\d{7}$/.test(cest.value)) {


### PR DESCRIPTION
## #311 — CINDOP_NFCE (parte limpa do B25d)

Mais uma fatia do catálogo v1.40 — a parte **determinística** do B25d: a NT **veda** o campo `cIndOp` (Código Indicador do Local da Operação) no **modelo 65 (NFC-e)**.

### Regra (nos dois motores)
- **`CINDOP_NFCE` (B25d):** NFC-e + `cIndOp` presente → **WARNING** (cita B25d). **RULES_COUNT 25 → 26**.

### Honestidade de escopo (não chutei)
O **domínio completo** do `cIndOp`, o **gatilho de obrigatoriedade** (leilão/licitação — não detectável do XML genérico) e o **UB66e-10** (coerência `vCBS` em área incentivada) dependem do **XSD/PDF oficial** da NT v1.40 → não implementados para não gerar falso-positivo num produto de compliance.

### QA
Backend `TestCindopNfce` (3) + regressão **88**; ruff + pyright limpos. Frontend 3 + anti-drift (**26**), **133** testes + build.

Avança #311. Refs #309.