### PR TITLE
chore(#365): aposenta a tabela vestigial cclass_trib_items

### DIFF
--- a/backend/app/alembic/versions/2026_06_30_0022_drop_cclass_trib_items.py
+++ b/backend/app/alembic/versions/2026_06_30_0022_drop_cclass_trib_items.py
@@ -1,0 +1,47 @@
+"""Drop cclass_trib_items — tabela vestigial (#365 follow-up).
+
+Desde o #365, a API pública /classtrib lê do classtrib.json (fonte única, igual ao
+motor) e ninguém mais lê esta tabela. O único escritor era o task sync_classtrib_svrs,
+agora removido (superado pelo scrape público diário → classtrib.json). Esta migration
+aposenta a tabela. ClassTribService (lookup/batch_validate) usa a API SVRS, não a tabela —
+não é afetado.
+
+Revision ID: 2026_06_30_0022
+Revises: 2026_06_26_0021
+"""
+
+from alembic import op
+
+revision = "2026_06_30_0022"
+down_revision = "2026_06_26_0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_cclass_trib_descricao")
+    op.execute("DROP INDEX IF EXISTS idx_cclass_trib_active")
+    op.execute("DROP INDEX IF EXISTS idx_cclass_trib_codigo")
+    op.execute("DROP TABLE IF EXISTS cclass_trib_items")
+
+
+def downgrade() -> None:
+    # Recria a estrutura (vazia) para reversibilidade do schema. Os dados não retornam —
+    # a fonte canônica passou a ser app/data/classtrib.json (#365).
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS cclass_trib_items (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            codigo          TEXT NOT NULL UNIQUE,
+            descricao       TEXT NOT NULL,
+            p_cbs           NUMERIC(8,4) NOT NULL DEFAULT 0,
+            p_ibs           NUMERIC(8,4) NOT NULL DEFAULT 0,
+            regime_especial TEXT,
+            vigencia_ini    DATE,
+            vigencia_fim    DATE,
+            is_active       BOOLEAN NOT NULL DEFAULT TRUE,
+            synced_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_cclass_trib_codigo ON cclass_trib_items(codigo)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_cclass_trib_active ON cclass_trib_items(is_active)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_cclass_trib_descricao ON cclass_trib_items USING gin(to_tsvector('portuguese', descricao))")

--- a/backend/app/tasks/task_i_compliance.py
+++ b/backend/app/tasks/task_i_compliance.py
@@ -1,4 +1,4 @@
-"""Task I — Calcular Compliance Score mensal por tenant e sincronizar cClassTrib."""
+"""Task I — Calcular Compliance Score mensal por tenant."""
 
 from __future__ import annotations
 
@@ -47,85 +47,6 @@ def compute_monthly_scores() -> dict:
 
     logger.info("compliance.compute_monthly_scores period=%s tenants=%d", period, processed)
     return {"period": period, "tenants_processed": processed}
-
-
-@celery.task(name="classtrib.sync_svrs", bind=False)
-def sync_classtrib_svrs() -> dict:
-    """Sincroniza tabela cClassTrib com a API SVRS. Roda semanalmente.
-
-    A API SVRS exige credenciais institucionais (retorna 403 sem autenticação).
-    Configure CLASSTRIB_API_TOKEN (env/secret) para enviar o header Authorization
-    Bearer; sem token, a API responde 403 e mantemos os dados da migration 0018
-    (regulamentos 30/abr/2026).
-    """
-    from app.config import settings
-    from app.database import SessionLocal
-    from app.services.classtrib_service import svrs_auth_headers
-    from sqlalchemy import text
-
-    SVRS_URL = settings.CLASSTRIB_API_URL
-
-    try:
-        import httpx
-        with httpx.Client(timeout=30, headers=svrs_auth_headers()) as client:
-            resp = client.get(SVRS_URL)
-
-        if resp.status_code == 403:
-            logger.warning(
-                "classtrib.sync_svrs: SVRS retornou 403 — credenciais necessárias. "
-                "Dados locais (migration 0018) permanecem válidos."
-            )
-            return {"synced": 0, "reason": "svrs_auth_required", "status_code": 403}
-
-        if resp.status_code == 404:
-            logger.warning("classtrib.sync_svrs: endpoint SVRS não encontrado (404).")
-            return {"synced": 0, "reason": "endpoint_not_found", "status_code": 404}
-
-        resp.raise_for_status()
-        items = resp.json()
-
-    except httpx.HTTPStatusError as exc:
-        logger.warning("classtrib.sync_svrs: HTTP %s — %s", exc.response.status_code, exc)
-        return {"synced": 0, "error": str(exc), "status_code": exc.response.status_code}
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("classtrib.sync_svrs: falha de rede (%s) — mantendo dados locais", exc)
-        return {"synced": 0, "error": str(exc)}
-
-    synced = 0
-    with SessionLocal() as db:
-        for item in items if isinstance(items, list) else []:
-            codigo = (item.get("codigo") or item.get("code") or "").strip()
-            descricao = (item.get("descricao") or item.get("description") or "").strip()
-            if not codigo:
-                continue
-            db.execute(
-                text("""
-                    INSERT INTO cclass_trib_items
-                        (codigo, descricao, p_cbs, p_ibs, regime_especial, vigencia_ini, synced_at, is_active)
-                    VALUES (:c, :d, :cbs, :ibs, :regime, :vi, now(), TRUE)
-                    ON CONFLICT (codigo) DO UPDATE SET
-                        descricao       = EXCLUDED.descricao,
-                        p_cbs           = EXCLUDED.p_cbs,
-                        p_ibs           = EXCLUDED.p_ibs,
-                        regime_especial = EXCLUDED.regime_especial,
-                        vigencia_ini    = EXCLUDED.vigencia_ini,
-                        synced_at       = now(),
-                        is_active       = TRUE
-                """),
-                {
-                    "c":      codigo,
-                    "d":      descricao,
-                    "cbs":    float(item.get("aliquotaCBS", item.get("p_cbs", 0.88))),
-                    "ibs":    float(item.get("aliquotaIBS", item.get("p_ibs", 0.176))),
-                    "regime": item.get("regimeEspecial", item.get("regime_especial")),
-                    "vi":     item.get("vigenciaIni", item.get("vigencia_ini", "2026-01-01")),
-                },
-            )
-            synced += 1
-        db.commit()
-
-    logger.info("classtrib.sync_svrs synced=%d items from SVRS", synced)
-    return {"synced": synced}
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/backend/tests/test_classtrib.py
+++ b/backend/tests/test_classtrib.py
@@ -1,4 +1,4 @@
-"""Testes de regressão para cClassTrib — endpoint (fonte: classtrib.json, #365) + sync task.
+"""Testes de regressão para cClassTrib — endpoint (fonte: classtrib.json, #365).
 
 Verifica que:
 - Os códigos essenciais (cesta básica, padrão, serviços) estão presentes no classtrib.json
@@ -6,12 +6,11 @@ Verifica que:
 - O endpoint /public/classtrib/{codigo} retorna last_synced_at
 - O endpoint /public/classtrib/search retorna resultados relevantes
 - O endpoint /classtrib/validate detecta divergência de NCM × cClassTrib
-- sync_classtrib_svrs trata 403 de forma graceful (sem lançar exceção)
+- svrs_auth_headers monta o header Authorization conforme CLASSTRIB_API_TOKEN
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
@@ -164,47 +163,6 @@ class TestClassTribValidate:
         assert resp.status_code == 401
 
 
-# ── Testes do task sync ───────────────────────────────────────────────────────
-
-class TestSyncClasstribSvrs:
-    def test_svrs_403_retorna_graceful(self):
-        """403 da SVRS não deve lançar exceção — retorna dict com reason."""
-        from app.tasks.task_i_compliance import sync_classtrib_svrs
-
-        mock_resp = MagicMock()
-        mock_resp.status_code = 403
-
-        with patch("httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.__enter__ = MagicMock(return_value=mock_client)
-            mock_client.__exit__ = MagicMock(return_value=False)
-            mock_client.get.return_value = mock_resp
-            mock_client_cls.return_value = mock_client
-
-            result = sync_classtrib_svrs()
-
-        assert result["synced"] == 0
-        assert result.get("reason") == "svrs_auth_required"
-        assert result.get("status_code") == 403
-
-    def test_svrs_network_error_retorna_graceful(self):
-        """Erro de rede não deve lançar exceção."""
-        import httpx
-        from app.tasks.task_i_compliance import sync_classtrib_svrs
-
-        with patch("httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.__enter__ = MagicMock(return_value=mock_client)
-            mock_client.__exit__ = MagicMock(return_value=False)
-            mock_client.get.side_effect = httpx.ConnectError("connection refused")
-            mock_client_cls.return_value = mock_client
-
-            result = sync_classtrib_svrs()
-
-        assert result["synced"] == 0
-        assert "error" in result
-
-
 class TestSvrsAuthHeaders:
     """#313 credential-ready: Authorization Bearer só quando CLASSTRIB_API_TOKEN setado."""
 
@@ -223,22 +181,3 @@ class TestSvrsAuthHeaders:
         monkeypatch.setattr(settings, "CLASSTRIB_API_TOKEN", "  tok-abc  ")
         h = svrs_auth_headers()
         assert h["Authorization"] == "Bearer tok-abc"  # trim aplicado
-
-    def test_sync_task_envia_authorization_quando_token(self, monkeypatch):
-        """O sync task injeta o header Authorization quando o token está configurado."""
-        from app.config import settings
-        from app.tasks.task_i_compliance import sync_classtrib_svrs
-        monkeypatch.setattr(settings, "CLASSTRIB_API_TOKEN", "tok-xyz")
-
-        mock_resp = MagicMock()
-        mock_resp.status_code = 403
-        with patch("httpx.Client") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.__enter__ = MagicMock(return_value=mock_client)
-            mock_client.__exit__ = MagicMock(return_value=False)
-            mock_client.get.return_value = mock_resp
-            mock_client_cls.return_value = mock_client
-            sync_classtrib_svrs()
-
-        _, kwargs = mock_client_cls.call_args
-        assert kwargs["headers"]["Authorization"] == "Bearer tok-xyz"


### PR DESCRIPTION
## Contexto
Depois do #365, a API `/classtrib` lê do `classtrib.json` e **ninguém mais lê** `cclass_trib_items`. O único escritor era o task `sync_classtrib_svrs` (sync via API com credencial — sempre 403, superado pelo scrape público diário).

## Mudanças
- Remove o task **`sync_classtrib_svrs`** de `task_i_compliance.py` (mantém `compute_monthly_scores`).
- **Migration `2026_06_30_0022`**: `DROP TABLE cclass_trib_items` (downgrade recria a estrutura vazia — dados não retornam, a fonte canônica é o JSON).
- Remove os testes do task (`TestSyncClasstribSvrs` + `test_sync_task_envia_authorization_quando_token`).

## ⚠️ Escopo ajustado (era "completa")
A checagem final de referências mostrou que **`ClassTribService` está VIVO** — usado por `validate_xml.batch_validate` e `validation.lookup`. Deletá-lo (como na opção "completa") **quebraria o motor**. Por isso **mantive** `classtrib_service.py`, `svrs_auth_headers`, configs `CLASSTRIB_API_*` e `TestSvrsAuthHeaders`. `ClassTribService` usa a API SVRS, **não** a tabela → o drop não o afeta.

## Validação
`ruff` ok · `pyright` 0 erros · testes públicos do `/classtrib` **16/16 locais (sem DB)** · `validate` via CI (Postgres) · `task_i_compliance` importa limpo (compute_monthly_scores intacto).

⚠️ Backend → merge dispara deploy-prod. O `DROP TABLE` só efetiva quando o alembic rodar na prod; o código novo não referencia a tabela, então não há janela de quebra (ordem segura).
