### PR TITLE
fix(infra): libera domínios do HubSpot na CSP

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -16,12 +16,12 @@ const securityHeaders = [
     key: "Content-Security-Policy",
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com https://*.googletagmanager.com",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com https://*.googletagmanager.com https://js.hs-scripts.com https://*.hs-scripts.com https://js.hs-analytics.net https://js.hs-banner.com https://js.hsadspixel.net https://js.usemessages.com https://*.hsforms.net",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://*.google-analytics.com https://*.googletagmanager.com",
+      "img-src 'self' data: blob: https://*.google-analytics.com https://*.googletagmanager.com https://*.hubspot.com https://*.hs-analytics.net",
       "font-src 'self'",
-      `connect-src 'self' ${apiBase} https://challenges.cloudflare.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com`,
-      "frame-src https://challenges.cloudflare.com",
+      `connect-src 'self' ${apiBase} https://challenges.cloudflare.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.hubspot.com https://*.hubapi.com https://*.hs-analytics.net`,
+      "frame-src https://challenges.cloudflare.com https://*.hubspot.com",
     ].join("; "),
   },
 ];


### PR DESCRIPTION
## Por quê

A **Content-Security-Policy** em [next.config.ts](frontend/next.config.ts) não incluía os domínios do HubSpot, mas [layout.tsx](frontend/src/app/layout.tsx) carrega o script de tracking via `<Script src="//js.hs-scripts.com/49735644.js">`.

Confirmado em produção (`curl -I https://tribultz.com.br`): o `script-src` só permitia `'self'` + Cloudflare + Google, então o **script do HubSpot estava bloqueado** — tracking, chat e forms não funcionavam.

## O que muda

Adiciona os domínios oficiais do HubSpot (validados contra a doc/comunidade do HubSpot) por diretiva:

| Diretiva | Adicionado |
|----------|-----------|
| `script-src`  | `js.hs-scripts.com` `*.hs-scripts.com` `js.hs-analytics.net` `js.hs-banner.com` `js.hsadspixel.net` `js.usemessages.com` `*.hsforms.net` |
| `img-src`     | `*.hubspot.com` `*.hs-analytics.net` |
| `connect-src` | `*.hubspot.com` `*.hubapi.com` `*.hs-analytics.net` |
| `frame-src`   | `*.hubspot.com` |

## Verificação

- `npm run build` → OK
- Server local: header `Content-Security-Policy` confirmado com os domínios do HubSpot (`hs-scripts.com`, `hubapi.com`, `hs-analytics.net` etc.).

## Deploy

Frontend via **Vercel** (não dispara o workflow da VM). A CSP é emitida pelo `next.config.ts`, então o merge já aplica.
