### PR TITLE
feat(#399): probe de object storage no /health/deep

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,7 +22,7 @@ JWT_SECRET=              # REQUIRED (min 32 chars, generate with: openssl rand -
 # ── MinIO / S3 (desenvolvimento local) ──────────────────────
 MINIO_ROOT_USER=         # REQUIRED
 MINIO_ROOT_PASSWORD=     # REQUIRED (min 8 chars)
-S3_ENDPOINT=http://minio:9000   # dev: MinIO | prod: https://s3.magalu.cloud
+S3_ENDPOINT=http://minio:9000   # dev: MinIO | prod: https://br-se1.magaluobjects.com
 S3_REGION=us-east-1             # Magalu Cloud: br-se1
 S3_FORCE_PATH_STYLE=true        # MinIO: true | Magalu Cloud: false
 S3_BUCKET=tribultz              # REQUIRED
@@ -35,7 +35,7 @@ MAGALU_ACCESS_KEY_ID=           # Magalu Cloud IAM Access Key
 MAGALU_SECRET_ACCESS_KEY=       # Magalu Cloud IAM Secret Key
 MAGALU_BUCKET_DOCUMENTS=tribultz-documents   # bucket principal (NF-e, PDF, batch)
 MAGALU_BUCKET_AUDIT=tribultz-audit-logs      # bucket de logs de auditoria LGPD
-MAGALU_S3_ENDPOINT=https://s3.magalu.cloud   # endpoint S3-compatible
+MAGALU_S3_ENDPOINT=https://br-se1.magaluobjects.com   # endpoint S3-compatible
 MAGALU_S3_REGION=br-se1                      # região brasileira
 # Em produção: copiar MAGALU_* para S3_* e setar S3_FORCE_PATH_STYLE=false
 

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -12,8 +12,10 @@ import smtplib
 import time
 from typing import Literal
 
+import boto3
 import httpx
 import redis as redis_lib
+from botocore.config import Config as BotoConfig
 from fastapi import APIRouter
 from pydantic import BaseModel
 from sqlalchemy import text
@@ -39,6 +41,7 @@ class DeepHealthResponse(BaseModel):
     ai_engine: ServiceStatus
     hubspot: ServiceStatus
     email: ServiceStatus
+    storage: ServiceStatus
     latency_ms: int
 
 
@@ -163,6 +166,39 @@ def _probe_ai_engine() -> ServiceStatus:
         return "unreachable"
 
 
+def _probe_s3() -> ServiceStatus:
+    """HEAD the configured object-storage bucket (boto3 head_bucket, timeout 3s).
+
+    O storage guarda XMLs enviados, bundles de export e evidências — é crítico:
+    sem ele não há validação com evidência. Retorna 'unconfigured' quando o
+    endpoint/bucket estão em branco, para não alertar em ambientes sem object
+    storage (dev). Qualquer falha real (endpoint morto, timeout, credencial
+    inválida) é 'unreachable' — o Uptime Monitor precisa gritar.
+    """
+    if not settings.S3_ENDPOINT or not settings.S3_BUCKET:
+        return "unconfigured"
+    try:
+        client = boto3.client(
+            "s3",
+            endpoint_url=settings.S3_ENDPOINT,
+            aws_access_key_id=settings.S3_ACCESS_KEY,
+            aws_secret_access_key=settings.S3_SECRET_KEY,
+            region_name=settings.S3_REGION,
+            config=BotoConfig(
+                signature_version="s3v4",
+                s3={"addressing_style": "path" if settings.S3_FORCE_PATH_STYLE else "virtual"},
+                connect_timeout=3,
+                read_timeout=3,
+                retries={"max_attempts": 0},
+            ),
+        )
+        client.head_bucket(Bucket=settings.S3_BUCKET)
+        return "ok"
+    except Exception as exc:
+        logger.warning("Health: object storage probe failed — %s", exc)
+        return "unreachable"
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 @router.api_route("", methods=["GET", "HEAD"], summary="Liveness probe")
@@ -197,10 +233,17 @@ def readiness() -> DeepHealthResponse:
     ai_status      = _probe_ai_engine()
     hubspot_status = _probe_hubspot()
     email_status   = _probe_email()
+    storage_status = _probe_s3()
 
     latency_ms = int((time.monotonic() - t0) * 1000)
 
-    critical_ok = db_status == "ok" and redis_status == "ok"
+    # storage é crítico: sem object storage não há validação com evidência.
+    # 'unconfigured' (dev sem storage) não alerta; 'unreachable' derruba o status.
+    critical_ok = (
+        db_status == "ok"
+        and redis_status == "ok"
+        and storage_status in ("ok", "unconfigured")
+    )
     optional_ok = (
         asaas_status   in ("ok", "unconfigured") and
         ai_status      in ("ok", "unconfigured") and
@@ -223,6 +266,7 @@ def readiness() -> DeepHealthResponse:
         ai_engine=ai_status,
         hubspot=hubspot_status,
         email=email_status,
+        storage=storage_status,
         latency_ms=latency_ms,
     )
 

--- a/backend/tests/test_health_deep.py
+++ b/backend/tests/test_health_deep.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -15,9 +16,19 @@ from app.main import app
 client = TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def _s3_probe_ok():
+    """Default o probe de storage para 'ok' em todos os testes deste arquivo, para
+    que os testes de readiness pré-existentes (que só mockam 6 probes) sigam verdes.
+    Os testes específicos de storage sobrescrevem com um patch interno; o unit test
+    do probe real vive em test_health_s3_probe.py (sem este autouse)."""
+    with patch("app.routers.health._probe_s3", return_value="ok"):
+        yield
+
+
 # ── Helper ────────────────────────────────────────────────────────────────────
 
-def _patch_probes(db="ok", redis="ok", asaas="unconfigured", ai="unconfigured", hubspot="unconfigured", email="unconfigured"):
+def _patch_probes(db="ok", redis="ok", asaas="unconfigured", ai="unconfigured", hubspot="unconfigured", email="unconfigured", storage="ok"):
     """Context manager that patches all six probe functions."""
     return (
         patch("app.routers.health._probe_db",         return_value=db),
@@ -26,6 +37,7 @@ def _patch_probes(db="ok", redis="ok", asaas="unconfigured", ai="unconfigured", 
         patch("app.routers.health._probe_ai_engine",   return_value=ai),
         patch("app.routers.health._probe_hubspot",     return_value=hubspot),
         patch("app.routers.health._probe_email",       return_value=email),
+        patch("app.routers.health._probe_s3",          return_value=storage),
     )
 
 
@@ -164,6 +176,54 @@ class TestReadiness:
         assert "latency_ms" in body
         assert isinstance(body["latency_ms"], int)
         assert body["latency_ms"] >= 0
+
+
+# ── Storage readiness (#399) ──────────────────────────────────────────────────
+
+class TestStorageReadiness:
+    def test_storage_unreachable_returns_error(self):
+        """Storage é crítico: unreachable derruba o status para 'error' (alerta)."""
+        with (
+            patch("app.routers.health._probe_db",         return_value="ok"),
+            patch("app.routers.health._probe_redis",       return_value="ok"),
+            patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
+            patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
+            patch("app.routers.health._probe_hubspot",     return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
+            patch("app.routers.health._probe_s3",          return_value="unreachable"),
+        ):
+            r = client.get("/health/ready")
+        assert r.json()["status"] == "error"
+        assert r.json()["storage"] == "unreachable"
+
+    def test_storage_unconfigured_stays_ok(self):
+        """Storage unconfigured (dev sem object storage) NÃO deve alertar."""
+        with (
+            patch("app.routers.health._probe_db",         return_value="ok"),
+            patch("app.routers.health._probe_redis",       return_value="ok"),
+            patch("app.routers.health._probe_asaas",       return_value="ok"),
+            patch("app.routers.health._probe_ai_engine",   return_value="ok"),
+            patch("app.routers.health._probe_hubspot",     return_value="ok"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
+            patch("app.routers.health._probe_s3",          return_value="unconfigured"),
+        ):
+            r = client.get("/health/ready")
+        assert r.json()["status"] == "ok"
+        assert r.json()["storage"] == "unconfigured"
+
+    def test_storage_ok_present_in_response(self):
+        with (
+            patch("app.routers.health._probe_db",         return_value="ok"),
+            patch("app.routers.health._probe_redis",       return_value="ok"),
+            patch("app.routers.health._probe_asaas",       return_value="unconfigured"),
+            patch("app.routers.health._probe_ai_engine",   return_value="unconfigured"),
+            patch("app.routers.health._probe_hubspot",     return_value="unconfigured"),
+            patch("app.routers.health._probe_email",       return_value="unconfigured"),
+            patch("app.routers.health._probe_s3",          return_value="ok"),
+        ):
+            r = client.get("/health/deep")
+        assert r.json()["storage"] == "ok"
+        assert r.json()["status"] == "ok"
 
 
 # ── Deep alias (/health/deep) ─────────────────────────────────────────────────

--- a/backend/tests/test_health_s3_probe.py
+++ b/backend/tests/test_health_s3_probe.py
@@ -1,0 +1,68 @@
+"""Unit tests for the object-storage probe (_probe_s3) — #399.
+
+Kept in a separate file (no autouse _probe_s3 patch) so the real function runs.
+boto3 is mocked; no live storage needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+
+class TestS3Probe:
+    def _cfg(self, cfg, endpoint="https://br-se1.magaluobjects.com", bucket="tribultz"):
+        cfg.S3_ENDPOINT = endpoint
+        cfg.S3_BUCKET = bucket
+        cfg.S3_ACCESS_KEY = "key"
+        cfg.S3_SECRET_KEY = "secret"
+        cfg.S3_REGION = "br-se1"
+        cfg.S3_FORCE_PATH_STYLE = False
+
+    def test_unconfigured_when_no_endpoint(self):
+        with patch("app.routers.health.settings") as cfg:
+            self._cfg(cfg, endpoint="")
+            from app.routers.health import _probe_s3
+            assert _probe_s3() == "unconfigured"
+
+    def test_unconfigured_when_no_bucket(self):
+        with patch("app.routers.health.settings") as cfg:
+            self._cfg(cfg, bucket="")
+            from app.routers.health import _probe_s3
+            assert _probe_s3() == "unconfigured"
+
+    def test_ok_when_head_bucket_succeeds(self):
+        mock_client = MagicMock()
+        with (
+            patch("app.routers.health.settings") as cfg,
+            patch("app.routers.health.boto3.client", return_value=mock_client),
+        ):
+            self._cfg(cfg)
+            from app.routers.health import _probe_s3
+            assert _probe_s3() == "ok"
+        mock_client.head_bucket.assert_called_once_with(Bucket="tribultz")
+
+    def test_unreachable_on_timeout(self):
+        mock_client = MagicMock()
+        mock_client.head_bucket.side_effect = Exception("connect timeout")
+        with (
+            patch("app.routers.health.settings") as cfg,
+            patch("app.routers.health.boto3.client", return_value=mock_client),
+        ):
+            self._cfg(cfg, endpoint="https://dead.endpoint.invalid")
+            from app.routers.health import _probe_s3
+            assert _probe_s3() == "unreachable"
+
+    def test_unreachable_on_invalid_credentials(self):
+        mock_client = MagicMock()
+        mock_client.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadBucket"
+        )
+        with (
+            patch("app.routers.health.settings") as cfg,
+            patch("app.routers.health.boto3.client", return_value=mock_client),
+        ):
+            self._cfg(cfg)
+            from app.routers.health import _probe_s3
+            assert _probe_s3() == "unreachable"


### PR DESCRIPTION
Closes #399.

## Problema
O `/health/deep` sondava 6 subsistemas (db, redis, asaas, ai, hubspot, email) mas **não o object storage** (Magalu), onde ficam XMLs enviados, bundles de export e **evidências**. Se o storage caísse, upload/validação/export quebravam e o **Uptime Monitor continuava verde**. É o cenário "um motor de evidência que falha em silêncio".

## Mudança
- **`_probe_s3()`** — `head_bucket` via boto3, timeout 3s, mesmo contrato dos probes existentes (`ok | unreachable | unconfigured`). Cliente com timeout curto e `retries=0` (não trava o health check num endpoint morto).
- **`storage`** no `DeepHealthResponse` e no `critical_ok`: storage é crítico (sem ele não há validação com evidência) → `unreachable` derruba o status para `error` e o Uptime Monitor alerta via Resend; `unconfigured` (dev sem storage) não alerta.
- **`.env.example`**: corrige o endpoint morto `s3.magalu.cloud` (não resolve no DNS) → `br-se1.magaluobjects.com` (2 ocorrências).

## Testes (44 passando, sem Postgres)
- Unit do probe (`test_health_s3_probe.py`): ok / timeout / credencial inválida / unconfigured.
- Readiness (`test_health_deep.py`): storage `unreachable` → `error`; `unconfigured` → `ok`; presença de `storage` na resposta.
- Fixture `autouse` mantém os testes de readiness pré-existentes verdes sem rodar o probe real.
- `ruff check` limpo nos arquivos alterados.

## DoD
- [x] `/health/deep` retorna `storage` com probe real (head_bucket)
- [x] Falha de storage derruba `status` para não-ok (alerta Resend)
- [x] Teste unitário do probe (mock boto3: ok, timeout, credencial inválida)
- [x] `.env.example` sem referência a `s3.magalu.cloud