### PR TITLE
feat(analytics): evento purchase no GA4 (server-side) via webhook ASAAS

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -50,6 +50,12 @@ SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.0
 SENTRY_RELEASE=
 
+# ── GA4 Measurement Protocol (evento purchase server-side) ───────────────────
+# Sem GA4_MP_API_SECRET → envio é no-op. Secret criado em:
+# GA4 → Admin → Fluxos de dados → (stream) → Measurement Protocol API secrets.
+GA4_MEASUREMENT_ID=G-KJ986WZ5ZJ
+GA4_MP_API_SECRET=
+
 # ── Cloudflare Turnstile (CAPTCHA) ───────────────────────────────────────────
 CAPTCHA_ENABLED=true
 TURNSTILE_SECRET_KEY=REQUIRED_FROM_CLOUDFLARE_DASHBOARD

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -47,6 +47,12 @@ class Settings(BaseSettings):
     SENTRY_TRACES_SAMPLE_RATE: float = 0.0
     SENTRY_RELEASE: str = ""
 
+    # ── GA4 Measurement Protocol (eventos server-side, ex.: purchase) ───────
+    # Sem API secret → envio é no-op. O api_secret é criado em:
+    # GA4 → Admin → Fluxos de dados → (stream) → Measurement Protocol API secrets.
+    GA4_MEASUREMENT_ID: str = "G-KJ986WZ5ZJ"
+    GA4_MP_API_SECRET: str = ""
+
     # ── Turnstile (CAPTCHA) ─────────────────────────────────
     TURNSTILE_SECRET_KEY: str = ""
     CAPTCHA_ENABLED: bool = False

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -186,7 +186,7 @@ async def asaas_webhook(
                 ga4_purchase.delay(
                     user_id=str(sub.user_id),
                     transaction_id=str(asaas_payment_id),
-                    value=round(int(confirmed_plan.price_cents) / 100, 2),
+                    value=round(int(confirmed_plan.price_cents) / 100, 2),  # type: ignore[arg-type]
                     plan=str(confirmed_plan.name),
                 )
 

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -180,6 +180,16 @@ async def asaas_webhook(
             from app.tasks.task_crm import crm_sync
             crm_sync.delay(user_id=str(sub.user_id), event_type="payment_confirmed")
 
+            # GA4 purchase (server-side): receita por usuário/canal. No-op sem secret.
+            if confirmed_plan:
+                from app.tasks.task_g_billing import ga4_purchase
+                ga4_purchase.delay(
+                    user_id=str(sub.user_id),
+                    transaction_id=str(asaas_payment_id),
+                    value=round(int(confirmed_plan.price_cents) / 100, 2),
+                    plan=str(confirmed_plan.name),
+                )
+
         return {"status": "ok", "action": "payment_confirmed"}
 
     # ── PAYMENT_OVERDUE ──

--- a/backend/app/services/ga4_mp.py
+++ b/backend/app/services/ga4_mp.py
@@ -1,0 +1,81 @@
+"""GA4 Measurement Protocol — envio de eventos server-side.
+
+Usado para o evento de receita `purchase`, que não pode ser disparado no
+navegador: o checkout ASAAS é hospedado (o usuário sai do site) e a confirmação
+chega no webhook do backend. Enviar `purchase` daqui fecha o ROI real
+(receita por canal/usuário).
+
+No-op sem `GA4_MP_API_SECRET` (mesmo padrão do Sentry) — zero impacto em dev/CI.
+O api_secret é criado em: GA4 → Admin → Fluxos de dados → Measurement Protocol.
+
+Limitação conhecida: sem o client_id real do navegador (cookie _ga), o evento
+não é "costurado" à sessão web do usuário. Usamos um client_id estável derivado
+do user_id — suficiente para contabilizar receita; o stitching completo (capturar
+o _ga no checkout) fica como follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_MP_URL = "https://www.google-analytics.com/mp/collect"
+
+
+def send_purchase(
+    *,
+    client_id: str,
+    transaction_id: str,
+    value: float,
+    plan: str,
+    currency: str = "BRL",
+    user_id: str | None = None,
+) -> bool:
+    """Envia um evento `purchase` ao GA4 via Measurement Protocol.
+
+    Retorna True se o request foi enviado, False se foi no-op (sem secret) ou falhou.
+    Nunca levanta — telemetria não pode quebrar o fluxo de pagamento.
+    """
+    if not settings.GA4_MP_API_SECRET or not settings.GA4_MEASUREMENT_ID:
+        return False
+
+    payload: dict = {
+        "client_id": client_id,
+        "events": [
+            {
+                "name": "purchase",
+                "params": {
+                    "transaction_id": transaction_id,
+                    "value": value,
+                    "currency": currency,
+                    "items": [{"item_name": plan, "price": value, "quantity": 1}],
+                },
+            }
+        ],
+    }
+    if user_id:
+        payload["user_id"] = user_id
+
+    try:
+        resp = httpx.post(
+            _MP_URL,
+            params={
+                "measurement_id": settings.GA4_MEASUREMENT_ID,
+                "api_secret": settings.GA4_MP_API_SECRET,
+            },
+            json=payload,
+            timeout=5.0,
+        )
+        # GA4 MP responde 2xx mesmo para payloads inválidos; logamos não-2xx.
+        if resp.status_code >= 300:
+            logger.warning("GA4 MP purchase status=%s body=%s", resp.status_code, resp.text[:200])
+            return False
+        return True
+    except Exception as exc:  # noqa: BLE001 — telemetria nunca quebra o webhook
+        logger.warning("GA4 MP purchase falhou: %s", exc)
+        return False

--- a/backend/app/tasks/task_g_billing.py
+++ b/backend/app/tasks/task_g_billing.py
@@ -172,3 +172,23 @@ def reset_monthly_usage():
         raise
     finally:
         db.close()
+
+
+@celery.task(name="billing.ga4_purchase")
+def ga4_purchase(user_id: str, transaction_id: str, value: float, plan: str) -> dict:
+    """Envia o evento `purchase` ao GA4 (Measurement Protocol) após pagamento confirmado.
+
+    Roda fora do request do webhook (não bloqueia a resposta ao ASAAS).
+    No-op se GA4_MP_API_SECRET não estiver configurado.
+    """
+    from app.services.ga4_mp import send_purchase
+
+    sent = send_purchase(
+        client_id=user_id,
+        transaction_id=transaction_id,
+        value=value,
+        plan=plan,
+        user_id=user_id,
+    )
+    logger.info("ga4_purchase tx=%s value=%s sent=%s", transaction_id, value, sent)
+    return {"sent": sent, "transaction_id": transaction_id}

--- a/backend/tests/test_ga4_mp.py
+++ b/backend/tests/test_ga4_mp.py
@@ -1,0 +1,72 @@
+"""Tests for GA4 Measurement Protocol service (server-side purchase event)."""
+from __future__ import annotations
+
+from app.services import ga4_mp
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 204, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+def test_noop_without_api_secret(monkeypatch):
+    """Sem GA4_MP_API_SECRET, não envia nada e retorna False."""
+    monkeypatch.setattr(ga4_mp.settings, "GA4_MP_API_SECRET", "", raising=False)
+    called = False
+
+    def _fake_post(*args, **kwargs):  # pragma: no cover - não deve ser chamado
+        nonlocal called
+        called = True
+        return _FakeResponse()
+
+    monkeypatch.setattr(ga4_mp.httpx, "post", _fake_post)
+    sent = ga4_mp.send_purchase(client_id="u1", transaction_id="pay_1", value=149.0, plan="Profissional")
+    assert sent is False
+    assert called is False
+
+
+def test_sends_purchase_with_correct_payload(monkeypatch):
+    monkeypatch.setattr(ga4_mp.settings, "GA4_MP_API_SECRET", "secret-123", raising=False)
+    monkeypatch.setattr(ga4_mp.settings, "GA4_MEASUREMENT_ID", "G-TEST", raising=False)
+    captured: dict = {}
+
+    def _fake_post(url, params=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        captured["json"] = json
+        return _FakeResponse(status_code=204)
+
+    monkeypatch.setattr(ga4_mp.httpx, "post", _fake_post)
+    sent = ga4_mp.send_purchase(
+        client_id="user-9", transaction_id="pay_42", value=149.0, plan="Profissional", user_id="user-9"
+    )
+
+    assert sent is True
+    assert captured["params"] == {"measurement_id": "G-TEST", "api_secret": "secret-123"}
+    body = captured["json"]
+    assert body["client_id"] == "user-9"
+    assert body["user_id"] == "user-9"
+    event = body["events"][0]
+    assert event["name"] == "purchase"
+    assert event["params"]["transaction_id"] == "pay_42"
+    assert event["params"]["value"] == 149.0
+    assert event["params"]["currency"] == "BRL"
+    assert event["params"]["items"][0]["item_name"] == "Profissional"
+
+
+def test_never_raises_on_network_error(monkeypatch):
+    monkeypatch.setattr(ga4_mp.settings, "GA4_MP_API_SECRET", "secret-123", raising=False)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(ga4_mp.httpx, "post", _boom)
+    # Não deve levantar — telemetria nunca quebra o webhook de pagamento.
+    assert ga4_mp.send_purchase(client_id="u", transaction_id="t", value=1.0, plan="X") is False
+
+
+def test_non_2xx_returns_false(monkeypatch):
+    monkeypatch.setattr(ga4_mp.settings, "GA4_MP_API_SECRET", "secret-123", raising=False)
+    monkeypatch.setattr(ga4_mp.httpx, "post", lambda *a, **k: _FakeResponse(status_code=400, text="bad"))
+    assert ga4_mp.send_purchase(client_id="u", transaction_id="t", value=1.0, plan="X") is False


### PR DESCRIPTION
## Por quê
O `begin_checkout` é client-side (#379), mas o **`purchase` não pode ser** — o checkout ASAAS é hospedado (o usuário sai do site) e a confirmação chega no **webhook** `/billing/webhooks/asaas`. Sem isso, o GA não tem o evento de **receita**, e o ROI por canal/usuário fica incompleto.

## O que muda
- [services/ga4_mp.py](backend/app/services/ga4_mp.py): `send_purchase()` via **GA4 Measurement Protocol** (`value`, `currency=BRL`, `items=[plano]`). **No-op sem `GA4_MP_API_SECRET`** (padrão do Sentry).
- [tasks/task_g_billing.py](backend/app/tasks/task_g_billing.py): task `billing.ga4_purchase` — roda fora do request, **não bloqueia** a resposta ao ASAAS.
- [routers/billing.py](backend/app/routers/billing.py): dispara `ga4_purchase.delay()` no `PAYMENT_CONFIRMED` (valor = `price_cents/100`, tx = `asaas_payment_id`).
- `config.py` + `.env.prod.template`: `GA4_MEASUREMENT_ID` / `GA4_MP_API_SECRET`.

## Verificação
- `tests/test_ga4_mp.py`: **4 testes** (no-op sem secret, payload correto, nunca levanta em erro de rede, não-2xx → False). ✅
- `ruff` limpo · `py_compile` OK.

## Config necessária (sua, no painel/VM)
1. GA4 → Admin → Fluxos de dados → **Measurement Protocol API secrets** → criar secret.
2. Setar `GA4_MP_API_SECRET` no `.env` da VM. (Não é rotação de chave — é provisionamento de um secret novo.)

## Limitação conhecida / follow-up
`client_id` é derivado do `user_id` (conta receita corretamente, mas não "costura" à sessão web). Follow-up: capturar o `_ga` client_id no checkout e persistir para atribuição completa.
