### PR TITLE
fix: remove navbar da landing do Founding Partners

### DIFF
--- a/frontend/src/app/founding-partners/page.tsx
+++ b/frontend/src/app/founding-partners/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { PublicNavbar } from "@/components/public/PublicNavbar";
 import { PublicFooter } from "@/components/public/PublicFooter";
 
 // Formulário oficial de inscrição do Programa Founding Partners.
@@ -49,7 +48,6 @@ const BENEFITS: { title: string; desc: string }[] = [
 export default function FoundingPartnersPage() {
   return (
     <div className="bg-white">
-      <PublicNavbar />
       <main>
         {/* HERO */}
         <section className="border-b border-slate-200 bg-gradient-to-b from-[#F4F7FF] to-white">


### PR DESCRIPTION
## Summary
- Remove `<PublicNavbar />` da página `/founding-partners` — a landing institucional do Programa Founding Partners não deve exibir o navbar público.
- Mantido o `PublicFooter`.

## Test plan
- [x] `npm test --silent` (153 testes, 0 falhas)
- [x] `npm run build` (build de produção sem erros, rota `/founding-partners` gerada estaticamente)