### PR TITLE
feat(#427): camada de licenciamento dos Founding Partners — Grant Adapter (RFC-0017 + ADR-0008)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -7,7 +7,7 @@ from alembic import context
 
 from app.database import Base
 from app.config import settings
-from app.models import api_key, auth, billing, documents, feedback, jobs, news, partner, reports  # noqa: F401
+from app.models import api_key, auth, billing, documents, feedback, founding_partner, jobs, news, partner, reports  # noqa: F401
 
 # Import models to register them with metadata
 

--- a/backend/app/alembic/versions/2026_07_08_0025_add_founding_partners.py
+++ b/backend/app/alembic/versions/2026_07_08_0025_add_founding_partners.py
@@ -1,0 +1,71 @@
+"""add_founding_partners — camada de licenciamento (RFC-0017 + ADR-0008)
+
+Grant Adapter dos Founding Partners:
+- ``early_adopters``: empresa admitida no programa (RF001).
+- ``early_grants``: autorização operacional (plano + vigência), sem assinatura
+  ASAAS. Nunca representa pagamento. ondelete: RESTRICT para tenants (histórico
+  preservado), CASCADE de grant → early_adopter.
+
+Revision ID: 2026_07_08_0025
+Revises: 2026_07_08_0024
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_08_0025"
+down_revision = "2026_07_08_0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "early_adopters",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("empresa", sa.String(length=200), nullable=False),
+        sa.Column("cnpj", sa.String(length=20), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("responsavel", sa.String(length=200), nullable=True),
+        sa.Column("telefone", sa.String(length=32), nullable=True),
+        sa.Column("origem", sa.String(length=32), nullable=False, server_default="outro"),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+        sa.Column("observacoes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT", name="fk_early_adopters_tenant_id"),
+    )
+    op.create_index("ix_early_adopters_tenant_id", "early_adopters", ["tenant_id"])
+    op.create_index("ix_early_adopters_email", "early_adopters", ["email"])
+
+    op.create_table(
+        "early_grants",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("early_adopter_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("plan_slug", sa.String(length=50), nullable=False, server_default="contador"),
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ends_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+        sa.Column("granted_by_email", sa.String(length=255), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["early_adopter_id"], ["early_adopters.id"], ondelete="CASCADE", name="fk_early_grants_adopter_id"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT", name="fk_early_grants_tenant_id"),
+    )
+    # Índice que serve a resolução de licença no login (tenant + janela de vigência).
+    op.create_index("ix_early_grants_resolve", "early_grants", ["tenant_id", "status", "ends_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_early_grants_resolve", table_name="early_grants")
+    op.drop_table("early_grants")
+    op.drop_index("ix_early_adopters_email", table_name="early_adopters")
+    op.drop_index("ix_early_adopters_tenant_id", table_name="early_adopters")
+    op.drop_table("early_adopters")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app.config import settings
 from app.core.logging import configure_logging
 from app.core.observability import init_sentry
-from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, simulator, sped, split_payment, support, tasks, validate, validate_xml, validation
+from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, founding_partners, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, simulator, sped, split_payment, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry
 
 configure_logging()
@@ -92,6 +92,7 @@ app.include_router(news.router)
 app.include_router(documents.router)
 app.include_router(support.router)
 app.include_router(admin.router)
+app.include_router(founding_partners.router)
 app.include_router(sped.router)
 app.include_router(classtrib.router)
 app.include_router(compliance.router)

--- a/backend/app/models/founding_partner.py
+++ b/backend/app/models/founding_partner.py
@@ -1,0 +1,149 @@
+"""Founding Partners — camada de licenciamento (RFC-0017 + ADR-0008).
+
+Duas entidades + um resolvedor:
+
+- ``EarlyAdopter`` — a empresa admitida no programa (RF001). "Founding Partner" é
+  o título de reconhecimento; a entidade técnica permanece Early Adopter.
+- ``EarlyGrant`` — a **autorização operacional**: concede um plano (Contador) por
+  uma vigência, sem assinatura ASAAS. Nunca representa pagamento.
+- ``resolve_effective_license`` — o Grant Adapter (ADR-0008): no login,
+  ``plan_slug = grant.plan_slug`` se houver Grant ativo, senão ``subscription``.
+
+Guardrails (RFC-0017 RNF001/002, ADR-0008): ASAAS é a única origem de assinaturas
+pagas; o Grant é autorização excepcional — nunca cria/altera Subscription.
+Expiração é **lazy no login** (sem Celery beat): "ativo = status ativo E
+hoje ∈ [starts_at, ends_at]".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text, func, select
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+# Enum de origem de aquisição (RFC-0017) — alimenta o Marketing Brain.
+EA_ORIGINS: tuple[str, ...] = (
+    "microsoft_forms",
+    "indicacao",
+    "linkedin",
+    "site",
+    "contato_direto",
+    "evento",
+    "outro",
+)
+
+EA_STATUSES: tuple[str, ...] = ("active", "closed")
+GRANT_STATUSES: tuple[str, ...] = ("active", "revoked", "expired")
+
+# Plano concedido por padrão a um Founding Partner (RF003).
+DEFAULT_GRANT_PLAN = "contador"
+
+
+class EarlyAdopter(Base):
+    __tablename__ = "early_adopters"
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    # A empresa provisionada (login vive aqui). RESTRICT: nunca apagar com histórico.
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False
+    )
+    empresa = Column(String(200), nullable=False)
+    cnpj = Column(String(20), nullable=True)
+    email = Column(String(255), nullable=False)
+    responsavel = Column(String(200), nullable=True)
+    telefone = Column(String(32), nullable=True)
+    origem = Column(String(32), nullable=False, server_default="outro")
+    status = Column(String(16), nullable=False, server_default="active")
+    observacoes = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class EarlyGrant(Base):
+    __tablename__ = "early_grants"
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    early_adopter_id = Column(
+        UUID(as_uuid=True), ForeignKey("early_adopters.id", ondelete="CASCADE"), nullable=False
+    )
+    # Denormalizado para a resolução no login ser uma consulta de tabela única.
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False
+    )
+    plan_slug = Column(String(50), nullable=False, server_default=DEFAULT_GRANT_PLAN)
+    starts_at = Column(DateTime(timezone=True), nullable=False)
+    ends_at = Column(DateTime(timezone=True), nullable=False)
+    status = Column(String(16), nullable=False, server_default="active")
+    granted_by_email = Column(String(255), nullable=True)
+    reason = Column(Text, nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+def _aware(dt: datetime) -> datetime:
+    """Garante timezone-aware (colunas são timezone=True; defensivo para SQLite/testes)."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def grant_is_active(grant: EarlyGrant, now: datetime | None = None) -> bool:
+    """Vigência efetiva (ADR-0008): status ativo E hoje ∈ [starts_at, ends_at].
+
+    Um Grant expirado (``ends_at`` no passado) ou revogado retorna ``False`` —
+    é assim que a expiração/revogação encerra o acesso automaticamente, sem beat.
+    """
+    if str(grant.status) != "active":
+        return False
+    moment = now or datetime.now(timezone.utc)
+    starts = _aware(cast(datetime, grant.starts_at))
+    ends = _aware(cast(datetime, grant.ends_at))
+    return starts <= moment <= ends
+
+
+def effective_grant_status(grant: EarlyGrant, now: datetime | None = None) -> str:
+    """Status para exibição no Command Center: 'active' vencido vira 'expired'."""
+    if str(grant.status) == "active" and not grant_is_active(grant, now):
+        return "expired"
+    return str(grant.status)
+
+
+def resolve_effective_license(
+    db: Session,
+    tenant_id,
+    subscription_plan_slug: str,
+    now: datetime | None = None,
+) -> tuple[str, str]:
+    """Grant Adapter (ADR-0008) — ponto único de resolução de licença.
+
+    Retorna ``(plan_slug, source)``: o plano do Grant ativo do tenant, se houver;
+    senão o plano da assinatura. **2 fontes, 1 pergunta, 1 ponto.** ASAAS intacto.
+    """
+    moment = now or datetime.now(timezone.utc)
+    grant = db.execute(
+        select(EarlyGrant)
+        .where(
+            EarlyGrant.tenant_id == tenant_id,
+            EarlyGrant.status == "active",
+            EarlyGrant.starts_at <= moment,
+            EarlyGrant.ends_at >= moment,
+        )
+        .order_by(EarlyGrant.ends_at.desc())
+        .limit(1)
+    ).scalars().first()
+    if grant is not None:
+        return str(grant.plan_slug), "early_grant"
+    return subscription_plan_slug, "subscription"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.auth import Tenant, User, UserTenant
+from app.models.founding_partner import resolve_effective_license
 from app.models.partner import Partner, normalize_partner_code
 from app.models.billing import Plan, Subscription, UsageTracking
 from app.schemas.auth import Token, TenantInfo, UserLogin, UserRead, UserRegister
@@ -200,6 +201,10 @@ async def login(login_data: UserLogin, request: Request, db: Session = Depends(g
         _, plan_obj = sub_row
         plan_slug = cast(str, plan_obj.slug)
 
+    # Grant Adapter (ADR-0008): Grant ativo tem precedência sobre a assinatura.
+    # Ponto único de resolução de licença — 2 fontes, ASAAS intacto.
+    plan_slug, license_source = resolve_effective_license(db, UUID(default_tenant_id), plan_slug)
+
     access_token = create_access_token(
         subject=str(user.id),
         extra_claims={
@@ -210,7 +215,10 @@ async def login(login_data: UserLogin, request: Request, db: Session = Depends(g
         },
     )
 
-    logger.info("login_success", extra={"user_id": str(user.id), "ip": ip})
+    logger.info(
+        "login_success",
+        extra={"user_id": str(user.id), "ip": ip, "license_source": license_source},
+    )
     return {
         "access_token": access_token,
         "token_type": "bearer",

--- a/backend/app/routers/founding_partners.py
+++ b/backend/app/routers/founding_partners.py
@@ -1,0 +1,356 @@
+"""Command Center — Founding Partners (RFC-0017 + ADR-0008).
+
+Administração operacional do programa Early Adopters pelo Owner (superadmin):
+admitir empresa, provisionar acesso, conceder/revogar Grant, encerrar. Toda
+mutação é auditada. **Guardrails:** nunca cria/altera Subscription; ASAAS segue
+sendo a única origem de assinaturas pagas; o Grant é autorização excepcional.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, time, timezone
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.database import get_db
+from app.models.auth import Tenant, User, UserTenant
+from app.models.billing import UsageTracking
+from app.models.founding_partner import (
+    DEFAULT_GRANT_PLAN,
+    EA_ORIGINS,
+    EarlyAdopter,
+    EarlyGrant,
+    effective_grant_status,
+)
+from app.routers.admin import _audit, _require_superadmin
+from app.routers.auth import _cnpj_to_slug
+
+router = APIRouter(prefix="/api/v1/admin/founding-partners", tags=["founding-partners"])
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _day_start(d: date) -> datetime:
+    return datetime.combine(d, time.min, tzinfo=timezone.utc)
+
+
+def _day_end(d: date) -> datetime:
+    return datetime.combine(d, time.max, tzinfo=timezone.utc)
+
+
+def _grant_out(g: EarlyGrant) -> dict[str, Any]:
+    return {
+        "id": str(g.id),
+        "plan_slug": cast(str, g.plan_slug),
+        "starts_at": cast(datetime, g.starts_at).isoformat(),
+        "ends_at": cast(datetime, g.ends_at).isoformat(),
+        "status": effective_grant_status(g),
+        "raw_status": cast(str, g.status),
+        "granted_by_email": g.granted_by_email,
+        "reason": g.reason,
+        "revoked_at": cast(datetime, g.revoked_at).isoformat() if g.revoked_at is not None else None,
+        "created_at": cast(datetime, g.created_at).isoformat(),
+    }
+
+
+def _ea_out(db: Session, ea: EarlyAdopter, grants: list[EarlyGrant]) -> dict[str, Any]:
+    mine = [g for g in grants if str(g.early_adopter_id) == str(ea.id)]
+    active = next((g for g in mine if effective_grant_status(g) == "active"), None)
+    return {
+        "id": str(ea.id),
+        "tenant_id": str(ea.tenant_id),
+        "empresa": cast(str, ea.empresa),
+        "cnpj": ea.cnpj,
+        "email": cast(str, ea.email),
+        "responsavel": ea.responsavel,
+        "telefone": ea.telefone,
+        "origem": cast(str, ea.origem),
+        "status": cast(str, ea.status),
+        "observacoes": ea.observacoes,
+        "created_at": cast(datetime, ea.created_at).isoformat(),
+        # Licença efetiva resolvida (o que o Grant Adapter entregaria no login).
+        "effective_plan": cast(str, active.plan_slug) if active is not None else None,
+        "grant_ends_at": cast(datetime, active.ends_at).isoformat() if active is not None else None,
+        "active_grant_id": str(active.id) if active is not None else None,
+        "grants": [_grant_out(g) for g in mine],
+    }
+
+
+def _revoke(db: Session, grant: EarlyGrant) -> None:
+    grant.status = "revoked"  # type: ignore[assignment]
+    grant.revoked_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+
+
+# ── Bodies ───────────────────────────────────────────────────────────────────
+
+
+class GrantBody(BaseModel):
+    plan_slug: str = DEFAULT_GRANT_PLAN
+    starts_on: date
+    ends_on: date
+    reason: str | None = None
+
+
+class EarlyAdopterCreate(BaseModel):
+    empresa: str
+    email: str
+    cnpj: str | None = None
+    responsavel: str | None = None
+    telefone: str | None = None
+    origem: str = "outro"
+    observacoes: str | None = None
+    # Senha inicial do 1º acesso (o Founding Partner troca depois). Login imediato.
+    initial_password: str
+    # Vigência opcional: se presente, já emite o primeiro Grant no cadastro.
+    grant: GrantBody | None = None
+
+
+class EarlyAdopterUpdate(BaseModel):
+    empresa: str | None = None
+    responsavel: str | None = None
+    telefone: str | None = None
+    origem: str | None = None
+    observacoes: str | None = None
+
+
+# ── Provisionamento ──────────────────────────────────────────────────────────
+
+
+def _provision_tenant_and_user(
+    db: Session, data: EarlyAdopterCreate
+) -> Tenant:
+    """Cria/reusa o Tenant e o usuário de login do Founding Partner.
+
+    Nunca cria Subscription (guardrail RNF002). Se o e-mail já existe, reusa o
+    usuário e seu tenant — não duplica identidade.
+    """
+    existing_user = db.execute(
+        select(User).where(User.email == data.email)
+    ).scalar_one_or_none()
+    if existing_user is not None:
+        tenant = db.get(Tenant, existing_user.tenant_id)
+        if tenant is None:  # defensivo
+            raise HTTPException(status_code=500, detail="Tenant do usuário não encontrado.")
+        return tenant
+
+    # Tenant por CNPJ (reusa slug canônico) ou slug derivado.
+    if data.cnpj:
+        slug = _cnpj_to_slug(data.cnpj)
+        tenant = db.execute(select(Tenant).where(Tenant.slug == slug)).scalar_one_or_none()
+        if tenant is None:
+            tenant = Tenant(name=data.empresa, slug=slug)
+            db.add(tenant)
+            db.flush()
+    else:
+        tenant = Tenant(name=data.empresa, slug=f"ea-{uuid.uuid4().hex[:12]}")
+        db.add(tenant)
+        db.flush()
+
+    user = User(
+        tenant_id=tenant.id,
+        email=data.email,
+        full_name=data.responsavel or data.empresa,
+        password_hash=get_password_hash(data.initial_password),
+        cnpj=data.cnpj or None,
+        phone=data.telefone or None,
+        account_type="contador",
+        role="contador",
+        lgpd_consent_at=datetime.now(timezone.utc),
+        email_verified=True,  # 1º acesso via credencial definida pelo Owner
+    )
+    db.add(user)
+    db.flush()
+    db.add(UserTenant(user_id=user.id, tenant_id=tenant.id, role="contador", is_default=True))
+    db.add(UsageTracking(tenant_id=tenant.id, user_id=user.id, period=datetime.now(timezone.utc).strftime("%Y-%m")))
+    return tenant
+
+
+def _issue_grant(
+    db: Session, ea: EarlyAdopter, body: GrantBody, actor_email: str
+) -> EarlyGrant:
+    if body.ends_on < body.starts_on:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Término não pode ser antes do início.")
+    # Um Grant efetivo por vez: revoga os ativos antes de emitir o novo.
+    for g in db.execute(
+        select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id, EarlyGrant.status == "active")
+    ).scalars().all():
+        _revoke(db, g)
+    grant = EarlyGrant(
+        early_adopter_id=ea.id,
+        tenant_id=ea.tenant_id,
+        plan_slug=(body.plan_slug or DEFAULT_GRANT_PLAN),
+        starts_at=_day_start(body.starts_on),
+        ends_at=_day_end(body.ends_on),
+        status="active",
+        granted_by_email=actor_email,
+        reason=body.reason,
+    )
+    db.add(grant)
+    db.flush()
+    return grant
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get("")
+def list_founding_partners(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    q: str | None = None,
+    status_filter: str | None = None,
+) -> dict[str, Any]:
+    stmt = select(EarlyAdopter)
+    if q:
+        stmt = stmt.where(EarlyAdopter.empresa.ilike(f"%{q}%") | EarlyAdopter.email.ilike(f"%{q}%"))
+    if status_filter in ("active", "closed"):
+        stmt = stmt.where(EarlyAdopter.status == status_filter)
+    eas = db.execute(stmt.order_by(EarlyAdopter.created_at.desc())).scalars().all()
+    ids = [ea.id for ea in eas]
+    grants = (
+        db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id.in_(ids))).scalars().all()
+        if ids
+        else []
+    )
+    return {"total": len(eas), "items": [_ea_out(db, ea, list(grants)) for ea in eas]}
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_founding_partner(
+    body: EarlyAdopterCreate,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    if not body.empresa.strip() or not body.email.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empresa e e-mail são obrigatórios.")
+    if len(body.initial_password) < 8:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Senha inicial deve ter no mínimo 8 caracteres.")
+    origem = body.origem.lower().strip()
+    if origem not in EA_ORIGINS:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Origem inválida: {body.origem}.")
+
+    tenant = _provision_tenant_and_user(db, body)
+    ea = EarlyAdopter(
+        tenant_id=tenant.id,
+        empresa=body.empresa.strip(),
+        cnpj=(body.cnpj or None),
+        email=body.email.strip(),
+        responsavel=(body.responsavel or None),
+        telefone=(body.telefone or None),
+        origem=origem,
+        observacoes=(body.observacoes or None),
+    )
+    db.add(ea)
+    db.flush()
+    _audit(db, _admin, "early_adopter.create", "early_adopter", ea.id, {"empresa": ea.empresa, "email": ea.email, "origem": origem})
+
+    grants: list[EarlyGrant] = []
+    if body.grant is not None:
+        g = _issue_grant(db, ea, body.grant, cast(str, _admin.email))
+        _audit(db, _admin, "early_grant.create", "early_grant", g.id, {"early_adopter_id": str(ea.id), "plan_slug": g.plan_slug, "ends_at": g.ends_at.isoformat()})
+        grants = [g]
+
+    db.commit()
+    db.refresh(ea)
+    for g in grants:
+        db.refresh(g)
+    return _ea_out(db, ea, grants)
+
+
+@router.patch("/{ea_id}")
+def update_founding_partner(
+    ea_id: UUID,
+    body: EarlyAdopterUpdate,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    changed: dict[str, Any] = {}
+    if body.origem is not None:
+        origem = body.origem.lower().strip()
+        if origem not in EA_ORIGINS:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Origem inválida: {body.origem}.")
+        ea.origem = origem  # type: ignore[assignment]
+        changed["origem"] = origem
+    for field in ("empresa", "responsavel", "telefone", "observacoes"):
+        val = getattr(body, field)
+        if val is not None:
+            setattr(ea, field, val or None)
+            changed[field] = val or None
+    _audit(db, _admin, "early_adopter.update", "early_adopter", ea.id, {"changed": changed})
+    db.commit()
+    grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
+    db.refresh(ea)
+    return _ea_out(db, ea, list(grants))
+
+
+@router.post("/{ea_id}/grants", status_code=status.HTTP_201_CREATED)
+def issue_grant(
+    ea_id: UUID,
+    body: GrantBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    if cast(str, ea.status) != "active":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Early Adopter encerrado não pode receber concessão.")
+    g = _issue_grant(db, ea, body, cast(str, _admin.email))
+    _audit(db, _admin, "early_grant.create", "early_grant", g.id, {"early_adopter_id": str(ea.id), "plan_slug": g.plan_slug, "starts_at": g.starts_at.isoformat(), "ends_at": g.ends_at.isoformat()})
+    db.commit()
+    db.refresh(g)
+    return _grant_out(g)
+
+
+@router.post("/grants/{grant_id}/revoke")
+def revoke_grant(
+    grant_id: UUID,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    grant = db.get(EarlyGrant, grant_id)
+    if grant is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Grant não encontrado.")
+    if cast(str, grant.status) != "active":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Grant já não está ativo.")
+    _revoke(db, grant)
+    _audit(db, _admin, "early_grant.revoke", "early_grant", grant.id, {"early_adopter_id": str(grant.early_adopter_id)})
+    db.commit()
+    db.refresh(grant)
+    return _grant_out(grant)
+
+
+@router.post("/{ea_id}/close")
+def close_founding_partner(
+    ea_id: UUID,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Encerra o programa para a empresa: revoga Grants ativos e marca como
+    closed — preservando histórico, dados e auditoria (RF005)."""
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    revoked = 0
+    for g in db.execute(
+        select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id, EarlyGrant.status == "active")
+    ).scalars().all():
+        _revoke(db, g)
+        revoked += 1
+    ea.status = "closed"  # type: ignore[assignment]
+    _audit(db, _admin, "early_adopter.close", "early_adopter", ea.id, {"grants_revogados": revoked})
+    db.commit()
+    grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
+    db.refresh(ea)
+    return _ea_out(db, ea, list(grants))

--- a/backend/tests/test_founding_partners_admin.py
+++ b/backend/tests/test_founding_partners_admin.py
@@ -1,0 +1,166 @@
+"""Founding Partners — Command Center: gate + fluxo do Grant (RFC-0017 / ADR-0008).
+
+- Gate: os endpoints são superadmin-only.
+- Integração (Postgres, como o CI): admite empresa, concede Plano Contador via
+  Grant (sem Subscription ASAAS), resolve a licença, expira/revoga → reverte,
+  encerra. Cobre os critérios de aceite da ordem.
+"""
+
+import os
+import uuid
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_password_hash
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.billing import Subscription
+from app.models.founding_partner import (
+    resolve_effective_license,
+)
+
+anon = TestClient(app)
+
+# ── Gate (sem DB) ─────────────────────────────────────────────────────────────
+
+_UUID = "00000000-0000-0000-0000-000000000000"
+ENDPOINTS = [
+    ("get", "/api/v1/admin/founding-partners", None),
+    ("post", "/api/v1/admin/founding-partners", {"empresa": "X", "email": "x@y.com", "initial_password": "12345678"}),
+    ("patch", f"/api/v1/admin/founding-partners/{_UUID}", {"empresa": "Y"}),
+    ("post", f"/api/v1/admin/founding-partners/{_UUID}/grants", {"starts_on": "2026-07-08", "ends_on": "2026-08-08"}),
+    ("post", f"/api/v1/admin/founding-partners/grants/{_UUID}/revoke", {}),
+    ("post", f"/api/v1/admin/founding-partners/{_UUID}/close", {}),
+]
+
+
+def test_endpoints_registrados_e_superadmin_only():
+    for method, path, body in ENDPOINTS:
+        resp = getattr(anon, method)(path, json=body) if body is not None else anon.get(path)
+        assert resp.status_code != 404, f"{method} {path} não registrado"
+        assert resp.status_code in (401, 403), f"{method} {path} deveria bloquear anônimo ({resp.status_code})"
+
+
+# ── Integração DB ─────────────────────────────────────────────────────────────
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+
+def _pg_available() -> bool:
+    try:
+        with create_engine(DATABASE_URL).connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark_db = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    from app.api.deps import get_current_user
+
+    tenant = Tenant(name="Admin", slug=f"admin-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+    admin = User(
+        tenant_id=tenant.id, email=f"owner-{uuid.uuid4().hex[:8]}@tribultz.com.br",
+        full_name="Owner", password_hash=get_password_hash("x"), role="superadmin", email_verified=True,
+    )
+    session.add(admin)
+    session.flush()
+
+    def _db():
+        yield session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = lambda: admin
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytestmark_db
+def test_fluxo_completo_grant(client, session):
+    email = f"fp-{uuid.uuid4().hex[:8]}@empresa.com"
+    hoje = date(2026, 7, 8)
+    # 1. Admite empresa já com Grant (Plano Contador, vigência).
+    r = client.post("/api/v1/admin/founding-partners", json={
+        "empresa": "Contabilidade Duquesa", "email": email, "origem": "microsoft_forms",
+        "initial_password": "SenhaForte1", "responsavel": "Kátia",
+        "grant": {"plan_slug": "contador", "starts_on": hoje.isoformat(), "ends_on": (hoje + timedelta(days=30)).isoformat()},
+    })
+    assert r.status_code == 201, r.text
+    ea = r.json()
+    assert ea["effective_plan"] == "contador"
+    tenant_id = uuid.UUID(ea["tenant_id"])
+
+    # 2. Usuário de login provisionado, SEM Subscription (guardrail ASAAS).
+    user = session.execute(select(User).where(User.email == email)).scalar_one()
+    assert user.email_verified is True
+    subs = session.scalar(select(func.count(Subscription.id)).where(Subscription.tenant_id == tenant_id))
+    assert subs == 0, "Grant nunca cria Subscription (RNF002)"
+
+    # 3. Grant Adapter resolve Contador no login (sem assinatura).
+    plan, source = resolve_effective_license(session, tenant_id, "trial")
+    assert (plan, source) == ("contador", "early_grant")
+
+    # 4. Revogação → reverte para a assinatura (trial).
+    grant_id = ea["active_grant_id"]
+    assert client.post(f"/api/v1/admin/founding-partners/grants/{grant_id}/revoke").status_code == 200
+    plan, source = resolve_effective_license(session, tenant_id, "trial")
+    assert (plan, source) == ("trial", "subscription")
+
+
+@pytestmark_db
+def test_expiracao_lazy_reverte_sem_beat(client, session):
+    email = f"fp-{uuid.uuid4().hex[:8]}@empresa.com"
+    r = client.post("/api/v1/admin/founding-partners", json={
+        "empresa": "Expira Ltda", "email": email, "initial_password": "SenhaForte1",
+    })
+    ea_id = r.json()["id"]
+    tenant_id = uuid.UUID(r.json()["tenant_id"])
+    # Grant que já venceu (ends_on no passado): concede e verifica que NÃO resolve.
+    ontem = date.today() - timedelta(days=2)
+    g = client.post(f"/api/v1/admin/founding-partners/{ea_id}/grants", json={
+        "starts_on": (ontem - timedelta(days=5)).isoformat(), "ends_on": ontem.isoformat(),
+    })
+    assert g.status_code == 201
+    plan, source = resolve_effective_license(session, tenant_id, "starter")
+    assert (plan, source) == ("starter", "subscription"), "grant vencido não deve resolver (expiração lazy)"
+
+
+@pytestmark_db
+def test_encerramento_revoga_e_bloqueia(client, session):
+    email = f"fp-{uuid.uuid4().hex[:8]}@empresa.com"
+    hoje = date.today()
+    r = client.post("/api/v1/admin/founding-partners", json={
+        "empresa": "Encerra Ltda", "email": email, "initial_password": "SenhaForte1",
+        "grant": {"starts_on": hoje.isoformat(), "ends_on": (hoje + timedelta(days=30)).isoformat()},
+    })
+    ea_id = r.json()["id"]
+    tenant_id = uuid.UUID(r.json()["tenant_id"])
+    assert resolve_effective_license(session, tenant_id, "trial")[0] == "contador"
+    # Encerra o programa → revoga o Grant ativo → acesso reverte.
+    close = client.post(f"/api/v1/admin/founding-partners/{ea_id}/close")
+    assert close.status_code == 200 and close.json()["status"] == "closed"
+    assert resolve_effective_license(session, tenant_id, "trial")[0] == "trial"

--- a/backend/tests/test_license_resolution.py
+++ b/backend/tests/test_license_resolution.py
@@ -1,0 +1,58 @@
+"""Grant Adapter — vigência e status efetivo (ADR-0008). Sem DB.
+
+"Grant ativo = status ativo E hoje ∈ [starts_at, ends_at]" — expiração lazy.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.founding_partner import (
+    EarlyGrant,
+    effective_grant_status,
+    grant_is_active,
+)
+
+NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def _grant(status="active", start_delta=-1, end_delta=+1) -> EarlyGrant:
+    return EarlyGrant(
+        status=status,
+        starts_at=NOW + timedelta(days=start_delta),
+        ends_at=NOW + timedelta(days=end_delta),
+        plan_slug="contador",
+    )
+
+
+def test_grant_ativo_dentro_da_janela():
+    assert grant_is_active(_grant(), NOW) is True
+
+
+def test_grant_expirado_nao_e_ativo():
+    # ends_at no passado — a expiração encerra o acesso sozinha (sem beat).
+    assert grant_is_active(_grant(start_delta=-10, end_delta=-1), NOW) is False
+
+
+def test_grant_futuro_nao_e_ativo():
+    assert grant_is_active(_grant(start_delta=+1, end_delta=+10), NOW) is False
+
+
+def test_grant_revogado_nunca_e_ativo():
+    assert grant_is_active(_grant(status="revoked"), NOW) is False
+
+
+def test_status_efetivo_vencido_vira_expired():
+    # status 'active' no banco, mas fora da janela → exibe 'expired'.
+    assert effective_grant_status(_grant(start_delta=-10, end_delta=-1), NOW) == "expired"
+
+
+def test_status_efetivo_ativo_permanece_active():
+    assert effective_grant_status(_grant(), NOW) == "active"
+
+
+def test_status_efetivo_revogado_permanece_revoked():
+    assert effective_grant_status(_grant(status="revoked"), NOW) == "revoked"
+
+
+def test_borda_inclusiva_no_inicio_e_fim():
+    g = EarlyGrant(status="active", starts_at=NOW, ends_at=NOW, plan_slug="contador")
+    assert grant_is_active(g, NOW) is True  # janela inclusiva nas duas pontas

--- a/frontend/src/app/admin/founding-partners/page.tsx
+++ b/frontend/src/app/admin/founding-partners/page.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState } from "react";
+import { useAdminData, adminPost } from "@/lib/useAdminData";
+
+// Command Center dos Founding Partners (RFC-0017 + ADR-0008). O Grant concede o
+// Plano Contador por uma vigência, sem assinatura ASAAS — autorização operacional.
+const ORIGINS: { value: string; label: string }[] = [
+  { value: "microsoft_forms", label: "Microsoft Forms" },
+  { value: "indicacao", label: "Indicação" },
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "site", label: "Site" },
+  { value: "contato_direto", label: "Contato direto" },
+  { value: "evento", label: "Evento" },
+  { value: "outro", label: "Outro" },
+];
+const ORIGIN_LABEL = Object.fromEntries(ORIGINS.map((o) => [o.value, o.label]));
+
+type Grant = {
+  id: string;
+  plan_slug: string;
+  starts_at: string;
+  ends_at: string;
+  status: string;
+};
+type EarlyAdopter = {
+  id: string;
+  empresa: string;
+  email: string;
+  responsavel: string | null;
+  origem: string;
+  status: string;
+  effective_plan: string | null;
+  grant_ends_at: string | null;
+  active_grant_id: string | null;
+  grants: Grant[];
+};
+type Resp = { total: number; items: EarlyAdopter[] };
+
+function today(offsetDays = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+const EMPTY = {
+  empresa: "",
+  email: "",
+  cnpj: "",
+  responsavel: "",
+  telefone: "",
+  origem: "microsoft_forms",
+  initial_password: "",
+  starts_on: today(),
+  ends_on: today(90),
+};
+
+export default function FoundingPartnersPage() {
+  const { data, error, loading, reload } = useAdminData<Resp>("/api/v1/admin/founding-partners");
+  const [form, setForm] = useState({ ...EMPTY });
+  const [busy, setBusy] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  async function create(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy("create");
+    setFormError(null);
+    try {
+      await adminPost("/api/v1/admin/founding-partners", {
+        empresa: form.empresa.trim(),
+        email: form.email.trim(),
+        cnpj: form.cnpj.trim() || null,
+        responsavel: form.responsavel.trim() || null,
+        telefone: form.telefone.trim() || null,
+        origem: form.origem,
+        initial_password: form.initial_password,
+        grant: { plan_slug: "contador", starts_on: form.starts_on, ends_on: form.ends_on },
+      });
+      setForm({ ...EMPTY });
+      setOpen(false);
+      reload();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Falha ao admitir.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function newGrant(ea: EarlyAdopter) {
+    const starts = window.prompt(`Nova concessão para "${ea.empresa}".\nInício (AAAA-MM-DD):`, today());
+    if (!starts) return;
+    const ends = window.prompt("Término (AAAA-MM-DD):", today(90));
+    if (!ends) return;
+    setBusy(ea.id);
+    try {
+      await adminPost(`/api/v1/admin/founding-partners/${ea.id}/grants`, {
+        plan_slug: "contador",
+        starts_on: starts.trim(),
+        ends_on: ends.trim(),
+      });
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha na concessão.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function revoke(ea: EarlyAdopter) {
+    if (!ea.active_grant_id) return;
+    if (!window.confirm(`Revogar a concessão ativa de "${ea.empresa}"? O acesso reverte imediatamente.`)) return;
+    setBusy(ea.id);
+    try {
+      await adminPost(`/api/v1/admin/founding-partners/grants/${ea.active_grant_id}/revoke`, {});
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha ao revogar.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function close(ea: EarlyAdopter) {
+    if (!window.confirm(`Encerrar o programa para "${ea.empresa}"? Revoga concessões ativas e preserva o histórico.`)) return;
+    setBusy(ea.id);
+    try {
+      await adminPost(`/api/v1/admin/founding-partners/${ea.id}/close`, {});
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha ao encerrar.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const inputCls = "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm";
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-bold text-slate-900">Founding Partners</h1>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+        >
+          {open ? "Fechar" : "Admitir empresa"}
+        </button>
+      </div>
+      <p className="mb-5 text-sm text-slate-500">
+        Programa Early Adopters. A concessão (Grant) libera o Plano Contador por uma vigência,
+        sem assinatura ASAAS — autorização operacional, nunca cobrança.
+      </p>
+
+      {open && (
+        <form onSubmit={create} className="mb-8 grid grid-cols-1 gap-3 rounded-xl border border-slate-200 p-4 md:grid-cols-2">
+          <h2 className="md:col-span-2 text-sm font-semibold text-slate-700">Admitir empresa + conceder acesso</h2>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">Empresa *</label>
+            <input className={inputCls} required value={form.empresa} onChange={(e) => setForm({ ...form, empresa: e.target.value })} />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">E-mail do responsável *</label>
+            <input className={inputCls} type="email" required value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">Responsável</label>
+            <input className={inputCls} value={form.responsavel} onChange={(e) => setForm({ ...form, responsavel: e.target.value })} />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">CNPJ</label>
+            <input className={inputCls} value={form.cnpj} onChange={(e) => setForm({ ...form, cnpj: e.target.value })} />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">Telefone</label>
+            <input className={inputCls} value={form.telefone} onChange={(e) => setForm({ ...form, telefone: e.target.value })} />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">Origem</label>
+            <select className={inputCls} value={form.origem} onChange={(e) => setForm({ ...form, origem: e.target.value })}>
+              {ORIGINS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-500">Senha inicial (1º acesso) *</label>
+            <input className={inputCls} type="text" required minLength={8} value={form.initial_password} onChange={(e) => setForm({ ...form, initial_password: e.target.value })} placeholder="mín. 8 caracteres" />
+          </div>
+          <div className="grid grid-cols-2 gap-2 md:col-span-2">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-500">Vigência — início</label>
+              <input className={inputCls} type="date" value={form.starts_on} onChange={(e) => setForm({ ...form, starts_on: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-500">Vigência — término</label>
+              <input className={inputCls} type="date" value={form.ends_on} onChange={(e) => setForm({ ...form, ends_on: e.target.value })} />
+            </div>
+          </div>
+          {formError && <p className="md:col-span-2 text-sm text-red-600">{formError}</p>}
+          <div className="md:col-span-2">
+            <button type="submit" disabled={busy === "create"} className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50">
+              {busy === "create" ? "Admitindo…" : "Admitir e conceder Plano Contador"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading && <p className="text-sm text-slate-500">Carregando…</p>}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      {data && (
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Empresa</th>
+                <th className="px-4 py-3">Responsável</th>
+                <th className="px-4 py-3">Origem</th>
+                <th className="px-4 py-3">Licença efetiva</th>
+                <th className="px-4 py-3">Programa</th>
+                <th className="px-4 py-3 text-right">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.items.map((ea) => (
+                <tr key={ea.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 font-medium text-slate-900">{ea.empresa}<div className="text-xs text-slate-400">{ea.email}</div></td>
+                  <td className="px-4 py-3 text-slate-600">{ea.responsavel ?? "—"}</td>
+                  <td className="px-4 py-3 text-slate-600">{ORIGIN_LABEL[ea.origem] ?? ea.origem}</td>
+                  <td className="px-4 py-3">
+                    {ea.effective_plan ? (
+                      <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                        {ea.effective_plan} · até {new Date(ea.grant_ends_at as string).toLocaleDateString("pt-BR")}
+                      </span>
+                    ) : (
+                      <span className="text-slate-300">sem concessão ativa</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${ea.status === "active" ? "bg-green-100 text-green-700" : "bg-slate-200 text-slate-600"}`}>
+                      {ea.status === "active" ? "Ativo" : "Encerrado"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right whitespace-nowrap">
+                    {ea.status === "active" && (
+                      <>
+                        {ea.active_grant_id ? (
+                          <button onClick={() => revoke(ea)} disabled={busy === ea.id} className="mr-2 rounded-lg border border-amber-200 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50 disabled:opacity-50">
+                            Revogar
+                          </button>
+                        ) : (
+                          <button onClick={() => newGrant(ea)} disabled={busy === ea.id} className="mr-2 rounded-lg border border-blue-200 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50">
+                            Conceder
+                          </button>
+                        )}
+                        <button onClick={() => close(ea)} disabled={busy === ea.id} className="rounded-lg border border-red-200 px-3 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-50">
+                          Encerrar
+                        </button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {data.items.length === 0 && (
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">Nenhum Founding Partner ainda.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -10,6 +10,7 @@ const NAV = [
   { href: "/admin", label: "Visão geral" },
   { href: "/admin/tenants", label: "Tenants" },
   { href: "/admin/partners", label: "Parceiros" },
+  { href: "/admin/founding-partners", label: "Founding Partners" },
   { href: "/admin/users", label: "Usuários" },
   { href: "/admin/usage", label: "Uso & Operações" },
   { href: "/admin/system", label: "Saúde do sistema" },


### PR DESCRIPTION
Fecha #427.

## Governança (ADR-0010)

**Repositório `tribultz-brain`:** nenhuma alteração necessária — a arquitetura já está canonizada em [ADR-0008](knowledge/decisions/2026-07-06-license-resolution-grant-adapter.md) (Grant Adapter) e [RFC-0017](knowledge/rfcs/RFC-0017-early-adopters.md). Sem novas decisões de negócio, arquitetura ou processo. **O Brain foi avaliado e permanece consistente.**

**Repositório `tribultz`:** esta entrega (implementação).

## O quê

Camada de autorização dos Founding Partners: conceder/manter/revogar acesso **sem qualquer acesso manual ao banco**. O Grant é autorização operacional — nunca pagamento, nunca Subscription, ASAAS intacto.

## Backend

- **`EarlyAdopter`** (RF001) + **`EarlyGrant`** (plano + vigência + status) + **migration `0025`** (FKs `RESTRICT` p/ tenants; índice de resolução).
- **`resolve_effective_license`** (Grant Adapter, ADR-0008) — ponto único no login: `grant.plan_slug` se Grant ativo, senão `subscription`. 2 fontes, ASAAS intacto, sem condicional espalhada.
- **Expiração lazy no login** (sem Celery beat): `ativo = status ativo E hoje ∈ [início, fim]`. Expira/revoga → reverte sozinho.
- **Command Center** (`/api/v1/admin/founding-partners`, superadmin, auditado): admitir empresa (provisiona tenant + usuário de login, **sem Subscription**), conceder/revogar Grant, definir vigência, encerrar.

## Frontend

- **`/admin/founding-partners`**: admitir empresa + conceder Plano Contador, ver licença efetiva, nova concessão, revogar, encerrar.

## Critérios de aceite (ordem) — cobertos

| Critério | Onde |
|---|---|
| Criar Grant pelo Command Center | `POST /founding-partners` / `.../grants` |
| Definir vigência | `starts_on` / `ends_on` |
| Plano Contador **sem** assinatura ASAAS | teste `test_fluxo_completo_grant` (0 Subscriptions) |
| Login normal | usuário provisionado, `email_verified`, resolução no login |
| Revogação automática na expiração | `test_expiracao_lazy_reverte_sem_beat` |
| Bloqueio após revogação | `test_fluxo_completo_grant` / `test_encerramento` |
| Auditoria | `_audit` em create/update/grant/revoke/close |
| **Sem alteração manual no banco** | todo o fluxo via Command Center |

## Verificação

- Backend: `ruff` + `pyright` limpos; **22 pass / 4 skip** local (integração DB roda no CI com Postgres + alembic).
- Frontend: `npm test` **153 pass**; `npm run build` ok (`/admin/founding-partners`).

_Nota: com esta entrega, os "known limitations" do Weekly Snapshot (EarlyAdopter/EarlyGrant/EffectiveLicense) passam de 0 — a Fase 1 começa a existir. Posso atualizar o baseline após o merge._