### PR TITLE
feat(#365): /classtrib lê do classtrib.json (fonte única) + alíquota 2026

### DIFF
--- a/backend/app/data/classtrib_table.py
+++ b/backend/app/data/classtrib_table.py
@@ -13,13 +13,26 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from app.data.uf_rates import CBS_TESTE_2026, IBS_TESTE_2026_TOTAL
+from app.data.uf_rates import (
+    CBS_NATIONAL_RATE,
+    CBS_TESTE_2026,
+    IBS_NATIONAL_RATE,
+    IBS_TESTE_2026_TOTAL,
+)
 
 _DATA = json.loads((Path(__file__).parent / "classtrib.json").read_text(encoding="utf-8"))
 CLASSTRIB_BY_CODE: dict[str, dict] = _DATA.get("by_code", {})
+# Data da última sincronização SVRS (bloco meta) — exposto como last_synced_at na API.
+CLASSTRIB_SYNCED_AT: str | None = _DATA.get("meta", {}).get("date")
 
 # CSTs do cClassTrib que zeram o tributo independentemente de redução.
 _ZERO_CSTS = {"400", "410"}
+
+# Alíquotas de referência em pontos percentuais (uf_rates guarda como fração).
+_CBS_PLENA = float(CBS_NATIONAL_RATE) * 100  # 8,8
+_IBS_PLENA = float(IBS_NATIONAL_RATE) * 100  # 17,7
+_CBS_2026 = float(CBS_TESTE_2026) * 100      # 0,9
+_IBS_2026 = float(IBS_TESTE_2026_TOTAL) * 100  # 0,1
 
 
 def classtrib_expected_zero(code: str) -> tuple[bool, bool] | None:
@@ -95,3 +108,63 @@ def classtrib_cst(code: str) -> str | None:
     if item is None:
         return None
     return str(item.get("cst", "")) or None
+
+
+def _regime_slug(cst: str, red_cbs: float, red_ibs: float) -> str:
+    """Rótulo de regime derivado (padrao/isencao/imunidade/reducao_integral/reducao_N).
+
+    Mesma lógica que populou cclass_trib_items na migration 0020 — agora servida
+    direto do JSON (fonte única, #365).
+    """
+    if cst == "400":
+        return "isencao"
+    if cst == "410":
+        return "imunidade"
+    r = max(red_cbs, red_ibs)
+    if r >= 100:
+        return "reducao_integral"
+    if r > 0:
+        return f"reducao_{int(r)}"
+    return "padrao"
+
+
+def classtrib_api_item(code: str) -> dict | None:
+    """cClassTrib no formato do endpoint público, derivado do classtrib.json (#365).
+
+    Substitui a leitura da tabela DB `cclass_trib_items` — assim a API pública e o motor
+    compartilham a MESMA fonte, e o re-sync diário mantém ambos frescos sem migration.
+    Alíquotas em pontos percentuais: p_cbs/p_ibs = referência PLENA (8,8/17,7); os campos
+    *_2026 = fase de teste de 2026 (0,9/0,1). Isenção (CST 400)/imunidade (410) → 0.
+    """
+    it = CLASSTRIB_BY_CODE.get(code)
+    if it is None:
+        return None
+    cst = str(it.get("cst", ""))
+    red_cbs = float(it.get("reduction_cbs_pct", 0) or 0)
+    red_ibs = float(it.get("reduction_ibs_pct", 0) or 0)
+    zero = cst in _ZERO_CSTS
+    return {
+        "codigo": code,
+        "descricao": (it.get("description") or "").strip() or code,
+        "p_cbs": 0.0 if zero else round(_CBS_PLENA * (1 - red_cbs / 100), 4),
+        "p_ibs": 0.0 if zero else round(_IBS_PLENA * (1 - red_ibs / 100), 4),
+        "p_cbs_2026": 0.0 if zero else round(_CBS_2026 * (1 - red_cbs / 100), 4),
+        "p_ibs_2026": 0.0 if zero else round(_IBS_2026 * (1 - red_ibs / 100), 4),
+        "regime_especial": _regime_slug(cst, red_cbs, red_ibs),
+        "vigencia_ini": (it.get("vigencia_ini") or "2026-01-01") or "2026-01-01",
+        "vigencia_fim": None,
+        "is_active": True,
+        "last_synced_at": CLASSTRIB_SYNCED_AT,
+    }
+
+
+def classtrib_api_search(q: str, limit: int) -> list[dict]:
+    """Busca por substring na descrição (case-insensitive), ordenada por descrição (#365)."""
+    ql = q.lower()
+    hits = [
+        classtrib_api_item(code)
+        for code, it in CLASSTRIB_BY_CODE.items()
+        if ql in (it.get("description") or "").lower()
+    ]
+    hits.sort(key=lambda r: r["descricao"] if r else "")
+    return [h for h in hits if h][:limit]

--- a/backend/app/routers/classtrib.py
+++ b/backend/app/routers/classtrib.py
@@ -12,12 +12,10 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import text
-from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.data.classtrib_table import classtrib_api_item, classtrib_api_search
 from app.data.ncm_cclasstrib_table import ncm_candidatos
-from app.database import get_db
 from app.models.auth import User
 
 router = APIRouter(tags=["classtrib"])
@@ -28,8 +26,10 @@ router = APIRouter(tags=["classtrib"])
 class ClassTribItem(BaseModel):
     codigo: str
     descricao: str
-    p_cbs: float
-    p_ibs: float
+    p_cbs: float            # alíquota de referência PLENA (8,8) ajustada pela redução
+    p_ibs: float            # alíquota de referência PLENA (17,7) ajustada pela redução
+    p_cbs_2026: float       # alíquota da fase de teste 2026 (0,9) ajustada pela redução
+    p_ibs_2026: float       # alíquota da fase de teste 2026 (0,1) ajustada pela redução
     regime_especial: Optional[str]
     vigencia_ini: Optional[date]
     vigencia_fim: Optional[date]
@@ -64,22 +64,9 @@ class ValidateClassTribResponse(BaseModel):
 def search_classtrib(
     q: str = Query(..., min_length=2, description="Texto para busca na descrição"),
     limit: int = Query(20, ge=1, le=100),
-    db: Session = Depends(get_db),
 ) -> Any:
-    rows = db.execute(
-        text("""
-            SELECT * FROM cclass_trib_items
-            WHERE is_active = TRUE
-              AND (
-                descricao ILIKE :q
-                OR to_tsvector('portuguese', descricao) @@ plainto_tsquery('portuguese', :q2)
-              )
-            ORDER BY descricao
-            LIMIT :lim
-        """),
-        {"q": f"%{q}%", "q2": q, "lim": limit},
-    ).mappings().all()
-    return [dict(r) for r in rows]
+    # Fonte única: classtrib.json (mesma do motor), via #365 — sem tabela DB.
+    return classtrib_api_search(q, limit)
 
 
 @router.get(
@@ -87,18 +74,11 @@ def search_classtrib(
     response_model=ClassTribItem,
     summary="Lookup cClassTrib por código (público)",
 )
-def get_classtrib(codigo: str, db: Session = Depends(get_db)) -> Any:
-    row = db.execute(
-        text("""
-            SELECT *, synced_at::text AS last_synced_at
-            FROM cclass_trib_items
-            WHERE codigo = :c AND is_active = TRUE
-        """),
-        {"c": codigo},
-    ).mappings().fetchone()
-    if row is None:
+def get_classtrib(codigo: str) -> Any:
+    item = classtrib_api_item(codigo)
+    if item is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"cClassTrib '{codigo}' não encontrado.")
-    return dict(row)
+    return item
 
 
 # ── Endpoint autenticado ──────────────────────────────────────────────────────
@@ -110,14 +90,10 @@ def get_classtrib(codigo: str, db: Session = Depends(get_db)) -> Any:
 )
 def validate_classtrib(
     payload: ValidateClassTribRequest,
-    db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> Any:
-    # Buscar o cClassTrib informado
-    item = db.execute(
-        text("SELECT * FROM cclass_trib_items WHERE codigo = :c AND is_active = TRUE"),
-        {"c": payload.classtrib_informado},
-    ).mappings().fetchone()
+    # Buscar o cClassTrib informado na fonte única (classtrib.json) — #365.
+    item = classtrib_api_item(payload.classtrib_informado)
 
     if item is None:
         return ValidateClassTribResponse(
@@ -130,8 +106,6 @@ def validate_classtrib(
             p_ibs_correto=None,
             finding=None,
         )
-
-    item = dict(item)
 
     # Sugestão pelo mapeamento oficial NCM→cClassTrib (anexos SVRS) — NÃO mais por prefixo
     # de capítulo na taxonomia de produto (#313 Part 2). A mesma NCM pode admitir vários

--- a/backend/tests/test_classtrib.py
+++ b/backend/tests/test_classtrib.py
@@ -1,8 +1,8 @@
-"""Testes de regressão para cClassTrib — migration 0018 + endpoint + sync task.
+"""Testes de regressão para cClassTrib — endpoint (fonte: classtrib.json, #365) + sync task.
 
 Verifica que:
-- Os códigos essenciais (cesta básica, padrão, serviços) estão presentes na DB
-- As alíquotas estão corretas por regime
+- Os códigos essenciais (cesta básica, padrão, serviços) estão presentes no classtrib.json
+- As alíquotas estão corretas por regime (plena + fase de teste 2026)
 - O endpoint /public/classtrib/{codigo} retorna last_synced_at
 - O endpoint /public/classtrib/search retorna resultados relevantes
 - O endpoint /classtrib/validate detecta divergência de NCM × cClassTrib
@@ -54,10 +54,10 @@ def auth_client():
     app.dependency_overrides.pop(get_current_user, None)
 
 
-# ── Testes de dados — via API (migration 0020: 156 cClassTrib de 6 dígitos) ───
+# ── Testes de dados — via API (fonte: classtrib.json, #365) ───────────────────
 
 class TestClassTribData:
-    """A migration 0020 re-seedou os 156 cClassTrib de 6 dígitos (fonte pública SVRS)."""
+    """A API lê os cClassTrib de 6 dígitos do classtrib.json (fonte única SVRS, #365)."""
 
     @pytest.mark.parametrize("codigo,regime,zero", [
         ("000001", "padrao", False),
@@ -77,10 +77,16 @@ class TestClassTribData:
             assert float(data["p_cbs"]) > 0.0
 
     def test_padrao_usa_aliquota_de_referencia_plena(self):
-        """000001 (padrão) → alíquota de REFERÊNCIA PLENA (8,8 / 17,7), não a de teste 2026."""
+        """000001 (padrão) → p_cbs/p_ibs = REFERÊNCIA PLENA (8,8 / 17,7)."""
         data = client.get("/api/v1/public/classtrib/000001").json()
         assert float(data["p_cbs"]) == 8.8
         assert float(data["p_ibs"]) == 17.7
+
+    def test_expoe_aliquota_da_fase_de_teste_2026(self):
+        """#365: a API também expõe a alíquota da fase de teste 2026 (0,9 / 0,1)."""
+        data = client.get("/api/v1/public/classtrib/000001").json()
+        assert float(data["p_cbs_2026"]) == 0.9
+        assert float(data["p_ibs_2026"]) == 0.1
 
     def test_search_por_termo_da_descricao(self):
         resp = client.get("/api/v1/public/classtrib/search?q=serviços")


### PR DESCRIPTION
## Problema (achado na varredura)
A API pública `/classtrib` lia da tabela DB `cclass_trib_items` (populada por **migration**), enquanto o **motor** valida contra `classtrib.json`. O re-sync diário (#392) só atualiza o JSON → a API **divergia** do que o motor valida. Num produto fiscal, a API pública não pode divergir do motor.

## Correção
`/classtrib` agora lê do **`classtrib.json`** (fonte única). O re-sync diário mantém **API e motor frescos juntos, sem migration manual**.
- `classtrib_table.py`: `classtrib_api_item` / `classtrib_api_search` derivam **regime** (mesma lógica da migration 0020) e **alíquotas** do JSON; `last_synced_at` vem do `meta.date`.
- Router: endpoints públicos (search/lookup) **não dependem mais de DB**; `validate` mantém só `get_current_user`.
- Schema: adiciona **`p_cbs_2026`/`p_ibs_2026`** (fase de teste 0,9/0,1) ao lado da **plena** (8,8/17,7) — conforme decisão de expor ambos.

## Validação
- Derivação confere com os testes (padrão→8,8/17,7; isenção/imunidade/redução integral→0; reducao_60→3,52).
- `pyright` 0 erros · `ruff` ok · testes dos endpoints públicos **14/14 locais (sem DB)** · `validate` validado no CI (com Postgres).

**Bônus:** os testes públicos do `/classtrib` deixaram de exigir Postgres. A tabela `cclass_trib_items` fica vestigial para a API (não removida — `task_i_compliance` ainda referencia; limpeza futura).

⚠️ Backend → o merge dispara deploy-prod (rollback-safe).