### PR TITLE
feat(rules): #311 — B25d-30 (Rej. 1110) + UB66e-10 (Rej. 1218); fecha o catálogo v1.40

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -1108,7 +1108,7 @@ def validate_xml(
                         recommendation=(
                             "Operações com benefício de ALC/Zona Franca (grupo gALCZFMCBS) exigem o número do "
                             "processo na SUFRAMA (nProcSuframa) do processo produtivo aprovado. Informe o nProcSuframa. "
-                            "SEFAZ: Rejeição UB66c-10 (Número do processo na SUFRAMA não informado)."
+                            "SEFAZ: Rejeição 1192 (regra UB66c-10 — número do processo na SUFRAMA não informado)."
                         ),
                         evidence_ids=[ev_id],
                     ),
@@ -1129,12 +1129,60 @@ def validate_xml(
                     where=FindingWhere(field="cIndOp", xpath=_xpath("cIndOp", doc_type), snippet=_cindop["snippet"]),
                     recommendation=(
                         "O campo cIndOp (Código Indicador do Local da Operação de Fornecimento) não é permitido "
-                        "na NFC-e (modelo 65) — remova-o. SEFAZ: regra B25d (NT 2025.002-RTC v1.40)."
+                        "na NFC-e (modelo 65) — remova-o. SEFAZ: Rejeição 1099 (regra B25d-10)."
                     ),
                     evidence_ids=[ev_id],
                 ),
                 Evidence(id=ev_id, type="xml", label="cIndOp — não permitido em NFC-e", xpath=_xpath("cIndOp", doc_type), snippet=_cindop["snippet"]),
             )
