### PR TITLE
feat(#424): Partner Attribution v1 — proveniência comercial (RFC-0025)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -7,7 +7,7 @@ from alembic import context
 
 from app.database import Base
 from app.config import settings
-from app.models import api_key, auth, billing, documents, feedback, jobs, news, reports  # noqa: F401
+from app.models import api_key, auth, billing, documents, feedback, jobs, news, partner, reports  # noqa: F401
 
 # Import models to register them with metadata
 

--- a/backend/app/alembic/versions/2026_07_08_0024_add_partners.py
+++ b/backend/app/alembic/versions/2026_07_08_0024_add_partners.py
@@ -1,0 +1,60 @@
+"""add_partners — Partner Attribution v1 (RFC-0025)
+
+Proveniência comercial: quem apresentou cada empresa à Tribultz.
+- Cria a tabela ``partners`` (entidade de origem — nunca comissão/contrato/financeiro).
+- Adiciona ``tenants.partner_id`` (FK opcional, permanente, um só Partner).
+- ondelete=RESTRICT: um Partner nunca é apagado enquanto houver empresa vinculada
+  (sem exclusão física — desativação via ``status``).
+
+Revision ID: 2026_07_08_0024
+Revises: 2026_07_02_0023
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_08_0024"
+down_revision = "2026_07_02_0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "partners",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("type", sa.String(length=32), nullable=False, server_default="other"),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("company", sa.String(length=200), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("phone", sa.String(length=32), nullable=True),
+        sa.Column("code", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("code", name="uq_partners_code"),
+    )
+    op.add_column(
+        "tenants",
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_tenants_partner_id",
+        "tenants",
+        "partners",
+        ["partner_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index("ix_tenants_partner_id", "tenants", ["partner_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tenants_partner_id", table_name="tenants")
+    op.drop_constraint("fk_tenants_partner_id", "tenants", type_="foreignkey")
+    op.drop_column("tenants", "partner_id")
+    op.drop_table("partners")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -26,6 +26,14 @@ class Tenant(Base):
     slug = Column(String(100), nullable=False, unique=True)
     is_active = Column(Boolean, nullable=False, default=True)
     pedagogical_mode_2026 = Column(Boolean, nullable=False, server_default="TRUE")
+    # Proveniência comercial (RFC-0025): quem apresentou esta empresa à Tribultz.
+    # Opcional, permanente, um só Partner. ondelete=RESTRICT: Partner nunca é
+    # apagado enquanto houver empresa vinculada (integridade referencial).
+    partner_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("partners.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
     # Using server_default=func.now() for creation
     # Using onupdate=func.now() to ensure python-side updates trigger the timestamp update
     # Schema just says DEFAULT now(), so DB side auto-update depends on triggers (not present in standard schema dump).

--- a/backend/app/models/partner.py
+++ b/backend/app/models/partner.py
@@ -1,0 +1,75 @@
+"""Partner — proveniência comercial (RFC-0025, Partner Attribution v1).
+
+Um Partner responde, de forma permanente, "quem apresentou esta empresa à
+Tribultz?". É **exclusivamente origem comercial** — nunca comissão, contrato ou
+financeiro (guardrail RFC-0025). A origem vive em ``tenants.partner_id``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import Column, DateTime, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+# Tipos de Partner (RFC-0025). Armazenados em minúsculo.
+PARTNER_TYPES: tuple[str, ...] = (
+    "lawyer",
+    "accountant",
+    "consultancy",
+    "erp",
+    "association",
+    "influencer",
+    "other",
+)
+
+PARTNER_STATUSES: tuple[str, ...] = ("active", "inactive")
+
+# Partner Code: uppercase, sem acento/espaço, [A-Z0-9_-], 3–32 chars (RFC-0025).
+_PARTNER_CODE_RE = re.compile(r"^[A-Z0-9_-]{3,32}$")
+
+
+def normalize_partner_code(raw: str | None) -> str | None:
+    """Normaliza um código para o formato canônico (uppercase, sem espaços).
+
+    Retorna ``None`` quando o valor é vazio ou não bate com o formato — cabe ao
+    chamador decidir o que fazer (na captura do /register, um código inválido
+    apenas não vincula; no CRUD, é erro de validação).
+    """
+    if not raw:
+        return None
+    code = raw.strip().upper()
+    if not _PARTNER_CODE_RE.match(code):
+        return None
+    return code
+
+
+class Partner(Base):
+    __tablename__ = "partners"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    type = Column(String(32), nullable=False, default="other")
+    name = Column(String(200), nullable=False)
+    company = Column(String(200), nullable=True)
+    email = Column(String(255), nullable=True)
+    phone = Column(String(32), nullable=True)
+    # Código único de indicação. Guardado sempre normalizado (uppercase).
+    code = Column(String(32), nullable=False, unique=True)
+    status = Column(String(16), nullable=False, server_default="active")
+    notes = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -16,6 +16,12 @@ from app.models.admin_audit import AdminAuditLog
 from app.models.api_key import ApiKey
 from app.models.auth import User, Tenant
 from app.models.billing import Payment, Plan, Subscription
+from app.models.partner import (
+    PARTNER_STATUSES,
+    PARTNER_TYPES,
+    Partner,
+    normalize_partner_code,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
@@ -329,24 +335,42 @@ def admin_tenants(
     limit: int = 50,
     offset: int = 0,
     q: str | None = None,
+    partner_id: UUID | None = None,
 ) -> dict[str, Any]:
     stmt = select(Tenant)
     if q:
         stmt = stmt.where(Tenant.name.ilike(f"%{q}%"))
+    if partner_id is not None:
+        stmt = stmt.where(Tenant.partner_id == partner_id)
     total = _safe_count(db, select(func.count()).select_from(stmt.subquery()))
     rows = db.execute(
         stmt.order_by(Tenant.created_at.desc()).limit(min(limit, 200)).offset(max(offset, 0))
     ).scalars().all()
-    items = [
-        {
-            "id": str(t.id),
-            "name": cast(str, t.name),
-            "is_active": bool(t.is_active),
-            "users": _safe_count(db, select(func.count(User.id)).where(User.tenant_id == t.id)),
-            "created_at": cast(datetime, t.created_at).isoformat(),
-        }
-        for t in rows
-    ]
+    # Proveniência comercial (RFC-0025): resolve os Partners referenciados em lote.
+    partner_ids = {t.partner_id for t in rows if t.partner_id is not None}
+    partners = {
+        p.id: p
+        for p in (
+            db.execute(select(Partner).where(Partner.id.in_(partner_ids))).scalars().all()
+            if partner_ids
+            else []
+        )
+    }
+    items = []
+    for t in rows:
+        p = partners.get(t.partner_id) if t.partner_id is not None else None
+        items.append(
+            {
+                "id": str(t.id),
+                "name": cast(str, t.name),
+                "is_active": bool(t.is_active),
+                "users": _safe_count(db, select(func.count(User.id)).where(User.tenant_id == t.id)),
+                "created_at": cast(datetime, t.created_at).isoformat(),
+                "partner_id": str(t.partner_id) if t.partner_id is not None else None,
+                "partner_name": cast(str, p.name) if p is not None else None,
+                "partner_code": cast(str, p.code) if p is not None else None,
+            }
+        )
     return {"total": total, "limit": limit, "offset": offset, "items": items}
 
 
@@ -504,3 +528,212 @@ def admin_audit_log_list(
         for r in rows
     ]
     return {"total": total, "limit": limit, "offset": offset, "items": items}
+
+
+# ── Partner Attribution — proveniência comercial (RFC-0025, superadmin) ───────
+#
+# Partner = EXCLUSIVAMENTE origem comercial. Nunca comissão/contrato/financeiro.
+# Sem exclusão física: desativação via status. Toda mutação é auditada.
+
+
+def _partner_out(db: Session, p: Partner) -> dict[str, Any]:
+    return {
+        "id": str(p.id),
+        "type": cast(str, p.type),
+        "name": cast(str, p.name),
+        "company": p.company,
+        "email": p.email,
+        "phone": p.phone,
+        "code": cast(str, p.code),
+        "status": cast(str, p.status),
+        "notes": p.notes,
+        "companies": _safe_count(db, select(func.count(Tenant.id)).where(Tenant.partner_id == p.id)),
+        "created_at": cast(datetime, p.created_at).isoformat(),
+        "updated_at": cast(datetime, p.updated_at).isoformat(),
+    }
+
+
+class PartnerCreateBody(BaseModel):
+    type: str = "other"
+    name: str
+    company: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    code: str
+    notes: str | None = None
+
+
+class PartnerUpdateBody(BaseModel):
+    type: str | None = None
+    name: str | None = None
+    company: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    code: str | None = None
+    notes: str | None = None
+
+
+class SetPartnerBody(BaseModel):
+    # partner_id = None desvincula a origem (raro; auditado).
+    partner_id: UUID | None = None
+
+
+def _validate_code_unique(db: Session, raw: str, exclude_id: UUID | None = None) -> str:
+    code = normalize_partner_code(raw)
+    if code is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Código inválido. Use A-Z, 0-9, _ ou -, 3 a 32 caracteres.",
+        )
+    stmt = select(Partner).where(Partner.code == code)
+    if exclude_id is not None:
+        stmt = stmt.where(Partner.id != exclude_id)
+    if db.execute(stmt).scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Já existe um Partner com o código {code}.",
+        )
+    return code
+
+
+@router.get("/partners")
+def admin_partners(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    limit: int = 50,
+    offset: int = 0,
+    q: str | None = None,
+    status_filter: str | None = None,
+) -> dict[str, Any]:
+    stmt = select(Partner)
+    if q:
+        stmt = stmt.where(Partner.name.ilike(f"%{q}%") | Partner.code.ilike(f"%{q}%"))
+    if status_filter in PARTNER_STATUSES:
+        stmt = stmt.where(Partner.status == status_filter)
+    total = _safe_count(db, select(func.count()).select_from(stmt.subquery()))
+    rows = db.execute(
+        stmt.order_by(Partner.created_at.desc()).limit(min(limit, 200)).offset(max(offset, 0))
+    ).scalars().all()
+    return {
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "items": [_partner_out(db, p) for p in rows],
+    }
+
+
+@router.post("/partners", status_code=status.HTTP_201_CREATED)
+def admin_create_partner(
+    body: PartnerCreateBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    ptype = body.type.lower().strip()
+    if ptype not in PARTNER_TYPES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Tipo inválido: {body.type}.")
+    if not body.name.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nome é obrigatório.")
+    code = _validate_code_unique(db, body.code)
+    partner = Partner(
+        type=ptype,
+        name=body.name.strip(),
+        company=(body.company or None),
+        email=(body.email or None),
+        phone=(body.phone or None),
+        code=code,
+        notes=(body.notes or None),
+    )
+    db.add(partner)
+    db.flush()
+    _audit(db, _admin, "partner.create", "partner", partner.id, {"code": code, "name": partner.name, "type": ptype})
+    db.commit()
+    db.refresh(partner)
+    return _partner_out(db, partner)
+
+
+@router.patch("/partners/{partner_id}")
+def admin_update_partner(
+    partner_id: UUID,
+    body: PartnerUpdateBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    partner = db.get(Partner, partner_id)
+    if partner is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner não encontrado.")
+    changed: dict[str, Any] = {}
+    if body.type is not None:
+        ptype = body.type.lower().strip()
+        if ptype not in PARTNER_TYPES:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Tipo inválido: {body.type}.")
+        partner.type = ptype  # type: ignore[assignment]
+        changed["type"] = ptype
+    if body.name is not None:
+        if not body.name.strip():
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nome é obrigatório.")
+        partner.name = body.name.strip()  # type: ignore[assignment]
+        changed["name"] = partner.name
+    if body.code is not None:
+        code = _validate_code_unique(db, body.code, exclude_id=partner_id)
+        partner.code = code  # type: ignore[assignment]
+        changed["code"] = code
+    for field in ("company", "email", "phone", "notes"):
+        val = getattr(body, field)
+        if val is not None:
+            setattr(partner, field, val or None)
+            changed[field] = val or None
+    _audit(db, _admin, "partner.update", "partner", partner.id, {"changed": changed})
+    db.commit()
+    db.refresh(partner)
+    return _partner_out(db, partner)
+
+
+@router.post("/partners/{partner_id}/active")
+def admin_set_partner_active(
+    partner_id: UUID,
+    body: SetActiveBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    partner = db.get(Partner, partner_id)
+    if partner is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner não encontrado.")
+    new_status = "active" if body.is_active else "inactive"
+    before = cast(str, partner.status)
+    partner.status = new_status  # type: ignore[assignment]
+    _audit(
+        db, _admin,
+        "partner.activate" if body.is_active else "partner.deactivate",
+        "partner", partner.id,
+        {"before": before, "after": new_status, "code": cast(str, partner.code)},
+    )
+    db.commit()
+    return {"id": str(partner.id), "status": new_status}
+
+
+@router.post("/tenants/{tenant_id}/partner")
+def admin_set_tenant_partner(
+    tenant_id: UUID,
+    body: SetPartnerBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Atribui/ajusta manualmente a origem de uma empresa (casos vindos do
+    Microsoft Forms + criação manual — RFC-0025)."""
+    tenant = db.get(Tenant, tenant_id)
+    if tenant is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant não encontrado.")
+    before = str(tenant.partner_id) if tenant.partner_id is not None else None
+    if body.partner_id is not None:
+        partner = db.get(Partner, body.partner_id)
+        if partner is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner não encontrado.")
+        if cast(str, partner.status) != "active":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Partner inativo não pode ser vinculado.")
+    tenant.partner_id = body.partner_id  # type: ignore[assignment]
+    _audit(
+        db, _admin, "tenant.set_partner", "tenant", tenant.id,
+        {"before": before, "after": str(body.partner_id) if body.partner_id else None},
+    )
+    db.commit()
+    return {"id": str(tenant.id), "partner_id": str(body.partner_id) if body.partner_id else None}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.auth import Tenant, User, UserTenant
+from app.models.partner import Partner, normalize_partner_code
 from app.models.billing import Plan, Subscription, UsageTracking
 from app.schemas.auth import Token, TenantInfo, UserLogin, UserRead, UserRegister
 from app.core.security import (
@@ -77,6 +78,31 @@ def _get_or_create_tenant_for_cnpj(
     db.add(tenant)
     db.flush()  # get the ID without committing
     return tenant
+
+
+def _attach_partner_from_code(db: Session, tenant: Tenant, raw_code: str) -> None:
+    """Captura a proveniência comercial (RFC-0025) sem nunca bloquear o cadastro.
+
+    Vincula ``tenant.partner_id`` ao Partner ativo cujo código bate com o link
+    ``?partner=/?ref=``. Regras (RFC-0025):
+    - Código inválido ou inativo → apenas loga; a empresa entra sem vínculo.
+    - A origem é permanente: se o tenant já tem Partner, não sobrescreve.
+    """
+    code = normalize_partner_code(raw_code)
+    if not code:
+        if raw_code:
+            logger.info("partner attribution ignorada: código inválido %r", raw_code)
+        return
+    if tenant.partner_id is not None:
+        return  # origem já registrada — permanente, não sobrescreve
+    partner = db.execute(
+        select(Partner).where(Partner.code == code)
+    ).scalar_one_or_none()
+    if partner is None or cast(str, partner.status) != "active":
+        logger.info("partner attribution ignorada: código %s inexistente/inativo", code)
+        return
+    tenant.partner_id = partner.id  # type: ignore[assignment]
+    logger.info("partner attribution: tenant %s → partner %s", tenant.slug, code)
 
 
 def _get_user_tenants(db: Session, user_id: UUID) -> list[TenantInfo]:
@@ -233,6 +259,8 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
     # Auto-create tenant from CNPJ
     if data.cnpj:
         tenant = _get_or_create_tenant_for_cnpj(db, data.cnpj, company_name)
+        # Proveniência comercial (RFC-0025): captura não-bloqueante do Partner.
+        _attach_partner_from_code(db, tenant, data.partner_code)
     else:
         # Fallback to default tenant
         tenant = db.execute(

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -37,6 +37,9 @@ class UserRegister(BaseModel):
     lgpd_consent: bool = False
     tenant_slug: str = "default"
     captcha_token: str = ""
+    # Proveniência comercial (RFC-0025): código do Partner que indicou a empresa,
+    # capturado do link ?partner=/?ref=. Inválido/inativo NÃO bloqueia o cadastro.
+    partner_code: str = ""
 
     @field_validator("phone")
     @classmethod

--- a/backend/tests/test_partner_admin.py
+++ b/backend/tests/test_partner_admin.py
@@ -65,8 +65,10 @@ def _pg_available() -> bool:
 
 pytestmark_db = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
 
-engine = create_engine(DATABASE_URL) if _pg_available() else None
-TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine) if engine else None
+# create_engine é lazy (não conecta aqui); a conexão real só acontece nas fixtures
+# dos testes não-pulados. Criado incondicionalmente para o tipo não ser Optional.
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 @pytest.fixture(name="session")

--- a/backend/tests/test_partner_admin.py
+++ b/backend/tests/test_partner_admin.py
@@ -1,0 +1,155 @@
+"""Partner Attribution v1 (RFC-0025) — gate de acesso + CRUD/captura (integração DB).
+
+- Gate: os endpoints de Partner são superadmin-only (sem token → 401/403, nunca 404/200).
+- Integração (Postgres, como o CI): cadastro de Partner, código único, captura
+  não-bloqueante no /register, atribuição manual e persistência da origem.
+"""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_password_hash
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.partner import Partner
+
+anon_client = TestClient(app)
+
+# ── Gate (sem DB) ─────────────────────────────────────────────────────────────
+
+PARTNER_READ = ["/api/v1/admin/partners"]
+_UUID = "00000000-0000-0000-0000-000000000000"
+PARTNER_MUTATIONS = [
+    ("post", "/api/v1/admin/partners", {"name": "X", "code": "XPTO"}),
+    ("patch", f"/api/v1/admin/partners/{_UUID}", {"name": "Y"}),
+    ("post", f"/api/v1/admin/partners/{_UUID}/active", {"is_active": False}),
+    ("post", f"/api/v1/admin/tenants/{_UUID}/partner", {"partner_id": None}),
+]
+
+
+def test_partner_endpoints_registrados():
+    for path in PARTNER_READ:
+        assert anon_client.get(path).status_code != 404, f"{path} não registrado"
+
+
+def test_partner_leitura_exige_superadmin():
+    for path in PARTNER_READ:
+        assert anon_client.get(path).status_code in (401, 403)
+
+
+def test_partner_mutacoes_exigem_superadmin():
+    for method, path, body in PARTNER_MUTATIONS:
+        resp = getattr(anon_client, method)(path, json=body)
+        assert resp.status_code in (401, 403), f"{method} {path} veio {resp.status_code}"
+
+
+# ── Integração DB (Postgres, igual ao CI) ─────────────────────────────────────
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+
+def _pg_available() -> bool:
+    try:
+        eng = create_engine(DATABASE_URL)
+        with eng.connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark_db = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
+
+engine = create_engine(DATABASE_URL) if _pg_available() else None
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine) if engine else None
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(name="superadmin")
+def superadmin_fixture(session):
+    from app.api.deps import get_current_user
+
+    tenant = Tenant(name="Admin Tenant", slug=f"admin-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+    admin = User(
+        tenant_id=tenant.id,
+        email=f"admin-{uuid.uuid4().hex[:8]}@tribultz.com.br",
+        full_name="Super Admin",
+        password_hash=get_password_hash("x"),
+        role="superadmin",
+        email_verified=True,
+    )
+    session.add(admin)
+    session.flush()
+
+    def override():
+        return admin
+
+    app.dependency_overrides[get_current_user] = override
+    yield admin
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytestmark_db
+def test_crud_partner_e_codigo_unico(client, superadmin):
+    code = f"KATIA{uuid.uuid4().hex[:4].upper()}"
+    # criar
+    r = client.post("/api/v1/admin/partners", json={"type": "lawyer", "name": "Kátia Advogados", "code": code.lower()})
+    assert r.status_code == 201, r.text
+    pid = r.json()["id"]
+    assert r.json()["code"] == code  # normalizado para uppercase
+    assert r.json()["status"] == "active"
+    # código duplicado → 409
+    assert client.post("/api/v1/admin/partners", json={"name": "Outro", "code": code}).status_code == 409
+    # código inválido → 400
+    assert client.post("/api/v1/admin/partners", json={"name": "Z", "code": "a b!"}).status_code == 400
+    # tipo inválido → 400
+    assert client.post("/api/v1/admin/partners", json={"name": "Z", "code": "ZZZ123", "type": "banco"}).status_code == 400
+    # editar
+    r = client.patch(f"/api/v1/admin/partners/{pid}", json={"name": "Kátia & Associados"})
+    assert r.status_code == 200 and r.json()["name"] == "Kátia & Associados"
+    # desativar (nunca apagar)
+    r = client.post(f"/api/v1/admin/partners/{pid}/active", json={"is_active": False})
+    assert r.status_code == 200 and r.json()["status"] == "inactive"
+
+
+@pytestmark_db
+def test_atribuicao_manual_e_filtro(client, superadmin, session):
+    partner = Partner(type="accountant", name="INSI", code=f"INSI{uuid.uuid4().hex[:4].upper()}")
+    tenant = Tenant(name="Empresa Forms", slug=f"cnpj-{uuid.uuid4().hex[:12]}")
+    session.add_all([partner, tenant])
+    session.flush()
+    # atribuição manual (caso Microsoft Forms)
+    r = client.post(f"/api/v1/admin/tenants/{tenant.id}/partner", json={"partner_id": str(partner.id)})
+    assert r.status_code == 200 and r.json()["partner_id"] == str(partner.id)
+    # a origem aparece no /admin/tenants e o filtro por partner funciona
+    r = client.get(f"/api/v1/admin/tenants?partner_id={partner.id}")
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert any(it["id"] == str(tenant.id) and it["partner_name"] == "INSI" for it in items)

--- a/backend/tests/test_partner_code.py
+++ b/backend/tests/test_partner_code.py
@@ -1,0 +1,59 @@
+"""Partner Code — regras de formato (RFC-0025). Sem DB.
+
+Único · uppercase · sem acento/espaço · [A-Z0-9_-] · 3–32 chars.
+"""
+
+import pytest
+
+from app.models.partner import PARTNER_STATUSES, PARTNER_TYPES, normalize_partner_code
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("KATIA", "KATIA"),
+        ("katia", "KATIA"),            # normaliza para uppercase
+        ("  duquesa  ", "DUQUESA"),    # trim
+        ("ACIJOINVILLE", "ACIJOINVILLE"),
+        ("INSI", "INSI"),
+        ("A-B_C0", "A-B_C0"),          # hífen, underscore e dígito são válidos
+        ("ABC", "ABC"),                # mínimo 3
+        ("A" * 32, "A" * 32),          # máximo 32
+    ],
+)
+def test_codigos_validos_normalizam(raw, expected):
+    assert normalize_partner_code(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",              # vazio
+        None,            # ausente
+        "ab",            # curto demais (2)
+        "A" * 33,        # longo demais (33)
+        "com espaco",    # espaço no meio
+        "acentuação",    # acento
+        "KA!TIA",        # símbolo fora do conjunto
+        "kátia",         # acento minúsculo
+        "a.b",           # ponto não permitido
+    ],
+)
+def test_codigos_invalidos_viram_none(raw):
+    assert normalize_partner_code(raw) is None
+
+
+def test_catalogo_de_tipos_rfc_0025():
+    assert PARTNER_TYPES == (
+        "lawyer",
+        "accountant",
+        "consultancy",
+        "erp",
+        "association",
+        "influencer",
+        "other",
+    )
+
+
+def test_status_possiveis():
+    assert PARTNER_STATUSES == ("active", "inactive")

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -9,6 +9,7 @@ import { getToken } from "@/lib/storage";
 const NAV = [
   { href: "/admin", label: "Visão geral" },
   { href: "/admin/tenants", label: "Tenants" },
+  { href: "/admin/partners", label: "Parceiros" },
   { href: "/admin/users", label: "Usuários" },
   { href: "/admin/usage", label: "Uso & Operações" },
   { href: "/admin/system", label: "Saúde do sistema" },

--- a/frontend/src/app/admin/partners/page.tsx
+++ b/frontend/src/app/admin/partners/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminData, adminPost, adminRequest } from "@/lib/useAdminData";
+
+// Proveniência comercial (RFC-0025). Partner = origem, NUNCA comissão/contrato/financeiro.
+const TYPES: { value: string; label: string }[] = [
+  { value: "lawyer", label: "Advogado" },
+  { value: "accountant", label: "Contador" },
+  { value: "consultancy", label: "Consultoria" },
+  { value: "erp", label: "ERP" },
+  { value: "association", label: "Associação" },
+  { value: "influencer", label: "Influenciador" },
+  { value: "other", label: "Outro" },
+];
+const TYPE_LABEL = Object.fromEntries(TYPES.map((t) => [t.value, t.label]));
+
+type Partner = {
+  id: string;
+  type: string;
+  name: string;
+  company: string | null;
+  email: string | null;
+  phone: string | null;
+  code: string;
+  status: string;
+  notes: string | null;
+  companies: number;
+  created_at: string;
+};
+type Resp = { total: number; items: Partner[] };
+
+const EMPTY = { type: "other", name: "", company: "", email: "", phone: "", code: "", notes: "" };
+
+export default function AdminPartnersPage() {
+  const { data, error, loading, reload } = useAdminData<Resp>("/api/v1/admin/partners?limit=200");
+  const [form, setForm] = useState({ ...EMPTY });
+  const [editing, setEditing] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  function edit(p: Partner) {
+    setEditing(p.id);
+    setForm({
+      type: p.type,
+      name: p.name,
+      company: p.company ?? "",
+      email: p.email ?? "",
+      phone: p.phone ?? "",
+      code: p.code,
+      notes: p.notes ?? "",
+    });
+    setFormError(null);
+  }
+
+  function resetForm() {
+    setEditing(null);
+    setForm({ ...EMPTY });
+    setFormError(null);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setFormError(null);
+    try {
+      const payload = {
+        type: form.type,
+        name: form.name.trim(),
+        company: form.company.trim() || null,
+        email: form.email.trim() || null,
+        phone: form.phone.trim() || null,
+        code: form.code.trim().toUpperCase(),
+        notes: form.notes.trim() || null,
+      };
+      if (editing) {
+        await adminRequest("PATCH", `/api/v1/admin/partners/${editing}`, payload);
+      } else {
+        await adminPost("/api/v1/admin/partners", payload);
+      }
+      resetForm();
+      reload();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Falha ao salvar.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function toggleActive(p: Partner) {
+    const verb = p.status === "active" ? "desativar" : "reativar";
+    if (!window.confirm(`Confirma ${verb} o Partner "${p.name}"? Fica registrado na auditoria.`)) return;
+    setBusy(true);
+    try {
+      await adminPost(`/api/v1/admin/partners/${p.id}/active`, { is_active: p.status !== "active" });
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha na ação.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const inputCls = "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm";
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Parceiros</h1>
+      <p className="mb-5 text-sm text-slate-500">
+        Proveniência comercial — quem apresentou cada empresa à Tribultz. É apenas origem;
+        não representa comissão, contrato nem financeiro.
+      </p>
+
+      <form onSubmit={submit} className="mb-8 grid grid-cols-1 gap-3 rounded-xl border border-slate-200 p-4 md:grid-cols-2">
+        <h2 className="md:col-span-2 text-sm font-semibold text-slate-700">
+          {editing ? "Editar Partner" : "Novo Partner"}
+        </h2>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">Nome *</label>
+          <input className={inputCls} value={form.name} required onChange={(e) => setForm({ ...form, name: e.target.value })} />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">Código *</label>
+          <input
+            className={`${inputCls} uppercase`}
+            value={form.code}
+            required
+            placeholder="KATIA"
+            onChange={(e) => setForm({ ...form, code: e.target.value.toUpperCase() })}
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">Tipo</label>
+          <select className={inputCls} value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value })}>
+            {TYPES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">Empresa</label>
+          <input className={inputCls} value={form.company} onChange={(e) => setForm({ ...form, company: e.target.value })} />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">E-mail</label>
+          <input className={inputCls} type="email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">Telefone</label>
+          <input className={inputCls} value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} />
+        </div>
+        <div className="md:col-span-2">
+          <label className="mb-1 block text-xs font-medium text-slate-500">Observações</label>
+          <textarea className={inputCls} rows={2} value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} />
+        </div>
+        {formError && <p className="md:col-span-2 text-sm text-red-600">{formError}</p>}
+        <div className="md:col-span-2 flex gap-2">
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {busy ? "Salvando…" : editing ? "Salvar alterações" : "Cadastrar Partner"}
+          </button>
+          {editing && (
+            <button type="button" onClick={resetForm} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50">
+              Cancelar
+            </button>
+          )}
+        </div>
+      </form>
+
+      {loading && <p className="text-sm text-slate-500">Carregando…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Código</th>
+                <th className="px-4 py-3">Nome</th>
+                <th className="px-4 py-3">Tipo</th>
+                <th className="px-4 py-3">Empresas</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3 text-right">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.items.map((p) => (
+                <tr key={p.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 font-mono text-xs text-slate-700">{p.code}</td>
+                  <td className="px-4 py-3 font-medium text-slate-900">{p.name}</td>
+                  <td className="px-4 py-3 text-slate-600">{TYPE_LABEL[p.type] ?? p.type}</td>
+                  <td className="px-4 py-3 text-slate-700">{p.companies}</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.status === "active" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
+                      {p.status === "active" ? "Ativo" : "Inativo"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button onClick={() => edit(p)} className="mr-2 rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50">
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => toggleActive(p)}
+                      disabled={busy}
+                      className={`rounded-lg px-3 py-1 text-xs font-medium disabled:opacity-50 ${p.status === "active" ? "border border-red-200 text-red-600 hover:bg-red-50" : "border border-green-200 text-green-700 hover:bg-green-50"}`}
+                    >
+                      {p.status === "active" ? "Desativar" : "Reativar"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {data.items.length === 0 && (
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">Nenhum Partner cadastrado.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/tenants/page.tsx
+++ b/frontend/src/app/admin/tenants/page.tsx
@@ -1,14 +1,31 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useAdminData, adminPost } from "@/lib/useAdminData";
 
-type Tenant = { id: string; name: string; is_active: boolean; users: number; created_at: string };
+type Tenant = {
+  id: string;
+  name: string;
+  is_active: boolean;
+  users: number;
+  created_at: string;
+  partner_id: string | null;
+  partner_name: string | null;
+  partner_code: string | null;
+};
 type Resp = { total: number; items: Tenant[] };
+type Partner = { id: string; name: string; code: string; status: string };
+type PartnersResp = { items: Partner[] };
 
 export default function AdminTenantsPage() {
-  const { data, error, loading, reload } = useAdminData<Resp>("/api/v1/admin/tenants?limit=100");
+  // Filtro por Partner (proveniência comercial — RFC-0025).
+  const [partnerFilter, setPartnerFilter] = useState<string>("");
+  const query = `/api/v1/admin/tenants?limit=100${partnerFilter ? `&partner_id=${partnerFilter}` : ""}`;
+  const { data, error, loading, reload } = useAdminData<Resp>(query);
+  const { data: partners } = useAdminData<PartnersResp>("/api/v1/admin/partners?limit=200");
   const [busy, setBusy] = useState<string | null>(null);
+
+  const partnerOptions = useMemo(() => partners?.items ?? [], [partners]);
 
   async function toggleActive(t: Tenant) {
     const verb = t.is_active ? "suspender" : "reativar";
@@ -24,12 +41,59 @@ export default function AdminTenantsPage() {
     }
   }
 
+  async function setPartner(t: Tenant) {
+    // Atribuição manual da origem (casos vindos do Microsoft Forms — RFC-0025).
+    const current = t.partner_id ?? "";
+    const options = partnerOptions
+      .filter((p) => p.status === "active")
+      .map((p) => `${p.code} — ${p.name}`)
+      .join("\n");
+    const answer = window.prompt(
+      `Origem comercial de "${t.name}".\nDigite o CÓDIGO do Partner (ou vazio para desvincular).\n\nPartners ativos:\n${options}`,
+      t.partner_code ?? "",
+    );
+    if (answer === null) return;
+    const code = answer.trim().toUpperCase();
+    const match = code ? partnerOptions.find((p) => p.code === code) : null;
+    if (code && !match) {
+      window.alert(`Nenhum Partner com o código ${code}.`);
+      return;
+    }
+    const nextId = match ? match.id : null;
+    if ((nextId ?? "") === current) return;
+    setBusy(t.id);
+    try {
+      await adminPost(`/api/v1/admin/tenants/${t.id}/partner`, { partner_id: nextId });
+      reload();
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : "Falha na ação.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
   return (
     <div>
       <h1 className="mb-1 text-2xl font-bold text-slate-900">Tenants</h1>
       <p className="mb-5 text-sm text-slate-500">
         {data ? `${data.total} tenant(s)` : "Organizações cadastradas na plataforma."}
       </p>
+
+      <div className="mb-4 flex items-center gap-2">
+        <label className="text-xs font-medium uppercase tracking-wide text-slate-500">Parceiro</label>
+        <select
+          value={partnerFilter}
+          onChange={(e) => setPartnerFilter(e.target.value)}
+          className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-700"
+        >
+          <option value="">Todos</option>
+          {partnerOptions.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.code} — {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
 
       {loading && <p className="text-sm text-slate-500">Carregando…</p>}
       {error && <p className="text-sm text-red-600">{error}</p>}
@@ -40,6 +104,7 @@ export default function AdminTenantsPage() {
             <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
               <tr>
                 <th className="px-4 py-3">Nome</th>
+                <th className="px-4 py-3">Parceiro</th>
                 <th className="px-4 py-3">Usuários</th>
                 <th className="px-4 py-3">Status</th>
                 <th className="px-4 py-3">Criado em</th>
@@ -50,6 +115,15 @@ export default function AdminTenantsPage() {
               {data.items.map((t) => (
                 <tr key={t.id} className="hover:bg-slate-50">
                   <td className="px-4 py-3 font-medium text-slate-900">{t.name}</td>
+                  <td className="px-4 py-3">
+                    {t.partner_name ? (
+                      <span title={t.partner_code ?? ""} className="text-slate-700">
+                        {t.partner_name}
+                      </span>
+                    ) : (
+                      <span className="text-slate-300">—</span>
+                    )}
+                  </td>
                   <td className="px-4 py-3 text-slate-700">{t.users}</td>
                   <td className="px-4 py-3">
                     <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${t.is_active ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
@@ -58,6 +132,13 @@ export default function AdminTenantsPage() {
                   </td>
                   <td className="px-4 py-3 text-slate-500">{new Date(t.created_at).toLocaleDateString("pt-BR")}</td>
                   <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => setPartner(t)}
+                      disabled={busy === t.id}
+                      className="mr-2 rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
+                    >
+                      Origem
+                    </button>
                     <button
                       onClick={() => toggleActive(t)}
                       disabled={busy === t.id}
@@ -69,7 +150,7 @@ export default function AdminTenantsPage() {
                 </tr>
               ))}
               {data.items.length === 0 && (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-slate-400">Nenhum tenant.</td></tr>
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">Nenhum tenant.</td></tr>
               )}
             </tbody>
           </table>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { FormEvent, useRef, useState } from "react";
+import { FormEvent, useEffect, useRef, useState } from "react";
 import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { Toast } from "@/components/common/Toast";
 import { registerWithApi } from "@/lib/api";
@@ -83,10 +83,20 @@ export default function RegisterPage() {
   const [paymentData, setPaymentData] = useState<{ checkout_url?: string; pix_qr_code?: string; pix_copy_paste?: string } | null>(null);
   const [toast, setToast] = useState<{ tone: "success" | "error"; msg: string } | null>(null);
   const [captchaToken, setCaptchaToken] = useState("");
+  // Proveniência comercial (RFC-0025): captura o código do link ?partner=/?ref=.
+  const [partnerCode, setPartnerCode] = useState("");
   const turnstileRef = useRef<TurnstileInstance>(null);
   const captchaConfigured = Boolean(TURNSTILE_SITE_KEY?.trim());
 
   const isPaidPlan = planSlug !== "trial";
+
+  useEffect(() => {
+    // Lê ?partner=/?ref= no carregamento (client-only, seguro no build).
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("partner") ?? params.get("ref");
+    if (code) setPartnerCode(code.trim().toUpperCase());
+  }, []);
 
   function validateStep1(): boolean {
     if (!fullName.trim() || !email.trim() || !password.trim()) {
@@ -145,6 +155,7 @@ export default function RegisterPage() {
         lgpd_consent: true,
         tenant_slug: "",
         captcha_token: captchaToken,
+        partner_code: partnerCode || undefined,
       });
 
       track("sign_up", { method: accountType, plan: planSlug });
@@ -282,6 +293,11 @@ export default function RegisterPage() {
       <section className="w-full max-w-2xl rounded-2xl border border-slate-200 bg-white p-8 shadow-2xl">
         <h1 className="text-2xl font-bold text-slate-900">Criar conta</h1>
         <p className="mt-1 text-sm font-medium text-tribultz-700">Garanta sua conformidade fiscal antes que a reforma tributária te pegue de surpresa.</p>
+        {partnerCode && (
+          <p className="mt-2 inline-block rounded-full bg-tribultz-50 px-3 py-1 text-xs font-medium text-tribultz-700">
+            Indicação: <span className="font-mono">{partnerCode}</span>
+          </p>
+        )}
 
         {/* Plan picker */}
         <fieldset className="mt-6 space-y-3">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,6 +63,8 @@ type RegisterRequest = {
   lgpd_consent: boolean;
   tenant_slug: string;
   captcha_token?: string;
+  // Proveniência comercial (RFC-0025): código do Partner do link ?partner=/?ref=.
+  partner_code?: string;
 };
 
 type RegisterResponse = {

--- a/frontend/src/lib/useAdminData.ts
+++ b/frontend/src/lib/useAdminData.ts
@@ -53,3 +53,21 @@ export async function adminPost(path: string, body: unknown): Promise<void> {
     throw new Error(detail.detail ?? `Erro ${res.status}`);
   }
 }
+
+/** Mutação autenticada com método arbitrário (ex.: PATCH). Retorna o JSON da resposta. */
+export async function adminRequest<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${getToken()}` },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail ?? `Erro ${res.status}`);
+  }
+  return (await res.json().catch(() => ({}))) as T;
+}


### PR DESCRIPTION
Fecha #424. Governança: `tribultz-brain` [RFC-0025](knowledge/rfcs/RFC-0025-partner-attribution.md).

## O quê

Primeira camada de **proveniência comercial**: responder, de forma permanente, *"quem apresentou esta empresa à Tribultz?"* — atributo do Tenant por todo o ciclo de vida. **Não** é um Programa de Parceiros. Partner = **exclusivamente origem comercial** (nunca comissão/contrato/financeiro).

## Backend

- **Entidade `Partner`** (`app/models/partner.py`): `type, name, company, email, phone, code(único), status, notes, timestamps`. Tipos: lawyer/accountant/consultancy/erp/association/influencer/other.
- **Migration `2026_07_08_0024`**: cria `partners`; adiciona `tenants.partner_id` (FK, `ondelete=RESTRICT` → Partner nunca apagado com empresa vinculada). Sem exclusão física — desativação via `status`.
- **Captura no `/register`** (`?partner=`/`?ref=` → `partner_code`): grava `partner_id` ao criar/reusar o Tenant por CNPJ. **Código inválido/inativo não bloqueia** o cadastro (só loga); origem é permanente (não sobrescreve).
- **CRUD admin** (superadmin, auditado): `GET/POST/PATCH /api/v1/admin/partners`, `POST /partners/{id}/active`. Código validado e único.
- **Atribuição manual**: `POST /api/v1/admin/tenants/{id}/partner` (casos vindos do Microsoft Forms).
- **`GET /tenants`** enriquecido com `partner_name/partner_code` + filtro `?partner_id`.

## Frontend

- **`/admin/tenants`**: coluna **Parceiro** + filtro por Partner + botão **Origem** (atribuição manual).
- **`/admin/partners`**: tela de cadastro/edição/ativação (sem dashboard/comissão/relatório).
- **`/register`**: lê `?partner=`/`?ref=` e envia `partner_code`; indicador discreto da indicação.

## Fora do escopo

Programa de Parceiros · Portal · Comissão · Financeiro · Ranking · Dashboard do parceiro · Pagamentos · Gamificação · Automação de indicação.

## Verificação

- Backend: `ruff check app/ tests/` limpo; `test_partner_code` + `test_partner_admin` → **22 passam, 2 skip** local (integração DB roda no CI, que sobe Postgres + alembic).
- Frontend: `npm test` **153 pass**; `npm run build` **ok** (rotas `/admin/partners`, `/admin/tenants`, `/register` geradas).