### PR TITLE
feat(roi): chain LLM 100% free + router de segurança + template fiel

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -80,9 +80,13 @@ HUBSPOT_API_BASE_URL=https://api.hubapi.com
 OPENROUTER_API_KEY=REQUIRED_FROM_OPENROUTER
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 CREW_MEMORY_TTL_SECONDS=3600
-LLM_FREE_PRIMARY=openai/gpt-4o-mini
-LLM_FREE_FALLBACK=anthropic/claude-haiku
-LLM_PAID_FALLBACK=anthropic/claude-sonnet-4-5
+# A cadeia de modelos é definida EM CÓDIGO (backend/app/crews/llm_config.py →
+# DEFAULT_FALLBACK_CHAIN): 6 tiers 100% FREE no OpenRouter (gpt-oss-20b/120b,
+# trinity-large, nemotron-super, gemma-4, llama-3.3-70b). Custo de LLM = R$ 0.
+# Não há var de env para trocar os modelos — editar llm_config.py se necessário.
+# (As antigas LLM_FREE_PRIMARY/LLM_FREE_FALLBACK/LLM_PAID_FALLBACK não eram
+#  lidas pelo runtime e apontavam para modelos PAGOS — removidas para não induzir
+#  configuração que geraria custo à toa.)
 
 # ── APIs Externas ─────────────────────────────────────────────────────────────
 CLASSTRIB_API_URL=https://dfe-api.svrs.rs.gov.br/api/ClassTrib

--- a/.env.prod.template
+++ b/.env.prod.template
@@ -89,8 +89,9 @@ OPENROUTER_API_KEY=REQUIRED_FROM_OPENROUTER
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 CREW_MEMORY_TTL_SECONDS=3600
 # A cadeia de modelos é definida EM CÓDIGO (backend/app/crews/llm_config.py →
-# DEFAULT_FALLBACK_CHAIN): 6 tiers 100% FREE no OpenRouter (gpt-oss-20b/120b,
-# trinity-large, nemotron-super, gemma-4, llama-3.3-70b). Custo de LLM = R$ 0.
+# DEFAULT_FALLBACK_CHAIN): 7 tiers 100% FREE no OpenRouter (gpt-oss-20b/120b,
+# trinity-large, nemotron-super, gemma-4, llama-3.3-70b + router openrouter/free
+# como rede de segurança). Custo de LLM = R$ 0.
 # Não há var de env para trocar os modelos — editar llm_config.py se necessário.
 # (As antigas LLM_FREE_PRIMARY/LLM_FREE_FALLBACK/LLM_PAID_FALLBACK não eram
 #  lidas pelo runtime e apontavam para modelos PAGOS — removidas para não induzir

--- a/backend/app/crews/llm_config.py
+++ b/backend/app/crews/llm_config.py
@@ -4,15 +4,18 @@ LLM configuration with tiered fallback for CrewAI agents.
 Benchmark realizado em 08/04/2026 contra OpenRouter free tier.
 Todos os modelos abaixo suportam tool calling e são 100% free.
 
-Cadeia de fallback (6 tiers, diversificação de providers):
+Cadeia de fallback (7 tiers, diversificação de providers):
   T1  openai/gpt-oss-20b:free          3.4s  131K ctx  OpenAI  (US)     — mais rápido
   T2  arcee-ai/trinity-large:free      8.3s  131K ctx  Arcee   (US)
   T3  openai/gpt-oss-120b:free         9.6s  131K ctx  OpenAI  (US)     — maior
   T4  nvidia/nemotron-3-super:free     11.6s 262K ctx  NVIDIA  (US)     — maior ctx
   T5  google/gemma-4-31b:free          ~429  262K ctx  Google  (US/EU)  — qualidade
   T6  meta-llama/llama-3.3-70b:free   ~429   65K ctx  Meta    (US)     — último recurso
+  T7  openrouter/free (router)          dyn   dyn      OpenRouter        — rede de segurança
 
 T5 e T6 ficam em 429 sob alta carga mas recuperam após backoff.
