### PR TITLE
feat(content): campanha contagem regressiva 03/08 (#407)

### DIFF
--- a/backend/app/alembic/versions/2026_07_14_0026_add_advisory_news_category.py
+++ b/backend/app/alembic/versions/2026_07_14_0026_add_advisory_news_category.py
@@ -1,0 +1,30 @@
+"""add Advisory category to news check constraint
+
+Revision ID: 2026_07_14_0026
+Revises: 2026_07_08_0025
+Create Date: 2026-07-14
+"""
+from alembic import op
+
+revision = "2026_07_14_0026"
+down_revision = "2026_07_08_0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("news_category_check", "news", type_="check")
+    op.create_check_constraint(
+        "news_category_check",
+        "news",
+        "category IN ('Feature', 'Fix', 'Security', 'Advisory')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("news_category_check", "news", type_="check")
+    op.create_check_constraint(
+        "news_category_check",
+        "news",
+        "category IN ('Feature', 'Fix', 'Security')",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from app.config import settings
 from app.core.logging import configure_logging
 from app.core.observability import init_sentry
 from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, founding_partners, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, simulator, sped, split_payment, support, tasks, validate, validate_xml, validation
-from app.services.news_seed import ensure_default_news_entry
+from app.services.news_seed import ensure_default_news_entry, ensure_regulatory_advisories
 
 configure_logging()
 init_sentry()  # no-op sem SENTRY_DSN — deve vir antes da criação do app FastAPI
@@ -20,6 +20,7 @@ init_sentry()  # no-op sem SENTRY_DSN — deve vir antes da criação do app Fas
 @asynccontextmanager
 async def lifespan(app: FastAPI):  # noqa: ARG001
     ensure_default_news_entry()
+    ensure_regulatory_advisories()
     yield
 
 

--- a/backend/app/models/news.py
+++ b/backend/app/models/news.py
@@ -10,7 +10,7 @@ class News(Base):
     __tablename__ = "news"
     __table_args__ = (
         CheckConstraint(
-            "category IN ('Feature', 'Fix', 'Security')",
+            "category IN ('Feature', 'Fix', 'Security', 'Advisory')",
             name="news_category_check",
         ),
     )

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/news", tags=["news"])
 
-NewsCategory = Literal["Feature", "Fix", "Security"]
+NewsCategory = Literal["Feature", "Fix", "Security", "Advisory"]
 
 
 class NewsResponse(BaseModel):

--- a/backend/app/services/news_seed.py
+++ b/backend/app/services/news_seed.py
@@ -16,6 +16,53 @@ DEFAULT_NEWS_DESCRIPTION = (
 )
 DEFAULT_NEWS_CATEGORY = "Feature"
 
+# Campanha "contagem regressiva 03/08" (#407). Categoria Advisory: fato
+# regulatório externo, não recurso novo do produto — cada entrada é honesta
+# sobre o que a Tribultz já cobre hoje vs. o que está em avaliação/roadmap.
+REGULATORY_ADVISORIES: list[dict[str, str]] = [
+    {
+        "title": "03/08/2026: SEFAZ passa a rejeitar NF-e sem IBS/CBS no Regime Normal (CRT 3)",
+        "description": (
+            "A partir de 03/08/2026 entram em produção, para o Regime Normal (CRT 3), as "
+            "regras UB12-10 e W34-20 da NT 2025.002-RTC v1.40: Rejeição 1115 (IBS/CBS ausente "
+            "no item) e Rejeição 1119 (grupo de totais IBSCBSTot ausente quando algum item "
+            "informa IBS/CBS). Simples Nacional e MEI entram em 04/01/2027. A Tribultz já "
+            "valida esses cenários antes da emissão, em /validate-xml. "
+            "Fonte: NT 2025.002-RTC v1.40 (SEFAZ/CONFAZ)."
+        ),
+    },
+    {
+        "title": "NT 2025.002 v1.50: novo grupo para o regime monofásico de combustíveis (CBS/IBS)",
+        "description": (
+            "Foi publicada a versão 1.50 da NT 2025.002-RTC, com um grupo específico para "
+            "operações do regime monofásico de combustíveis e novos indicadores de "
+            "cClassTrib. A cobertura dessas regras no motor de validação da Tribultz está "
+            "em avaliação — acompanhe as próximas atualizações neste changelog. "
+            "Fonte: NT 2025.002-RTC v1.50 (Portal Nacional da NF-e)."
+        ),
+    },
+    {
+        "title": "Novos leiautes: NT 2026.002 (presencial/não presencial) e NT 2026.003 (DANFE Simplificado T2)",
+        "description": (
+            "Foram publicados os schemas das Notas Técnicas 2026.002 (indicador de operação "
+            "presencial/não presencial) e 2026.003 (DANFE Simplificado modelo T2). O impacto "
+            "no parser de validação da Tribultz está em avaliação — acompanhe as próximas "
+            "atualizações neste changelog. Fonte: Portal Nacional da NF-e / SEFAZ."
+        ),
+    },
+    {
+        "title": "Split Payment: Receita Federal e CGIBS publicam Manual de Integração e Swagger da Plataforma Pública",
+        "description": (
+            "O Ato Conjunto RFB/CGIBS nº 2/2026 (03/06/2026) autorizou a publicação do Manual "
+            "de Integração e da especificação técnica (Swagger) da Plataforma Pública do "
+            "Split Payment, mecanismo de retenção automática de IBS/CBS previsto para 2027. "
+            "A Tribultz oferece hoje conteúdo e simulação de impacto em /split-payment. "
+            "Fonte: Receita Federal / Comitê Gestor do IBS."
+        ),
+    },
+]
+REGULATORY_ADVISORY_CATEGORY = "Advisory"
+
 
 def ensure_default_news_entry() -> None:
     if not inspect(engine).has_table("news"):
@@ -40,3 +87,30 @@ def ensure_default_news_entry() -> None:
         )
         db.commit()
         logger.info("default_news_seeded title=%s", DEFAULT_NEWS_TITLE)
+
+
+def ensure_regulatory_advisories() -> None:
+    """Semeia as 4 notícias regulatórias da campanha 03/08 (#407), idempotente."""
+    if not inspect(engine).has_table("news"):
+        return
+
+    with SessionLocal() as db:
+        for entry in REGULATORY_ADVISORIES:
+            existing = db.scalar(
+                select(News.id).where(
+                    News.title == entry["title"],
+                    News.category == REGULATORY_ADVISORY_CATEGORY,
+                )
+            )
+            if existing is not None:
+                continue
+
+            db.add(
+                News(
+                    title=entry["title"],
+                    description=entry["description"],
+                    category=REGULATORY_ADVISORY_CATEGORY,
+                )
+            )
+            db.commit()
+            logger.info("regulatory_advisory_seeded title=%s", entry["title"])

--- a/backend/tests/test_news.py
+++ b/backend/tests/test_news.py
@@ -170,6 +170,25 @@ def test_post_news_validation_rejects_short_title(client, publish_token):
     assert resp.status_code == 422
 
 
+def test_post_news_accepts_advisory_category(client, publish_token, session):
+    """Advisory (#407): categoria de aviso regulatório, distinta de Feature/Fix/Security."""
+    title = f"Advisory test {uuid.uuid4().hex[:8]}"
+    resp = client.post(
+        "/api/v1/news",
+        json={"title": title, "description": "Aviso regulatório de teste.", "category": "Advisory"},
+        headers={"Authorization": f"Bearer {publish_token}"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["category"] == "Advisory"
+
+    session.expire_all()
+    row = session.execute(
+        text("SELECT category FROM news WHERE id = :id"),
+        {"id": resp.json()["id"]},
+    ).fetchone()
+    assert row.category == "Advisory"
+
+
 def test_post_news_validation_rejects_invalid_category(client, publish_token):
     resp = client.post(
         "/api/v1/news",

--- a/backend/tests/test_news_seed.py
+++ b/backend/tests/test_news_seed.py
@@ -1,0 +1,46 @@
+"""Tests for the regulatory advisories seed (#407 — campanha 03/08)."""
+
+import os
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.news import News
+from app.services.news_seed import REGULATORY_ADVISORIES, ensure_regulatory_advisories
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+VerifySession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _cleanup(titles: set[str]) -> None:
+    with VerifySession() as db:
+        db.query(News).filter(News.title.in_(titles)).delete(synchronize_session=False)
+        db.commit()
+
+
+def test_ensure_regulatory_advisories_seeds_all_four():
+    titles = {entry["title"] for entry in REGULATORY_ADVISORIES}
+    _cleanup(titles)  # garante estado limpo mesmo se um run anterior falhou no meio
+    try:
+        ensure_regulatory_advisories()
+
+        with VerifySession() as db:
+            rows = db.scalars(select(News).where(News.category == "Advisory")).all()
+            assert {row.title for row in rows} == titles
+    finally:
+        _cleanup(titles)
+
+
+def test_ensure_regulatory_advisories_is_idempotent():
+    titles = {entry["title"] for entry in REGULATORY_ADVISORIES}
+    _cleanup(titles)
+    try:
+        ensure_regulatory_advisories()
+        ensure_regulatory_advisories()
+
+        with VerifySession() as db:
+            rows = db.scalars(select(News).where(News.category == "Advisory")).all()
+            assert len(rows) == len(REGULATORY_ADVISORIES)
+    finally:
+        _cleanup(titles)

--- a/frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx
+++ b/frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx
@@ -1,0 +1,79 @@
+---
+title: "NF-e rejeitada a partir de 03/08/2026: o que muda para o Regime Normal (CRT 3)"
+description: "A partir de 03/08/2026 a SEFAZ passa a rejeitar NF-e sem IBS/CBS para o Regime Normal (CRT 3). Entenda as Rejeições 1115 e 1119, os prazos reais e como se preparar."
+slug: "nfe-rejeitada-03-08-2026-regime-normal-crt3"
+category: "Reforma Tributária"
+author:
+  name: "Equipe Tribultz"
+  jobTitle: "Conteúdo Fiscal"
+  url: "https://tribultz.com.br/sobre"
+publishedAt: "2026-07-14T12:00:00.000Z"
+tags:
+  - "Reforma Tributária"
+  - NF-e
+  - CBS
+  - IBS
+  - "Rejeição 1115"
+  - "Rejeição 1119"
+  - "CRT 3"
+legalRefs:
+  - instrumento: "NT 2025.002-RTC v1.40"
+    descricao: "Regras UB12-10 (Rejeição 1115) e W34-20 (Rejeição 1119) — produção obrigatória a partir de 03/08/2026 para o Regime Normal (CRT 3) e 04/01/2027 para Simples Nacional/MEI."
+  - instrumento: "Ato Conjunto RFB/CGIBS nº 1/2025"
+    artigo: "Art. 3º"
+    descricao: "Prazo de carência de penalidade por obrigação acessória de IBS/CBS: sem multa para fatos geradores até 31/07/2026; a partir de 01/08/2026 a penalidade volta a ser aplicável."
+  - instrumento: "LC 227/2026"
+    artigo: "Art. 348, §§ 3º e 4º"
+    descricao: "Se a autuação decorrer exclusivamente do descumprimento desta obrigação acessória, há ainda 60 dias para regularizar sem multa."
+  - instrumento: "LC 214/2025"
+    descricao: "Institui CBS, IBS e o Imposto Seletivo; base legal do grupo gIBSCBS e do campo cClassTrib na NF-e."
+---
+
+<p>Se a sua empresa emite NF-e pelo Regime Normal (CRT 3), 03/08/2026 é uma data para ter marcada com destaque no calendário fiscal. É o dia em que a SEFAZ passa a rejeitar, na prática, documentos que não trazem corretamente os campos de IBS e CBS. Não é mais um aviso do sistema. É bloqueio de emissão.</p>
+
+<p>Este texto separa o que muda de fato, quem é afetado primeiro, e onde a confusão mais comum costuma acontecer: misturar a data de rejeição na emissão com a data em que a multa por obrigação acessória passa a valer. São coisas diferentes, e tratar as duas como se fossem uma só leva a decisões erradas de prioridade.</p>
+
+<h2>O que muda em 03/08/2026</h2>
+<p>A partir dessa data entram em produção obrigatória, para quem emite no Regime Normal (CRT 3), duas regras da NT 2025.002-RTC v1.40 que hoje já existem no ambiente de homologação, mas que passam a valer de verdade no ambiente de produção da SEFAZ:</p>
+<ul>
+<li>Regra <strong>UB12-10</strong>, associada à <strong>Rejeição 1115</strong>: item da NF-e sem preenchimento de IBS/CBS.</li>
+<li>Regra <strong>W34-20</strong>, associada à <strong>Rejeição 1119</strong>: grupo de totais da nota (o total de IBS/CBS/IS, tecnicamente chamado de IBSCBSTot) ausente quando ao menos um item já informa IBS/CBS.</li>
+</ul>
+<p>Na prática: se um item da nota tem os campos de IBS/CBS preenchidos mas o bloco de totais da NF-e não reflete essa soma, ou se algum item simplesmente não traz esses campos, o documento não é mais aceito. Antes dessa data, esse tipo de inconsistência tende a passar; depois, não passa.</p>
+
+<h2>Quem é afetado primeiro: Regime Normal x Simples Nacional/MEI</h2>
+<p>Essa obrigatoriedade é faseada por CRT (Código de Regime Tributário), o campo que identifica o regime do emitente na própria NF-e:</p>
+<ul>
+<li><strong>CRT 3 (Regime Normal):</strong> segue o cronograma de 03/08/2026 — é quem sente o impacto primeiro.</li>
+<li><strong>CRT 1/2 (Simples Nacional) e CRT 4 (MEI):</strong> só se tornam obrigatórios a partir de 04/01/2027. Até lá, a ausência de IBS/CBS nesses regimes é tratada como alerta, não como bloqueio.</li>
+</ul>
+<p>Se a sua empresa opera com filiais ou parceiros em regimes diferentes, vale checar CNPJ por CNPJ qual CRT está declarado — é comum encontrar cadastro desatualizado, e isso muda completamente a urgência de cada caso.</p>
+
+<h2>Duas datas, dois eventos diferentes — não confundir</h2>
+<p>Esse é o ponto onde a maioria das análises apressadas erra. Existem duas datas próximas, mas com significados distintos:</p>
+<ul>
+<li><strong>01/08/2026</strong> — fim do prazo de carência de <em>multa por obrigação acessória</em> de IBS/CBS (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º). Até 31/07/2026, o descumprimento dessa obrigação acessória não gera multa; a partir de 01/08/2026, gera.</li>
+<li><strong>03/08/2026</strong> — data em que a <em>rejeição na emissão</em> (Rejeições 1115 e 1119, Regime Normal) passa a valer em produção na SEFAZ. É o primeiro dia útil após 01/08/2026 (sábado) e 02/08/2026 (domingo).</li>
+</ul>
+<p>Ou seja: a partir de 01/08 já existe risco de multa por obrigação acessória descumprida, e a partir de 03/08 o documento simplesmente para de ser aceito se o problema persistir. Uma coisa reforça a outra, mas não são o mesmo evento.</p>
+<p>Há ainda um detalhe pouco divulgado: se a autuação decorrer <em>exclusivamente</em> do descumprimento dessa obrigação acessória de IBS/CBS, a LC 227/2026 (art. 348, §§ 3º e 4º) prevê mais 60 dias de prazo para regularizar antes da aplicação efetiva da multa. Isso não reduz o risco, mas muda o cronograma de reação em caso de autuação — vale conhecer antes de entrar em pânico.</p>
+
+<h2>Como se preparar antes do dia 3</h2>
+<p>O erro mais caro aqui não é técnico, é de sequência: descobrir o problema depois que a nota já foi rejeitada em produção, no meio do faturamento do mês.</p>
+<ol>
+<li><strong>Confirme o CRT declarado</strong> em cada CNPJ emissor — é a base de tudo o que vem depois.</li>
+<li><strong>Reveja o cadastro de produtos</strong> quanto à classificação tributária (cClassTrib) usada nos itens que carregam IBS/CBS.</li>
+<li><strong>Valide a consistência entre item e totais</strong> — o valor de IBS/CBS somado nos itens precisa bater com o grupo de totais da nota.</li>
+<li><strong>Rode notas reais (não só exemplos do ERP) contra as regras da NT 2025.002 v1.40 antes de 03/08</strong>, para achar inconsistência enquanto ainda é só alerta, não bloqueio.</li>
+</ol>
+<p>Se fizer sentido para a sua operação, a Tribultz já identifica esses dois cenários — item sem IBS/CBS e grupo de totais ausente ou inconsistente — antes da emissão, direto em <a href="https://tribultz.com.br/validate-xml">/validate-xml</a>, com a <a href="https://tribultz.com.br/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir">base legal e a recomendação</a> de correção junto de cada achado. O valor prático está em antecipar o que a SEFAZ vai rejeitar, não em prometer que a nota nunca vai ter problema.</p>
+
+<h2>Perguntas frequentes</h2>
+<h3>Minha empresa é Simples Nacional. Preciso me preocupar agora?</h3>
+<p>A obrigatoriedade para Simples Nacional e MEI só entra em 04/01/2027. Mas cadastro, classificação e parametrização de ERP levam tempo para ajustar — vale começar a revisar antes, sem a pressão do prazo de agosto.</p>
+<h3>03/08/2026 é sábado ou dia útil?</h3>
+<p>01/08/2026 cai num sábado e 02/08/2026 num domingo; 03/08/2026 é segunda-feira, o primeiro dia útil em que o cronograma de produção da SEFAZ passa a valer.</p>
+<h3>Se eu corrigir rápido depois de uma rejeição, ainda corro risco de multa?</h3>
+<p>Rejeição na emissão e multa por obrigação acessória são apuradas de forma diferente. O prazo de 60 dias do art. 348 da LC 227/2026 vale para autuação exclusivamente por essa obrigação acessória — não é uma tolerância automática para toda rejeição de nota.</p>
+
+<p>A melhor forma de chegar em agosto sem sobressalto não é decorar o número da rejeição. É saber, hoje, para cada CNPJ e cada família de produto, se o item e o total da nota já estão consistentes com o que a SEFAZ vai exigir a partir do dia 3.</p>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/blogFiscalLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/blogFiscalLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts src/lib/deadlineCountdown.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "content:lint": "tsx scripts/content-lint.ts",
     "content:lint:fix": "tsx scripts/content-lint.ts --fix",

--- a/frontend/src/app/validate-xml/page.tsx
+++ b/frontend/src/app/validate-xml/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import DeadlineCountdownBanner from "@/components/common/DeadlineCountdownBanner";
 import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
 import { downloadJobReportPdf, generateCorrectedXml, getJob, openExceptionRequest, PlanRequiredError, validateXml } from "@/lib/api";
@@ -204,6 +205,8 @@ export default function ValidateXmlPage() {
 
   return (
     <section className="space-y-5">
+      <DeadlineCountdownBanner />
+
       <header>
         <h1 className="text-2xl font-bold text-slate-900">Validar XML</h1>
         <p className="text-sm text-slate-500">

--- a/frontend/src/components/common/DeadlineCountdownBanner.tsx
+++ b/frontend/src/components/common/DeadlineCountdownBanner.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { daysUntilDeadline } from "@/lib/deadlineCountdown";
+
+/**
+ * Countdown banner for the 03/08/2026 SEFAZ production deadline (Regime Normal/CRT 3,
+ * Rejeições 1115/1119 — NT 2025.002 v1.40, #403). Self-expiring: renders null once the
+ * deadline has passed, so no manual flag needs to be flipped after the date (#407).
+ */
+export default function DeadlineCountdownBanner() {
+  const days = daysUntilDeadline();
+  if (days <= 0) return null;
+
+  return (
+    <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-2.5 text-sm text-amber-900">
+      <span className="font-semibold">
+        {days} dia{days !== 1 ? "s" : ""} até 03/08/2026
+      </span>{" "}
+      — a SEFAZ passa a rejeitar NF-e do Regime Normal (CRT 3) sem IBS/CBS no item
+      (Rejeição 1115) ou sem o grupo de totais IBSCBSTot (Rejeição 1119). Valide antes
+      que a SEFAZ rejeite.{" "}
+      <Link
+        href="/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3"
+        className="font-medium underline hover:text-amber-950"
+      >
+        Entenda o prazo
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/public/NewsFeed.tsx
+++ b/frontend/src/components/public/NewsFeed.tsx
@@ -6,7 +6,7 @@ type NewsItem = {
   id: string;
   title: string;
   description: string;
-  category: "Feature" | "Fix" | "Security";
+  category: "Feature" | "Fix" | "Security" | "Advisory";
   created_at: string;
 };
 
@@ -21,6 +21,7 @@ const categoryStyles: Record<NewsItem["category"], string> = {
   Feature: "bg-emerald-100 text-emerald-800",
   Fix: "bg-amber-100 text-amber-800",
   Security: "bg-rose-100 text-rose-800",
+  Advisory: "bg-blue-100 text-blue-800",
 };
 
 export function NewsFeed({ limit, compact = false }: NewsFeedProps) {

--- a/frontend/src/lib/deadlineCountdown.test.ts
+++ b/frontend/src/lib/deadlineCountdown.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { daysUntilDeadline } from "./deadlineCountdown";
+
+test("#407 daysUntilDeadline: dias antes do prazo → positivo", () => {
+  assert.equal(daysUntilDeadline(new Date("2026-08-02T00:00:00-03:00")), 1);
+  assert.equal(daysUntilDeadline(new Date("2026-07-14T00:00:00-03:00")), 20);
+});
+
+test("#407 daysUntilDeadline: no dia do prazo → 0 (banner some)", () => {
+  assert.equal(daysUntilDeadline(new Date("2026-08-03T00:00:00-03:00")), 0);
+});
+
+test("#407 daysUntilDeadline: depois do prazo → negativo (banner some)", () => {
+  assert.ok(daysUntilDeadline(new Date("2026-08-04T00:00:00-03:00")) < 0);
+  assert.ok(daysUntilDeadline(new Date("2027-01-01T00:00:00-03:00")) < 0);
+});

--- a/frontend/src/lib/deadlineCountdown.ts
+++ b/frontend/src/lib/deadlineCountdown.ts
@@ -1,0 +1,10 @@
+/**
+ * Prazo de produção da SEFAZ (Regime Normal/CRT 3, Rejeições 1115/1119 — NT 2025.002
+ * v1.40, #403). Usado pelo banner de contagem regressiva no /validate-xml (#407).
+ */
+export const DEADLINE = new Date("2026-08-03T00:00:00-03:00");
+
+export function daysUntilDeadline(now: Date = new Date()): number {
+  const diffMs = DEADLINE.getTime() - now.getTime();
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+}


### PR DESCRIPTION
## Summary

Closes #407 — a maior janela de aquisição do ano: a partir de **03/08/2026** a SEFAZ passa a rejeitar NF-e do Regime Normal (CRT 3) sem IBS/CBS (Rejeição 1115, regra UB12-10) ou sem o grupo de totais IBSCBSTot (Rejeição 1119, regra W34-20) — NT 2025.002 v1.40, já implementado no motor (#403). Simples Nacional/MEI entram em 04/01/2027.

- **feat(backend)**: nova categoria `Advisory` de news (migration + model + router), distinta de `Feature/Fix/Security` porque é fato regulatório externo, não recurso novo do produto. Seed idempotente das 4 notícias da campanha — cada uma honesta sobre o que a Tribultz já cobre hoje vs. o que está em avaliação/roadmap (ver detalhe abaixo).
- **feat(blog)**: post pilar [`nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx`](frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx) — só cita códigos/regras que já existem no motor, sem cClassTrib/CST fabricado (passa no guard anti-fabricação do #394/#395).
- **feat(validate-xml)**: banner de contagem regressiva para 03/08/2026, auto-expira por comparação de data (sem flag manual pra lembrar de remover depois do prazo).
- **docs(sales)**: âncora de deadline atualizada no GPT de vendas (`tribultz-brain`, já commitado separadamente).

### Nota sobre honestidade das 4 notícias (Advisory)

Das 4 notícias da campanha, só a do marco 03/08 é uma feature já implementada (#403). As outras 3 (NT v1.50 monofásica, schemas NT 2026.002/2026.003, split payment) descrevem publicações regulatórias reais mas **não implementadas ainda** no motor (issues #404/#405 seguem abertas; split payment é conteúdo/simulação, não integração real) — a descrição de cada uma deixa isso explícito ("em avaliação", "conteúdo e simulação de impacto"), para não fabricar capacidade de produto que ainda não existe.

## Test plan

- [x] Frontend: `npm test --silent` (156 testes, incluindo o guard `blogFiscalLint` rodando sobre o novo post) + `npm run build`
- [x] Backend: `alembic upgrade head` (migration nova aplicada limpa) + `pytest tests/ -q` (667 testes) + `ruff check app/ tests/`
- [x] `npm run content:lint` sobre o post novo — 0 findings