### PR TITLE
feat(blog): guard anti-fabricação cClassTrib/CST no CI

### DIFF
--- a/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
+++ b/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
@@ -108,10 +108,10 @@ A obrigação se aplica a **todos os contribuintes que emitem NF-e ou NFS-e** e 
 - Prestadores de serviços que emitem NFS-e via portais municipais integrados ao SPED
 - Distribuidores e varejistas em operações B2B e B2C
 
-**Exceções** (sem obrigação de preencher gIBSCBS):
-- Operações com CST 070 (imunidade) e CST 080 (não incidência)
+**Casos especiais:**
+- **Imunidade e não incidência** não são dispensa de preenchimento: usam **CST 410** e preenchem o grupo gIBSCBS normalmente
 - Micro empreendedores individuais (MEI) em operações simplificadas
-- Operações com CFOP de devolução sem incidência de IBS/CBS
+- Operações de devolução seguem regra específica de preenchimento (sem incidência de IBS/CBS)
 
 Em caso de dúvida sobre a obrigatoriedade no seu tipo de operação, consulte a NT 2025.002 seção 3.1 ou o [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico).
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/blogFiscalLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "content:lint": "tsx scripts/content-lint.ts",
     "content:lint:fix": "tsx scripts/content-lint.ts --fix",

--- a/frontend/src/lib/blogFiscalLint.test.ts
+++ b/frontend/src/lib/blogFiscalLint.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { lintBlogFiscal, type ClassTribValid } from "./blogFiscalLint";
+
+const here = dirname(fileURLToPath(import.meta.url)); // frontend/src/lib
+// Fonte oficial vive no backend (monorepo); o checkout do CI traz tudo.
+const CLASSTRIB = join(here, "..", "..", "..", "backend", "app", "data", "classtrib.json");
+const BLOG_DIR = join(here, "..", "..", "content", "blog");
+
+const data = JSON.parse(readFileSync(CLASSTRIB, "utf-8")) as {
+  by_code: Record<string, unknown>;
+  cst_descriptions: Record<string, unknown>;
+};
+const valid: ClassTribValid = {
+  codes: new Set(Object.keys(data.by_code)),
+  csts: new Set(Object.keys(data.cst_descriptions)),
+};
+
+test("blog: nenhum cClassTrib/CST fabricado nos posts (vs tabela oficial SVRS)", () => {
+  const files = readdirSync(BLOG_DIR).filter((f) => f.endsWith(".mdx"));
+  assert.ok(files.length > 0, "deve haver posts para validar");
+  const problems: string[] = [];
+  for (const f of files) {
+    const mdx = readFileSync(join(BLOG_DIR, f), "utf-8");
+    for (const finding of lintBlogFiscal(mdx, valid)) {
+      problems.push(`${f}: [${finding.rule}] ${finding.message}`);
+    }
+  }
+  assert.equal(problems.length, 0, `Conteúdo fiscal fabricado detectado:\n${problems.join("\n")}`);
+});
+
+test("guard: cClassTrib descrito como '8 dígitos' → erro", () => {
+  const f = lintBlogFiscal("O cClassTrib tem 8 dígitos organizados em grupos.", valid);
+  assert.ok(f.some((x) => x.rule === "CCLASSTRIB_DIGITOS"));
+});
+
+test("guard: cClassTrib '6 dígitos' → ok", () => {
+  const f = lintBlogFiscal("O cClassTrib tem 6 dígitos.", valid);
+  assert.equal(f.filter((x) => x.rule === "CCLASSTRIB_DIGITOS").length, 0);
+});
+
+test("guard: código cClassTrib inexistente (6 díg) → erro", () => {
+  const f = lintBlogFiscal("Use o código `999999` no campo.", valid);
+  assert.ok(f.some((x) => x.rule === "CCLASSTRIB_INEXISTENTE"));
+});
+
+test("guard: <cClassTrib> de 8 dígitos → erro", () => {
+  const f = lintBlogFiscal("<cClassTrib>20003400</cClassTrib>", valid);
+  assert.ok(f.some((x) => x.rule === "CCLASSTRIB_INEXISTENTE"));
+});
+
+test("guard: exemplo fabricado de 8 díg rotulado cClassTrib → erro", () => {
+  const f = lintBlogFiscal("o cClassTrib `20003400` aponta o regime", valid);
+  assert.ok(f.some((x) => x.rule === "CCLASSTRIB_INEXISTENTE"));
+});
+
+test("guard: NCM de 8 díg em backtick NÃO é confundido com cClassTrib", () => {
+  const f = lintBlogFiscal("o NCM `30049099` é de medicamentos", valid);
+  assert.equal(f.length, 0);
+});
+
+test("guard: CST inexistente (500) → erro", () => {
+  const f = lintBlogFiscal("Itens imunes usam CST 500.", valid);
+  assert.ok(f.some((x) => x.rule === "CST_INEXISTENTE"));
+});
+
+test("guard: conteúdo correto → sem findings", () => {
+  const f = lintBlogFiscal(
+    "O cClassTrib tem 6 dígitos. Ex.: `000001` (CST 000) e `200003` (CST 200).",
+    valid,
+  );
+  assert.equal(f.length, 0);
+});