+
+    # ── Rule 28: RETIRADA_CINDOP — B25d-30: cIndOp 010104/010105 exige Local de Retirada (#311) ──
+    # Spec oficial (NT v1.40): se cIndOp = "010104" (leilão/licitação) ou "010105" (irregularidade)
+    # e o grupo Local de Retirada (retirada/F01) não foi informado → Rejeição 1110. Modelo 55.
+    if doc_type == "NFE":
+        _cind = _first_tag(xml, ["cIndOp"])
+        if _cind and _cind["value"].strip() in ("010104", "010105") and not re.search(r"<retirada(?=[\s>])", xml, re.IGNORECASE):
+            ev_id = "E_XML_RETIRADA_CINDOP"
+            _add(
+                Finding(
+                    id="F_RETIRADA_CINDOP", severity="WARNING", rule_id="RETIRADA_CINDOP",
+                    title=f'cIndOp {_cind["value"].strip()} exige o grupo Local de Retirada (ausente)',
+                    where=FindingWhere(field="retirada", xpath=_xpath("retirada", doc_type), snippet=_cind["snippet"]),
+                    recommendation=(
+                        "cIndOp 010104 (leilão/licitação) ou 010105 (irregularidade) exige o grupo Local de "
+                        "Retirada (retirada) informado. SEFAZ: Rejeição 1110 (regra B25d-30)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="Local de Retirada ausente (cIndOp 010104/010105)", xpath=_xpath("retirada", doc_type), snippet=_cind["snippet"]),
+            )
+
+    # ── Rule 29: ALCZFM_CBS_CALC — UB66e-10: vTribRegCBS = vBC × pAliqEfetRegCBS/100 (#311) ──
+    # Spec oficial (Rejeição 1218): coerência do valor da CBS na operação ALC/ZFM. WARNING.
+    _alc2 = re.search(r"<gALCZFMCBS\b[^>]*>([\s\S]*?)</gALCZFMCBS>", xml, re.IGNORECASE)
+    if is_nfe and _alc2:
+        _blk = _alc2.group(1)
+        _vtrib = _first_tag(_blk, ["vTribRegCBS"])
+        _palq = _first_tag(_blk, ["pAliqEfetRegCBS"])
+        _vbc_t = _first_tag(xml, ["vBC"])
+        if _vtrib and _palq and _vbc_t:
+            _exp = round(_to_float(_vbc_t["value"]) * _to_float(_palq["value"]) / 100, 2)
+            _decl = _to_float(_vtrib["value"])
+            if abs(_decl - _exp) > 0.01:
+                ev_id = "E_XML_ALCZFM_CBS_CALC"
+                _add(
+                    Finding(
+                        id="F_ALCZFM_CBS_CALC", severity="WARNING", rule_id="ALCZFM_CBS_CALC",
+                        title=f"vTribRegCBS ({_decl}) diverge do calculado ({_exp}) na operação ALC/ZFM",
+                        where=FindingWhere(field="vTribRegCBS", xpath=_xpath("vTribRegCBS", doc_type), snippet=_vtrib["snippet"]),
+                        recommendation=(
+                            "Em operação ALC/ZFM, vTribRegCBS deve ser vBC × (pAliqEfetRegCBS / 100). "
+                            "Ajuste o valor. SEFAZ: Rejeição 1218 (regra UB66e-10)."
+                        ),
+                        evidence_ids=[ev_id],
+                    ),
+                    Evidence(id=ev_id, type="xml", label="ALC/ZFM — vTribRegCBS incoerente", xpath=_xpath("vTribRegCBS", doc_type), snippet=_vtrib["snippet"]),
+                )
 
     # ── NT v1.40 — anotar código de rejeição SEFAZ nas detecções (#311) ───────
     # Apenas NF-e/NFC-e (rejeições da SEFAZ NF-e; NFS-e tem regras próprias).

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -805,3 +805,48 @@ class TestCindopNfce:
 
     def test_nfce_sem_cindop_sem_finding(self):
         assert self._find(self._doc("65", False), "NFCE") == []
+
+
+class TestB25d30Ub66e:
+    """#311 — B25d-30 (Rej. 1110: cIndOp 010104/010105 exige Local de Retirada) +
+    UB66e-10 (Rej. 1218: vTribRegCBS = vBC × pAliqEfetRegCBS/100 na operação ALC/ZFM)."""
+
+    def _nfe(self, cindop=None, retirada=False, alc="", vbc="1000.00"):
+        cind = f"<cIndOp>{cindop}</cIndOp>" if cindop else ""
+        ret = "<retirada><xLgr>Rua X</xLgr></retirada>" if retirada else ""
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            f'{cind}{ret}'
+            '<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib>'
+            f'<gIBSCBS><vBC>{vbc}</vBC></gIBSCBS>{alc}</IBSCBS></imposto></det>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml, rule):
+        return [f for f in validate_xml(xml, "NFE").findings if f.rule_id == rule]
+
+    # B25d-30
+    def test_cindop_sem_retirada_warning(self):
+        f = self._find(self._nfe(cindop="010104", retirada=False), "RETIRADA_CINDOP")
+        assert any(x.id == "F_RETIRADA_CINDOP" and x.severity == "WARNING" for x in f)
+
+    def test_cindop_com_retirada_sem_finding(self):
+        assert self._find(self._nfe(cindop="010105", retirada=True), "RETIRADA_CINDOP") == []
+
+    def test_cindop_outro_valor_sem_finding(self):
+        assert self._find(self._nfe(cindop="000000", retirada=False), "RETIRADA_CINDOP") == []
+
+    # UB66e-10
+    _ALC = "<gALCZFMCBS><tpALCZFMCBS>2</tpALCZFMCBS><nProcSuframa>1234567890</nProcSuframa><pAliqEfetRegCBS>8.80</pAliqEfetRegCBS><vTribRegCBS>{v}</vTribRegCBS></gALCZFMCBS>"
+
+    def test_alczfm_cbs_coerente_sem_finding(self):
+        # 1000 × 8.80/100 = 88.00
+        xml = self._nfe(alc=self._ALC.format(v="88.00"))
+        assert self._find(xml, "ALCZFM_CBS_CALC") == []
+
+    def test_alczfm_cbs_incoerente_warning(self):
+        xml = self._nfe(alc=self._ALC.format(v="50.00"))
+        f = self._find(xml, "ALCZFM_CBS_CALC")
+        assert any(x.id == "F_ALCZFM_CBS_CALC" and x.severity == "WARNING" for x in f)

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -4,7 +4,7 @@
  * Fonte única reutilizada por copy, blog e metadados (SEO/OG/Twitter), para que o
  * site nunca divirja do engine. Conta as regras de validação ATIVAS do
  * `xmlRules.ts`, excluindo os placeholders (lembretes que só emitem ALERT e não
- * validam nada). Hoje: 28 ruleIds distintos − 2 placeholders = 26.
+ * validam nada). Hoje: 30 ruleIds distintos − 2 placeholders = 28.
  *
  * Anti-drift: `rulesMeta.test.ts` extrai os ruleIds reais do `xmlRules.ts` e falha
  * se esta contagem sair de sincronia com o engine. Ao adicionar/remover uma regra,
@@ -15,7 +15,7 @@
 export const PLACEHOLDER_RULE_IDS: readonly string[] = ["BENEFITS_PLACEHOLDER", "NCM_PLACEHOLDER"];
 
 /** Quantidade canônica de regras determinísticas ativas. */
-export const RULES_COUNT = 26;
+export const RULES_COUNT = 28;
 
 /** Rótulo padrão ancorado à autoridade externa (a NT define o conjunto de regras). */
 export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas à NT 2025.002-RTC v1.40`;

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -1085,3 +1085,42 @@ test("#311 CINDOP_NFCE: NFC-e sem cIndOp → sem finding", () => {
     .findings.filter((x) => x.rule_id === "CINDOP_NFCE");
   assert.equal(f.length, 0);
 });
+
+// ── #311 — RETIRADA_CINDOP (B25d-30) + ALCZFM_CBS_CALC (UB66e-10) ────────────
+function b25Nfe(opts: { cindop?: string; retirada?: boolean; alc?: string } = {}): string {
+  const cind = opts.cindop ? `<cIndOp>${opts.cindop}</cIndOp>` : "";
+  const ret = opts.retirada ? "<retirada><xLgr>Rua X</xLgr></retirada>" : "";
+  const alc = opts.alc ?? "";
+  return `<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>` +
+    `<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>${cind}${ret}` +
+    `<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>` +
+    `<imposto><IBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib>` +
+    `<gIBSCBS><vBC>1000.00</vBC></gIBSCBS>${alc}</IBSCBS></imposto></det>` +
+    `</infNFe></NFe></nfeProc>`;
+}
+function b25Find(xml: string, rule: string) {
+  return validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml }).findings.filter((f) => f.rule_id === rule);
+}
+const ALC = (v: string) => `<gALCZFMCBS><tpALCZFMCBS>2</tpALCZFMCBS><nProcSuframa>1234567890</nProcSuframa><pAliqEfetRegCBS>8.80</pAliqEfetRegCBS><vTribRegCBS>${v}</vTribRegCBS></gALCZFMCBS>`;
+
+test("#311 RETIRADA_CINDOP: cIndOp 010104 sem retirada → WARNING (1110)", () => {
+  const f = b25Find(b25Nfe({ cindop: "010104", retirada: false }), "RETIRADA_CINDOP");
+  assert.ok(f.some((x) => x.id === "F_RETIRADA_CINDOP" && x.severity === "WARNING"));
+});
+
+test("#311 RETIRADA_CINDOP: com retirada → sem finding", () => {
+  assert.equal(b25Find(b25Nfe({ cindop: "010105", retirada: true }), "RETIRADA_CINDOP").length, 0);
+});
+
+test("#311 RETIRADA_CINDOP: cIndOp de outro valor → sem finding", () => {
+  assert.equal(b25Find(b25Nfe({ cindop: "000000" }), "RETIRADA_CINDOP").length, 0);
+});
+
+test("#311 ALCZFM_CBS_CALC: vTribRegCBS coerente (88.00) → sem finding", () => {
+  assert.equal(b25Find(b25Nfe({ alc: ALC("88.00") }), "ALCZFM_CBS_CALC").length, 0);
+});
+
+test("#311 ALCZFM_CBS_CALC: vTribRegCBS incoerente → WARNING (1218)", () => {
+  const f = b25Find(b25Nfe({ alc: ALC("50.00") }), "ALCZFM_CBS_CALC");
+  assert.ok(f.some((x) => x.id === "F_ALCZFM_CBS_CALC" && x.severity === "WARNING"));
+});

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -1048,7 +1048,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
             evidenceId: evId,
             recommendation:
               "Operações com benefício de ALC/Zona Franca (grupo gALCZFMCBS) exigem o número do processo na " +
-              "SUFRAMA (nProcSuframa) do processo produtivo aprovado. Informe o nProcSuframa. SEFAZ: Rejeição UB66c-10.",
+              "SUFRAMA (nProcSuframa) do processo produtivo aprovado. Informe o nProcSuframa. SEFAZ: Rejeição 1192 (regra UB66c-10).",
           }),
           makeEvidence({ id: evId, type: "xml", label: "ALC/ZFM — nProcSuframa ausente", xpath: inferXpath("nProcSuframa", docType), snippet: alc[0].slice(0, 200) }),
         );
@@ -1073,10 +1073,68 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           evidenceId: evId,
           recommendation:
             "O campo cIndOp (Código Indicador do Local da Operação de Fornecimento) não é permitido na " +
-            "NFC-e (modelo 65) — remova-o. SEFAZ: regra B25d (NT 2025.002-RTC v1.40).",
+            "NFC-e (modelo 65) — remova-o. SEFAZ: Rejeição 1099 (regra B25d-10).",
         }),
         makeEvidence({ id: evId, type: "xml", label: "cIndOp — não permitido em NFC-e", xpath: inferXpath("cIndOp", docType), snippet: cindop.snippet }),
       );
+    }
+  }
+
+  // ── Rule: RETIRADA_CINDOP — B25d-30: cIndOp 010104/010105 exige Local de Retirada (#311) ──
+  if (docType === "NFE") {
+    const cind = firstTag(xml, ["cIndOp"]);
+    const v = cind?.value.trim();
+    if (cind && (v === "010104" || v === "010105") && !/<retirada(?=[\s>])/i.test(xml)) {
+      const evId = makeEvidenceId("RETIRADA_CINDOP");
+      pushFindingAndEvidence(findings, evidences, evidenceById,
+        makeFinding({
+          id: "F_RETIRADA_CINDOP",
+          severity: "WARNING",
+          ruleId: "RETIRADA_CINDOP",
+          title: `cIndOp ${v} exige o grupo Local de Retirada (ausente)`,
+          field: "retirada",
+          xpath: inferXpath("retirada", docType),
+          snippet: cind.snippet,
+          evidenceId: evId,
+          recommendation:
+            "cIndOp 010104 (leilão/licitação) ou 010105 (irregularidade) exige o grupo Local de Retirada " +
+            "(retirada) informado. SEFAZ: Rejeição 1110 (regra B25d-30).",
+        }),
+        makeEvidence({ id: evId, type: "xml", label: "Local de Retirada ausente (cIndOp 010104/010105)", xpath: inferXpath("retirada", docType), snippet: cind.snippet }),
+      );
+    }
+  }
+
+  // ── Rule: ALCZFM_CBS_CALC — UB66e-10: vTribRegCBS = vBC × pAliqEfetRegCBS/100 (#311) ──
+  {
+    const alc = xml.match(/<gALCZFMCBS\b[^>]*>([\s\S]*?)<\/gALCZFMCBS>/i);
+    if (isNfe && alc) {
+      const vtrib = firstTag(alc[1], ["vTribRegCBS"]);
+      const palq = firstTag(alc[1], ["pAliqEfetRegCBS"]);
+      const vbc = firstTag(xml, ["vBC"]);
+      if (vtrib && palq && vbc) {
+        const exp = Math.round((parseFloat(vbc.value) * parseFloat(palq.value)) / 100 * 100) / 100;
+        const decl = parseFloat(vtrib.value) || 0;
+        if (Math.abs(decl - exp) > 0.01) {
+          const evId = makeEvidenceId("ALCZFM_CBS_CALC");
+          pushFindingAndEvidence(findings, evidences, evidenceById,
+            makeFinding({
+              id: "F_ALCZFM_CBS_CALC",
+              severity: "WARNING",
+              ruleId: "ALCZFM_CBS_CALC",
+              title: `vTribRegCBS (${decl}) diverge do calculado (${exp}) na operação ALC/ZFM`,
+              field: "vTribRegCBS",
+              xpath: inferXpath("vTribRegCBS", docType),
+              snippet: vtrib.snippet,
+              evidenceId: evId,
+              recommendation:
+                "Em operação ALC/ZFM, vTribRegCBS deve ser vBC × (pAliqEfetRegCBS / 100). " +
+                "Ajuste o valor. SEFAZ: Rejeição 1218 (regra UB66e-10).",
+            }),
+            makeEvidence({ id: evId, type: "xml", label: "ALC/ZFM — vTribRegCBS incoerente", xpath: inferXpath("vTribRegCBS", docType), snippet: vtrib.snippet }),
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## #311 — fecha o catálogo v1.40 (fonte oficial)

Baixei o **PDF oficial da NT 2025.002-RTC** (97 páginas, extraído com pdfplumber) e li as **condições exatas** das regras — fechando as últimas fatias **com precisão**, sem chute.

### Regras novas (dois motores)
- **`RETIRADA_CINDOP` (B25d-30, Rej. 1110):** `cIndOp` = 010104 (leilão/licitação) ou 010105 (irregularidade) exige o grupo **Local de Retirada** → WARNING.
- **`ALCZFM_CBS_CALC` (UB66e-10, Rej. 1218):** `vTribRegCBS = vBC × (pAliqEfetRegCBS/100)` na operação ALC/ZFM → coerência → WARNING.

### Citações refinadas (códigos confirmados no PDF)
- `CINDOP_NFCE` → **Rejeição 1099** (B25d-10) · `ALCZFM_NPROC` → **Rejeição 1192** (UB66c-10).

**RULES_COUNT 26 → 28.**

### Único residual
**B25d-20 (Rej. 1102):** `cIndOp` com `indNFe=0` — depende da **tabela externa** "Código Indicador de Local da Operação" (flag `indNFe` por código), não presente no leiaute. É o único item que ainda exige a tabela de domínio.

### QA
Backend `TestB25d30Ub66e` (6) + regressão **93**; ruff + pyright. Frontend 5 + anti-drift (**28**), **138** + build.

Fecha grande parte do #311. Refs #309.