### PR TITLE
fix(blog): corrige conteúdo fabricado sobre cClassTrib (6 díg + CSTs reais)

### DIFF
--- a/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
+++ b/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
@@ -36,37 +36,38 @@ legalRefs:
     link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria"
   - instrumento: "Convênio ICMS 142/2018"
     artigo: "Anexo I e II"
-    descricao: "NCMs sujeitos à substituição tributária e obrigação de CEST — relevante para determinar o subgrupo cClassTrib em operações com ST."
+    descricao: "NCMs sujeitos à substituição tributária e obrigação de CEST — relevante para determinar o cClassTrib aplicável em operações com ST."
 ---
 
 ## O que é o cClassTrib e por que ele importa
 
 Antes da Reforma Tributária, o regime fiscal de um produto era determinado por uma combinação implícita de CFOP, CST de ICMS e alíquota. O contador precisava saber "de cabeça" que NCM 3004.90.99 em operação com destino para pessoa física tem alíquota X de PIS/COFINS e Y de ICMS. A lógica ficava nos manuais internos e na experiência das equipes.
 
-A LC 214/2025 mudou isso com o **cClassTrib**: um código de 8 dígitos que torna explícito, no próprio XML da NF-e, qual regime tributário CBS/IBS se aplica ao item. Não há mais ambiguidade: o código está declarado, a SEFAZ valida, e qualquer inconsistência resulta em rejeição.
+A LC 214/2025 mudou isso com o **cClassTrib**: um código de 6 dígitos que torna explícito, no próprio XML da NF-e, qual regime tributário CBS/IBS se aplica ao item. Não há mais ambiguidade: o código está declarado, a SEFAZ valida, e qualquer inconsistência resulta em rejeição.
 
 Para o contribuinte, isso significa uma vantagem e uma responsabilidade simultâneas. A vantagem: o regime fiscal fica documentado no documento fiscal. A responsabilidade: manter o cadastro de produtos atualizado com o cClassTrib correto para cada NCM.
 
-### Estrutura do cClassTrib: 8 dígitos, 3 grupos
+### Estrutura do cClassTrib: 6 dígitos, 2 grupos
 
 ```
-┌───────┬───────────┬─────────────┐
-│  CST  │ Subgrupo  │ Modificador │
-│ 3 dig │  3 dig    │   2 dig     │
-└───────┴───────────┴─────────────┘
-  Regime   Categoria    Variação
+┌───────┬──────────────┐
+│  CST  │  Sequencial  │
+│ 3 dig │    3 dig     │
+└───────┴──────────────┘
+ Situação    Identificador
+tributária   da classificação
 ```
 
 | Grupo | Posição | O que define |
 |-------|---------|-------------|
-| CST | 1–3 | Regime tributário (padrão, reduzido, isento, monofásico...) |
-| Subgrupo | 4–6 | Categoria fiscal do produto (alimentos, medicamentos, combustíveis...) |
-| Modificador | 7–8 | Variação dentro do subgrupo (cesta básica nacional, ZFM, exportação...) |
+| CST | 1–3 | Código de Situação Tributária IBS/CBS (tributado, reduzido, isento, imune, monofásico...) |
+| Sequencial | 4–6 | Identificador da classificação específica dentro daquele CST, atribuído pela tabela oficial |
 
-Exemplo: `20003400`
-- `200` → CST 200 = alíquota reduzida
-- `034` → alimentos da cesta básica nacional (LC 214, art. 21)
-- `00` → sem modificador adicional
+Exemplo real: `200003`
+- `200` → CST 200 = tributação com redução de alíquota
+- `003` → classificação específica (Anexo 1 da LC 214 — alimentos da cesta básica nacional, com redução a zero)
+
+> Atenção: o cClassTrib **não** embute "categoria de produto" nos dígitos. Os 3 primeiros são o CST; os 3 últimos são um número sequencial da tabela oficial SVRS. É a combinação completa (6 dígitos) que aponta o regime e a base legal — não há subgrupo nem modificador semântico.
 
 ### Onde o cClassTrib aparece no XML da NF-e
 
