### PR TITLE
fix(blog): remove credencial fiscal fabricada do byline dos posts

### DIFF
--- a/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
+++ b/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
@@ -4,9 +4,8 @@ description: "Como o NCM determina o Anexo da LC 214, o cClassTrib e o regime IB
 slug: "classtrib-2026-mapear-ncm-regime-ibs-cbs"
 category: "Reforma Tributária"
 author:
-  name: "Mickel Baptista"
-  jobTitle: "Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"
-  credentials: "Especialista em Compliance Fiscal — Reforma Tributária CBS/IBS (LC 214/2025)"
+  name: "Equipe Tribultz"
+  jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
 updatedAt: "2026-06-05"

--- a/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
+++ b/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
@@ -4,9 +4,8 @@ description: "Guia do cClassTrib na Reforma de 2026: estrutura do código, mapea
 slug: "classtrib-2026-ncm-mapeamento-completo"
 category: "Reforma Tributária"
 author:
-  name: "Mickel Baptista"
-  jobTitle: "Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"
-  credentials: "Especialista em Compliance Fiscal — Reforma Tributária CBS/IBS (LC 214/2025)"
+  name: "Equipe Tribultz"
+  jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
 updatedAt: "2026-06-05"

--- a/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
+++ b/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
@@ -4,9 +4,8 @@ description: "Classifique produtos na NCM com TIPI, Regras Gerais de Interpreta�
 slug: "como-classificar-ncm-corretamente-2026"
 category: "Classificação Fiscal"
 author:
-  name: "Mickel Baptista"
-  jobTitle: "Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"
-  credentials: "Especialista em Compliance Fiscal — Reforma Tributária CBS/IBS (LC 214/2025)"
+  name: "Equipe Tribultz"
+  jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
 updatedAt: "2026-06-05"

--- a/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
+++ b/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
@@ -4,9 +4,8 @@ description: "A Rejeição 1024 bloqueia a NF-e quando o CST é incompatível co
 slug: "rejeicao-1024-nfe-cbs-ibs-como-corrigir"
 category: "Compliance Fiscal"
 author:
-  name: "Mickel Baptista"
-  jobTitle: "Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"
-  credentials: "Especialista em Compliance Fiscal — Reforma Tributária CBS/IBS (LC 214/2025)"
+  name: "Equipe Tribultz"
+  jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
 updatedAt: "2026-06-05"


### PR DESCRIPTION
## Problema
4 posts do blog exibiam o byline **"Mickel Baptista — Especialista em Compliance Fiscal, CRC-SP 999.999/O-1"**:
- **`CRC-SP 999.999/O-1` é um registro de contador fabricado** (placeholder 999.999) — atribuir CRC inexistente a conteúdo fiscal é risco de credibilidade/legal.
- A especialização "Compliance Fiscal" não corresponde ao autor (que é de software/produto).

## Correção
Byline atribuído ao autor institucional neutro **"Equipe Tribultz / Conteúdo Fiscal"** (o mesmo que o `soroSync` já usa em posts novos) e removida a linha `credentials` (campo opcional; no JSON-LD só virava `description` quando presente).

**Posts:** rejeicao-1024, classtrib-2026-ncm-mapeamento-completo, classtrib-2026-mapear-ncm-regime-ibs-cbs, como-classificar-ncm-corretamente-2026.

## Verificação
- `grep` confirma **0 ocorrências** de CRC/credencial fiscal/"Mickel Baptista" nos posts.
- `npm run build` ✅ · `npm test` 138/138 ✅ (inclui soroSync/contentLint).
- `soroSync` já era neutro → posts futuros não recriam o problema.

> Byline definitivo de conteúdo fiscal aguarda revisão de especialista fiscal (decisão do autor).