### PR TITLE
chore(#417): Tribultz Weekly Snapshot — framework de baseline semanal

### DIFF
--- a/tools/operational-baseline/README.md
+++ b/tools/operational-baseline/README.md
@@ -1,0 +1,37 @@
+# Tribultz Weekly Snapshot
+
+Retrato semanal do estado da empresa — **produto, infraestrutura, dados, saúde** —
+como referência de regressão e linha do tempo operacional. Não é RFC, não é
+feature: **é hábito.** Roda toda sexta.
+
+## Uso
+
+```bash
+bash tools/operational-baseline/operational_baseline.sh
+# → tools/operational-baseline/output/AAAA-MM-DD.md
+```
+
+Depois, **preencher à mão o bloco de reflexão** no fim do snapshot gerado.
+
+## O ritual (toda sexta)
+
+1. Rodar o gerador.
+2. Preencher a reflexão obrigatória (aprendizado / risco / decisão / evidência / prioridade).
+3. `diff` contra o snapshot da sexta anterior → "o que mudou?".
+4. Commitar o novo `output/AAAA-MM-DD.md`.
+
+## O que ele mede
+
+Ver [`baseline_config.yml`](baseline_config.yml). Cada métrica declara sua **fonte**:
+
+- **repo** — medido sempre (grep/ls no checkout): regras, cClassTrib, routers, endpoints, páginas, migrations, TODO/FIXME, storage probe, known limitations.
+- **gh** — GitHub CLI, se disponível: issues abertas / P2.
+- **db** — banco (usuários, empresas, API keys, laudos, XML processados, migrations pendentes): hoje `n/d`; preenchido quando rodado em ambiente com DB (CI/VM). O **slot existe desde a semana 1** — o histórico importa mais que o número.
+- **manual** — RFCs abertas (vivem no `tribultz-brain`).
+
+## Princípio
+
+Mede o que dá para medir; declara `n/d` o que não dá. Nunca afirma um estado sem
+evidência — o mesmo princípio que a Tribultz aplica ao produto, aplicado a si mesma.
+As "known limitations" (Early Adopter / Grant / Effective License / TERA) são
+rastreadas por **ausência** (grep = 0); quando passarem de 0, a Fase 1 começou a existir.

--- a/tools/operational-baseline/baseline_config.yml
+++ b/tools/operational-baseline/baseline_config.yml
@@ -1,0 +1,38 @@
+# Tribultz Weekly Snapshot — configuração das métricas.
+# Cada métrica declara sua FONTE. O script preenche o que consegue medir no
+# ambiente atual; o que depende de fonte indisponível vira "n/d" (o slot
+# permanece, para o histórico ser consistente desde a semana 1).
+#
+# Fontes: repo (grep/ls no checkout) · gh (GitHub CLI) · db (banco — CI/VM) · manual
+
+next_priority: "TERA (RFC-0018) — ver tribultz-brain rfcs/README (ordem revenue-first)"
+
+metrics:
+  produto:
+    - { nome: "Regras determinísticas", fonte: repo }   # RULES_COUNT
+    - { nome: "cClassTrib",             fonte: repo }   # CLASSTRIB_COUNT
+    - { nome: "Routers (backend)",      fonte: repo }
+    - { nome: "Endpoints (rotas)",      fonte: repo }
+    - { nome: "Páginas (frontend)",     fonte: repo }
+  infraestrutura:
+    - { nome: "Migrations (arquivos)",  fonte: repo }
+    - { nome: "Migrations pendentes",   fonte: db }
+    - { nome: "Health storage probe",   fonte: repo }
+  dados:
+    - { nome: "Usuários",       fonte: db }
+    - { nome: "Empresas",       fonte: db }
+    - { nome: "API Keys",       fonte: db }
+    - { nome: "Laudos gerados", fonte: db }
+    - { nome: "XML processados",fonte: db }
+  saude:
+    - { nome: "TODO/FIXME",     fonte: repo }
+    - { nome: "Issues abertas", fonte: gh }
+    - { nome: "Issues P2",      fonte: gh }
+    - { nome: "RFCs abertas",   fonte: manual }  # vivem no tribultz-brain
+
+# Known limitations rastreadas por ausência (grep whole-word) — devem ser 0 na Fase 0.
+known_limitations:
+  - { termo: "EarlyAdopter",     destrava: "RFC-0017" }
+  - { termo: "EarlyGrant",       destrava: "ADR-0008" }
+  - { termo: "EffectiveLicense", destrava: "ADR-0008" }
+  - { termo: "TERA",             destrava: "RFC-0018" }

--- a/tools/operational-baseline/operational_baseline.sh
+++ b/tools/operational-baseline/operational_baseline.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Tribultz Weekly Snapshot — retrato semanal do estado da empresa (produto + infra
+# + dados + saúde). Hábito: rodar toda sexta.
+#
+#   bash tools/operational-baseline/operational_baseline.sh [repo_root]
+#
+# Mede o que consegue no ambiente atual; fontes indisponíveis viram "n/d" (o slot
+# permanece, para o histórico ser consistente). Não falha se um grep achar 0.
+set +e
+export PATH="$PATH:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${1:-$(cd "$HERE/../.." && pwd)}"
+cd "$ROOT" || exit 1
+TEMPLATE="$HERE/templates/snapshot.md"
+CONFIG="$HERE/baseline_config.yml"
+DATE="$(date +%F)"
+OUT="$HERE/output/$DATE.md"
+
+# ── medições ──────────────────────────────────────────────────────────────────
+n_lines() { wc -l | tr -d ' '; }
+count()   { grep -oE "$1 = [0-9]+" frontend/src/lib/validation/rulesMeta.ts 2>/dev/null | grep -oE '[0-9]+' | head -1; }
+absent()  { grep -rnwE "$1" backend/app frontend/src 2>/dev/null | grep -viE 'test|\.md|snapshot' | n_lines; }
+
+REF="$(git rev-parse --short HEAD 2>/dev/null || echo '?')"
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+WEEK="$(date +%V)"
+RULES="$(count RULES_COUNT)";       RULES="${RULES:-n/d}"
+CLASSTRIB="$(count CLASSTRIB_COUNT)"; CLASSTRIB="${CLASSTRIB:-n/d}"
+ROUTERS="$(ls backend/app/routers/*.py 2>/dev/null | grep -v __init__ | n_lines)"
+ENDPOINTS="$(grep -rhoE '@router\.(get|post|put|delete|patch|api_route)' backend/app/routers 2>/dev/null | n_lines)"
+PAGES="$(ls -d frontend/src/app/*/ 2>/dev/null | n_lines)"
+MIGRATIONS="$(ls backend/app/alembic/versions/*.py 2>/dev/null | n_lines)"
+TODOS="$(grep -rnE 'TODO|FIXME|XXX' backend/app frontend/src 2>/dev/null | grep -viE '\.md|snapshot' | n_lines)"
+S3="$(grep -c '_probe_s3' backend/app/routers/health.py 2>/dev/null)"
+[ "${S3:-0}" -gt 0 ] 2>/dev/null && STORAGE_PROBE="presente" || STORAGE_PROBE="AUSENTE"
+
+# gh (se disponível)
+if command -v gh >/dev/null 2>&1; then
+  ISSUES_OPEN="$(gh issue list --repo mickbap/tribultz --state open --limit 200 --json number -q 'length' 2>/dev/null)"
+  ISSUES_P2="$(gh issue list --repo mickbap/tribultz --state open --label P2 --limit 200 --json number -q 'length' 2>/dev/null)"
+fi
+ISSUES_OPEN="${ISSUES_OPEN:-n/d}"; ISSUES_P2="${ISSUES_P2:-n/d}"
+
+# db (não medido aqui — preenchido em ambiente com banco: CI/VM)
+USERS="n/d (requer DB)"; TENANTS="n/d (requer DB)"; APIKEYS="n/d (requer DB)"
+LAUDOS="n/d (requer DB)"; XMLS="n/d (requer DB)"; PENDING_MIGS="n/d (requer DB)"
+RFCS="ver tribultz-brain (status: proposed)"
+
+EA="$(absent EarlyAdopter)"; EG="$(absent EarlyGrant)"
+EL="$(absent EffectiveLicense)"; TERA="$(absent TERA)"
+NEXT_PRIORITY="$(grep -E '^next_priority:' "$CONFIG" | sed -E 's/^next_priority: *"?//; s/"? *$//')"
+
+# ── render (substitui {{VAR}} no template) ────────────────────────────────────
+render="$(cat "$TEMPLATE")"
+for kv in DATE WEEK REF BRANCH RULES CLASSTRIB ROUTERS ENDPOINTS PAGES \
+          MIGRATIONS PENDING_MIGS STORAGE_PROBE USERS TENANTS APIKEYS LAUDOS XMLS \
+          TODOS ISSUES_OPEN ISSUES_P2 RFCS EA EG EL TERA NEXT_PRIORITY; do
+  val="${!kv}"
+  render="${render//\{\{$kv\}\}/$val}"
+done
+printf '%s\n' "$render" > "$OUT"
+echo "Snapshot: $OUT (semana $WEEK, ref $BRANCH@$REF)"

--- a/tools/operational-baseline/output/2026-07-05.md
+++ b/tools/operational-baseline/output/2026-07-05.md
@@ -1,0 +1,61 @@
+# Tribultz Weekly Snapshot — Semana 27
+
+- **Data:** 2026-07-05
+- **Ref:** `chore/weekly-snapshot @ 8f1fd0f`
+- **Gerado por:** `tools/operational-baseline/operational_baseline.sh` (hábito: toda sexta)
+
+## Produto
+| Métrica | Valor |
+|---|---|
+| Regras determinísticas (`RULES_COUNT`) | 30 |
+| cClassTrib (`CLASSTRIB_COUNT`) | 164 |
+| Routers (backend) | 27 |
+| Endpoints (rotas) | 110 |
+| Páginas (frontend) | 37 |
+
+## Infraestrutura
+| Métrica | Valor |
+|---|---|
+| Migrations (arquivos) | 23 |
+| Migrations pendentes | n/d (requer DB) |
+| Health — storage probe | presente |
+
+## Dados
+| Métrica | Valor |
+|---|---|
+| Usuários | n/d (requer DB) |
+| Empresas (tenants) | n/d (requer DB) |
+| API Keys | n/d (requer DB) |
+| Laudos gerados | n/d (requer DB) |
+| XML processados | n/d (requer DB) |
+
+## Saúde
+| Métrica | Valor |
+|---|---|
+| TODO/FIXME no código | 3 |
+| Issues abertas | 12 |
+| Issues P2 (prioritárias) | 3 |
+| RFCs abertas | ver tribultz-brain (status: proposed) |
+
+## Motor / Known Limitations (Fase 1 — por design)
+| Item | Ocorrências | Destrava |
+|---|---|---|
+| Early Adopter | 0 | RFC-0017 |
+| Early Grant | 0 | ADR-0008 |
+| Effective License | 0 | ADR-0008 |
+| TERA | 0 | RFC-0018 |
+
+_Devem ser 0 na Fase 0. Quando passarem de 0, a Fase 1 começou a existir._
+
+## Próxima prioridade
+TERA (RFC-0018) — ver tribultz-brain rfcs/README (ordem revenue-first)
+
+---
+
+## Reflexão da semana (obrigatório — preencher à mão)
+
+- **Maior aprendizado da semana:** o desacoplamento autorização × pagamento **já existia implícito** no código (o login lê a `Subscription` local, não o ASAAS ao vivo) — a arquitetura que queríamos é evolução, não revolução.
+- **Maior risco da semana:** o RF004 do RFC-0017 (login que pula validação de pagamento) — segurança-crítico; motivou **suspender** a implementação até o ADR de License Resolver.
+- **Maior decisão tomada:** virada de *Build* → *Evidence Acquisition* + ordem revenue-first (TERA primeiro); e o princípio "o cliente escreve a Discovery, não o Brain".
+- **Maior evidência coletada:** #399 (storage probe) **em produção** (deploy-prod ✅); e este próprio primeiro Weekly Snapshot.
+- **Maior prioridade da próxima semana:** implementar o **TERA (RFC-0018)**.

--- a/tools/operational-baseline/templates/snapshot.md
+++ b/tools/operational-baseline/templates/snapshot.md
@@ -1,0 +1,61 @@
+# Tribultz Weekly Snapshot — Semana {{WEEK}}
+
+- **Data:** {{DATE}}
+- **Ref:** `{{BRANCH}} @ {{REF}}`
+- **Gerado por:** `tools/operational-baseline/operational_baseline.sh` (hábito: toda sexta)
+
+## Produto
+| Métrica | Valor |
+|---|---|
+| Regras determinísticas (`RULES_COUNT`) | {{RULES}} |
+| cClassTrib (`CLASSTRIB_COUNT`) | {{CLASSTRIB}} |
+| Routers (backend) | {{ROUTERS}} |
+| Endpoints (rotas) | {{ENDPOINTS}} |
+| Páginas (frontend) | {{PAGES}} |
+
+## Infraestrutura
+| Métrica | Valor |
+|---|---|
+| Migrations (arquivos) | {{MIGRATIONS}} |
+| Migrations pendentes | {{PENDING_MIGS}} |
+| Health — storage probe | {{STORAGE_PROBE}} |
+
+## Dados
+| Métrica | Valor |
+|---|---|
+| Usuários | {{USERS}} |
+| Empresas (tenants) | {{TENANTS}} |
+| API Keys | {{APIKEYS}} |
+| Laudos gerados | {{LAUDOS}} |
+| XML processados | {{XMLS}} |
+
+## Saúde
+| Métrica | Valor |
+|---|---|
+| TODO/FIXME no código | {{TODOS}} |
+| Issues abertas | {{ISSUES_OPEN}} |
+| Issues P2 (prioritárias) | {{ISSUES_P2}} |
+| RFCs abertas | {{RFCS}} |
+
+## Motor / Known Limitations (Fase 1 — por design)
+| Item | Ocorrências | Destrava |
+|---|---|---|
+| Early Adopter | {{EA}} | RFC-0017 |
+| Early Grant | {{EG}} | ADR-0008 |
+| Effective License | {{EL}} | ADR-0008 |
+| TERA | {{TERA}} | RFC-0018 |
+
+_Devem ser 0 na Fase 0. Quando passarem de 0, a Fase 1 começou a existir._
+
+## Próxima prioridade
+{{NEXT_PRIORITY}}
+
+---
+
+## Reflexão da semana (obrigatório — preencher à mão)
+
+- **Maior aprendizado da semana:** _(preencher)_
+- **Maior risco da semana:** _(preencher)_
+- **Maior decisão tomada:** _(preencher)_
+- **Maior evidência coletada:** _(preencher)_
+- **Maior prioridade da próxima semana:** _(preencher)_


### PR DESCRIPTION
Closes #417.

Eleva o Operational Baseline v1.0 a um **framework leve** — o retrato semanal da empresa (produto + infra + dados + saúde), como referência de regressão e linha do tempo operacional. Não é RFC, não é feature: é **hábito** (rodar toda sexta).

## Estrutura (`tools/operational-baseline/`)
- `operational_baseline.sh` — gerador (preenche o template a partir de medições)
- `baseline_config.yml` — métricas + fonte de cada uma (repo / gh / db / manual)
- `templates/snapshot.md` — template com bloco de reflexão obrigatório
- `output/2026-07-05.md` — **Semana 27**, primeira fotografia
- `README.md` — o ritual

## Princípio (o mesmo do produto)
Mede o que dá para medir; declara `n/d` o que não dá — nunca afirma um estado sem evidência. Métricas de **dados** (usuários, empresas, laudos, XML…) ficam `n/d` hoje (sem DB), mas o **slot existe desde a semana 1** — o histórico importa mais que o número. As **known limitations** (Early Adopter / Grant / Effective License / TERA) são rastreadas por **ausência** (grep = 0): quando passarem de 0, a Fase 1 começou a existir.

## Semana 27 (medido)
30 regras · 164 cClassTrib · 27 routers · 110 endpoints · 37 páginas · 23 migrations · storage probe presente · 3 TODO/FIXME · 12 issues (3 P2) · known limitations = 0.

Diff é 100% `tools/` — não toca app, build nem deploy.