### PR TITLE
fix(blog): título/description do post de alíquota (estava 'sem título')

### DIFF
--- a/frontend/content/blog/como-calcular-aliquota-cbs-ibs.mdx
+++ b/frontend/content/blog/como-calcular-aliquota-cbs-ibs.mdx
@@ -1,6 +1,6 @@
 ---
-title: "tribultz.com.br"
-description: "Latest articles from tribultz.com.br"
+title: "Como calcular alíquota CBS IBS sem erro"
+description: "Veja como calcular alíquota CBS IBS com base legal, classificação fiscal e regras por operação para evitar rejeições, multas e retrabalho."
 slug: "como-calcular-aliquota-cbs-ibs"
 category: "Reforma Tributária"
 author:


### PR DESCRIPTION
## Problema
A página https://tribultz.com.br/blog/como-calcular-aliquota-cbs-ibs aparecia **sem título**: o frontmatter trazia `title: "tribultz.com.br"` (título do **canal** RSS) e `description: "Latest articles from tribultz.com.br"` (genérica). Bug da versão antiga do parser do Soro, no **primeiro** post gerado (#352). O parser atual já extrai corretamente (o post "penalidades" veio certo).

## Correção
Restaura os valores reais do item no feed Soro:
- **title:** `Como calcular alíquota CBS IBS sem erro`
- **description:** texto próprio do item (base legal, classificação, regras por operação).

Conteúdo-only (Vercel).