### PR TITLE
fix(#411): support — admin de tenant não é staff; isolamento cross-tenant fechado

### DIFF
--- a/backend/app/routers/support.py
+++ b/backend/app/routers/support.py
@@ -228,16 +228,30 @@ def list_tickets(
     return db.execute(stmt).scalars().all()
 
 
+def _is_tribultz_staff(user: User) -> bool:
+    """Só `superadmin` é equipe Tribultz. `admin` é papel de TENANT (default do
+    primeiro usuário de cada conta) e não dá acesso cross-tenant (#411)."""
+    return str(getattr(user, "role", "")) == "superadmin"
+
+
+def _get_ticket_scoped(db: Session, ticket_id: UUID, current_user: User) -> SupportTicket:
+    """Ticket do tenant do usuário; staff Tribultz enxerga qualquer tenant."""
+    ticket = db.get(SupportTicket, ticket_id)
+    if ticket is None or (
+        not _is_tribultz_staff(current_user)
+        and str(ticket.tenant_id) != str(current_user.tenant_id)
+    ):
+        raise HTTPException(status_code=404, detail="Ticket não encontrado.")
+    return ticket
+
+
 @router.get("/tickets/{ticket_id}", response_model=TicketRead)
 def get_ticket(
     ticket_id: UUID,
     db: Annotated[Session, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_user)],
 ):
-    ticket = db.get(SupportTicket, ticket_id)
-    if ticket is None or str(ticket.tenant_id) != str(current_user.tenant_id):
-        raise HTTPException(status_code=404, detail="Ticket não encontrado.")
-    return ticket
+    return _get_ticket_scoped(db, ticket_id, current_user)
 
 
 @router.post("/tickets/{ticket_id}/messages", response_model=MessageRead, status_code=201)
@@ -247,11 +261,9 @@ def add_message(
     db: Annotated[Session, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_user)],
 ):
-    ticket = db.get(SupportTicket, ticket_id)
-    if ticket is None or str(ticket.tenant_id) != str(current_user.tenant_id):
-        raise HTTPException(status_code=404, detail="Ticket não encontrado.")
+    _get_ticket_scoped(db, ticket_id, current_user)
 
-    is_staff = str(getattr(current_user, "role", "")) in ("superadmin", "admin")
+    is_staff = _is_tribultz_staff(current_user)
     msg = SupportMessage(
         ticket_id=ticket_id,
         user_id=current_user.id,
@@ -270,9 +282,7 @@ def list_messages(
     db: Annotated[Session, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_user)],
 ):
-    ticket = db.get(SupportTicket, ticket_id)
-    if ticket is None or str(ticket.tenant_id) != str(current_user.tenant_id):
-        raise HTTPException(status_code=404, detail="Ticket não encontrado.")
+    _get_ticket_scoped(db, ticket_id, current_user)
 
     stmt = (
         select(SupportMessage)
@@ -289,8 +299,7 @@ def update_ticket_status(
     db: Annotated[Session, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_user)],
 ):
-    role = str(getattr(current_user, "role", ""))
-    if role not in ("superadmin", "admin"):
+    if not _is_tribultz_staff(current_user):
         raise HTTPException(status_code=403, detail="Acesso restrito à equipe Tribultz.")
 
     ticket = db.get(SupportTicket, ticket_id)

