### PR TITLE
chore(#420): Weekly Snapshot — pasta por ano + snapshot só fatos

### DIFF
--- a/tools/operational-baseline/README.md
+++ b/tools/operational-baseline/README.md
@@ -15,10 +15,15 @@ Depois, **preencher à mão o bloco de reflexão** no fim do snapshot gerado.
 
 ## O ritual (toda sexta)
 
-1. Rodar o gerador.
-2. Preencher a reflexão obrigatória (aprendizado / risco / decisão / evidência / prioridade).
+1. Rodar o gerador → `output/AAAA/AAAA-MM-DD.md` (**só fatos** — produto mede).
+2. **Interpretar no Brain** (não aqui): criar `tribultz-brain` → `knowledge/discovery/weekly/AAAA-Wnn.md`
+   com as 6 perguntas da Weekly Review (RFC-0023) — **Brain interpreta**.
 3. `diff` contra o snapshot da sexta anterior → "o que mudou?".
-4. Commitar o novo `output/AAAA-MM-DD.md`.
+4. Commitar o novo `output/AAAA/AAAA-MM-DD.md`.
+
+> **Regra: produto mede, Brain interpreta.** O snapshot nunca contém análise —
+> só fatos. Isso impede que o fato (imutável) e a interpretação (revisável) se
+> contaminem. Ver RFC-0023 no `tribultz-brain`.
 
 ## O que ele mede
 

--- a/tools/operational-baseline/operational_baseline.sh
+++ b/tools/operational-baseline/operational_baseline.sh
@@ -15,7 +15,9 @@ cd "$ROOT" || exit 1
 TEMPLATE="$HERE/templates/snapshot.md"
 CONFIG="$HERE/baseline_config.yml"
 DATE="$(date +%F)"
-OUT="$HERE/output/$DATE.md"
+YEAR="$(date +%Y)"
+mkdir -p "$HERE/output/$YEAR"
+OUT="$HERE/output/$YEAR/$DATE.md"
 
 # ── medições ──────────────────────────────────────────────────────────────────
 n_lines() { wc -l | tr -d ' '; }

--- a/tools/operational-baseline/output/2026/2026-07-05.md
+++ b/tools/operational-baseline/output/2026/2026-07-05.md
@@ -1,8 +1,13 @@
 # Tribultz Weekly Snapshot — Semana 27
 
 - **Data:** 2026-07-05
-- **Ref:** `chore/weekly-snapshot @ 8f1fd0f`
+- **Ref:** `chore/weekly-snapshot-refine @ 3a0244f`
 - **Gerado por:** `tools/operational-baseline/operational_baseline.sh` (hábito: toda sexta)
+
+> **Produto mede, Brain interpreta.** Este documento contém **apenas fatos** —
+> nenhuma análise. A interpretação da semana (aprendizado, risco, decisão,
+> evidência, prioridade, hipóteses derrotadas) vive no Brain: `tribultz-brain`
+> → `knowledge/discovery/weekly/AAAA-Wnn.md` (RFC-0023).
 
 ## Produto
 | Métrica | Valor |
@@ -33,8 +38,8 @@
 | Métrica | Valor |
 |---|---|
 | TODO/FIXME no código | 3 |
-| Issues abertas | 12 |
-| Issues P2 (prioritárias) | 3 |
+| Issues abertas | 13 |
+| Issues P2 (prioritárias) | 4 |
 | RFCs abertas | ver tribultz-brain (status: proposed) |
 
 ## Motor / Known Limitations (Fase 1 — por design)
@@ -52,10 +57,4 @@ TERA (RFC-0018) — ver tribultz-brain rfcs/README (ordem revenue-first)
 
 ---
 
-## Reflexão da semana (obrigatório — preencher à mão)
-
-- **Maior aprendizado da semana:** o desacoplamento autorização × pagamento **já existia implícito** no código (o login lê a `Subscription` local, não o ASAAS ao vivo) — a arquitetura que queríamos é evolução, não revolução.
-- **Maior risco da semana:** o RF004 do RFC-0017 (login que pula validação de pagamento) — segurança-crítico; motivou **suspender** a implementação até o ADR de License Resolver.
-- **Maior decisão tomada:** virada de *Build* → *Evidence Acquisition* + ordem revenue-first (TERA primeiro); e o princípio "o cliente escreve a Discovery, não o Brain".
-- **Maior evidência coletada:** #399 (storage probe) **em produção** (deploy-prod ✅); e este próprio primeiro Weekly Snapshot.
-- **Maior prioridade da próxima semana:** implementar o **TERA (RFC-0018)**.
+_Fatos apenas. Interpretação da semana → `tribultz-brain` `knowledge/discovery/weekly/` (RFC-0023: Produto mede, Brain interpreta)._

--- a/tools/operational-baseline/templates/snapshot.md
+++ b/tools/operational-baseline/templates/snapshot.md
@@ -4,6 +4,11 @@
 - **Ref:** `{{BRANCH}} @ {{REF}}`
 - **Gerado por:** `tools/operational-baseline/operational_baseline.sh` (hábito: toda sexta)
 
+> **Produto mede, Brain interpreta.** Este documento contém **apenas fatos** —
+> nenhuma análise. A interpretação da semana (aprendizado, risco, decisão,
+> evidência, prioridade, hipóteses derrotadas) vive no Brain: `tribultz-brain`
+> → `knowledge/discovery/weekly/AAAA-Wnn.md` (RFC-0023).
+
 ## Produto
 | Métrica | Valor |
 |---|---|
@@ -52,10 +57,4 @@ _Devem ser 0 na Fase 0. Quando passarem de 0, a Fase 1 começou a existir._
 
 ---
 
-## Reflexão da semana (obrigatório — preencher à mão)
-
-- **Maior aprendizado da semana:** _(preencher)_
-- **Maior risco da semana:** _(preencher)_
-- **Maior decisão tomada:** _(preencher)_
-- **Maior evidência coletada:** _(preencher)_
-- **Maior prioridade da próxima semana:** _(preencher)_
+_Fatos apenas. Interpretação da semana → `tribultz-brain` `knowledge/discovery/weekly/` (RFC-0023: Produto mede, Brain interpreta)._


### PR DESCRIPTION
Closes #420. Refino do framework (PR #418), a partir de review.

## Mudanças
1. **`output/AAAA/`** — snapshots organizados por ano (`output/2026/2026-07-05.md`). Em 2 anos, navegação limpa.
2. **Snapshot = só fatos** — o bloco de Reflexão saiu. A regra **"produto mede, Brain interpreta"** passa a valer: a interpretação da semana (aprendizado, risco, decisão, evidência, prioridade, e a nova 6ª pergunta *"o que acreditávamos sexta passada que a semana provou errado"*) vive no **Brain** (`discovery/weekly/AAAA-Wnn.md`, RFC-0023).

## Por quê
Fato (imutável, medido) e interpretação (revisável, humana) não devem se contaminar no mesmo artefato. O produto mede; o Brain pensa.

Contraparte no `tribultz-brain`: RFC-0023 (Weekly Review) + a 1ª Weekly Review (Semana 27) já commitadas. Diff aqui é 100% `tools/` — não toca app/build/deploy.