### PR TITLE
chore(infra): documenta vars do Sentry no .env.prod.template

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -42,6 +42,14 @@ ENVIRONMENT=production
 ALLOWED_ORIGINS=https://tribultz.com.br,https://www.tribultz.com.br
 FRONTEND_URL=https://tribultz.com.br
 
+# ── Observabilidade / Sentry (error tracking) ────────────────────────────────
+# Backend lê estas vars (app/config.py). Sem SENTRY_DSN o init é no-op.
+# Pode ser definido aqui ou via workflow "ops-set-sentry.yml" (Actions).
+# DSN obtido em: sentry.io → Project → Settings → Client Keys (DSN)
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.0
+SENTRY_RELEASE=
+
 # ── Cloudflare Turnstile (CAPTCHA) ───────────────────────────────────────────
 CAPTCHA_ENABLED=true
 TURNSTILE_SECRET_KEY=REQUIRED_FROM_CLOUDFLARE_DASHBOARD


### PR DESCRIPTION
## O que muda

O backend (`backend/app/config.py` + `init_sentry()` em `main.py`) lê `SENTRY_DSN` / `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_RELEASE`, e existe o workflow `ops-set-sentry.yml`, mas o `.env.prod.template` não documentava essas vars.

Adicionadas ao template (vazias por padrão; `init_sentry()` é no-op sem `SENTRY_DSN`), para que o `.env` da VM tenha a referência.

## Escopo
- Apenas `.env.prod.template`. Sem mudança de código/runtime/build.
