### PR TITLE
fix(seo): remove sufixo duplicado '| Tribultz' no title

### DIFF
--- a/frontend/src/app/blog/[slug]/page.tsx
+++ b/frontend/src/app/blog/[slug]/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
   const post = getPostBySlug(slug);
   if (!post) return {};
   return {
-    title: `${post.title} | Tribultz`,
+    title: post.title,
     description: post.description,
     alternates: { canonical: `${SITE_URL}/blog/${post.slug}` },
     openGraph: {

--- a/frontend/src/app/blog/page.tsx
+++ b/frontend/src/app/blog/page.tsx
@@ -6,7 +6,7 @@ import { JsonLd } from "@/components/seo/JsonLd";
 const SITE_URL = "https://tribultz.com.br";
 
 export const metadata: Metadata = {
-  title: "Blog | Tribultz — Reforma Tributária CBS/IBS",
+  title: "Blog — Reforma Tributária CBS/IBS",
   description:
     "Artigos técnicos sobre cClassTrib, NCM, Rejeição 1024 e compliance CBS/IBS para a Reforma Tributária de 2026.",
   alternates: { canonical: `${SITE_URL}/blog` },

--- a/frontend/src/app/diagnostico/layout.tsx
+++ b/frontend/src/app/diagnostico/layout.tsx
@@ -7,7 +7,7 @@ import { DIAGNOSTICO_SCHEMA } from "@/components/seo/schemas";
 import { RULES_COUNT } from "@/lib/validation/rulesMeta";
 
 export const metadata: Metadata = {
-  title: "Diagnóstico Gratuito NF-e — Conformidade IBS/CBS 2026 | Tribultz",
+  title: "Diagnóstico Gratuito NF-e — Conformidade IBS/CBS 2026",
   description:
     `Valide sua NF-e, NFC-e ou NFS-e gratuitamente contra as ${RULES_COUNT} regras da NT 2025.002-RTC. ` +
     "Evite multas de 18% por não destacar IBS e CBS. Diagnóstico instantâneo.",


### PR DESCRIPTION
## Problema
Títulos com **sufixo duplicado**: `... | Tribultz | Tribultz`. O layout raiz define `title.template: "%s | Tribultz"` ([layout.tsx:34](frontend/src/app/layout.tsx#L34)), mas algumas páginas já anexavam `| Tribultz` na própria `metadata.title`, então o template duplicava.

Confirmado no ar nas páginas afetadas:
- `/blog` e `/blog/[slug]` (todos os posts)
- `/diagnostico`

## Correção
Remove o `| Tribultz` manual dessas 3 páginas — o template adiciona uma única vez.

| Página | Antes | Depois |
|---|---|---|
| post | `Título \| Tribultz \| Tribultz` | `Título \| Tribultz` |
| /blog | `Blog \| Tribultz — ... \| Tribultz` | `Blog — ... \| Tribultz` |
| /diagnostico | `... 2026 \| Tribultz \| Tribultz` | `... 2026 \| Tribultz` |

Home/calculadora/classificacao usam `title.absolute` e **não** eram afetadas (verificado no ar). Gates locais: `npm test` 138/138 ✅, `npm run build` ✅.