--- a/frontend/src/lib/blogFiscalLint.ts
+++ b/frontend/src/lib/blogFiscalLint.ts
@@ -1,0 +1,81 @@
+/**
+ * Guard determinístico anti-fabricação para o conteúdo do blog (follow-up do #349).
+ *
+ * O `contentLint` pega alíquota-plena-sem-contexto e linguagem de promessa, mas NÃO
+ * pegava conteúdo técnico FABRICADO sobre o conceito-bandeira — ex.: cClassTrib
+ * descrito como "8 dígitos" (o oficial tem 6), códigos inexistentes (`20003400`) e
+ * CSTs inventados (500/610/700). Esse erro chegou a ser publicado (corrigido no #394).
+ *
+ * Este guard valida as afirmações sobre cClassTrib/CST de um post contra a TABELA
+ * OFICIAL SVRS (`backend/app/data/classtrib.json`). Roda no CI via `blogFiscalLint.test.ts`
+ * sobre todos os posts — determinístico, sem LLM, custo zero de token.
+ *
+ * Filosofia: somos uma empresa de validação determinística — dogfood no nosso conteúdo.
+ */
+
+export type FiscalFinding = { rule: string; severity: "error"; message: string };
+
+/** Conjuntos válidos derivados de classtrib.json (codes = by_code; csts = cst_descriptions). */
+export type ClassTribValid = { codes: Set<string>; csts: Set<string> };
+
+export function lintBlogFiscal(mdx: string, valid: ClassTribValid): FiscalFinding[] {
+  const out: FiscalFinding[] = [];
+
+  // A) Afirmação de tamanho: "cClassTrib … N dígitos" / "N dígitos … cClassTrib".
+  //    O cClassTrib oficial tem 6 dígitos (CST[3] + sequencial[3]). `[^.\n]` não cruza
+  //    frase/linha, evitando capturar o "3 dígitos" que descreve só o CST.
+  const digitRx = [
+    /cClassTrib[^.\n]{0,45}?\b(\d{1,2})\s*d[íi]gitos/gi,
+    /\b(\d{1,2})\s*d[íi]gitos[^.\n]{0,30}?cClassTrib/gi,
+  ];
+  for (const rx of digitRx) {
+    for (const m of mdx.matchAll(rx)) {
+      if (m[1] !== "6") {
+        out.push({
+          rule: "CCLASSTRIB_DIGITOS",
+          severity: "error",
+          message: `cClassTrib descrito como ${m[1]} dígitos — o oficial tem 6 (CST[3] + sequencial[3]).`,
+        });
+      }
+    }
+  }
+
+  // B) Valores no XML <cClassTrib>…</cClassTrib> devem existir na tabela.
+  for (const m of mdx.matchAll(/<cClassTrib>\s*([0-9]+)\s*<\/cClassTrib>/gi)) {
+    if (!valid.codes.has(m[1])) out.push(codeFinding(m[1]));
+  }
+
+  // C) Token de exatamente 6 dígitos em backtick → tratado como cClassTrib; deve existir.
+  for (const m of mdx.matchAll(/`([0-9]{6})`/g)) {
+    if (!valid.codes.has(m[1])) out.push(codeFinding(m[1]));
+  }
+
+  // D) Token de 7–8 dígitos em backtick rotulado como cClassTrib (e não NCM) → inválido
+  //    por tamanho (o oficial tem 6). Pega exemplos fabricados como `20003400`.
+  for (const m of mdx.matchAll(/`([0-9]{7,8})`/g)) {
+    const idx = m.index ?? 0;
+    const ctx = mdx.slice(Math.max(0, idx - 45), idx + 45);
+    if (/cClassTrib/i.test(ctx) && !/\bNCM\b/i.test(ctx)) out.push(codeFinding(m[1]));
+  }
+
+  // E) CST IBS/CBS de 3 dígitos citado ("CST 500", "CST `610`") deve constar no conjunto oficial.
+  for (const m of mdx.matchAll(/\bCST\s*`?([0-9]{3})`?/gi)) {
+    if (!valid.csts.has(m[1])) {
+      out.push({
+        rule: "CST_INEXISTENTE",
+        severity: "error",
+        message: `CST \`${m[1]}\` não consta na tabela oficial IBS/CBS (ex.: 000, 200, 400, 410, 510, 550, 620, 800).`,
+      });
+    }
+  }
+
+  return out;
+}
+
+function codeFinding(code: string): FiscalFinding {
+  const why =
+    code.length !== 6
+      ? `tem ${code.length} dígitos — o oficial tem 6`
+      : "não existe na tabela oficial SVRS";
+  return { rule: "CCLASSTRIB_INEXISTENTE", severity: "error", message: `cClassTrib \`${code}\` ${why}.` };
+}


### PR DESCRIPTION
## Por quê
O erro corrigido no #394 (cClassTrib descrito como 8 díg, códigos/CSTs inventados) passou porque o `contentLint` só valida **alíquota-sem-contexto** e **promessas** — não pega fabricação técnica do conceito-bandeira.

## O que faz
`lintBlogFiscal` (determinístico, sem LLM) valida cada post contra a **tabela oficial SVRS** (`backend/app/data/classtrib.json`):
- **cClassTrib** citado (em `<cClassTrib>`, backtick de 6 díg, ou rotulado) → deve **existir na tabela** e ter **6 dígitos**;
- **CST IBS/CBS** de 3 díg (`CST 500`) → deve constar em `cst_descriptions` (000/200/400/410/510/550/620/800…);
- distingue **NCM** (8 díg, em `<NCM>`/`NCM \`…\``) de cClassTrib fabricado — sem falso-positivo.

Roda sobre **todos os posts** em `blogFiscalLint.test.ts` (entra no `npm test` → gate do `frontend-build` em todo PR). Inclui 8 testes unitários do comportamento.

## Dogfooding: já pegou um resíduo real
Ao rodar, o gate flagrou um erro que **passou batido no #394**: `CST 070`/`CST 080` (imunidade/não incidência) no `classtrib-mapear` — o correto é **CST 410**, que preenche o grupo normalmente. Corrigido neste PR.

## Gates
`npm test` **147/147** (138 + 9) · `npm run build` ✅.