### PR TITLE
docs(marketing): versão final — âncora empresa emissora + tom deadline

### DIFF
--- a/docs/marketing/posicionamento-e-vendas.md
+++ b/docs/marketing/posicionamento-e-vendas.md
@@ -1,23 +1,37 @@
-# Instruções de Marketing & Vendas — Tribultz (RASCUNHO)
+# Instruções de Marketing & Vendas — Tribultz
+
+> **Decisões cravadas (29/06/2026):** público primário = **empresa que emite**
+> (âncora); tom = **agressivo/deadline** (Rejeição 1024 + penalidades ago-2026);
+> export auditável = **gate pago a partir do Profissional** (mantido, #384).
+> Contador é público **secundário** (expansão), não a âncora da copy.
 
 > **Princípio inegociável:** vender **só o que o produto entrega e gateia**. Cada
-> promessa de tier paga tem de bater com um gate **real** no código (server-side).
-> O prospecto deste mercado testa antes de assinar — blefe descoberto = venda
-> perdida + credibilidade perdida. Esta régua só é válida a partir do PR #384
-> (gate de export server-side); antes dele, PDF/evidência eram entregues de graça.
+> promessa de tier paga bate com um gate **real** no código (server-side, #384).
+> O prospecto testa antes de assinar — blefe descoberto = venda + credibilidade
+> perdidas.
 
-## 1. A régua: grátis (ativação) × pago (conversão)
+## 1. Posicionamento (âncora: empresa emissora)
+
+**Quem é o alvo:** empresa que **emite** NF-e/NFS-e/NFC-e e tem medo concreto de
+**Rejeição 1024** (CST × cClassTrib incompatível) e das **penalidades CBS/IBS a
+partir de agosto/2026** (fim do período pedagógico).
+
+**Mensagem-mãe:**
+> **"Sua NF-e vai ser rejeitada — e a partir de agosto/2026 isso vira multa. Veja de graça onde está o erro. Tenha o laudo auditável que comprova a correção."**
+
+A primeira frase vende o **risco** (agressivo), a segunda a **prova grátis**
+(ativação), a terceira o **artefato pago** (conversão).
+
+## 2. A régua: grátis (ativação) × pago (conversão)
 
 | | Entregue | Papel no funil |
 |---|---|---|
-| **Grátis (trial)** | Evidência **on-screen**: findings, severidade, **base legal** (LC citada), recomendação, evidência de fonte | **Ativação** — o prospecto *vê* funcionar e confia |
-| **Pago** | **Exportar o artefato auditável (PDF)** + volume + lote + multi-CNPJ + API + dashboard | **Conversão** — o entregável que vai pro contador/auditor/fisco |
+| **Grátis (trial)** | Evidência **on-screen**: findings, severidade, **base legal** (LC citada), recomendação, evidência de fonte | **Ativação** — o emissor *vê* o erro e o risco |
+| **Pago** | **Exportar o laudo auditável (PDF)** + volume + lote + multi-CNPJ + API + dashboard | **Conversão** — o documento que comprova/defende perante o fisco |
 
-Mensagem-mãe: **"Veja de graça que sua NF-e está certa. Pague para ter o documento auditável que comprova."**
+## 3. O que cada tier entrega (fonte: `frontend/src/lib/plan.ts` + gate #384)
 
-## 2. O que cada tier realmente entrega (fonte: `frontend/src/lib/plan.ts`)
-
-| Tier | Preço | Validações | Export PDF auditável | Lote | Multi-CNPJ | API | Dashboard |
+| Tier | Preço | Validações | Export PDF | Lote | Multi-CNPJ | API | Dashboard |
 |------|-------|-----------|:---:|:---:|:---:|:---:|:---:|
 | **Trial** | grátis (3 dias) | 5 (total) | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Starter** | R$ 49,90/mês | 10/mês | ❌ | ❌ | ❌ | ❌ | ✅ |
@@ -25,45 +39,50 @@ Mensagem-mãe: **"Veja de graça que sua NF-e está certa. Pague para ter o docu
 | **Empresarial** | R$ 249/mês | 2.000/mês | ✅ | ✅ | ✅ (até 10 CNPJs) | ✅ | ✅ |
 | **Contador** | R$ 349/mês | ilimitadas | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-**Fato comercial que marketing PRECISA respeitar:** o **export auditável (PDF) começa no Profissional**. Starter é "on-screen + dashboard + mais volume" — **não** exporta. A alavanca do artefato é o salto Starter→Profissional.
+**Fato comercial inviolável na copy:** o **export auditável (PDF) começa no
+Profissional**. **Starter NÃO exporta** — é "veja na tela + dashboard + mais
+volume". A alavanca do laudo é o salto **Starter → Profissional**.
 
-## 3. Ganchos de conversão reais (por que assinar)
+## 4. Funil de conversão (empresa emissora)
 
-1. **O artefato auditável (PDF)** — o documento com base legal que se entrega ao contador, anexa numa defesa de autuação ou arquiva como prova de compliance. Só no Profissional+. **Esta é a alavanca principal.**
-2. **Volume / continuidade** — 5 (trial) → 10 → 500 → 2.000 → ilimitado. Quem valida NF-e recorrentemente estoura a cota rápido.
-3. **Lote** (validação em massa) — Profissional+.
-4. **Multi-CNPJ (filiais)** — Empresarial (até 10) e Contador.
-5. **API** — integração ao ERP/automação — Profissional+.
+1. **Topo (medo):** anúncio/landing martela Rejeição 1024 + deadline ago-2026.
+2. **Ativação (prova grátis):** trial mostra o erro na tela com a LC citada — "está vendo? sua nota tem isto."
+3. **Conversão (o laudo):** "para corrigir com segurança e ter o **documento auditável** que comprova, assine o **Profissional**." O artefato é o gancho — e agora é pago de verdade.
+4. **Expansão:** volume (estoura a cota) → upgrade; filiais → Empresarial; escritório/carteira → Contador.
 
-## 4. Mensagens por persona
+## 5. Mensagens por persona (ordem de prioridade)
 
-- **Empresa pequena / emissor avulso (→ Starter/Profissional):** "Evite a Rejeição 1024 e as penalidades de ago/2026. Teste grátis; quando precisar do laudo auditável, assine."
-- **Empresa com volume / filiais (→ Empresarial):** "Valide em lote, até 10 CNPJs, com relatório auditável e API pro seu ERP."
-- **Contador / escritório (→ Contador):** "Validações ilimitadas, multi-CNPJ, justificativa técnica por finding e API — a ferramenta da sua carteira de clientes."
+1. **Empresa emissora avulsa/pequena (PRIMÁRIA → Profissional):**
+   "Pare de tomar Rejeição 1024. Valide grátis, corrija e **baixe o laudo auditável** antes que a multa de ago/2026 chegue."
+2. **Empresa com volume / filiais (→ Empresarial):**
+   "Valide em lote, até 10 CNPJs, laudo auditável e API pro seu ERP — compliance de CBS/IBS em escala."
+3. **Contador / escritório (SECUNDÁRIA → Contador):**
+   "Blinde sua carteira: validações ilimitadas, multi-CNPJ, justificativa técnica por finding e API." *(expansão, não a âncora da campanha inicial)*
 
-## 5. Guardrails para a máquina de vendas (GPT) — OBRIGATÓRIO
+## 6. Tom: agressivo / deadline (guia de escrita)
+
+- **Liderar com risco concreto:** "Rejeição 1024", "multa a partir de ago/2026", "fim do período pedagógico".
+- **Contador regressivo / prazo** é aceitável (ago-2026 é fato público, já usado no site).
+- **Verbos diretos:** "Pare de…", "Evite a multa", "Não emita no escuro".
+- **Limite ético:** urgência é sobre **fato regulatório real**, nunca FUD inventado. Não prometer imunidade a multa — prometer **evidência e laudo** que sustentam a correção.
+
+## 7. Guardrails para a máquina de vendas (GPT) — OBRIGATÓRIO
 
 **NUNCA:**
-- Prometer feature que não tem gate real (a régua acima é a fonte da verdade).
-- Dizer que **Starter** exporta PDF/relatório auditável — **não exporta**.
-- Inventar número de regras/códigos. Use os reais do produto (`RULES_COUNT`, `CLASSTRIB_COUNT`) — e não cite valor fixo que pode envelhecer.
-- Dar conselho fiscal/jurídico definitivo. A Tribultz **valida e evidencia**; a decisão é do contribuinte/contador.
+- Prometer feature sem gate real (a régua da seção 3 é a fonte da verdade).
+- Dizer que **Starter** exporta PDF/laudo — **não exporta**.
+- Inventar nº de regras/códigos — usar os reais do produto (`RULES_COUNT`, `CLASSTRIB_COUNT`), sem cravar valor que envelhece.
+- Dar conselho fiscal/jurídico definitivo nem **prometer que elimina multa**. A Tribultz **valida e evidencia**; a decisão é do contribuinte/contador.
 
 **SEMPRE:**
-- Vender a **evidência on-screen como prova grátis** (CTA: "teste e veja") e o **export auditável como o motivo de assinar**.
-- Ancorar urgência nos fatos do domínio já públicos no site: **Rejeição 1024** (erro CST × cClassTrib) e **penalidades CBS/IBS a partir de ago/2026** (fim do período pedagógico).
-- Ser honesto sobre limites: cota de validações é o limitador real do trial (5) e dos planos.
-- Direcionar a dúvida fiscal específica ao WhatsApp (lead `generate_lead`) — ver [[utm-conventions]] para marcar a origem.
+- Vender **on-screen = prova grátis** ("teste e veja o erro") e **export = motivo de assinar** (o laudo auditável).
+- Ancorar urgência em **Rejeição 1024** e **penalidades ago-2026** (fatos do site).
+- Ser honesto sobre limites: a **cota de validações** é o limitador real (trial = 5).
+- Mandar dúvida fiscal específica pro **WhatsApp** (evento `generate_lead`) com UTM ([[utm-conventions]]).
 
-## 6. Atribuição (fechar o loop com o GA4)
+## 8. Atribuição — fechar o loop (GA4)
 Todo link de campanha usa UTMs ([[utm-conventions]]). Os eventos do funil
-(`generate_lead` → `sign_up` → `begin_checkout` → `purchase`) já estão
-instrumentados, então marketing consegue medir **conversão e receita por canal**
-— a base para decidir onde investir.
-
----
-
-### Decisões que peço confirmação antes de finalizar
-1. **Salto Starter→Profissional (3×) para liberar export** — manter, ou criar um tier intermediário / permitir X exports/mês no Starter como gancho?
-2. **Tom de urgência** (Rejeição 1024 / ago/2026) — quão agressivo? Hoje o site já usa.
-3. Público-alvo primário para a copy inicial: **empresas** ou **contadores**?
+(`generate_lead` → `sign_up` → `begin_checkout` → `purchase`) estão
+instrumentados (#379/#380), então marketing mede **conversão e receita por
+canal** — base para realocar verba. KPI-âncora: **CAC por canal × receita
+(`purchase`)**.


### PR DESCRIPTION
## Versão final das instruções de marketing/vendas
Fecha o rascunho (#385) com as 3 decisões cravadas:

| Decisão | Escolha |
|---|---|
| Público primário | **Empresa que emite** (Rejeição 1024 / ago-2026); contador = secundário |
| Tom | **Agressivo / deadline** (fatos regulatórios reais, sem FUD) |
| Export por tier | **Mantido** — laudo auditável pago a partir do Profissional (#384) |

→ #384 e #385 ficam coerentes; **sem retrabalho de gate**.

## O que mudou no texto ([doc](docs/marketing/posicionamento-e-vendas.md))
- **Mensagem-mãe** reescrita no tom deadline: risco → prova grátis → laudo pago.
- **Posicionamento** ancorado na empresa emissora; personas reordenadas por prioridade (contador vira expansão).
- **Funil** explícito (medo → ativação on-screen → conversão pelo laudo → expansão por volume/filiais/carteira).
- **Guia de tom** agressivo com limite ético (urgência sobre fato regulatório real; nunca prometer "elimina multa").
- **Guardrails do GPT** atualizados (incl. "nunca prometer imunidade a multa").
- KPI-âncora: **CAC por canal × receita (`purchase`)**, fechando o loop com #379/#380 + UTMs (#381).
- Removido status RASCUNHO e a seção de decisões pendentes.