--- a/backend/tests/test_support_tenancy.py
+++ b/backend/tests/test_support_tenancy.py
@@ -1,0 +1,163 @@
+"""#411: isolamento de tenant e papéis no /api/v1/support.
+
+Bug auditado em 02/07/2026: `update_ticket_status` aceitava role "admin"
+(papel default de todo primeiro usuário de tenant) como se fosse staff
+Tribultz e não validava tenant — admin do tenant B podia alterar status de
+ticket do tenant A. `add_message` marcava admins de tenant como is_staff.
+
+Padrão de auth: override de get_current_user (idêntico a test_exceptions.py).
+DB real (Postgres do testcontainer) com transaction rollback por teste.
+"""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.support import SupportTicket
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _make_user(session, role: str = "admin") -> User:
+    tenant = Tenant(name=f"Tenant {uuid.uuid4().hex[:6]}", slug=f"tenant-{uuid.uuid4()}")
+    session.add(tenant)
+    session.commit()
+    session.refresh(tenant)
+
+    user = User(
+        email=f"user-{uuid.uuid4()}@tribultz.com",
+        full_name="Usuário Teste",
+        password_hash="hashed",
+        tenant_id=tenant.id,
+        role=role,
+        email_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _make_ticket(session, owner: User) -> SupportTicket:
+    ticket = SupportTicket(
+        tenant_id=owner.tenant_id,
+        user_id=owner.id,
+        title="Erro na validação",
+        description="Detalhe do problema.",
+    )
+    session.add(ticket)
+    session.commit()
+    session.refresh(ticket)
+    return ticket
+
+
+@pytest.fixture(name="owner_a")
+def owner_a_fixture(session):
+    return _make_user(session, role="admin")
+
+
+@pytest.fixture(name="admin_b")
+def admin_b_fixture(session):
+    """Admin de OUTRO tenant — não pode tocar em nada do tenant A."""
+    return _make_user(session, role="admin")
+
+
+@pytest.fixture(name="superadmin")
+def superadmin_fixture(session):
+    return _make_user(session, role="superadmin")
+
+
+def _client_as(session, user: User) -> TestClient:
+    def override_get_db():
+        yield session
+
+    def override_get_current_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+# ── update_ticket_status: papéis e tenant ─────────────────────────────────
+
+
+def test_admin_de_outro_tenant_nao_altera_status(session, owner_a, admin_b):
+    ticket = _make_ticket(session, owner_a)
+    client = _client_as(session, admin_b)
+    resp = client.patch(f"/api/v1/support/tickets/{ticket.id}/status", json={"status": "closed"})
+    assert resp.status_code == 403, resp.text
+    session.refresh(ticket)
+    assert str(ticket.status) == "open"
+
+
+def test_admin_do_proprio_tenant_nao_e_staff_para_status(session, owner_a):
+    """Role 'admin' é admin do TENANT, não equipe Tribultz — endpoint é staff-only."""
+    ticket = _make_ticket(session, owner_a)
+    client = _client_as(session, owner_a)
+    resp = client.patch(f"/api/v1/support/tickets/{ticket.id}/status", json={"status": "closed"})
+    assert resp.status_code == 403, resp.text
+
+
+def test_superadmin_altera_status_de_qualquer_tenant(session, owner_a, superadmin):
+    ticket = _make_ticket(session, owner_a)
+    client = _client_as(session, superadmin)
+    resp = client.patch(f"/api/v1/support/tickets/{ticket.id}/status", json={"status": "in_progress"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "in_progress"
+
+
+# ── add_message: is_staff reservado a superadmin ──────────────────────────
+
+
+def test_admin_de_tenant_nao_e_is_staff_na_mensagem(session, owner_a):
+    ticket = _make_ticket(session, owner_a)
+    client = _client_as(session, owner_a)
+    resp = client.post(f"/api/v1/support/tickets/{ticket.id}/messages", json={"body": "Alguma novidade?"})
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["is_staff"] is False
+
+
+def test_superadmin_e_is_staff_na_mensagem(session, owner_a, superadmin):
+    ticket = _make_ticket(session, owner_a)
+    client = _client_as(session, superadmin)
+    resp = client.post(f"/api/v1/support/tickets/{ticket.id}/messages", json={"body": "Estamos analisando."})
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["is_staff"] is True
+
+
+# ── sanidade: leitura cross-tenant continua bloqueada ─────────────────────
+
+
+def test_leitura_cross_tenant_segue_404(session, owner_a, admin_b):
+    ticket = _make_ticket(session, owner_a)
+    client = _client_as(session, admin_b)
+    assert client.get(f"/api/v1/support/tickets/{ticket.id}").status_code == 404
+    assert client.get(f"/api/v1/support/tickets/{ticket.id}/messages").status_code == 404


### PR DESCRIPTION
Closes #411.

## O que muda
Auditoria multi-tenant de 02/07/2026 encontrou confusão de papéis em `app/routers/support.py`: o papel `admin` (default do **primeiro usuário de todo tenant**) era tratado como equipe Tribultz.

1. **`PATCH /tickets/{id}/status`**: era `role in ('superadmin','admin')` **sem check de tenant** → qualquer conta registrada podia alterar status de ticket de outro tenant por UUID (disparando e-mail ao dono). Agora: **só `superadmin`**.
2. **`POST /tickets/{id}/messages`**: `is_staff` era atribuído a admins de tenant (apareciam como 'equipe Tribultz' na thread). Agora: **`is_staff` só para `superadmin`**.
3. **Helper único `_get_ticket_scoped`** para GET ticket / GET+POST messages: usuário comum enxerga só o próprio tenant; **superadmin (staff) ganha bypass** — antes o staff **não conseguia ler nem responder** ticket de cliente (o check de mesmo-tenant bloqueava), o que tornava o fluxo de suporte inoperante.

## Testes
`tests/test_support_tenancy.py` (6 novos, padrão do test_exceptions.py):
- admin do tenant B → PATCH status do ticket do tenant A = **403**, status intacto
- admin do próprio tenant → PATCH status = 403 (staff-only)
- superadmin → PATCH status cross-tenant = 200
- admin de tenant → mensagem com `is_staff=False`; superadmin → `is_staff=True` (cross-tenant)
- sanidade: leitura cross-tenant por não-staff segue 404

## Gates
Backend **620 passed**, ruff limpo, pyright 0 erros nos arquivos alterados. Frontend não afetado.