### PR TITLE
chore(#432): backend — python-jose 3.4.0 + python-multipart 0.0.31 (CVEs auth/uploads)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,10 +5,10 @@ pydantic-settings==2.10.1
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 alembic==1.14.1
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
 bcrypt==4.0.1
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.20
+python-multipart==0.0.31
 boto3==1.35.93
 redis==5.2.1
 httpx==0.28.1


### PR DESCRIPTION
Parte do hardening pós-incidente (#432). **`tribultz-brain`: nenhuma alteração.**

## O quê (patches de segurança contidos)
| Pacote | De → Para | Corrige |
|---|---|---|
| `python-jose[cryptography]` | 3.3.0 → **3.4.0** | PYSEC-2024-232/233, PYSEC-2025-185 (JWT/auth) |
| `python-multipart` | 0.0.20 → **0.0.31** | CVE-2026-53538/53539/53540, 42561, 40347… (form/upload) |

## Verificação
- Local: instala, `app` importa, **JWT round-trip (jose) ok**, 36 testes sem-DB passam.
- CI: 664 testes com Postgres (auth/login e upload/validate-xml cobrem jose/multipart).

## Adiado (risco alto — rastreado em #432, NÃO neste PR)
- `litellm` 1.82.0 → 1.83.x (múltiplos CVEs) — **pinada pelo CrewAI**, core de IA: bump precisa de validação de runtime.
- `weasyprint` 63.1 → 68.0 — **major**, geração de PDF.
- `uv` (dev) e conflito `tomli/tomli-w` do CrewAI (pré-existente).
