### PR TITLE
chore(#424): baseline de infraestrutura pós Partner Attribution

### DIFF
--- a/tools/operational-baseline/output/2026/2026-07-08.md
+++ b/tools/operational-baseline/output/2026/2026-07-08.md
@@ -1,0 +1,60 @@
+# Tribultz Weekly Snapshot — Semana 28
+
+- **Data:** 2026-07-08
+- **Ref:** `chore/baseline-partner @ c909f92`
+- **Gerado por:** `tools/operational-baseline/operational_baseline.sh` (hábito: toda sexta)
+
+> **Produto mede, Brain interpreta.** Este documento contém **apenas fatos** —
+> nenhuma análise. A interpretação da semana (aprendizado, risco, decisão,
+> evidência, prioridade, hipóteses derrotadas) vive no Brain: `tribultz-brain`
+> → `knowledge/discovery/weekly/AAAA-Wnn.md` (RFC-0023).
+
+## Produto
+| Métrica | Valor |
+|---|---|
+| Regras determinísticas (`RULES_COUNT`) | 30 |
+| cClassTrib (`CLASSTRIB_COUNT`) | 164 |
+| Routers (backend) | 27 |
+| Endpoints (rotas) | 115 |
+| Páginas (frontend) | 37 |
+
+## Infraestrutura
+| Métrica | Valor |
+|---|---|
+| Migrations (arquivos) | 24 |
+| Migrations pendentes | n/d (requer DB) |
+| Health — storage probe | presente |
+
+## Dados
+| Métrica | Valor |
+|---|---|
+| Usuários | n/d (requer DB) |
+| Empresas (tenants) | n/d (requer DB) |
+| API Keys | n/d (requer DB) |
+| Laudos gerados | n/d (requer DB) |
+| XML processados | n/d (requer DB) |
+
+## Saúde
+| Métrica | Valor |
+|---|---|
+| TODO/FIXME no código | 3 |
+| Issues abertas | 15 |
+| Issues P2 (prioritárias) | 6 |
+| RFCs abertas | ver tribultz-brain (status: proposed) |
+
+## Motor / Known Limitations (Fase 1 — por design)
+| Item | Ocorrências | Destrava |
+|---|---|---|
+| Early Adopter | 0 | RFC-0017 |
+| Early Grant | 0 | ADR-0008 |
+| Effective License | 0 | ADR-0008 |
+| TERA | 0 | RFC-0018 |
+
+_Devem ser 0 na Fase 0. Quando passarem de 0, a Fase 1 começou a existir._
+
+## Próxima prioridade
+TERA (RFC-0018) — ver tribultz-brain rfcs/README (ordem revenue-first)
+
+---
+
+_Fatos apenas. Interpretação da semana → `tribultz-brain` `knowledge/discovery/weekly/` (RFC-0023: Produto mede, Brain interpreta)._


### PR DESCRIPTION
Atualiza o registro de infraestrutura (`tools/operational-baseline/`) após o merge da RFC-0025 ([#425](https://github.com/mickbap/tribultz/pull/425)) e o deploy em produção.

## Snapshot 2026-07-08 (semana 28, ref `c909f92`)

| Métrica | 05/07 → 08/07 |
|---|---|
| Endpoints (rotas) | 110 → **115** (CRUD de Partner + atribuição manual) |
| Migrations (arquivos) | 23 → **24** (`2026_07_08_0024_add_partners`) |

Demais métricas estáveis. Campos `requer DB` permanecem `n/d` fora do ambiente com banco (idêntico ao snapshot anterior).

## Estado da produção (pós-deploy)

- `deploy-prod` verde — `alembic upgrade 2026_07_02_0023 → 2026_07_08_0024` aplicado **antes** do restart, `api healthy`, `worker running`.
- `GET https://api.tribultz.com.br/health/deep` → **200**, todos os subsistemas `ok`.

Não afeta `backend/**` nem `infra/**` — não dispara novo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)