+T7 é o router free do OpenRouter: auto-seleciona um modelo free disponível
+filtrando por tool calling — resiliente à volatilidade do free tier.
 Nenhum modelo pago na cadeia — 100% free tier.
 """
 
@@ -105,6 +108,18 @@ TIER_LLAMA33_70B = ModelTier(
     backoff_base=2.0,
 )
 
+# Rede de segurança: router free do OpenRouter. Auto-seleciona um modelo free
+# disponível filtrando por tool calling. Resiliente à volatilidade do free tier
+# (modelos saem da lista sem aviso). Só é acionado se TODOS os tiers acima
+# falharem — garante que a cadeia nunca "morre" e o custo continua R$ 0.
+TIER_FREE_ROUTER = ModelTier(
+    name="openrouter-free-router",
+    model_id="openrouter/openrouter/free",
+    is_free=True,
+    max_retries=3,
+    backoff_base=2.0,
+)
+
 # Cadeia padrão — ordem por confiabilidade observada no benchmark
 DEFAULT_FALLBACK_CHAIN: list[ModelTier] = [
     TIER_GPT_OSS_20B,      # primário: mais rápido (3.4s), confiável
@@ -113,6 +128,7 @@ DEFAULT_FALLBACK_CHAIN: list[ModelTier] = [
     TIER_NEMOTRON_SUPER,   # 4º: 11.6s, 262K ctx, NVIDIA
     TIER_GEMMA4_31B,       # 5º: alta qualidade, pode 429
     TIER_LLAMA33_70B,      # 6º: último recurso, provado em PT-BR
+    TIER_FREE_ROUTER,      # 7º: rede de segurança — router free auto-seleciona
 ]
 
 # Aliases para compatibilidade retroativa

--- a/backend/tests/crews/test_llm_config.py
+++ b/backend/tests/crews/test_llm_config.py
@@ -11,6 +11,7 @@ from app.crews.llm_config import (
     TIER_NEMOTRON_SUPER,
     TIER_GEMMA4_31B,
     TIER_LLAMA33_70B,
+    TIER_FREE_ROUTER,
     LLMUnavailableError,
     ModelTier,
     _is_overloaded_or_rate_limited,
@@ -37,8 +38,8 @@ class TestModelTiers:
         assert FREE_FALLBACK.is_free is True
         assert "free" in FREE_FALLBACK.model_id
 
-    def test_default_chain_has_six_tiers(self):
-        assert len(DEFAULT_FALLBACK_CHAIN) == 6
+    def test_default_chain_has_seven_tiers(self):
+        assert len(DEFAULT_FALLBACK_CHAIN) == 7
 
     def test_default_chain_order(self):
         assert DEFAULT_FALLBACK_CHAIN == [
@@ -48,7 +49,14 @@ class TestModelTiers:
             TIER_NEMOTRON_SUPER,
             TIER_GEMMA4_31B,
             TIER_LLAMA33_70B,
+            TIER_FREE_ROUTER,
         ]
+
+    def test_free_router_is_last_resort(self):
+        """O router free é a rede de segurança — sempre o último tier."""
+        assert DEFAULT_FALLBACK_CHAIN[-1] == TIER_FREE_ROUTER
+        assert TIER_FREE_ROUTER.is_free is True
+        assert TIER_FREE_ROUTER.model_id == "openrouter/openrouter/free"
 
     def test_all_tiers_are_free(self):
         """Benchmark 08/04/2026: 100% free tier, zero paid models."""
@@ -56,9 +64,12 @@ class TestModelTiers:
             assert tier.is_free is True, f"Tier {tier.name} must be free"
 
     def test_all_tiers_have_tool_calling_models(self):
-        """All models in the chain must be tool-calling capable (benchmark verified)."""
+        """All models são free + tool-calling (modelos :free do benchmark + router free)."""
         for tier in DEFAULT_FALLBACK_CHAIN:
-            assert ":free" in tier.model_id, f"Tier {tier.name} must use a :free model"
+            assert tier.is_free is True, f"Tier {tier.name} must be free"
+            assert ":free" in tier.model_id or tier.model_id.endswith("/free"), (
+                f"Tier {tier.name} must use a :free model or the openrouter/free router"
+            )
 
     def test_primary_is_fastest_model(self):
         """gpt-oss-20b was fastest in benchmark (3.4s) — should be first."""


### PR DESCRIPTION
## ROI / eficiência — LLM 100% free, mais resiliente

### 1. Template não induz mais a modelos pagos
O runtime roteia LLM pela `DEFAULT_FALLBACK_CHAIN` em [llm_config.py](backend/app/crews/llm_config.py) — **free**. Mas o `.env.prod.template` documentava modelos **pagos** (`gpt-4o-mini`, `claude-haiku`, `claude-sonnet-4-5`) em vars que **não são lidas pelo runtime**. Removidas → evita que alguém religue e passe a pagar LLM à toa.

### 2. Router free como 7º tier (rede de segurança) — foco em fallback free de alto desempenho
Modelos free são voláteis no OpenRouter (saem da lista sem aviso — ex.: Kimi K2.6). Adicionei `TIER_FREE_ROUTER` (`openrouter/openrouter/free`) no fim da cadeia: o [router free](https://openrouter.ai/openrouter/free) **auto-seleciona** um modelo free disponível filtrando por **tool calling**. Garante que a cadeia nunca "morra", mantendo **custo R$ 0** mesmo se algum tier for descontinuado.

Os 6 tiers benchmarkados (08/04/2026) foram **mantidos intactos** — só adicionei a rede de segurança no fim.

## Verificação
- `tests/crews/test_llm_config.py`: **30 testes passando** (atualizados p/ 7 tiers + asserção que aceita o `/free` do router).
- `ruff`: limpo.
- Demais falhas da suíte são DB local (`connection refused`), não relacionadas.

## Escopo
- `backend/app/crews/llm_config.py` (novo tier + docstring)
- `backend/tests/crews/test_llm_config.py`
- `.env.prod.template` (comentário fiel: 7 tiers, 100% free)

Fonte do router: [OpenRouter — Free Models Router](https://openrouter.ai/openrouter/free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)