### PR TITLE
feat(billing): gate de export auditável server-side (Path A — vê grátis / exporta pago)

### DIFF
--- a/frontend/src/app/validate-xml/page.tsx
+++ b/frontend/src/app/validate-xml/page.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 import { ChangeEvent, FormEvent, useMemo, useState } from "react";
 import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
-import { generateCorrectedXml, getJob, openExceptionRequest, validateXml } from "@/lib/api";
-import { buildAuditableReportCsv, buildAuditableReportHtml, downloadCsv, downloadPdf } from "@/lib/export/auditableReport";
+import { downloadJobReportPdf, generateCorrectedXml, getJob, openExceptionRequest, PlanRequiredError, validateXml } from "@/lib/api";
+import { canAccess } from "@/lib/plan";
 import { Finding, Job, ValidateXmlRequest, ValidationEvidence, ValidationResultV11, XmlDocumentType } from "@/lib/types";
 import { CST_TABLE, detectDocumentType } from "@/lib/validation/xmlRules";
 
@@ -49,6 +49,8 @@ export default function ValidateXmlPage() {
   const [correcting, setCorrecting] = useState(false);
   const [correctionDownloadUrl, setCorrectionDownloadUrl] = useState<string | null>(null);
   const [awaitingCorrectionConfirm, setAwaitingCorrectionConfirm] = useState(false);
+  const [exportingPdf, setExportingPdf] = useState(false);
+  const canExport = canAccess("hasPdfReports");
 
   const evidenceMap = useMemo(() => {
     const map = new Map<string, ValidationEvidence>();
@@ -120,6 +122,23 @@ export default function ValidateXmlPage() {
       setError(err instanceof Error ? err.message : "Falha ao validar XML.");
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function onExportPdf(): Promise<void> {
+    if (!result) return;
+    setToast(null);
+    setExportingPdf(true);
+    try {
+      await downloadJobReportPdf(result.job.id);
+    } catch (err) {
+      if (err instanceof PlanRequiredError) {
+        setToast({ tone: "info", msg: "Relatório PDF auditável disponível nos planos Profissional e Contador." });
+      } else {
+        setToast({ tone: "error", msg: err instanceof Error ? err.message : "Falha ao gerar o relatório PDF." });
+      }
+    } finally {
+      setExportingPdf(false);
     }
   }
 
@@ -262,20 +281,24 @@ export default function ValidateXmlPage() {
               >
                 Abrir Audit
               </Link>
-              <button
-                type="button"
-                onClick={() => downloadCsv(buildAuditableReportCsv(result, documentType), result.job.id)}
-                className="rounded border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100"
-              >
-                CSV
-              </button>
-              <button
-                type="button"
-                onClick={() => downloadPdf(buildAuditableReportHtml(result, documentType), result.job.id)}
-                className="rounded border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100"
-              >
-                PDF
-              </button>
+              {canExport ? (
+                <button
+                  type="button"
+                  onClick={onExportPdf}
+                  disabled={exportingPdf}
+                  className="rounded border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100 disabled:opacity-70"
+                >
+                  {exportingPdf ? "Gerando..." : "Baixar PDF auditável"}
+                </button>
+              ) : (
+                <Link
+                  href="/billing"
+                  className="rounded border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-100"
+                  title="Exportação do relatório auditável (PDF) disponível nos planos Profissional e Contador"
+                >
+                  📄 Exportar PDF auditável — Profissional
+                </Link>
+              )}
               {awaitingCorrectionConfirm ? (
                 <span className="inline-flex items-center gap-2 rounded border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs text-amber-800">
                   <span>⚠️ Isso consumirá <strong>1 validação</strong> do seu plano.</span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -319,6 +319,51 @@ export async function exportJobEvidenceZip(jobId: string): Promise<JobEvidenceZi
   return { filename, bytes };
 }
 
+/** Sinaliza que o recurso exige plano pago (HTTP 403 do gate server-side). */
+export class PlanRequiredError extends Error {
+  constructor(message = "Recurso disponível em planos pagos.") {
+    super(message);
+    this.name = "PlanRequiredError";
+  }
+}
+
+/**
+ * Baixa o relatório PDF auditável do job via endpoint server-side **gated**
+ * (`GET /jobs/{id}/report.pdf`, exige Profissional/Contador). O artefato é
+ * gerado e autorizado no servidor — o gate não é burlável no cliente.
+ * Lança PlanRequiredError em 403.
+ */
+export async function downloadJobReportPdf(jobId: string): Promise<void> {
+  if (!jobId) throw new Error("jobId obrigatório para exportar o relatório.");
+
+  const res = await fetch(`${API_BASE}/api/v1/jobs/${encodeURIComponent(jobId)}/report.pdf`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${getToken()}`,
+      "X-Tenant-Id": getTenantId(),
+      Accept: "application/pdf",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    if (res.status === 403) throw new PlanRequiredError();
+    const detail = await res.text().catch(() => "Erro de API");
+    throw new Error(`API ${res.status}: ${detail}`);
+  }
+
+  const blob = await res.blob();
+  const filename = contentDispositionFilename(res.headers.get("content-disposition")) ?? `relatorio_${jobId}.pdf`;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 export async function openExceptionRequest(payload: {
   job_id: string;
   finding_id: string;


### PR DESCRIPTION
## Contexto (decisão de produto)
A auditoria expôs um FATAL **comercial**: o trial via a evidência on-screen (ok, ativação) **e também exportava** o relatório auditável montado no **browser**, furando os gates que já existem no servidor. Os botões CSV/PDF eram client-side (burláveis) — e o card de billing anuncia PDF como pago. Decisão: **Path A** — on-screen grátis (isca), **export = alavanca paga real, server-side**.

## O que muda
- **Remove a geração client-side** de PDF/CSV em [validate-xml](frontend/src/app/validate-xml/page.tsx).
- O export agora passa pelo endpoint **já gated** `GET /api/v1/jobs/{id}/report.pdf` (`require_plan("profissional","contador")` em [jobs.py:275](backend/app/routers/jobs.py:275)) → o artefato é gerado e autorizado **no servidor**. Não é burlável no cliente.
- **Trial/Starter**: CTA `📄 Exportar PDF auditável — Profissional` (→ `/billing`).
- **Profissional/Contador**: `Baixar PDF auditável` (download autenticado do servidor).
- [api.ts](frontend/src/lib/api.ts): `downloadJobReportPdf()` + `PlanRequiredError` (trata 403 como upgrade).

## Por que é "de verdade" (não burlável)
Defesa em profundidade: o gate de UI (`canAccess`) é só UX; **o enforcement real é o `require_plan` no endpoint do servidor**. Mesmo editando o cliente, o trial recebe **403**. Não há mais builder de artefato no browser do validate-xml.

## On-screen segue grátis
Findings, severidade, base legal (badges LC) e evidência de fonte continuam visíveis a todos — ativação preservada.

## Verificação
- `npm run build` ✅ · `npm test` 138/138 ✅ · eslint dos arquivos limpo (o único erro `any` em api.ts:456 é **pré-existente**, só deslocado pelas linhas novas).

## Nota / follow-up
O **CSV client-side** do validate-xml foi **removido** (era vetor de bypass e não é o artefato anunciado como pago). Se planos pagos pedirem CSV, adiciono um endpoint server CSV gated em follow-up.
