### PR TITLE
feat(analytics): instrumenta funil de aquisição no GA4 (sign_up, begin_checkout, generate_lead)

### DIFF
--- a/frontend/src/app/billing/page.tsx
+++ b/frontend/src/app/billing/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { apiFetch } from "@/lib/api";
+import { track } from "@/lib/analytics";
 import {
   getPlanSlug,
   setPlanSlug,
@@ -114,6 +115,7 @@ export default function BillingPage() {
         method: "POST",
         body: JSON.stringify({ plan_slug: targetSlug, billing_type: "PIX" }),
       });
+      track("begin_checkout", { plan: targetSlug, context: "upgrade" });
       setUpgradeResult(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro ao processar upgrade.");

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { PublicNavbar } from "@/components/public/PublicNavbar";
+import { WhatsAppLink } from "@/components/public/WhatsAppLink";
 import { PublicFooter } from "@/components/public/PublicFooter";
 import { NewsFeed } from "@/components/public/NewsFeed";
 import { RULES_COUNT, CLASSTRIB_COUNT } from "@/lib/validation/rulesMeta";
@@ -85,23 +86,22 @@ function WhatsAppIcon({ size = 18 }: { size?: number }) {
   );
 }
 
-function WhatsAppButton({ label = "Falar pelo WhatsApp", variant = "green" }: { label?: string; variant?: "green" | "outline-white" | "outline-dark" }) {
+function WhatsAppButton({ label = "Falar pelo WhatsApp", variant = "green", source = "cta" }: { label?: string; variant?: "green" | "outline-white" | "outline-dark"; source?: string }) {
   const styles: Record<string, React.CSSProperties> = {
     green: { background: "#25D366", color: "#fff", boxShadow: "0 8px 24px rgba(37,211,102,0.30)" },
     "outline-white": { background: "transparent", color: "#fff", border: "1.5px solid rgba(255,255,255,0.55)" },
     "outline-dark": { background: "transparent", color: "#25D366", border: "1.5px solid #25D366" },
   };
   return (
-    <a
+    <WhatsAppLink
       href={WA_URL}
-      target="_blank"
-      rel="noopener noreferrer"
+      source={source}
       className="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-bold transition-all hover:brightness-95 hover:scale-[1.02]"
       style={styles[variant]}
     >
       <WhatsAppIcon />
       {label}
-    </a>
+    </WhatsAppLink>
   );
 }
 
@@ -221,7 +221,7 @@ export default function HomePage() {
                   >
                     Criar conta grátis →
                   </Link>
-                  <WhatsAppButton label="Falar com a gente" variant="outline-dark" />
+                  <WhatsAppButton label="Falar com a gente" variant="outline-dark" source="hero" />
                   <Link href="/diagnostico" className="text-sm font-semibold text-[#2956E3] underline-offset-4 hover:underline">
                     Ver como funciona
                   </Link>
@@ -299,7 +299,7 @@ export default function HomePage() {
               <p className="text-base font-bold text-[#24292E]">NF-e rejeitada? Penalidades CBS/IBS chegam em agosto/2026.</p>
               <p className="mt-1 text-sm text-[#334155]">Nosso time fiscal responde em minutos — sem enrolação. <span className="font-semibold">(51) 99188-1026</span>.</p>
             </div>
-            <WhatsAppButton label="Chamar agora" variant="green" />
+            <WhatsAppButton label="Chamar agora" variant="green" source="cta_meio" />
           </div>
         </section>
 
@@ -400,23 +400,21 @@ export default function HomePage() {
               </p>
             </div>
             <div className="flex shrink-0 flex-wrap gap-3">
-              <a
+              <WhatsAppLink
                 href={WA_REJEICAO}
-                target="_blank"
-                rel="noopener noreferrer"
+                source="rejeicao_1024"
                 className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 text-sm font-bold text-white hover:bg-red-700"
               >
                 <WhatsAppIcon size={16} />
                 Resolver a Rejeição 1024
-              </a>
-              <a
+              </WhatsAppLink>
+              <WhatsAppLink
                 href={WA_ERP}
-                target="_blank"
-                rel="noopener noreferrer"
+                source="integrar_erp"
                 className="inline-flex items-center gap-2 rounded-lg border border-red-300 bg-white px-5 py-2.5 text-sm font-semibold text-red-700 hover:bg-red-50"
               >
                 Integrar ao ERP →
-              </a>
+              </WhatsAppLink>
             </div>
           </div>
         </section>
@@ -456,7 +454,7 @@ export default function HomePage() {
                   >
                     Criar conta grátis
                   </Link>
-                  <WhatsAppButton label="Falar com um especialista" variant="outline-white" />
+                  <WhatsAppButton label="Falar com um especialista" variant="outline-white" source="cta_final" />
                   <Link href="/pricing" className="text-sm font-semibold text-white underline underline-offset-4 opacity-80 hover:opacity-100">
                     Ver todos os planos
                   </Link>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -5,6 +5,7 @@ import { FormEvent, useRef, useState } from "react";
 import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { Toast } from "@/components/common/Toast";
 import { registerWithApi } from "@/lib/api";
+import { track } from "@/lib/analytics";
 
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
@@ -146,7 +147,10 @@ export default function RegisterPage() {
         captcha_token: captchaToken,
       });
 
+      track("sign_up", { method: accountType, plan: planSlug });
+
       if (isPaidPlan && (result.checkout_url || result.pix_qr_code)) {
+        track("begin_checkout", { plan: planSlug, payment: billingType });
         setPaymentData({
           checkout_url: result.checkout_url,
           pix_qr_code: result.pix_qr_code,

--- a/frontend/src/components/public/WhatsAppLink.tsx
+++ b/frontend/src/components/public/WhatsAppLink.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { CSSProperties, ReactNode } from "react";
+import { track } from "@/lib/analytics";
+
+/**
+ * Link de WhatsApp com tracking de lead (GA4 `generate_lead`).
+ *
+ * Wrapper client genérico: preserva o estilo de cada CTA (className/style) e só
+ * adiciona o disparo do evento no clique. Server components podem renderizá-lo
+ * normalmente passando `children` (ícone + label) já renderizados.
+ */
+export function WhatsAppLink({
+  href,
+  source,
+  className,
+  style,
+  children,
+}: {
+  href: string;
+  /** Origem do lead, vira parâmetro do evento (ex.: "hero", "rejeicao_1024"). */
+  source: string;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      style={style}
+      onClick={() => track("generate_lead", { method: "whatsapp", source })}
+    >
+      {children}
+    </a>
+  );
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,0 +1,17 @@
+/**
+ * Disparo de eventos GA4 (gtag) para o funil de aquisição.
+ *
+ * No-op no SSR e quando não há consentimento — o gtag respeita o Consent Mode
+ * configurado em layout.tsx (analytics_storage começa "denied"). Ver [[consent]].
+ *
+ * Taxonomia (eventos recomendados do GA4):
+ *   - sign_up        → cadastro concluído
+ *   - begin_checkout → início de checkout de plano pago (ASAAS)
+ *   - generate_lead  → lead de alta intenção (clique no WhatsApp)
+ */
+type GtagParams = Record<string, unknown>;
+
+export function track(event: string, params: GtagParams = {}): void {
+  if (typeof window === "undefined") return;
+  window.gtag?.("event", event, params);
+}


### PR DESCRIPTION
## Objetivo
Medir **aquisição de clientes de alto desempenho** no GA4 — hoje só havia `page_view`. Adiciona os eventos do funil (nomenclatura recomendada do GA4) para conectar tráfego → lead → cadastro → checkout.

## Eventos instrumentados
| Evento | Onde dispara | Parâmetros |
|--------|--------------|-----------|
| `sign_up` | cadastro concluído ([register](frontend/src/app/register/page.tsx)) | `method` (empresa/contador), `plan` |
| `begin_checkout` | início de checkout de plano pago (register + [billing/upgrade](frontend/src/app/billing/page.tsx)) | `plan`, `payment`/`context` |
| `generate_lead` | clique no WhatsApp na landing | `method=whatsapp`, `source` (hero, cta_meio, cta_final, rejeicao_1024, integrar_erp) |

## Implementação
- [lib/analytics.ts](frontend/src/lib/analytics.ts): helper `track()` — no-op no SSR e **respeita o Consent Mode** (só conta após "Aceitar").
- [components/public/WhatsAppLink.tsx](frontend/src/components/public/WhatsAppLink.tsx): client link com tracking, preservando o estilo de cada CTA. `page.tsx` (server) o renderiza normalmente.

## Verificação
- `npm run build` ✅ · `eslint` dos arquivos alterados sem erros (só warnings pré-existentes).
- Validação end-to-end (eventos no GA DebugView/Realtime) após deploy na Vercel.

## Próximo passo (config GA, fora deste PR)
Marcar `sign_up`, `begin_checkout`, `generate_lead` como **eventos-chave (conversões)** no GA4 assim que começarem a aparecer.