### PR TITLE
docs(marketing): kit de copy (landing/ads/email/WhatsApp) + README índice

### DIFF
--- a/docs/marketing/README.md
+++ b/docs/marketing/README.md
@@ -1,0 +1,42 @@
+# Material de Marketing — Tribultz
+
+Ponto de entrada único do material de aquisição/vendas. Tudo aqui é coerente com
+o produto **real** (gates server-side, #384) e com as decisões cravadas em
+29/06/2026: **público primário = empresa que emite**, **tom agressivo/deadline**,
+**export auditável pago a partir do Profissional**.
+
+## Índice
+
+| Documento | O que é |
+|-----------|---------|
+| [posicionamento-e-vendas.md](posicionamento-e-vendas.md) | **Fonte da verdade** de posicionamento: régua grátis×pago, tiers, personas, guardrails, KPIs |
+| [system-prompt-gpt-vendas.md](system-prompt-gpt-vendas.md) | System prompt (markdown) para colar no GPT de vendas |
+| [copy/landing-hero.md](copy/landing-hero.md) | Headlines, sub, benefícios e CTAs da landing |
+| [copy/anuncios.md](copy/anuncios.md) | Variações Google Ads (RSA) e Meta |
+| [copy/email-whatsapp.md](copy/email-whatsapp.md) | Sequências de e-mail e mensagens de WhatsApp |
+| [../analytics/utm-conventions.md](../analytics/utm-conventions.md) | Padrão de UTMs (atribuição por canal) |
+
+## A régua, em uma linha
+**Veja de graça que sua NF-e está certa (on-screen). Pague para ter o laudo auditável que comprova (Profissional+).**
+
+## Fontes canônicas (não inventar/divergir)
+- **Preços e o que cada plano entrega:** site `tribultz.com.br` + `frontend/src/lib/plan.ts`.
+- **Gate de export:** `require_plan` no backend (#384) — export = Profissional+.
+- **Nº de regras/códigos:** valores reais do produto (`RULES_COUNT`, `CLASSTRIB_COUNT`) — nunca cravar número fixo na copy.
+
+## Guardrails (valem para toda peça e para o GPT)
+- ❌ Nunca prometer imunidade/eliminação de multa → ✅ "evidência e laudo que **sustentam** a correção".
+- ❌ Nunca dizer que **Starter exporta** o laudo → exporta só Profissional+.
+- ❌ Não dar parecer fiscal/jurídico definitivo → encaminhar caso específico ao **WhatsApp** do time.
+- ❌ Não inventar números/casos/descontos.
+
+## Medição (fecha o loop)
+Funil instrumentado no GA4: `generate_lead` → `sign_up` → `begin_checkout` →
+`purchase` (#379/#380). Toda campanha usa UTMs. **KPI-âncora: CAC por canal ×
+receita (`purchase`).**
+
+## Como usar
+1. Leia o **posicionamento** (contexto e limites).
+2. Pegue a **copy** do canal que vai rodar; marque os links com **UTM**.
+3. Para o atendimento automatizado, cole o **system prompt** no GPT de vendas.
+4. Acompanhe conversão/receita por canal no GA4 e realoque verba.

--- a/docs/marketing/copy/anuncios.md
+++ b/docs/marketing/copy/anuncios.md
@@ -1,0 +1,52 @@
+# Copy — Anúncios (Google & Meta)
+
+> Tom deadline, âncora empresa emissora. CTA = trial grátis (ou WhatsApp).
+> Marque os links com UTM ([utm-conventions](../../analytics/utm-conventions.md)).
+> Guardrails: sem promessa de imunidade a multa; Starter não exporta; nº de regras
+> não inventado.
+
+## Google Ads — Responsive Search Ad
+
+**Headlines (≤ 30 caracteres):**
+1. Pare a Rejeição 1024
+2. Valide CBS/IBS antes de emitir
+3. Multa de CBS/IBS em 2026
+4. cClassTrib errado? Corrija já
+5. Teste grátis sua NF-e
+6. Laudo auditável CBS/IBS
+7. NF-e sem rejeição
+8. CST × cClassTrib validado
+9. Reforma Tributária: fique ok
+10. Valide a LC 214 agora
+
+**Descriptions (≤ 90 caracteres):**
+1. Veja na tela onde sua NF-e erra, com a base legal. Teste grátis, sem cartão.
+2. Evite a Rejeição 1024 e a multa de ago/2026. Validação CST × cClassTrib.
+3. Laudo auditável em PDF para o contador e o fisco. Comece grátis.
+4. Validação CBS/IBS da LC 214 antes de emitir. Resultado na hora.
+
+**Sugestão de campanha/keywords:** `rejeição 1024`, `cClassTrib`, `validar NF-e CBS IBS`, `penalidade CBS IBS 2026`, `CST cClassTrib`.
+**utm:** `utm_source=google&utm_medium=cpc&utm_campaign=rejeicao_1024`
+
+## Meta (Instagram/Facebook) — variação 1 (dor)
+- **Texto primário:** Tomou Rejeição 1024 de novo? O culpado quase sempre é o cClassTrib incompatível com o CST. A Tribultz mostra o erro na tela — de graça — com a LC que sustenta a correção. E a partir de agosto/2026 esse erro vira multa.
+- **Headline:** Pare a Rejeição 1024 na origem
+- **Descrição:** Teste grátis, sem cartão
+- **CTA:** Saiba mais
+- **utm:** `utm_source=meta&utm_medium=paid&utm_campaign=rejeicao_1024`
+
+## Meta — variação 2 (prazo)
+- **Texto primário:** O período pedagógico da Reforma acaba em agosto/2026. Depois disso, erro de CBS/IBS na NF-e é multa. Valide CST × cClassTrib e as regras da LC 214 antes de emitir — e tenha o laudo auditável que comprova a conformidade.
+- **Headline:** A multa de CBS/IBS está chegando
+- **Descrição:** Comece grátis hoje
+- **CTA:** Cadastre-se
+
+## Meta — variação 3 (ERP/escala)
+- **Texto primário:** Emite em volume ou tem filiais? Valide CBS/IBS em lote, em vários CNPJs, com laudo auditável e API pro seu ERP. Comece testando uma nota de graça.
+- **Headline:** Compliance CBS/IBS em escala
+- **Descrição:** Lote, multi-CNPJ e API
+- **CTA:** Saiba mais
+
+## Limites de claim
+- Nunca "garantimos zero multa". Use "evidência e laudo que sustentam a correção".
+- Não prometer export no grátis nem no Starter.

--- a/docs/marketing/copy/email-whatsapp.md
+++ b/docs/marketing/copy/email-whatsapp.md
@@ -1,0 +1,56 @@
+# Copy — E-mail & WhatsApp
+
+> Sequências curtas de ativação→conversão. Âncora: empresa emissora. Tom deadline.
+> Régua: on-screen grátis → laudo pago (Profissional). Links com UTM
+> ([utm-conventions](../../analytics/utm-conventions.md)). Guardrails: sem promessa
+> de imunidade a multa; Starter não exporta.
+
+## E-mail — sequência de 3 toques
+
+### E-mail 1 — Ativação (D+0, pós-cadastro/lead)
+- **Assunto:** Valide sua primeira nota agora (leva 30s)
+- **Corpo:**
+  Você se cadastrou para parar de tomar Rejeição 1024 — vamos provar que funciona.
+  Cole ou suba um XML e veja **na tela, de graça**, onde sua NF-e erra: a
+  incompatibilidade CST × cClassTrib, a severidade e a **base legal (LC)** que
+  sustenta a correção.
+  **→ [Validar uma nota grátis](https://tribultz.com.br/validate-xml?utm_source=email&utm_medium=email&utm_campaign=ativacao&utm_content=email1)**
+  Sem cartão. Resultado imediato.
+
+### E-mail 2 — Valor / o laudo (D+2)
+- **Assunto:** Ver o erro é grátis. Provar a correção é o que importa.
+- **Corpo:**
+  Identificar o problema na tela já te protege da rejeição. Mas quando o contador
+  (ou o fisco) pede **comprovação**, você precisa do **laudo auditável em PDF** —
+  com os findings e a base legal de cada apontamento.
+  Esse documento está no plano **Profissional (R$ 149/mês)**, junto de validação
+  em lote e API pro seu ERP.
+  **→ [Ver planos](https://tribultz.com.br/pricing?utm_source=email&utm_medium=email&utm_campaign=conversao&utm_content=email2)**
+
+### E-mail 3 — Prazo (D+5)
+- **Assunto:** O período pedagógico acaba em agosto/2026
+- **Corpo:**
+  Até agosto/2026, erro de CBS/IBS na NF-e é aviso. Depois, é multa. Deixe sua
+  emissão validada e com laudo auditável antes do prazo — não no susto.
+  **→ [Assinar o Profissional](https://tribultz.com.br/billing?utm_source=email&utm_medium=email&utm_campaign=conversao&utm_content=email3)**
+  Dúvida sobre um caso específico? Responda este e-mail ou fale no WhatsApp.
+
+## WhatsApp — mensagens curtas
+> O link do site dentro da mensagem leva a UTM (o `wa.me` não).
+
+### WA 1 — Ativação
+> Oi, {nome}! Aqui é da Tribultz. Quer ver, de graça, se sua NF-e passa nas regras
+> de CBS/IBS? Manda um XML ou testa aqui: https://tribultz.com.br/validate-xml?utm_source=whatsapp&utm_medium=social&utm_campaign=ativacao — a gente mostra o erro e a LC na hora.
+
+### WA 2 — Conversão (quando pedir relatório/prova)
+> Na tela você vê tudo sem pagar. O **laudo auditável em PDF** (pra entregar ao
+> contador ou anexar numa defesa) está no Profissional, R$ 149/mês — já vem com
+> lote e API. Planos: https://tribultz.com.br/pricing?utm_source=whatsapp&utm_medium=social&utm_campaign=conversao
+
+### WA 3 — Prazo
+> Lembrando: o período pedagógico da Reforma vai até ago/2026. Depois, erro de
+> CBS/IBS vira multa. Quer que eu te ajude a deixar a emissão validada antes disso?
+
+## Limites de claim
+- Não escrever "você não toma multa". Escrever "evidência e laudo que sustentam a correção".
+- Não oferecer export no grátis/Starter. Encaminhar dúvida fiscal específica ao time (não dar parecer definitivo).

--- a/docs/marketing/copy/landing-hero.md
+++ b/docs/marketing/copy/landing-hero.md
@@ -1,0 +1,48 @@
+# Copy — Landing / Hero
+
+> Tom: agressivo/deadline. Âncora: empresa emissora (Rejeição 1024 / ago-2026).
+> Régua: on-screen = prova grátis · export do laudo = pago (Profissional+).
+> Guardrails: nunca prometer imunidade a multa; nunca dizer que Starter exporta;
+> não citar nº fixo de regras. Fonte: [posicionamento](../posicionamento-e-vendas.md).
+
+## Hero (variação A — risco direto)
+- **Headline:** Sua NF-e vai ser rejeitada. A partir de agosto/2026, isso vira multa.
+- **Sub:** A Tribultz valida CST × cClassTrib e as regras de CBS/IBS da LC 214 **antes** de você emitir — e mostra, com a base legal, exatamente onde está o erro.
+- **CTA primário:** Validar uma nota grátis
+- **CTA secundário:** Falar no WhatsApp
+- **Microcopy sob o CTA:** Sem cartão. Veja o resultado na hora.
+
+## Hero (variação B — dor nomeada)
+- **Headline:** Rejeição 1024 de novo? O problema é o cClassTrib errado.
+- **Sub:** Descubra em segundos a incompatibilidade CST × cClassTrib que derruba sua nota — com a LC que sustenta a correção.
+- **CTA primário:** Testar grátis agora
+
+## Hero (variação C — prazo/contagem)
+- **Headline:** Faltam meses para a multa de CBS/IBS. Sua emissão está pronta?
+- **Sub:** Valide, corrija e tenha o **laudo auditável** que comprova a conformidade antes do fim do período pedagógico (ago/2026).
+- **CTA primário:** Começar grátis
+
+## Bíblia de benefícios (blocos abaixo do hero)
+1. **Veja o erro na tela — de graça.** Cole ou suba o XML e receba os findings com severidade, a **base legal (LC citada)** e a recomendação. Prova antes de pagar.
+2. **Pare a Rejeição 1024 na origem.** Validação de CST × cClassTrib e das regras da Reforma (LC 214), com evidência por finding.
+3. **Tenha o laudo auditável.** Exporte o relatório em PDF para entregar ao contador, anexar numa defesa ou arquivar como prova de compliance. *(planos Profissional+)*
+4. **Escale.** Validação em lote, multi-CNPJ (filiais) e API para o seu ERP.
+
+## Prova / confiança
+- Evidência no formato auditável (Findings/Evidence) citando os códigos oficiais de rejeição.
+- Base legal por finding (LC 214 / LC 227).
+- *(Sem números inventados — se exibir contagem de regras/códigos, puxar o valor real do produto.)*
+
+## Faixa de planos (resumo honesto)
+- **Grátis (trial):** veja o diagnóstico na tela. 5 validações / 3 dias.
+- **Starter — R$ 49,90/mês:** mais volume + dashboard. *(não exporta laudo)*
+- **Profissional — R$ 149/mês:** **laudo auditável em PDF** + lote + API. ⭐ o tier do documento que comprova.
+- **Empresarial / Contador:** multi-CNPJ, volume maior/ilimitado.
+
+## CTA final (rodapé da página)
+- **Headline:** Não emita no escuro até agosto.
+- **CTA:** Validar grátis · ou **falar com o time no WhatsApp**
+
+## ⚠️ Limites de claim (não ultrapassar)
+- Não escrever "garantimos zero multa" / "imunidade a autuação". Escrever "evidência e laudo que **sustentam** a correção".
+- Não atribuir ao Starter o export do laudo.


### PR DESCRIPTION
## Compilação do material de marketing
Fecha o material de aquisição/vendas, ancorado no posicionamento final (#386) e nos gates reais (#384). Ponto de entrada: [docs/marketing/README.md](docs/marketing/README.md).

**Peças:**
- [copy/landing-hero.md](docs/marketing/copy/landing-hero.md) — 3 variações de hero (risco / dor 1024 / prazo), bíblia de benefícios, faixa de planos honesta, CTA final.
- [copy/anuncios.md](docs/marketing/copy/anuncios.md) — Google RSA (10 headlines ≤30, 4 descriptions ≤90) + 3 variações Meta, com UTMs e keywords.
- [copy/email-whatsapp.md](docs/marketing/copy/email-whatsapp.md) — e-mail de 3 toques (ativação → laudo → prazo) + 3 mensagens de WhatsApp, links UTM-tagados.
- [README.md](docs/marketing/README.md) — índice único, **fontes canônicas** (site/plan.ts/#384), **guardrails** e **KPI-âncora (CAC × receita `purchase`)**.

**Consistência:** tom deadline + âncora empresa emissora em tudo; guardrails repetidos em cada peça (sem prometer imunidade a multa; Starter não exporta; sem número inventado de regras; dúvida fiscal → WhatsApp).