### PR TITLE
fix(observability): Sentry também no Celery (worker + beat)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -3,6 +3,11 @@
 from celery import Celery
 from celery.schedules import crontab
 from app.config import settings
+from app.core.observability import init_sentry
+
+# Error tracking nos processos worker/beat (no-op sem SENTRY_DSN).
+# A API inicializa em app/main.py; aqui cobrimos as tasks de fundo.
+init_sentry()
 
 celery = Celery(
     "tribultz",

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -25,6 +25,7 @@ def init_sentry() -> bool:
 
     try:
         import sentry_sdk
+        from sentry_sdk.integrations.celery import CeleryIntegration
         from sentry_sdk.integrations.fastapi import FastApiIntegration
         from sentry_sdk.integrations.starlette import StarletteIntegration
 
@@ -35,7 +36,8 @@ def init_sentry() -> bool:
             traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
             # Não enviar PII (cabeçalhos/corpo) — dados fiscais são sensíveis (LGPD).
             send_default_pii=False,
-            integrations=[StarletteIntegration(), FastApiIntegration()],
+            # FastAPI/Starlette cobrem a API; Celery cobre worker e beat (tasks de fundo).
+            integrations=[StarletteIntegration(), FastApiIntegration(), CeleryIntegration()],
         )
         logger.info("Sentry inicializado (environment=%s)", settings.ENVIRONMENT)
         return True


### PR DESCRIPTION
## Gap encontrado ao revisar o Sentry
A API (`app/main.py`) inicializa o Sentry, mas o **processo Celery não** — então erros nas **tasks de fundo** (validação, relatório, billing, CRM, `ga4_purchase`, beat schedules) **não eram reportados**.

## O que muda
- [observability.py](backend/app/core/observability.py): adiciona `CeleryIntegration()` ao `sentry_sdk.init`.
- [celery_app.py](backend/app/celery_app.py): chama `init_sentry()` no boot do worker/beat (no-op sem `SENTRY_DSN`).

## Verificação
- `ruff` ✅ · `pyright` ✅ (0 erros) · `CeleryIntegration` disponível no `sentry-sdk[fastapi]==2.63.0` ✅
- 6 testes (sentry/observability/celery) passando.

## Notas sobre o free tier (Developer plan)
- `send_default_pii=False` mantido → não envia dados fiscais (LGPD) ✅
- `traces_sample_rate=0.0` (default) → **não gasta cota de performance/spans**, ideal pro free tier ✅
- Só falta (sua ação): garantir `SENTRY_DSN` no `.env` da VM (via workflow `ops-set-sentry.yml` ou direto).