### PR TITLE
feat(rules): Rejeição 1024 — CLASSTRIB_CST_COMPAT (cClassTrib × CST)

### DIFF
--- a/backend/app/data/classtrib_table.py
+++ b/backend/app/data/classtrib_table.py
@@ -83,3 +83,15 @@ def classtrib_expected_aliquota_2026(code: str) -> tuple[float, float] | None:
     exp_cbs = float(CBS_TESTE_2026) * (1 - red_cbs / 100)
     exp_ibs = float(IBS_TESTE_2026_TOTAL) * (1 - red_ibs / 100)
     return round(exp_cbs, 6), round(exp_ibs, 6)
+
+
+def classtrib_cst(code: str) -> str | None:
+    """CST oficial registrado para o cClassTrib (fonte SVRS) — usado na Rejeição 1024.
+
+    Cada cClassTrib pertence a exatamente um CST. Retorna o CST registrado, ou None se o
+    código for desconhecido. Permite validar a compatibilidade cClassTrib × CST (UB14-20).
+    """
+    item = CLASSTRIB_BY_CODE.get(code)
+    if item is None:
+        return None
+    return str(item.get("cst", "")) or None

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -30,6 +30,7 @@ from app.services.xml_correction_service import correct_xml
 from app.api.plan_gate import require_plan, check_usage_limit, increment_usage
 from app.data.ncm_codes import VALID_NCM_CODES
 from app.data.classtrib_table import (
+    classtrib_cst,
     classtrib_dfe_allowed,
     classtrib_expected_aliquota_2026,
     classtrib_expected_zero,
@@ -752,6 +753,31 @@ def validate_xml(
             _add(
                 Finding(id="F_CNPJ_UNAVAIL", severity="ALERT", rule_id="CNPJ_ACTIVE", title="Verificação de CNPJ indisponível — API fora do ar", where=FindingWhere(field="CNPJ", xpath=_xpath("CNPJ", doc_type)), recommendation="APIs de consulta CNPJ temporariamente indisponíveis. Verifique manualmente.", evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="CNPJ — API indisponível", xpath=_xpath("CNPJ", doc_type)),
+            )
+
+    # ── Rule: CLASSTRIB_CST_COMPAT — cClassTrib compatível com o CST (Rejeição 1024) ──
+    # CARRO-CHEFE: cada cClassTrib é registrado sob um CST específico (fonte oficial SVRS).
+    # Se o CST declarado no grupo IBSCBS difere do CST do cClassTrib → incompatibilidade,
+    # que a SEFAZ rejeita com a Rejeição 1024 (regra UB14-20). FATAL: é a rejeição dura que
+    # o produto se propõe a prevenir; dado oficial e determinístico → alta confiança.
+    if has_ibscbs and c_class_trib and cst and re.match(r"^\d{6}$", c_class_trib["value"]):
+        _reg_cst = classtrib_cst(c_class_trib["value"])
+        _decl_cst = cst["value"].strip()
+        if _reg_cst and _decl_cst and _decl_cst != _reg_cst:
+            ev_id = "E_XML_CLASSTRIB_CST_COMPAT"
+            _add(
+                Finding(
+                    id="F_CLASSTRIB_CST_COMPAT", severity="FATAL", rule_id="CLASSTRIB_CST_COMPAT",
+                    title=f'cClassTrib {c_class_trib["value"]} incompatível com o CST {_decl_cst} (esperado CST {_reg_cst})',
+                    where=FindingWhere(field="cClassTrib", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]),
+                    recommendation=(
+                        f'O cClassTrib {c_class_trib["value"]} é registrado sob o CST {_reg_cst} (tabela oficial SVRS), '
+                        f'mas a nota declarou o CST {_decl_cst}. Corrija o CST ou o cClassTrib. '
+                        "SEFAZ: Rejeição 1024 (regra UB14-20 — cClassTrib incompatível com o CST informado)."
+                    ),
+                    evidence_ids=[ev_id],
+                ),
+                Evidence(id=ev_id, type="xml", label="cClassTrib × CST incompatível (Rejeição 1024)", xpath=_xpath("cClassTrib", doc_type), snippet=c_class_trib["snippet"]),
             )
 
     # ── Rule 19: ALIQUOTA_CLASSTRIB — alíquota-zero coerente com o cClassTrib (#278) ──

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -850,3 +850,35 @@ class TestB25d30Ub66e:
         xml = self._nfe(alc=self._ALC.format(v="50.00"))
         f = self._find(xml, "ALCZFM_CBS_CALC")
         assert any(x.id == "F_ALCZFM_CBS_CALC" and x.severity == "WARNING" for x in f)
+
+
+class TestClasstribCstCompat:
+    """Rejeição 1024 (UB14-20): cClassTrib incompatível com o CST declarado.
+    Carro-chefe — cada cClassTrib é registrado sob um CST oficial (SVRS)."""
+
+    def _nfe(self, code, cst):
+        return (
+            '<nfeProc><NFe><infNFe><ide><mod>55</mod></ide>'
+            '<emit><CNPJ>12345678000195</CNPJ><CRT>3</CRT></emit>'
+            '<det nItem="1"><prod><NCM>84713012</NCM><vProd>1000.00</vProd></prod>'
+            f'<imposto><IBSCBS><CST>{cst}</CST><cClassTrib>{code}</cClassTrib>'
+            '<gIBSCBS><vBC>1000.00</vBC></gIBSCBS></IBSCBS></imposto></det>'
+            '</infNFe></NFe></nfeProc>'
+        )
+
+    def _find(self, xml):
+        return [f for f in validate_xml(xml, "NFE").findings if f.rule_id == "CLASSTRIB_CST_COMPAT"]
+
+    def test_cst_compativel_sem_finding(self):
+        # 000001 é registrado sob CST 000
+        assert self._find(self._nfe("000001", "000")) == []
+
+    def test_cst_incompativel_fatal(self):
+        f = self._find(self._nfe("000001", "200"))
+        assert any(x.id == "F_CLASSTRIB_CST_COMPAT" and x.severity == "FATAL" for x in f)
+
+    def test_outro_classtrib_compativel_sem_finding(self):
+        assert self._find(self._nfe("200001", "200")) == []
+
+    def test_classtrib_desconhecido_sem_finding(self):
+        assert self._find(self._nfe("999999", "000")) == []


### PR DESCRIPTION
## 🚩 Rejeição 1024 — a lacuna-bandeira fechada

A **Rejeição 1024** (cClassTrib incompatível com o CST) é o diferencial que o produto **vende** ("evite a 1024", blog, OG, copy) — mas, ao ler o PDF oficial da NT (UB14-20 / Msg 1024), descobri que **o motor não a validava**. Marketing prometia, engine não entregava. Esta regra fecha a lacuna.

### Mudança
- **`classtrib_cst(code)`**: o CST oficial registrado de cada cClassTrib (fonte SVRS — cada cClassTrib pertence a exatamente um CST).
- **Regra `CLASSTRIB_CST_COMPAT` (UB14-20):** CST declarado no grupo IBSCBS ≠ CST do cClassTrib → **FATAL**, citando **Rejeição 1024**.

### Por que FATAL (e seguro)
Determinístico, dado **oficial** (SVRS): cada cClassTrib pertence a um único CST. O único caso em que diferem **é exatamente a incompatibilidade que a SEFAZ rejeita** com a 1024. É a rejeição dura que o produto se propõe a prevenir → FATAL é o comportamento correto.

### Arquitetura
Backend-only (depende da tabela SVRS), como `ALIQUOTA_CLASSTRIB`/`CLASSTRIB_DOC_TYPE`.

### QA
`TestClasstribCstCompat` (4) + regressão `validate_xml` **97**; ruff + pyright limpos.

Refs #309, #311.