@@ -75,19 +76,19 @@ O campo fica dentro do grupo `gIBSCBS`, que é filho do elemento `det` (detalhe 
 ```xml
 <det nItem="1">
   <prod>
-    <NCM>10063021</NCM>   ← arroz beneficiado
+    <NCM>39269090</NCM>   ← produto industrializado (tributação padrão)
     ...
   </prod>
   <gIBSCBS>
     <CBS>
-      <CST>200</CST>
-      <cClassTrib>20003400</cClassTrib>
+      <CST>000</CST>
+      <cClassTrib>000001</cClassTrib>
       <pCBS>0.90</pCBS>
       <vCBS>0.45</vCBS>
     </CBS>
     <IBS>
-      <CST>200</CST>
-      <cClassTrib>20003400</cClassTrib>
+      <CST>000</CST>
+      <cClassTrib>000001</cClassTrib>
       <pIBS>0.10</pIBS>
       <vIBS>0.05</vIBS>
     </IBS>
@@ -118,21 +119,20 @@ Em caso de dúvida sobre a obrigatoriedade no seu tipo de operação, consulte a
 
 ## Os principais CSTs do IBS/CBS em 2026
 
-O campo `CST` dentro de `gIBSCBS` é derivado dos três primeiros dígitos do cClassTrib. É diferente do CST do ICMS. A tabela abaixo resume os CSTs ativos na NT 2025.002 V1.36:
+O campo `CST` dentro de `gIBSCBS` é derivado dos três primeiros dígitos do cClassTrib. É diferente do CST do ICMS. A tabela abaixo resume os principais CSTs (situação tributária IBS/CBS) da tabela oficial:
 
-| CST | Regime | Alíquota CBS | Alíquota IBS | Aplicação típica |
-|-----|--------|-------------|-------------|-----------------|
-| 000 | Padrão | 0,90% | 0,10% | Produtos industrializados em geral |
-| 200 | Reduzido | Varia | Varia | Medicamentos, cesta básica estendida |
-| 210 | Red. + cashback | Varia | Varia | Medicamentos destinados a beneficiários CadÚnico |
-| 400 | Isento | 0% | 0% | Exportações, papel p/ impressão de livros |
-| 500 | Imune | 0% | 0% | Livros, templos, entidades filantrópicas |
-| 610 | Monofásico — produtor | Concentrado | Concentrado | Gasolina, diesel, GLP (fabricante/importador) |
-| 620 | Monofásico — downstream | 0% | 0% | Combustíveis (distribuidor, posto, varejista) |
-| 700 | Suspensão | 0% | 0% | Drawback, ZPE, regimes aduaneiros especiais |
-| 800 | Diferimento | 0% | 0% | Operações entre contribuintes no mesmo Estado |
+| CST | Situação tributária (oficial) | Aplicação típica |
+|-----|-------------------------------|------------------|
+| 000 | Tributação integral | Regime padrão — produtos e serviços em geral |
+| 200 | Alíquota reduzida | Itens dos Anexos da LC 214 (cesta básica, saúde, educação...) |
+| 400 | Isenção | Hipóteses de isenção previstas em lei |
+| 410 | Imunidade e não incidência | Livros, exportações e demais imunidades constitucionais |
+| 510 | Diferimento | Operações com diferimento do recolhimento |
+| 550 | Suspensão | Exportação, drawback e regimes suspensivos |
+| 620 | Tributação monofásica | Combustíveis e demais itens do regime monofásico |
+| 800 | Transferência de crédito | Operações específicas de transferência de crédito |
 
-> A alíquota "varia" no CST 200 significa que o percentual exato depende do Anexo da LC 214 em que o produto está listado. Não existe uma alíquota padrão para "reduzido" — cada subgrupo tem a sua.
+> No **regime padrão (CST 000)**, a alíquota na fase de teste de 2026 é **0,9% (CBS) e 0,1% (IBS)**. Para os demais CSTs, o percentual depende do Anexo/regime aplicável. Há ainda CSTs para alíquotas uniformes (010/011), alíquota fixa (220/221), redução de base (222), diferimento com redução (515) e ajustes (810/811/820/830) — o aplicável vem sempre dos 3 primeiros dígitos do cClassTrib oficial.
 
 ---
 
@@ -160,9 +160,8 @@ Qual Anexo?
    I  II III IV ...
    │
    ▼
-cClassTrib = prefixo do regime
-           + subgrupo do Anexo
-           + modificador aplicável
+cClassTrib = CST (3 díg, prefixo do regime)
+           + sequencial (3 díg, da tabela SVRS)
 ```
 
 ### Principais Anexos da LC 214 e seus regimes
@@ -172,10 +171,12 @@ cClassTrib = prefixo do regime
 | Anexo I | Cesta básica nacional | 200 | Arroz, feijão, carnes (bovino, suíno, aves), ovos, leite UHT, manteiga |
 | Anexo II | Alíquota reduzida (50%) | 200 | Medicamentos, dispositivos médicos, saneamento básico, transporte coletivo |
 | Anexo III | Redução específica | 200 | Produtos agrícolas não incluídos no Anexo I |
-| Anexo IV | Imunidade | 500 | Livros, periódicos, papel destinado à impressão |
-| Anexo V | Monofásico | 610/620 | Combustíveis, lubrificantes, tabaco, bebidas alcoólicas |
-| Anexo VI | Cashback | 210 | Medicamentos e alimentos para beneficiários CadÚnico |
-| Regime padrão | — | 000 | Qualquer NCM não listado nos Anexos I–VI |
+| Imunidade / não incidência | — | 410 | Livros, periódicos, papel destinado à impressão |
+| Monofásico | — | 620 | Combustíveis, lubrificantes |
+| Exportação / suspensão | — | 550 | Bens e serviços destinados ao exterior |
+| Regime padrão | — | 000 | Qualquer NCM não listado nos Anexos de redução |
+
+> O **cashback** (devolução de parte do IBS/CBS a famílias do CadÚnico) **não** é um CST: o item mantém o CST do seu regime (ex.: 200) e a devolução ocorre fora do cClassTrib.
 
 ---
 
@@ -183,9 +184,9 @@ cClassTrib = prefixo do regime
 
 Um NCM enquadrado em múltiplos regimes é mais comum do que parece. Tome o NCM `3004.90.99` (medicamentos):
 
-- Venda para farmácia → CST 200 (Anexo II — alíquota reduzida)
-- Venda para exportação → CST 400 (isento, fora do território nacional)
-- Venda para beneficiário CadÚnico via programa governamental → CST 210 (cashback)
+- Venda no mercado interno → CST 200 (alíquota reduzida, Anexo de dispositivos médicos)
+- Venda para exportação → CST 550 (suspensão, operação destinada ao exterior)
+- Venda a beneficiário CadÚnico → o item mantém seu CST (ex.: 200); o cashback é uma devolução ao consumidor, fora do cClassTrib
 
 O NCM é o mesmo. O produto é o mesmo. O regime muda conforme **quem compra** e **para qual finalidade**.
 
@@ -193,11 +194,11 @@ Outros fatores que modificam o regime além do NCM:
 
 | Fator | Impacto no cClassTrib |
 |-------|----------------------|
-| Tipo de destinatário (PF, PJ, entidade filantrópica) | Pode alterar CST entre 000, 200 e 400 |
-| CFOP da operação (interna, interestadual, exportação) | Exportações são sempre CST 400/500 |
+| Tipo de destinatário (PF, PJ, entidade filantrópica) | Pode alterar CST entre 000, 200 e 410 |
+| CFOP da operação (interna, interestadual, exportação) | Exportações usam CST 550 (suspensão) ou 410 (não incidência) |
 | Regime tributário do emitente (Simples, Lucro Presumido) | Afeta base de cálculo, não o cClassTrib |
-| Produto estar sujeito a ST (Convênio 142/2018) | Exige CEST e pode alterar subgrupo cClassTrib |
-| Produto estar em ZFM ou ZPE | CST 700 (suspensão) |
+| Produto estar sujeito a ST (Convênio 142/2018) | Exige CEST e pode alterar o cClassTrib aplicável |
+| Produto estar em ZFM ou ZPE | CST 550 (suspensão); a ZFM tem ajustes próprios (CST 810) |
 
 ---
 
@@ -213,7 +214,7 @@ Consulte se o NCM aparece nos Anexos I a VI da LC 214. A maioria dos produtos n�
 Considerando destinatário, CFOP e finalidade, determine qual CST se aplica à saída específica.
 
 **4. Consulte a tabela cClassTrib SVRS**
-Acesse a tabela oficial em [dfe-portal.svrs.rs.gov.br](https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria) ou use a [API da Tribultz](https://tribultz.com.br/classificacao). Informe o NCM e o regime — a ferramenta retorna o cClassTrib completo (8 dígitos) com a base legal.
+Acesse a tabela oficial em [dfe-portal.svrs.rs.gov.br](https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria) ou use a [API da Tribultz](https://tribultz.com.br/classificacao). Informe o NCM e o regime — a ferramenta retorna o cClassTrib completo (6 dígitos) com a base legal.
 
 **5. Valide a compatibilidade CST × cClassTrib**
 Confirme que os três primeiros dígitos do cClassTrib coincidem com o CST que será emitido no XML. Esse é o ponto exato que a SEFAZ valida para a [Rejeição 1024](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir).
@@ -239,7 +240,7 @@ Durante o período de transição, contribuintes do Simples Nacional recolhem um
 
 ### Erro 1: usar o mesmo cClassTrib para todos os produtos
 
-O cClassTrib não é um campo de preenchimento livre — ele precisa refletir o Anexo correto da LC 214 para o NCM específico. Usar `00000000` ou qualquer código genérico para todos os produtos resulta em Rejeição 1024 para qualquer item que não seja do regime padrão.
+O cClassTrib não é um campo de preenchimento livre — ele precisa refletir o Anexo correto da LC 214 para o NCM específico. Usar `000001` (regime padrão) ou qualquer código genérico para todos os produtos resulta em Rejeição 1024 para qualquer item que não seja do regime padrão.
 
 ### Erro 2: confundir o CST do ICMS com o CST do CBS/IBS
 
@@ -249,9 +250,9 @@ São dois campos diferentes no XML. O CST dentro de `gIBSCBS` é derivado do cCl
 
 Toda vez que o NCM de um produto é corrigido (TIPI é revisada periodicamente), o cClassTrib associado pode mudar. Equipes que atualizam o NCM mas esquecem de revisar o cClassTrib acabam com incompatibilidade silenciosa que só aparece na SEFAZ.
 
-### Erro 4: ignorar o modificador (dígitos 7–8)
+### Erro 4: preencher CST e cClassTrib de forma independente
 
-Dois produtos com o mesmo NCM e o mesmo CST podem ter cClassTribs diferentes se um deles tem modificador (ex: `20003400` para cesta básica nacional vs `20003401` para cesta básica estendida). A diferença de 1 dígito resulta em Rejeição 1025 (cClassTrib inválido) ou 1028 (não permitido para o CST).
+Vários ERPs permitem informar o CST do grupo `gIBSCBS` e o `cClassTrib` em campos separados, sem amarração entre eles. Se o operador escolhe um CST (ex.: `000`) mas deixa um cClassTrib de outro prefixo (ex.: `200003`), os três primeiros dígitos não coincidem com o CST declarado — e a SEFAZ rejeita com 1024. A regra de ouro: o **cClassTrib é a fonte**, e o CST do grupo IBS/CBS deve sempre espelhar os seus três primeiros dígitos.
 
 ---
 
@@ -285,7 +286,7 @@ A NT 2025.002 especifica qual versão da tabela é aceita pela SEFAZ. Se seu ERP
 
 **Produto com NCM que não está em nenhum Anexo da LC 214 usa qual cClassTrib?**
 
-Usa o regime padrão: CST 000, cClassTrib com prefixo `000`. O subgrupo (dígitos 4–6) ainda precisa ser correto para o tipo de produto — mas a alíquota é a padrão do período (CBS 0,9%, IBS 0,1% em 2026).
+Usa o regime padrão: CST 000, cClassTrib `000001` (ou outro de prefixo `000`). O código sequencial (dígitos 4–6) ainda precisa corresponder à classificação correta na tabela SVRS — e a alíquota é a padrão do período (CBS 0,9%, IBS 0,1% em 2026).
 
 **Posso ter dois cClassTribs diferentes para o mesmo produto no cadastro?**
 
@@ -293,7 +294,7 @@ Não no mesmo item da NF-e — cada linha de produto tem um único cClassTrib. M
 
 **O cClassTrib está relacionado ao CEST?**
 
-Indiretamente. O CEST identifica produtos sujeitos à substituição tributária (ST) do ICMS — ele é obrigatório para NCMs listados no Convênio ICMS 142/2018. O cClassTrib não depende do CEST, mas para produtos com ST, o subgrupo do cClassTrib pode ser diferente (há subgrupos específicos para operações com ST já retido). Leia mais sobre CEST no artigo [cClassTrib 2026: mapeamento NCM × cClassTrib](/blog/classtrib-2026-ncm-mapeamento-completo).
+Indiretamente. O CEST identifica produtos sujeitos à substituição tributária (ST) do ICMS — ele é obrigatório para NCMs listados no Convênio ICMS 142/2018. O cClassTrib não depende do CEST, mas para produtos com ST o cClassTrib aplicável pode variar conforme a operação. Leia mais sobre CEST no artigo [cClassTrib 2026: mapeamento NCM × cClassTrib](/blog/classtrib-2026-ncm-mapeamento-completo).
 
 **Existe um cClassTrib para operações de devolução?**
 

--- a/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
+++ b/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
@@ -47,27 +47,26 @@ Se você emite NF-e e ainda não adaptou seu emissor ou ERP ao novo campo, este 
 
 ---
 
-## Estrutura do cClassTrib: 8 dígitos que definem o regime
+## Estrutura do cClassTrib: 6 dígitos que definem o regime
 
-O cClassTrib tem **8 dígitos** organizados em três grupos:
+O cClassTrib tem **6 dígitos** organizados em dois grupos:
 
 | Posição | Tamanho | Significado |
 |---------|---------|-------------|
-| 1–3 | 3 dígitos | **Grupo CST** — espelha o CST aplicável (000 = padrão, 200 = reduzido, 400 = isento, 600 = monofásico, etc.) |
-| 4–6 | 3 dígitos | **Subgrupo de produto** — categoria fiscal do item (alimentos, medicamentos, combustíveis, etc.) |
-| 7–8 | 2 dígitos | **Modificador** — variação dentro do subgrupo (cesta básica nacional, ZFM, regime especial, etc.) |
+| 1–3 | 3 dígitos | **CST** — Código de Situação Tributária IBS/CBS (000 = tributação integral, 200 = redução, 400 = isenção, 620 = monofásico, etc.) |
+| 4–6 | 3 dígitos | **Sequencial** — identificador da classificação específica dentro daquele CST, atribuído pela tabela oficial SVRS |
 
-Exemplo: `20003400`
+Exemplo: `200003`
 
-- `200` → CST 200 (alíquota reduzida)
-- `034` → Alimentos da cesta básica nacional (LC 214, art. 21)
-- `00` → Sem modificador adicional
+- `200` → CST 200 (tributação com redução de alíquota)
+- `003` → classificação do Anexo 1 da LC 214 (alimentos da cesta básica nacional, redução a zero)
 
-Outro exemplo: `60001200`
+Outro exemplo: `000001`
 
-- `600` → CST 600 (monofásico zero — downstream)
-- `012` → Combustíveis e lubrificantes (LC 214, art. 171)
-- `00` → Operação normal
+- `000` → CST 000 (tributação integral — regime padrão)
+- `001` → primeira classificação do regime padrão na tabela SVRS
+
+> O cClassTrib **não** tem "subgrupo" nem "modificador" semântico nos dígitos. Os 3 primeiros são o CST; os 3 últimos são um número sequencial. É a combinação dos 6 dígitos que aponta o regime e a base legal.
 
 ---
 
@@ -79,11 +78,11 @@ Exemplos de combinações inválidas mais comuns:
 
 | CST declarado | cClassTrib informado | Resultado |
 |------------|---------------------|-----------|
-| 000 (padrão) | 20003400 (reduzido) | **Rejeição 1024** |
-| 200 (reduzido) | 00001200 (padrão) | **Rejeição 1024** |
-| 400 (isento) | 60001200 (monofásico) | **Rejeição 1024** |
-| 000 (padrão) | 00001200 (padrão) | Válido ✓ |
-| 200 (reduzido) | 20003400 (cesta básica) | Válido ✓ |
+| 000 (padrão) | 200003 (prefixo 200, redução) | **Rejeição 1024** |
+| 200 (reduzido) | 000001 (prefixo 000, padrão) | **Rejeição 1024** |
+| 400 (isento) | 620xxx (prefixo 620, monofásico) | **Rejeição 1024** |
+| 000 (padrão) | 000001 (prefixo 000) | Válido ✓ |
+| 200 (reduzido) | 200003 (prefixo 200) | Válido ✓ |
 
 O problema ocorre com frequência quando:
 
@@ -120,19 +119,18 @@ Após identificar o cClassTrib, valide que os três primeiros dígitos coincidem
 
 A tabela a seguir resume os principais regimes tributários CBS/IBS e os prefixos cClassTrib correspondentes na NT 2025.002 (versão V1.36, atualização de abril de 2026):
 
-| Regime | CST | Prefixo cClassTrib | Exemplos de produtos |
+| Regime (situação tributária oficial) | CST | Prefixo cClassTrib | Exemplos de produtos |
 |--------|-----|--------------------|---------------------|
-| Padrão (alíquota plena) | 000 | 000 | Produtos industrializados em geral |
-| Alíquota reduzida | 200 | 200 | Medicamentos, itens da cesta básica estendida |
-| Alíquota reduzida — cesta básica nacional | 200 | 200 | Arroz, feijão, carnes, ovos, leite |
-| Isento | 400 | 400 | Exportações, papel para impressão de livros |
-| Imune | 500 | 500 | Livros, templos, entidades filantrópicas |
-| Monofásico (produtor recolhe) | 610 | 610 | Gasolina, diesel, GLP — produtor/importador |
-| Monofásico zero (downstream) | 620 | 620 | Combustíveis — postos, distribuidores |
-| Suspensão | 700 | 700 | Drawback, regimes aduaneiros especiais |
-| Diferimento | 800 | 800 | Operações entre contribuintes no mesmo Estado |
+| Tributação integral (padrão) | 000 | 000 | Produtos industrializados em geral |
+| Alíquota reduzida | 200 | 200 | Medicamentos, itens da cesta básica, alimentos |
+| Isenção | 400 | 400 | Hipóteses de isenção previstas em lei |
+| Imunidade e não incidência | 410 | 410 | Livros, periódicos, papel para impressão |
+| Diferimento | 510 | 510 | Operações com diferimento do recolhimento |
+| Suspensão | 550 | 550 | Exportações, drawback, regimes suspensivos |
+| Tributação monofásica | 620 | 620 | Combustíveis e lubrificantes |
+| Transferência de crédito | 800 | 800 | Operações específicas de transferência de crédito |
 
-> **Atenção**: a tabela completa tem mais de 200 cClassTrib distintos. Os prefixos acima são os grupos de alto nível. O código completo (8 dígitos) depende do NCM e do regime específico do produto.
+> **Atenção**: a tabela oficial SVRS tem mais de 160 cClassTrib distintos (e cresce a cada atualização). Os prefixos acima são os grupos de alto nível (o CST). O código completo (6 dígitos) depende do NCM e do regime específico do produto.
 
 ---
 
@@ -186,7 +184,7 @@ A tabela cClassTrib é atualizada periodicamente pela SVRS. A versão vigente em
 
 - Inclusão de novos cClassTrib para dispositivos médicos com benefício fiscal (LC 214, art. 53)
 - Revisão dos cClassTrib para veículos elétricos (CST 200, alíquota reduzida)
-- Novos modificadores para operações em Zona Franca de Manaus
+- Novos cClassTrib para ajustes de IBS em operações na Zona Franca de Manaus (CST 810)
 
 Se seu sistema foi configurado com uma versão anterior da tabela, alguns cClassTrib podem ter sido descontinuados, causando rejeição mesmo que a combinação CST × prefixo seja válida formalmente.
 

--- a/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
+++ b/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
@@ -99,21 +99,20 @@ A validação é sequencial: se a nota falha na camada 1, ela não chega à cama
 
 ### Cenário 1: ERP ativou CBS/IBS com cClassTrib genérico
 
-É o mais comum. O fornecedor do ERP lançou a atualização para o leiaute NT 2025.002 e, como valor padrão no campo `cClassTrib`, usou `00000000` ou um código genérico como `00001000` (regime padrão, subgrupo genérico).
+É o mais comum. O fornecedor do ERP lançou a atualização para o leiaute NT 2025.002 e, como valor padrão no campo `cClassTrib`, usou `000001` ou outro código genérico do regime padrão (CST 000).
 
-O problema: se o produto tem CST 200 (alíquota reduzida) no cadastro, o cClassTrib genérico `00001000` começa com `000` — incompatível com CST 200, que exige prefixo `200`. Resultado: Rejeição 1024 em cada nota que emite esse produto.
+O problema: se o produto tem CST 200 (alíquota reduzida) no cadastro, o cClassTrib genérico `000001` começa com `000` — incompatível com CST 200, que exige prefixo `200`. Resultado: Rejeição 1024 em cada nota que emite esse produto.
 
 **Resolução:** Mapear todos os produtos com CST ≠ 000 e atribuir o cClassTrib correto. A [API da Tribultz](https://tribultz.com.br/classificacao) retorna o cClassTrib a partir do NCM em menos de 1 segundo.
 
 ### Cenário 2: NCM com múltiplos cClassTribs possíveis
 
-Alguns NCMs se enquadram em mais de um regime tributário dependendo do destinatário, da UF ou da finalidade do produto. Por exemplo, o NCM `3004.90.99` (medicamentos) pode ter:
+Alguns NCMs se enquadram em mais de um regime tributário dependendo do destinatário, da UF ou da finalidade da operação. Por exemplo, o NCM `3004.90.99` (medicamentos/dispositivos médicos) pode ter:
 
-- cClassTrib `20003100` → alíquota reduzida (venda a pessoa física)
-- cClassTrib `40003100` → isento (venda a entidade beneficente)
-- cClassTrib `50003100` → imune (exportação)
+- cClassTrib `200005` → CST 200, redução de alíquota (Anexo 4 — venda no mercado interno)
+- cClassTrib de prefixo `550` → CST 550, exportação de bens
 
-Se o ERP usa o primeiro cClassTrib para todas as saídas, notas para exportação ou para entidades beneficentes terão CST 400 ou 500 com cClassTrib prefixo `200` — Rejeição 1024.
+Se o ERP usa o código de redução (`200005`, prefixo `200`) para uma saída de exportação — que exige CST 550 — os três primeiros dígitos não batem com o CST declarado: Rejeição 1024.
 
 **Resolução:** Cadastrar variantes de produto por destinatário, ou usar regras de parametrização no ERP que selecionem o cClassTrib correto baseado no tipo de operação (CFOP).
 


### PR DESCRIPTION
## 🔴 Achado: conteúdo técnico fabricado sobre o cClassTrib
A verificação fiscal profunda (pedida na sequência da varredura) comparou as afirmações dos posts contra a **fonte canônica** (`backend/app/data/classtrib.json` + engine). Três posts descreviam **erradamente o conceito-bandeira** do produto — provavelmente gerados cedo com estrutura plausível porém fictícia.

### Verdade-base (nossos dados/engine)
- cClassTrib = **6 dígitos** = `CST (3) + sequencial (3)`.
- 164 códigos reais; CSTs oficiais: 000, 200, 400, **410** (imunidade), **510** (diferimento), **550** (suspensão), **620** (monofásica), 800 (transferência de crédito)…

### Correções
| Erro publicado | Correto |
|---|---|
| "cClassTrib tem **8 dígitos**" | **6 dígitos** |
| Estrutura "CST + Subgrupo + Modificador" | CST(3) + **sequencial**(3); sem subgrupo/modificador semântico |
| Exemplos `20003400`, `60001200`, `00000000`, `20003100` | reais: `000001`, `200003`, `200005`, prefixo `550` |
| CST **500** (imune) | **410** (imunidade e não incidência) |
| CST **610/600** (monofásico) | **620** (tributação monofásica) |
| CST **700** (suspensão) | **550** (suspensão) |
| CST **800** = "diferimento" | diferimento é **510**; 800 = transferência de crédito |
| CST **210** "cashback" | cashback não é CST (é devolução ao consumidor) |
| XML `<cClassTrib>20003400</cClassTrib>` | `000001` (item padrão, 0,9%/0,1% consistente) |

**Posts:** `classtrib-2026-mapear-ncm-regime-ibs-cbs`, `classtrib-2026-ncm-mapeamento-completo`, `rejeicao-1024-nfe-cbs-ibs-como-corrigir`. (`como-classificar` estava OK — suas menções a "8 dígitos" eram sobre o **NCM**, que é mesmo 8 díg.)

## Gates
contentLint limpo (só PROMESSA advisório) · `npm test` 138/138 · `npm run build` ✅. Conteúdo-only (Vercel).