### PR TITLE
chore(infra): inventário de segredos, verificação de acessos e contexto durável no repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Scripts shell precisam de LF: com CRLF o macOS/Linux falham com "bad interpreter".
+# Necessário porque o repo é editado tanto no Windows quanto no Mac.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,12 @@ celerybeat.pid
 .env
 .env.prod
 .envrc
+# Backups de .env — contêm segredos de produção (ex.: .env.prod.bak.20260715-085246,
+# .env.bak.1782742372 gerados em rotações/deploys na VM)
+.env.bak*
+.env.*.bak*
+.env.prod.bak*
+*.env.bak*
 
 # Secrets locais — NUNCA commitar
 secrets/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ cd frontend && npm test --silent && npm run build
 cd backend && source .venv/bin/activate && python -m pytest tests/ -q && ruff check app/ tests/
 ```
 
+## Contexto durável — leia antes de agir
+
+- `docs/context/` — conhecimento que vale para qualquer máquina: vocabulário fiscal oficial, base legal, regras da contabilidade, referências de APIs, convenções e decisões de produto. **Fonte de verdade**; a memória local do agente é só cache. Nunca colocar credencial lá.
+- `docs/infra/secrets_inventory.md` — onde os segredos vivem, como validar sem expor valores, onboarding de máquina nova. Fonte de verdade dos segredos: `/opt/tribultz/.env` na VM.
+- `tools/check_access.sh` — valida SSH, mgc, gh, Vercel, drift do `.env.prod` e saúde da produção.
+
 ## Regras de domínio
 
 - **CBS**: Contribuição sobre Bens e Serviços (federal) — fase de teste 2026: **0,9%**; referência plena (regime cheio, ~2033): **8,8%**

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,0 +1,35 @@
+# Contexto do projeto — conhecimento durável
+
+Conhecimento acumulado sobre o Tribultz que **vale para qualquer máquina e qualquer agente**: vocabulário fiscal, base legal, regras do time de contabilidade, referências de APIs externas, convenções de trabalho e decisões de produto.
+
+Estes arquivos nasceram como memória local do Claude em `~/.claude/projects/<caminho>/memory/`. Foram promovidos para cá em 2026-07-15 porque memória local **não viaja**: ela vive fora do repositório, o diretório deriva do caminho do projeto, e nada disso sai no `git clone`. Ao migrar do Windows para o Mac, todo esse conhecimento seria perdido em silêncio — vocabulário fiscal errado, bugs conhecidos reintroduzidos, decisões de produto esquecidas.
+
+## Regra desta pasta
+
+**Nunca coloque credencial aqui.** Nem API key, token, senha, chave privada ou connection string com senha. Esta pasta é versionada — e **o histórico do git é permanente**: um segredo commitado continua acessível a quem tiver o repositório, mesmo depois de deletado do HEAD. Deletar não desfaz o vazamento.
+
+Onde as credenciais vivem, como validá-las e como configurar máquina nova: `docs/infra/secrets_inventory.md`. A fonte de verdade é `/opt/tribultz/.env` na VM.
+
+## Relação com a memória local do agente
+
+Estes arquivos são a **fonte de verdade**. A memória local de cada máquina é cache — útil para o que é efêmero ou específico daquele computador, mas nunca a referência.
+
+Se um agente aprender algo durável (uma convenção, uma armadilha técnica, uma decisão de produto), o lugar é aqui — via PR, revisável — e não só na memória de uma máquina. Foi exatamente esse o erro que motivou esta pasta.
+
+## Índice
+
+| Arquivo | Conteúdo |
+|---|---|
+| `user_techlead.md` | Quem é o dono do produto |
+| `project_s7_vocabulary.md` | Vocabulário fiscal oficial do time de contabilidade |
+| `project_s7_legal_bases.md` | Base legal da reforma (LC 214, LC 227) |
+| `project_s7_accounting_feedback.md` | Regras e requisitos de relatório definidos pela contabilidade |
+| `reference_nt2025002_apis.md` | NT 2025.002-RTC, Calculadora Serpro, ClassTrib SVRS, homologação NF-e |
+| `project_s9_domain.md` | Domínio, DNS, Turnstile (site key é pública) |
+| `project_s19_sprint.md` | Contexto da sprint 19 e padrão de E2E |
+| `project_chat_removed.md` | Chat fiscal removido do produto — não citar em marketing |
+| `project_secrets_source_of_truth.md` | Fonte de verdade dos segredos é a VM, não a cópia local |
+| `feedback_no_token_rotation.md` | Ordem vigente: não rotacionar credenciais nesta fase |
+| `feedback_migrations.md` | Migrations de produção: executar sem pedir confirmação |
+| `feedback_bash_vs_native_tools.md` | Usar Read/Grep/Glob em vez de cat/grep/find |
+| `feedback_sqlalchemy_cast_syntax.md` | Nunca usar cast `::type` ao lado de `:param` em `sqlalchemy.text()` |

--- a/docs/context/feedback_bash_vs_native_tools.md
+++ b/docs/context/feedback_bash_vs_native_tools.md
@@ -1,0 +1,21 @@
+---
+name: feedback-bash-vs-native-tools
+description: Não usar Bash (cat/grep/find/ls/head/tail/wc) quando há Read/Grep/Glob nativos — bypassa o hook do rtk e queima tokens
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 66d28250-4616-49f4-b284-b3dafc9878a4
+---
+
+Quando precisar ler arquivos, buscar conteúdo ou listar diretórios, usar SEMPRE as tools dedicadas (Read, Grep, Glob) em vez de chamar `cat`, `grep`, `find`, `ls`, `head`, `tail`, `wc` via Bash.
+
+**Why:** O `rtk discover` em 24 sessões mostrou que esses comandos foram chamados 280+ vezes via Bash (cat 46×, grep 117×, find 51×, ls 59×, wc 7×). O hook do rtk só intercepta Bash, mas mesmo com filtragem o ganho por chamada é baixo (~8-15%) — enquanto as tools nativas evitam o overhead completamente e produzem output mais limpo. Resultado: gastamos tokens à toa e ainda assim o gain agregado do rtk fica diluído (12% global em vez do potencial real).
+
+**How to apply:**
+- Ler arquivo conhecido → **Read** (nunca `cat`, `head`, `tail`)
+- Buscar conteúdo/regex → **Grep** (nunca `grep`, `rg`, `Select-String`)
+- Buscar arquivos por nome/padrão → **Glob** (nunca `find`, `ls -R`, `Get-ChildItem -Recurse`)
+- Contar linhas → **Read** + contar, ou aceitar e usar Bash se for one-shot
+- Só usar Bash para coisas que são genuinamente shell: git, gh, npm, docker, ssh, curl, pytest, ruff, etc.
+
+Exceção legítima: pipelines complexos onde a combinação shell é mais simples (`gh pr list ... | head`) — aí Bash compensa.

--- a/docs/context/feedback_migrations.md
+++ b/docs/context/feedback_migrations.md
@@ -1,0 +1,11 @@
+---
+name: Rodar migrations sem pedir confirmação
+description: Migrations de produção (alembic upgrade head) devem ser executadas sem pedir confirmação — fazem parte da operação normal de deploy
+type: feedback
+originSessionId: 4a99577d-66f7-4eb8-9afc-dc28f63fb249
+---
+Rodar `alembic upgrade head` em produção via SSH não requer confirmação prévia.
+
+**Why:** É parte da operação normal de deploy. Pedir confirmação é overhead desnecessário para o techlead.
+
+**How to apply:** Ao detectar migrations pendentes na VM de produção, aplicar diretamente e reportar o resultado.

--- a/docs/context/feedback_no_token_rotation.md
+++ b/docs/context/feedback_no_token_rotation.md
@@ -1,0 +1,16 @@
+---
+name: feedback-no-token-rotation
+description: "Ordem mandatória — não rotacionar, revogar nem encerrar sessões de credenciais enquanto o produto não escala"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 2725625b-729e-478f-8fcd-089f1a5735b6
+---
+
+**Não rotacionar, revogar nem encerrar sessão de nenhuma credencial** (API key, token, senha, sessão OAuth) enquanto o produto não escala. Ordem mandatória dada em 2026-07-15. Vale inclusive para credenciais comprovadamente vazadas ou revogadas — reportar, nunca agir.
+
+**Why:** durante a fase de implementação o objetivo é acesso livre e sem atrito a partir de qualquer máquina (Windows e Mac), evitando conflito de acessos. O custo de propagar uma rotação (VM `/opt/tribultz/.env`, `.env.prod` local, `secrets/credentials.md`, memória, GitHub Actions) supera o risco aceito nesta fase. A condição de expiração é o produto escalar — reavaliar então, não antes.
+
+**How to apply:** ao encontrar credencial vazada, revogada ou frágil (ex.: Resend com 401, `GITHUB_TOKEN` de produção sendo OAuth pessoal, `refresh_token` do mgc exposto), documentar em `docs/infra/secrets_inventory.md` e seguir — não propor rotação repetidamente, não executar `logout`/`revoke`. O caso já foi apresentado e a decisão é do usuário.
+
+Nota factual associada: deploy **não usa** credencial local nenhuma (frontend pelo `vercel[bot]` via GitHub App; backend pelo Actions com `MAGALU_SSH_KEY`), então ação em credencial local nunca conflita com deploy. Contexto de acessos em [[project-secrets-source-of-truth]].

--- a/docs/context/feedback_sqlalchemy_cast_syntax.md
+++ b/docs/context/feedback_sqlalchemy_cast_syntax.md
@@ -1,0 +1,26 @@
+---
+name: feedback_sqlalchemy_cast_syntax
+description: Nunca usar ::type cast do PostgreSQL ao lado de :param em sqlalchemy.text() — conflito de parser quebra queries silenciosamente em prod
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 04cdcbf6-aacd-4e03-83e6-c6800b214cc8
+---
+
+**Regra:** Dentro de `sqlalchemy.text()`, nunca combinar parâmetros nomeados (`:param`) com o operador de cast do PostgreSQL (`::type`). O parser do SQLAlchemy interpreta `:start:` (de `:start::date`) como nome de parâmetro malformado → `psycopg2.errors.SyntaxError` em runtime.
+
+**Why:** Bug descoberto em produção em 30/05/2026 durante o primeiro teste de pagamento real. O dashboard inteiro retornava 500 para qualquer usuário logado. O erro é silencioso no desenvolvimento (sem banco real), explode só em prod.
+
+**How to apply:** Sempre substituir:
+```sql
+-- ❌ Errado
+AND created_at >= :start::date
+
+-- ✅ Correto
+AND created_at >= CAST(:start AS date)
+```
+Ao revisar ou escrever queries com `sqlalchemy.text()`, verificar ativamente se há `::` precedido de `:param`. Vale para qualquer cast: `::uuid`, `::date`, `::text`, `::int`, etc.
+
+**Arquivos corrigidos:** `app/routers/compliance.py`, `app/tasks/task_i_compliance.py`  
+**Issue:** #272  
+**Relacionado a:** [[feedback_bash_vs_native_tools]]

--- a/docs/context/project_chat_removed.md
+++ b/docs/context/project_chat_removed.md
@@ -1,0 +1,11 @@
+---
+name: Funcionalidade de chat fiscal removida do produto
+description: O assistente de chat (dúvidas fiscais via LC 214/LC 227) foi removido do produto comercial
+type: project
+originSessionId: ba762a7a-dc5b-4e90-bdb3-75fb2fa5e9b6
+---
+A funcionalidade de chat fiscal — onde o usuário poderia fazer perguntas sobre LC 214 e LC 227 diretamente na plataforma — **foi retirada do produto**.
+
+**Why:** Decisão tomada pelo tech lead em mai/2026. Motivo exato não registrado, mas confirmado que não deve ser citada como funcionalidade ativa em comunicações comerciais ou marketing.
+
+**How to apply:** Não mencionar chat, assistente fiscal ou dúvidas por chat em textos de LinkedIn, landing pages, demos ou qualquer material voltado ao ICP (contadores, CFOs, gestores fiscais). O router `chat.py` e as páginas `/chat` e `/diagnostico` ainda existem no código, mas não são produto comercial ativo.

--- a/docs/context/project_s19_sprint.md
+++ b/docs/context/project_s19_sprint.md
@@ -1,0 +1,54 @@
+---
+name: project_s19_sprint
+description: "Estado do backlog S20/S21 — sessão 17/05/2026: #175 e #173 mergeados em prod, prioridades atualizadas com pesquisa competitiva"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 0f924a49-e6b8-433d-86d6-78f4c30337a6
+---
+
+## Estado em 17/05/2026 (atualizado)
+
+### PRs mergeados nesta sessão
+
+| PR | Branch | Issue | Alembic |
+|----|--------|-------|---------|
+| #255 | `feat/175-public-api-classify` | #175 API pública pay-per-call | migration 0016 aplicada em prod |
+| #256 | `feat/173-erp-export-formats` | #173 ERP Export por jobs | sem migration nova |
+| #259 | `feat/site-update-may2026` | site marketing | aguardando CI |
+
+### Deploy prod
+
+- Deploy automático disparado e concluído para ambos os PRs (#255 e #256)
+- `alembic upgrade head` executado: `2026_05_17_0016 (head)` — tabela `api_keys` em produção
+- SSH: `ubuntu@201.54.20.18` com `id_ed25519`; compose em `/opt/tribultz/infra/docker-compose.prod.yml`
+
+### Backlog priorizado (pesquisa competitiva mai/2026)
+
+| # | Título | Prioridade | Motivo |
+|---|--------|-----------|--------|
+| #170 | NCM Auto-classify via IA | **P1** | Maior dor não resolvida do mercado; nenhum concorrente tem; temos fundação (#175) |
+| #257 | Dual-regime report (PIS/COFINS vs CBS/IBS) | P2 | Diferenciador vs Sovos; CFOs precisam |
+| #169 | Split Payment Dashboard | P2 | Dor do CFO; janela até 2027; nenhum concorrente cobre bem |
+| #258 | Credit tracking dashboard | P2 | Sticky feature; Thomson Reuters só enterprise |
+| #225 | Refactor jobs.py ORM | P3 | Debt técnico |
+
+### Issues novas criadas (pesquisa mai/2026)
+
+- **#257** — Dual-regime report (exibir PIS/COFINS + ICMS lado a lado com CBS/IBS)
+- **#258** — Credit tracking dashboard (rastreabilidade de crédito por operação)
+
+### Pesquisa competitiva mai/2026 — achados-chave
+
+- **Maior gap de mercado**: NCM → cClassTrib automatizado com evidência legal — não existe hoje
+- **Urgência real**: penalidades CBS/IBS a partir de ago/2026 (era "período educacional" antes)
+- **Concorrentes principais**: Sovos (pre-clearance + dual-regime), Thomson Reuters (enterprise), Tecnospeed/PlugNotas (middleware para software houses)
+- **Nosso diferenciador**: validação pós-fato com evidência auditável + API classify + export ERP multi-formato
+- **Emerging threat**: Tax Radar (taxradar.app) — startup construindo mapeamento NCM/cClassTrib; monitorar
+
+### Infra — estado em 17/05/2026
+
+- VM Magalu: ubuntu@201.54.20.18, compose em /opt/tribultz/infra/docker-compose.prod.yml
+- Containers: infra-api-1, infra-worker-1, infra-beat-1, infra-redis-1
+- Alembic head: 2026_05_17_0016 (add_api_keys)
+- Branch main: commit após merge #256

--- a/docs/context/project_s7_accounting_feedback.md
+++ b/docs/context/project_s7_accounting_feedback.md
@@ -1,0 +1,34 @@
+---
+name: S7 Accounting Team Feedback
+description: Requisitos do time de contabilidade para validações fiscais, relatório auditável e exemplos — recebido em 2026-03-21
+type: project
+---
+
+## Top 5 Validações priorizadas pelo time de contabilidade
+
+1. **Falta IBS e CBS** — precisa informar o percentual de cada um nas notas
+2. **Cálculo IBS/CBS incorreto** — alíquotas de 0,10% (CBS) e 0,90% (IBS) precisam aparecer conforme montante da nota
+3. **Código ClassTrib incorreto** — verificar conforme categoria do negócio
+4. **CEST incorreto** — códigos novos da classificação, muitos contribuintes não estão usando
+5. **Layout do documento incorreto** — de acordo com padrões do portal nacional de NFS-e
+
+**Why:** Estas são as validações que o time de contabilidade considera mais urgentes e frequentes no dia a dia. Veio diretamente dos stakeholders de domínio.
+
+**How to apply:** Usar como base para issue #34 (Top 10 rules phase 1). Cada regra precisa ser determinística com evidência auditável no formato Findings/Evidence v1.1.
+
+## Formato de relatório auditável solicitado
+
+**Tabela de validação:**
+- Validação → Inputs necessários → Regra → Severidade → Evidência mínima → Saída esperada
+
+**Colunas do relatório de nota:**
+- NF | BASE ICMS | VALOR ICMS | IBS | CBS | CEST | CLASSTRIB
+
+**Exemplos:** Querem 3 documentos anonimizados com gabarito PASS/FAIL/ALERTA — preferem exemplos do dia a dia de trabalho real.
+
+**Prazo sugerido pelo time:** 48-72h para o modelo de relatório (texto simples).
+
+## Alíquotas de referência informadas
+- CBS: 0,10%
+- IBS: 0,90%
+- (Estes são valores do período de teste/transição da reforma)

--- a/docs/context/project_s7_legal_bases.md
+++ b/docs/context/project_s7_legal_bases.md
@@ -1,0 +1,13 @@
+---
+name: S7 Legal Bases
+description: Referências legais da reforma tributária usadas como base para regras de validação
+type: reference
+---
+
+- **LC 214** (lei geral da reforma): https://www.planalto.gov.br/ccivil_03/leis/lcp/Lcp214.htm
+- **LC 227** (13/jan/2026 — atualizações): https://www.in.gov.br/web/dou/-/lei-complementar-n-227-de-13-de-janeiro-de-2026-681157850
+- **Nota do Gov sobre regulamentação**: https://www.gov.br/fazenda/pt-br/assuntos/noticias/2026/janeiro/nova-lei-de-regulamentacao-da-reforma-tributaria-aprofunda-o-federalismo-fiscal-cooperativo
+
+**Why:** Time de contabilidade indicou estas como fontes oficiais. Regras do motor devem ser rastreáveis a artigos específicos destas leis.
+
+**How to apply:** Ao implementar regras determinísticas (#34), cada regra deve referenciar o artigo/inciso da LC correspondente como evidência legal.

--- a/docs/context/project_s7_vocabulary.md
+++ b/docs/context/project_s7_vocabulary.md
@@ -1,0 +1,23 @@
+---
+name: S7 Fiscal Vocabulary
+description: Vocabulário fiscal oficial definido pelo time de contabilidade para uso no sistema
+type: project
+---
+
+Termos oficiais definidos pelo time de contabilidade em 2026-03-21:
+
+| Termo | Significado |
+|---|---|
+| CEST | Classificação principal |
+| ClassTrib | Nova classificação conforme reforma |
+| IBS | Imposto sobre Bens e Serviços (novo, estadual/municipal) |
+| CBS | Contribuição sobre Bens e Serviços (novo, federal) |
+| Nota Nacional | Nota de serviço emitida no portal nacional |
+| ISS | Imposto sobre o serviço (atual, será substituído) |
+| ICMS | Imposto dos produtos (atual, será substituído) |
+| Split Payment | O "novo" modo de crédito do governo |
+| Cashback | Retorno do imposto pago ao consumidor |
+
+**Why:** Padronizar terminologia entre código, UI, relatórios e comunicação com stakeholders.
+
+**How to apply:** Usar estes termos em labels, mensagens de erro/alerta, e relatórios de validação. Manter consistência com o que o time de contabilidade espera ver.

--- a/docs/context/project_s9_domain.md
+++ b/docs/context/project_s9_domain.md
@@ -1,0 +1,17 @@
+---
+name: S9 domain and hosting
+description: Domain tribultz.com.br acquired via Hostinger, DNS pointed to Cloudflare, Turnstile widget created.
+type: project
+---
+
+Domain tribultz.com.br acquired via Hostinger. DNS nameservers changed to Cloudflare (anna.ns.cloudflare.com, justin.ns.cloudflare.com) on 2026-03-22.
+
+Cloudflare Turnstile widget "Tribultz Console" created with:
+- Hostnames: tribultz.com.br + localhost
+- Mode: Managed (Recommended)
+- Site Key: 0x4AAAAAACukcOT9w9KF8vHm (public, safe for frontend)
+- Secret Key: stored in backend .env only (NEVER commit)
+
+**Why:** CAPTCHA required for login/register to prevent brute-force and bot abuse.
+
+**How to apply:** Use NEXT_PUBLIC_TURNSTILE_SITE_KEY env var in frontend, TURNSTILE_SECRET_KEY in backend .env. Backend captcha_service.py already validates tokens. Frontend needs widget integration on login + register pages.

--- a/docs/context/project_secrets_source_of_truth.md
+++ b/docs/context/project_secrets_source_of_truth.md
@@ -1,0 +1,18 @@
+---
+name: project-secrets-source-of-truth
+description: "A fonte de verdade dos segredos é /opt/tribultz/.env na VM, não o .env.prod local — que sofre drift silencioso"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 2725625b-729e-478f-8fcd-089f1a5735b6
+---
+
+A fonte de verdade dos segredos de produção é **`/opt/tribultz/.env` na VM Magalu** (root, `0600`) — o arquivo que os containers leem. O `.env.prod` local é apenas um espelho e **sofre drift em silêncio**.
+
+Em 2026-07-15 o `.env.prod` local estava 3 meses defasado (8/abr vs 29/jun na VM) e não tinha `GITHUB_TOKEN`, `NEWS_PUBLISH_TOKEN`, `SENTRY_DSN` e `SENTRY_TRACES_SAMPLE_RATE`, além de ter HubSpot desligado quando a VM tem ligado com token real. Foi sincronizado nessa data.
+
+**Why:** tratar a cópia local como referência (para migrar a um cofre, popular outra máquina ou fazer deploy) apaga silenciosamente tokens que só existem na VM. Foi exatamente o risco que quase se materializou numa tentativa de mover os segredos para um cofre em Docker.
+
+**How to apply:** antes de qualquer operação que trate segredos como fonte, puxar da VM primeiro — `ssh -i ~/.ssh/id_ed25519 ubuntu@201.54.20.18 'sudo cat /opt/tribultz/.env' > .env.prod` (com backup antes). Para detectar drift sem expor valores, comparar o md5 de cada valor chave a chave. Inventário completo, runbook de validação e onboarding de máquina nova (incl. Mac) em `docs/infra/secrets_inventory.md`.
+
+Pendências abertas em 2026-07-15: chave Resend revogada (401) e `GITHUB_TOKEN` de produção sendo o OAuth pessoal do `gh` CLI — detalhes em [[reference-services]]. Infra da VM em [[reference-magalu-cloud]].

--- a/docs/context/reference_nt2025002_apis.md
+++ b/docs/context/reference_nt2025002_apis.md
@@ -1,0 +1,79 @@
+---
+name: nt-2025-002-apis-externas-cbs-ibs
+description: "Referências técnicas da reforma tributária — NT 2025.002-RTC, Calculadora Oficial (sandbox público), ClassTrib SVRS, homologação NF-e"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 86fbe835-d1ef-4d60-8194-eca70a214920
+---
+
+## NT 2025.002-RTC (atual: v1.40 — 20/05/2026; v1.50 emergente p/ monofásico combustíveis)
+- Download: https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=AklZnck3o6I%3D
+- Define grupo IBSCBS em det/imposto para NF-e/NFC-e
+- CSTs: 000, 001, 002, 070, 200, 410, 510, 515, 550, 620, 800, 810, 811, 830
+- Alíquotas teste 2026 (simbólicas): CBS 0.90%, IBS 0.10% (IBS estadual 0,10% / municipal 0%)
+- Alíquotas de REFERÊNCIA definitivas (Fazenda 2024): CBS 8,8% + IBS 17,7% = ~26,5% (é o que o código usa em uf_rates.py)
+- ⚠️ CLAUDE.md do projeto lista alíquotas referência INVERTIDAS (CBS 0,10% / IBS 0,90%) — doc bug; código está correto
+
+### Progressão de versões e prazos (verificado 13/06/2026)
+- v1.36 (30/04/2026, Ajuste SINIEF 49/2025) ← versão referenciada no código Tribultz
+- v1.40 (20/05/2026): novos campos/grupos/regras; Evento 211110 alterado, 211120 (destinação consumo pessoal) ELIMINADO; novas rejeições (1106, 960); DFeReferenciado obrigatório p/ devolução por item a partir de 01/09/2026
+- v1.50 (emergente): reformulação layout monofásico de combustíveis; homologação até 01/09/2026, produção 03/11/2026
+- **Prazos obrigatoriedade (Regime Normal CRT=3): homologação 01/07/2026, produção 03/08/2026. Simples/MEI: 04/01/2027**
+- Regulamentos IBS e CBS publicados 30/04/2026 (MF + CGIBS); Split Payment — Ato Conjunto RFB/CGIBS nº 02 de 27/05/2026, doc técnico no DOU 03/06/2026, mecanismo só em 2027 (B2B voluntário)
+- Guia FlexDocs: https://flexdocs.net/guiaNFe/gerarNFe.detalhe.imp.IBSCBS.html
+- Guia TecnoSpeed: https://blog.tecnospeed.com.br/nota-tecnica-reforma-tributaria-nfe-nfce/
+
+## Calculadora Oficial CBS/IBS (Receita Federal) — Validado 24/03/2026
+- Portal home: https://piloto-cbs.tributos.gov.br
+- Calculadora: https://piloto-cbs.tributos.gov.br/servico/calculadora-consumo/calculadora
+
+### Módulos do portal (6 total)
+| Módulo | URL | Acesso |
+|--------|-----|--------|
+| Calcular Tributos sobre Consumo | /servico/calculadora-consumo/calculadora | **ABERTO** (sem login) |
+| Simular Operações de Consumo | - | Bloqueado (login gov.br) |
+| Minhas Apurações Assistidas CBS (PR) | - | Bloqueado (login gov.br) |
+| Consultar Ressarcimentos CBS (PR) | - | Bloqueado (login gov.br) |
+| Consultar Transferências CBS (PR) | - | Bloqueado (login gov.br) |
+| **Gerar Credencial para API (PR)** | - | **Bloqueado** (login gov.br) — investigar para 6tech/Tribultz |
+
+### Calculadora — 4 modos
+1. **Regime Geral** (`/calculadora/regime-geral`)
+   - Operação de Consumo: Data Fato Gerador (art.10 LC 214/25), Bem/Serviço, UF+Município, NCM+Descrição
+   - Tributação: CST (dropdown), cClassTrib (dropdown), Valor Base de Cálculo, Quantidade, Unidade de Medida
+   - Botões: Importar, Exportar, URL, QR Code, PDF, **XML**
+2. **Pedágio** (`/calculadora/pedagio`)
+   - Ocorrência (data), Valor da Operação (sem tributos), Tributação, Trechos (UF+Município+Extensão km)
+3. **Split Payment Simplificado** (`/calculadora/simplificado`)
+   - Data da Operação, CPF/CNPJ, Valor Pago
+4. **Bases de Cálculo** (`/calculadora/bases-de-calculo`)
+   - Modelos: CBS e IBS para Bens, IS para Bens - Ad valorem, NFS-e
+   - Ano do Fato Gerador: 2026
+   - Valores que integram a base: Valor do Bem, Ajustes, Juros, Multas, Encargos, Frete, Imposto Seletivo, Outros tributos, Demais importâncias
+   - Valores que NÃO integram: ICMS, ISS, PIS, Cofins, PIS Importação, COFINS Importação, COSIP, IPI, Desconto Incondicional
+
+### Outputs da Calculadora
+- CBS (federal), IBS estadual, IBS municipal, IS (seletivo)
+- Memória de cálculo com base legal
+- **Gerador de XML** — trecho XML com tags IBSCBS para NF-e
+- Relatório PDF, QR Code, URL compartilhável
+
+### Próximos passos — API
+- "Gerar Credencial para API (PR)" está bloqueado — requer login gov.br
+- Investigar: como 6tech/Tribultz pode obter credencial para integração via API
+- Possível fluxo: login gov.br empresarial → gerar credencial → chamar API programaticamente
+- **Apuração Assistida (sandbox)**: Simula não cumulatividade — compra (crédito RAD), venda (débito), compensação
+
+## Conformidade Fácil (ClassTrib)
+- Endpoint: https://cff.svrs.rs.gov.br/api/v1/consultas/classTrib
+
+## Homologação NF-e
+- SVAN: https://hom.nfe.fazenda.gov.br
+- NFS-e Nacional: IE 999999 (homologação), IE 530000 (produção)
+
+## Dados de mercado (março 2026)
+- 61.880 documentos fiscais de teste emitidos
+- 153 empresas (CNPJs) testando
+- 21 software houses integradas
+- PlugNotas: integrou calculadora oficial diretamente na emissão

--- a/docs/context/user_techlead.md
+++ b/docs/context/user_techlead.md
@@ -1,0 +1,7 @@
+---
+name: Tech Lead Tribultz
+description: Usuário é tech lead do projeto Tribultz, plataforma de compliance fiscal CBS/IBS
+type: user
+---
+
+Tech lead responsável pelo projeto Tribultz. Comunica-se em português. Trabalha com time de contabilidade como stakeholder de domínio fiscal. Coordena sprints com backlog no GitHub Issues.

--- a/docs/infra/secrets_inventory.md
+++ b/docs/infra/secrets_inventory.md
@@ -1,0 +1,136 @@
+# Inventário de Segredos — Tribultz
+
+> Validado em 2026-07-15. **Este arquivo não contém valores de credenciais** — apenas onde vivem, como validar e o que está pendente. Pode ser commitado.
+
+## Fonte de verdade
+
+**`/opt/tribultz/.env` na VM de produção** (root, `0600`). É o arquivo que os containers realmente leem.
+
+Cópias locais derivam dela e ficam obsoletas em silêncio. Em 2026-07-15 o `.env.prod` local estava 3 meses defasado e não tinha `GITHUB_TOKEN`, `NEWS_PUBLISH_TOKEN`, `SENTRY_DSN` nem `SENTRY_TRACES_SAMPLE_RATE`. Antes de tratar qualquer cópia local como referência, sincronize:
+
+```bash
+cp .env.prod ".env.prod.bak.$(date +%Y%m%d-%H%M%S)"
+ssh -i ~/.ssh/id_ed25519 ubuntu@201.54.20.18 'sudo cat /opt/tribultz/.env' > .env.prod
+```
+
+## Onde os segredos estão hoje
+
+| Local | Conteúdo | Versionado? |
+|-------|----------|-------------|
+| `/opt/tribultz/.env` (VM) | 48 chaves — fonte de verdade | não (fora do git) |
+| `.env.prod` (local) | espelho da VM | não — `.gitignore:139` |
+| `.env` (local) | dev; maioria placeholder, não credencial real | não — `.gitignore:138` |
+| `secrets/credentials.md` | credenciais de produção em markdown | não — `.gitignore:143` |
+| `.secrets/auth.json` | login de app (email/password/tenant) | não — `.gitignore:213` |
+| `frontend/.vercel/*.local` | só `VERCEL_OIDC_TOKEN` (efêmero) e vars públicas | não — `.gitignore:236` |
+| GitHub Actions Secrets | deploy: `MAGALU_SSH_KEY`, `MAGALU_SSH_HOST`, `MAGALU_SSH_USER` | n/a |
+| Memória do Claude | `reference_magalu_cloud.md`, `reference_services.md` | n/a |
+
+Nenhum segredo está rastreado pelo git — só `.env.prod.template` e os `.env.example`. Verificado em 2026-07-15.
+
+Não existe token de deploy da Vercel: o deploy do frontend é via integração GitHub, não via token.
+
+## Como validar (sem imprimir valores)
+
+```bash
+g(){ grep -E "^$1=" .env.prod | head -1 | cut -d= -f2- | tr -d '"'"'"'\r'; }
+
+# OpenRouter / Asaas / Resend / HubSpot — espera-se HTTP 200
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $(g OPENROUTER_API_KEY)" https://openrouter.ai/api/v1/key
+curl -s -o /dev/null -w '%{http_code}\n' -H "access_token: $(g ASAAS_API_KEY)"          https://api.asaas.com/v3/myAccount
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $(g SMTP_PASSWORD)"   https://api.resend.com/domains
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $(g HUBSPOT_PRIVATE_APP_TOKEN)" 'https://api.hubapi.com/crm/v3/objects/contacts?limit=1'
+
+# Object Storage Magalu
+curl -s -o /dev/null -w '%{http_code}\n' --aws-sigv4 "aws:amz:$(g S3_REGION):s3" \
+  --user "$(g S3_ACCESS_KEY):$(g S3_SECRET_KEY)" "$(g S3_ENDPOINT)/$(g S3_BUCKET)/?list-type=2&max-keys=1"
+
+# Cloudflare — espera-se "success":true e "status":"active"
+curl -s -H "Authorization: Bearer <token>" https://api.cloudflare.com/client/v4/user/tokens/verify
+
+# Magalu CLI e SSH
+mgc virtual-machine instances list --api-key <key>
+ssh -i ~/.ssh/id_ed25519 ubuntu@201.54.20.18 'echo ok'
+```
+
+Para comparar cópia local com a VM sem expor valores, compare o md5 de cada valor chave a chave — foi assim que o drift de 3 meses foi detectado.
+
+## Estado em 2026-07-15
+
+Válidos: Magalu (API key, SSH, Object Storage), Cloudflare, Turnstile, Asaas produção, OpenRouter, HubSpot, GitHub.
+
+**Pendências abertas:**
+
+1. **Resend revogado.** A chave é idêntica em `.env.prod`, `secrets/credentials.md` e na memória, e as três retornam **HTTP 401**. E-mail transacional está quebrado em produção com `EMAIL_VERIFICATION_ENABLED=true` — provavelmente ninguém consegue concluir cadastro. Ao rotacionar, a nova chave precisa entrar em **quatro** lugares: `/opt/tribultz/.env` (VM), `.env.prod` (local), `secrets/credentials.md` e a memória.
+
+2. **`GITHUB_TOKEN` de produção é um OAuth pessoal.** O valor em `/opt/tribultz/.env` é byte a byte o mesmo token `gho_` do `gh` CLI do `mickbap` (confirmado por hash). Consequências: `gh auth logout`, troca de máquina ou expiração do OAuth derrubam produção junto; e o escopo `repo` alcança todos os repositórios da conta, não só este. Deveria ser um fine-grained PAT restrito a `mickbap/tribultz` ou um GitHub App.
+
+3. **`gh` CLI sem escopo `workflow`.** Escopos atuais: `gist`, `read:org`, `repo`. Alterar `.github/workflows/**` via API/CLI falha; só via push.
+
+## Por que "funciona no Windows" e não no Mac
+
+Validado em 2026-07-15. A intuição de que Magalu e Vercel "acessam via GitHub por causa dos deploys" mistura duas coisas distintas — **deploy** e **acesso operacional** — e a resposta é diferente para cada serviço.
+
+**Magalu: não existe login nenhum em máquina alguma.** `~/AppData/Roaming/mgc/default/auth.yaml` (Windows) tem `access_token`, `refresh_token`, `access_key_id` e `secret_access_key` **todos vazios**. Sem credencial explícita, o mgc falha com `RefreshToken is not set`. O acesso "funciona" no Windows apenas porque a API key é injetada a cada comando via `--api-key`, lida de `secrets/credentials.md` / memória do Claude — nenhum dos dois vai para o Mac. **Essa é a causa raiz do bloqueio no Mac: não há o que "levar junto" além da string da key.**
+
+Duas formas de resolver, ambas verificadas:
+- **`MGC_API_KEY` como variável de ambiente** — funciona, apesar de não aparecer em `mgc --help`. É o caminho mais simples.
+- **`mgc auth login`** — fluxo OAuth por navegador. Falha em bash headless (sem TTY), mas funciona num Mac com GUI. Gera sessão persistente de verdade.
+
+Não existe caminho para *persistir uma key já existente*: `mgc auth api-key` só tem `create`, `get`, `list` e `revoke`.
+
+**Vercel: login é por máquina, e não há nada para migrar.** O CLI usa OAuth — `auth.json` guarda um access token de ~8h mais um `refreshToken` que o renova sozinho. Copiar esse arquivo para o Mac é inútil (expira e é vinculado à sessão). No Mac: `vercel login`. Só é necessário para deploy manual.
+
+**Nenhum deploy depende do seu laptop.** O frontend é publicado pelo `vercel[bot]` via GitHub App (deployments de Production e Preview criados por ele em 2026-07-14). O backend é publicado pelo GitHub Actions via SSH, usando os secrets `MAGALU_SSH_KEY` / `MAGALU_SSH_HOST` / `MAGALU_SSH_USER`. Ou seja: mesmo com zero credencial local, **você nunca fica sem conseguir fazer deploy** — o que se perde sem credencial local é o acesso operacional (inspecionar VM, ler logs, rodar migrations).
+
+## Verificação de acessos
+
+`bash tools/check_access.sh` — checa SSH, mgc, gh, Vercel, drift do `.env.prod` e saúde da produção, com PASS/FAIL e a correção de cada falha. Não contém nem escreve segredos; lê a key de `$MGC_API_KEY`. Rode isso **no Mac antes de depender dele**.
+
+## Onboarding em máquina nova (incl. Mac)
+
+```bash
+# 1. Chave SSH — o macOS RECUSA chave com permissão frouxa; o Windows tolera
+chmod 600 ~/.ssh/id_ed25519
+ssh-keygen -lf ~/.ssh/id_ed25519.pub   # esperado: SHA256:ydI3GwtHcGHjUvcCzFQgOp7zypbiVwqqiicGlhun7gg (tribultz-infra)
+ssh -i ~/.ssh/id_ed25519 ubuntu@201.54.20.18 'echo ok'
+
+# 2. mgc CLI — no Mac use o build darwin_arm64 (Apple Silicon) ou darwin_amd64 (Intel)
+#    Releases oficiais: github.com/MagaluCloud/mgccli — confira o sha256 contra mgccli_<ver>_checksums.txt
+curl -sLO https://github.com/MagaluCloud/mgccli/releases/download/v0.61.2/mgccli_0.61.2_darwin_arm64.tar.gz
+shasum -a 256 mgccli_0.61.2_darwin_arm64.tar.gz    # comparar com o checksums.txt da release
+tar xzf mgccli_0.61.2_darwin_arm64.tar.gz && sudo mv mgc /usr/local/bin/ && mgc --version
+
+# 3. Credencial da Magalu — SEM isto o mgc não funciona (não há login persistido).
+#    Traga a API key da máquina antiga por um canal seguro (gerenciador de senhas).
+#    Opção A — variável de ambiente (verificada; não aparece no --help):
+echo 'export MGC_API_KEY="<a key de tribultz-cli-tenant>"' >> ~/.zshrc && source ~/.zshrc
+mgc virtual-machine instances list        # esperado: tribultz-api / running
+#    Opção B — login OAuth de verdade (funciona no Mac por ter navegador):
+mgc auth login
+
+# 4. .env.prod — puxe da VM, nunca copie de outra máquina
+ssh -i ~/.ssh/id_ed25519 ubuntu@201.54.20.18 'sudo cat /opt/tribultz/.env' > .env.prod
+
+# 5. gh CLI
+gh auth login
+
+# 6. Vercel — só para deploy manual; deploy por push não precisa disto
+npm i -g vercel && vercel login
+cd frontend && vercel link      # org team_Yj7YsH3ejoP3hlLyQivNVlS4, projeto tribultz
+
+# 7. Validar tudo antes de confiar na máquina
+bash tools/check_access.sh
+```
+
+Não copie `~/Library/Application Support/com.vercel.cli/auth.json` nem o `auth.yaml` do mgc da máquina antiga: o primeiro expira em horas e o segundo está vazio.
+
+`mgc auth login --headless` não funciona sem TTY — use sempre `--api-key` explícito.
+
+No Windows, `mgc` está em `C:\mgc\mgc.exe` e `C:\mgc` foi adicionado ao PATH do usuário em 2026-07-15 (shells já abertos precisam ser reiniciados para enxergar).
+
+## Se um dia migrar para um cofre
+
+Avaliado em 2026-07-15 e **adiado**. Um container de segredos exposto na VM exigiria abrir porta nova para a internet — hoje o UFW só abre 22/80/443 com fail2ban, e um cofre exposto aumentaria a superfície de ataque justamente no serviço mais sensível. Para o tamanho atual do time, SOPS + age (arquivo cifrado versionado, decifrado localmente) resolve o acesso multi-máquina sem servidor nem porta aberta. Vault/Infisical só compensa com rotação automática e auditoria multi-usuário.
+
+Qualquer migração deve usar **a VM como origem**, nunca uma cópia local.

--- a/docs/infra/secrets_inventory.md
+++ b/docs/infra/secrets_inventory.md
@@ -79,6 +79,19 @@ Duas formas de resolver, ambas verificadas:
 
 Não existe caminho para *persistir uma key já existente*: `mgc auth api-key` só tem `create`, `get`, `list` e `revoke`.
 
+### Armadilha dos dois tenants
+
+A conta tem **dois tenants Magalu**, e `mgc auth login` cai no **errado** por padrão:
+
+| Tenant | Hospeda a VM? |
+|--------|---------------|
+| `mickel.baptista@outlook.com` (pessoal) | não — é onde o `mgc auth login` cai por padrão |
+| `mickel@6tech.net.br` (managed) | **sim** — `tribultz-api` e o Object Storage vivem aqui |
+
+Sintoma: login funciona, nenhum erro aparece, e `mgc virtual-machine instances list` volta **vazio** — parece falta de permissão, mas é tenant errado. Selecione o tenant correto após o login (`mgc auth tenant list`).
+
+> ⚠️ **`mgc auth tenant set` imprime `access_token` e `refresh_token` completos em texto puro no stdout.** Redirecione a saída (`> /dev/null`) e nunca rode esse comando com o terminal compartilhado, em screenshot ou em sessão de agente cujo transcript fique salvo. Um `refresh_token` vazado continua valendo até a sessão ser encerrada com `mgc auth logout`.
+
 **Vercel: login é por máquina, e não há nada para migrar.** O CLI usa OAuth — `auth.json` guarda um access token de ~8h mais um `refreshToken` que o renova sozinho. Copiar esse arquivo para o Mac é inútil (expira e é vinculado à sessão). No Mac: `vercel login`. Só é necessário para deploy manual.
 
 **Nenhum deploy depende do seu laptop.** O frontend é publicado pelo `vercel[bot]` via GitHub App (deployments de Production e Preview criados por ele em 2026-07-14). O backend é publicado pelo GitHub Actions via SSH, usando os secrets `MAGALU_SSH_KEY` / `MAGALU_SSH_HOST` / `MAGALU_SSH_USER`. Ou seja: mesmo com zero credencial local, **você nunca fica sem conseguir fazer deploy** — o que se perde sem credencial local é o acesso operacional (inspecionar VM, ler logs, rodar migrations).

--- a/docs/infra/secrets_inventory.md
+++ b/docs/infra/secrets_inventory.md
@@ -89,12 +89,20 @@ Não existe caminho para *persistir uma key já existente*: `mgc auth api-key` s
 
 A conta tem **dois tenants Magalu**, e `mgc auth login` cai no **errado** por padrão:
 
-| Tenant | Hospeda a VM? |
-|--------|---------------|
-| `mickel.baptista@outlook.com` (pessoal) | não — é onde o `mgc auth login` cai por padrão |
-| `mickel@6tech.net.br` (managed) | **sim** — `tribultz-api` e o Object Storage vivem aqui |
+| Tenant | UUID | Hospeda a VM? |
+|--------|------|---------------|
+| `mickel.baptista@outlook.com` (pessoal) | `ff4cd2a8-5f78-42d1-b047-ec90c1afe100` | não — é onde o `mgc auth login` cai por padrão |
+| `mickel@6tech.net.br` (managed) | `77554d12-fe63-4697-ac4f-9bfb3bc926a4` | **sim** — `tribultz-api` e o Object Storage vivem aqui |
 
-Sintoma: login funciona, nenhum erro aparece, e `mgc virtual-machine instances list` volta **vazio** — parece falta de permissão, mas é tenant errado. Selecione o tenant correto após o login (`mgc auth tenant list`).
+Sintoma: login funciona, nenhum erro aparece, e `mgc virtual-machine instances list` volta **vazio** — parece falta de permissão, mas é tenant errado.
+
+```bash
+mgc auth tenant list      # lista os dois — seguro, não imprime token
+mgc auth tenant current   # mostra o ativo — seguro, não imprime token
+mgc auth tenant set 77554d12-fe63-4697-ac4f-9bfb3bc926a4 > /dev/null 2>&1   # PERIGOSO sem redirect
+```
+
+> Ao conferir a saída do mgc, não filtre por `name:` ou `state:`: o CLI injeta códigos ANSI de cor **entre** a palavra e os dois-pontos, e o grep literal nunca casa — parece que a VM sumiu quando ela está lá. Filtre por um valor contíguo (ex.: `tribultz-api`) ou use `| sed -E 's/\x1b\[[0-9;]*m//g'` antes do grep.
 
 > ⚠️ **`mgc auth tenant set` imprime `access_token` e `refresh_token` completos em texto puro no stdout.** Redirecione a saída (`> /dev/null`) e nunca rode esse comando com o terminal compartilhado, em screenshot ou em sessão de agente cujo transcript fique salvo. Um `refresh_token` vazado continua valendo até a sessão ser encerrada com `mgc auth logout`.
 

--- a/docs/infra/secrets_inventory.md
+++ b/docs/infra/secrets_inventory.md
@@ -59,13 +59,19 @@ Para comparar cópia local com a VM sem expor valores, compare o md5 de cada val
 
 Válidos: Magalu (API key, SSH, Object Storage), Cloudflare, Turnstile, Asaas produção, OpenRouter, HubSpot, GitHub.
 
-**Pendências abertas:**
+> 🔒 **Ordem vigente (2026-07-15): NÃO rotacionar, revogar nem encerrar sessão de credencial alguma enquanto o produto não escala.** Vale inclusive para as pendências listadas abaixo — inclusive as comprovadamente vazadas ou já revogadas. Documentar e seguir; não propor rotação de novo. O objetivo da fase é acesso livre e sem atrito a partir de Windows e Mac. Reavaliar quando o produto escalar.
+>
+> Contexto que sustenta a ordem: **deploy não usa credencial local alguma** — frontend pelo `vercel[bot]` (GitHub App), backend pelo Actions com `MAGALU_SSH_KEY`. Nenhuma ação sobre credencial local pode conflitar com deploy.
+
+**Pendências abertas** (registradas, sem ação — ver ordem acima)**:**
 
 1. **Resend revogado.** A chave é idêntica em `.env.prod`, `secrets/credentials.md` e na memória, e as três retornam **HTTP 401**. E-mail transacional está quebrado em produção com `EMAIL_VERIFICATION_ENABLED=true` — provavelmente ninguém consegue concluir cadastro. Ao rotacionar, a nova chave precisa entrar em **quatro** lugares: `/opt/tribultz/.env` (VM), `.env.prod` (local), `secrets/credentials.md` e a memória.
 
 2. **`GITHUB_TOKEN` de produção é um OAuth pessoal.** O valor em `/opt/tribultz/.env` é byte a byte o mesmo token `gho_` do `gh` CLI do `mickbap` (confirmado por hash). Consequências: `gh auth logout`, troca de máquina ou expiração do OAuth derrubam produção junto; e o escopo `repo` alcança todos os repositórios da conta, não só este. Deveria ser um fine-grained PAT restrito a `mickbap/tribultz` ou um GitHub App.
 
 3. **`gh` CLI sem escopo `workflow`.** Escopos atuais: `gist`, `read:org`, `repo`. Alterar `.github/workflows/**` via API/CLI falha; só via push.
+
+4. **`refresh_token` do mgc exposto em transcript** (Mac, 2026-07-15). Um `mgc auth tenant set` imprimiu `access_token` e `refresh_token` completos em texto puro numa sessão de agente. O `refresh_token` continua cunhando access tokens até um `mgc auth logout` — que, por ordem vigente, **não será executado**. Prevenção: sempre redirecionar a saída desse comando (`> /dev/null 2>&1`).
 
 ## Por que "funciona no Windows" e não no Mac
 

--- a/tools/check_access.sh
+++ b/tools/check_access.sh
@@ -60,13 +60,19 @@ if ! command -v mgc >/dev/null 2>&1; then
   bad "mgc não está no PATH" "instale: github.com/MagaluCloud/mgccli (Mac: darwin_arm64) e confira o sha256"
 else
   ok "mgc encontrado: $(mgc --version 2>/dev/null | head -1)"
-  if [ -z "$MGC_API_KEY" ]; then
-    bad "MGC_API_KEY não está definida" "export MGC_API_KEY=... — NÃO existe login persistido; sem essa var o mgc falha com 'RefreshToken is not set'"
-  else
-    if mgc virtual-machine instances list 2>/dev/null | grep -q 'tribultz-api'; then
-      ok "API key válida — VM tribultz-api visível"
+  # Testa o acesso de verdade, não a forma de autenticar: serve tanto para
+  # sessão OAuth (mgc auth login) quanto para MGC_API_KEY.
+  if mgc virtual-machine instances list 2>/dev/null | grep -q 'tribultz-api'; then
+    if [ -n "$MGC_API_KEY" ]; then
+      ok "acesso ok — VM tribultz-api visível (via MGC_API_KEY)"
     else
+      ok "acesso ok — VM tribultz-api visível (via sessão de 'mgc auth login')"
+    fi
+  else
+    if [ -n "$MGC_API_KEY" ]; then
       bad "MGC_API_KEY definida mas a chamada falhou" "key errada/revogada, ou tenant sem permissão"
+    else
+      bad "sem acesso à Magalu" "rode 'mgc auth login' (OAuth por navegador, cria sessão persistente) OU export MGC_API_KEY=... — sem um dos dois o mgc falha com 'RefreshToken is not set'"
     fi
   fi
 fi

--- a/tools/check_access.sh
+++ b/tools/check_access.sh
@@ -11,7 +11,10 @@
 VM_HOST="201.54.20.18"
 VM_USER="ubuntu"
 SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
-KEY_FP="SHA256:ydI3GwtHcGHjUvcCzFQgOp7zypbiVwqqiicGlhun7gg"   # tribultz-infra (público)
+# Fingerprints das chaves autorizadas na VM (públicos — não são segredo).
+# Ao adicionar uma máquina, autorize a chave em ~/.ssh/authorized_keys na VM e liste aqui.
+KEY_FPS="SHA256:ydI3GwtHcGHjUvcCzFQgOp7zypbiVwqqiicGlhun7gg=tribultz-infra (Windows)
+SHA256:6DqZCh26dT2Ce0KPD8ZwMXPtZ9++3siBctZKD1E+8ig=tribultz-infra (Mac)"
 API="https://api.tribultz.com.br"
 FRONTEND="https://tribultz.com.br"
 
@@ -42,9 +45,18 @@ else
     echo -e "  ${DIM}· permissão não verificada (Windows usa ACL, não modo POSIX)${NC}"
   fi
   FP=$(ssh-keygen -lf "${SSH_KEY}.pub" 2>/dev/null | awk '{print $2}')
-  if [ -z "$FP" ]; then warn "sem ${SSH_KEY}.pub para conferir fingerprint"
-  elif [ "$FP" = "$KEY_FP" ]; then ok "fingerprint confere (tribultz-infra)"
-  else bad "fingerprint diferente do esperado" "esperado $KEY_FP, obtido $FP"; fi
+  if [ -z "$FP" ]; then
+    warn "sem ${SSH_KEY}.pub para conferir fingerprint"
+  else
+    NAME=$(printf '%s\n' "$KEY_FPS" | grep -F "$FP=" | cut -d= -f2-)
+    if [ -n "$NAME" ]; then
+      ok "chave reconhecida: $NAME"
+    else
+      # Não é falha: a autoridade é o teste de conexão logo abaixo. Uma chave nova
+      # e legítima simplesmente ainda não foi listada em KEY_FPS.
+      warn "chave não listada em KEY_FPS ($FP)" "se a conexão abaixo funcionar, a chave é válida — considere adicioná-la a KEY_FPS"
+    fi
+  fi
 
   if ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=12 -o StrictHostKeyChecking=accept-new \
        "$VM_USER@$VM_HOST" 'exit 0' 2>/dev/null; then
@@ -70,7 +82,10 @@ else
     fi
   else
     if [ -n "$MGC_API_KEY" ]; then
-      bad "MGC_API_KEY definida mas a chamada falhou" "key errada/revogada, ou tenant sem permissão"
+      bad "MGC_API_KEY definida mas a chamada falhou" "key errada/revogada, ou key de outro tenant"
+    elif mgc auth tenant list >/dev/null 2>&1; then
+      # Autenticado, mas sem enxergar a VM: quase sempre é tenant errado.
+      bad "autenticado, mas a VM tribultz-api não aparece" "TENANT ERRADO. A conta tem 2 tenants e o 'mgc auth login' cai no pessoal (mickel.baptista@outlook.com) por padrão; a VM vive no mickel@6tech.net.br (managed). Veja 'mgc auth tenant list' e selecione o correto. ATENÇÃO: 'mgc auth tenant set' IMPRIME access_token e refresh_token em texto puro — redirecione a saída (> /dev/null) ou não compartilhe o terminal."
     else
       bad "sem acesso à Magalu" "rode 'mgc auth login' (OAuth por navegador, cria sessão persistente) OU export MGC_API_KEY=... — sem um dos dois o mgc falha com 'RefreshToken is not set'"
     fi

--- a/tools/check_access.sh
+++ b/tools/check_access.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# ============================================================
+# TRIBULTZ — Verificação de Acessos (macOS / Linux / Git Bash)
+# Run: bash tools/check_access.sh
+# Requires: curl, ssh, bash. Opcionais: mgc, gh, vercel
+#
+# Não contém segredos e não escreve nenhum. Lê a API key da Magalu
+# de $MGC_API_KEY. Só faz chamadas de leitura.
+# ============================================================
+
+VM_HOST="201.54.20.18"
+VM_USER="ubuntu"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
+KEY_FP="SHA256:ydI3GwtHcGHjUvcCzFQgOp7zypbiVwqqiicGlhun7gg"   # tribultz-infra (público)
+API="https://api.tribultz.com.br"
+FRONTEND="https://tribultz.com.br"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; DIM='\033[2m'; NC='\033[0m'
+PASS=0; FAIL=0; WARN=0
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; PASS=$((PASS+1)); }
+bad()  { echo -e "  ${RED}✗${NC} $1"; [ -n "$2" ] && echo -e "    ${DIM}→ $2${NC}"; FAIL=$((FAIL+1)); }
+warn() { echo -e "  ${YELLOW}!${NC} $1"; [ -n "$2" ] && echo -e "    ${DIM}→ $2${NC}"; WARN=$((WARN+1)); }
+code() { curl -s -o /dev/null -w '%{http_code}' -m 15 "$@"; }
+
+echo
+echo "=== 1. SSH → VM de produção ==============================="
+if [ ! -f "$SSH_KEY" ]; then
+  bad "chave $SSH_KEY não existe" "copie a chave privada da máquina antiga (ela NÃO está no git)"
+else
+  # macOS/Linux recusam chave com permissão frouxa; Git Bash no Windows usa ACL e ignora
+  case "$(uname -s)" in
+    Darwin) PERM=$(stat -f '%Lp' "$SSH_KEY" 2>/dev/null) ;;
+    Linux)  PERM=$(stat -c '%a' "$SSH_KEY" 2>/dev/null) ;;
+    *)      PERM="" ;;   # MINGW/MSYS/CYGWIN: permissão POSIX não é significativa
+  esac
+  if [ -n "$PERM" ]; then
+    case "$PERM" in
+      600|400) ok "permissão da chave: $PERM" ;;
+      *)       bad "permissão da chave é $PERM — o SSH recusa a chave" "chmod 600 $SSH_KEY" ;;
+    esac
+  else
+    echo -e "  ${DIM}· permissão não verificada (Windows usa ACL, não modo POSIX)${NC}"
+  fi
+  FP=$(ssh-keygen -lf "${SSH_KEY}.pub" 2>/dev/null | awk '{print $2}')
+  if [ -z "$FP" ]; then warn "sem ${SSH_KEY}.pub para conferir fingerprint"
+  elif [ "$FP" = "$KEY_FP" ]; then ok "fingerprint confere (tribultz-infra)"
+  else bad "fingerprint diferente do esperado" "esperado $KEY_FP, obtido $FP"; fi
+
+  if ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=12 -o StrictHostKeyChecking=accept-new \
+       "$VM_USER@$VM_HOST" 'exit 0' 2>/dev/null; then
+    ok "SSH conecta em $VM_USER@$VM_HOST"
+  else
+    bad "SSH falhou" "a chave pública precisa estar em ~/.ssh/authorized_keys na VM; confira também o firewall (porta 22)"
+  fi
+fi
+
+echo
+echo "=== 2. Magalu Cloud (mgc CLI) ============================="
+if ! command -v mgc >/dev/null 2>&1; then
+  bad "mgc não está no PATH" "instale: github.com/MagaluCloud/mgccli (Mac: darwin_arm64) e confira o sha256"
+else
+  ok "mgc encontrado: $(mgc --version 2>/dev/null | head -1)"
+  if [ -z "$MGC_API_KEY" ]; then
+    bad "MGC_API_KEY não está definida" "export MGC_API_KEY=... — NÃO existe login persistido; sem essa var o mgc falha com 'RefreshToken is not set'"
+  else
+    if mgc virtual-machine instances list 2>/dev/null | grep -q 'tribultz-api'; then
+      ok "API key válida — VM tribultz-api visível"
+    else
+      bad "MGC_API_KEY definida mas a chamada falhou" "key errada/revogada, ou tenant sem permissão"
+    fi
+  fi
+fi
+
+echo
+echo "=== 3. GitHub (gh CLI) ===================================="
+if ! command -v gh >/dev/null 2>&1; then
+  warn "gh não instalado" "brew install gh && gh auth login"
+elif gh auth status >/dev/null 2>&1; then
+  ok "gh autenticado ($(gh api user --jq .login 2>/dev/null))"
+  gh auth status 2>&1 | grep -qi "'workflow'" \
+    && ok "escopo workflow presente" \
+    || warn "sem escopo workflow" "não edita .github/workflows via API — só via push. Corrigir: gh auth refresh -h github.com -s workflow"
+else
+  bad "gh não autenticado" "gh auth login"
+fi
+
+echo
+echo "=== 4. Vercel ============================================="
+echo -e "  ${DIM}Deploy NÃO depende desta máquina: quem publica é o vercel[bot] via GitHub App.${NC}"
+if ! command -v vercel >/dev/null 2>&1; then
+  warn "vercel CLI não instalado" "só é necessário para deploy manual (vercel --prod). Deploy por push não precisa."
+elif vercel whoami >/dev/null 2>&1; then
+  ok "vercel CLI autenticado ($(vercel whoami 2>/dev/null | tail -1))"
+else
+  warn "vercel CLI não autenticado" "vercel login — depois 'vercel link' (org team_Yj7YsH3ejoP3hlLyQivNVlS4, projeto tribultz). Não bloqueia deploys."
+fi
+
+echo
+echo "=== 5. .env.prod local vs VM (fonte de verdade) ==========="
+if [ ! -f .env.prod ]; then
+  warn ".env.prod não existe aqui" "ssh -i $SSH_KEY $VM_USER@$VM_HOST 'sudo cat /opt/tribultz/.env' > .env.prod"
+elif ! ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=12 "$VM_USER@$VM_HOST" 'exit 0' 2>/dev/null; then
+  warn "sem SSH — não dá para comparar com a VM"
+else
+  H=$(command -v md5sum >/dev/null && echo md5sum || echo "md5 -q")
+  ssh -i "$SSH_KEY" -o BatchMode=yes "$VM_USER@$VM_HOST" \
+    'sudo grep -E "^[A-Za-z_][A-Za-z0-9_]*=" /opt/tribultz/.env | while IFS="=" read -r k v; do v="${v%\"}"; v="${v#\"}"; printf "%s %s\n" "$k" "$(printf "%s" "$v" | md5sum | cut -c1-8)"; done' 2>/dev/null | sort > /tmp/_vm.$$
+  grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .env.prod | while IFS='=' read -r k v; do
+    v="${v%\"}"; v="${v#\"}"; v="${v%$'\r'}"
+    printf "%s %s\n" "$k" "$(printf "%s" "$v" | $H | cut -c1-8)"
+  done | sort > /tmp/_lo.$$
+  D=$(join /tmp/_vm.$$ /tmp/_lo.$$ 2>/dev/null | awk '$2!=$3' | wc -l | tr -d ' ')
+  M=$(join -v1 /tmp/_vm.$$ /tmp/_lo.$$ 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$D" = "0" ] && [ "$M" = "0" ]; then
+    ok "em sincronia com a VM ($(wc -l < /tmp/_vm.$$ | tr -d ' ') chaves)"
+  else
+    bad "drift: $D valores divergem, $M chaves da VM faltam aqui" "a VM é a fonte de verdade — puxe de lá, não copie de outra máquina"
+    join -v1 /tmp/_vm.$$ /tmp/_lo.$$ 2>/dev/null | awk '{print "      falta: "$1}'
+  fi
+  rm -f /tmp/_vm.$$ /tmp/_lo.$$
+fi
+
+echo
+echo "=== 6. Produção no ar ====================================="
+C=$(code "$FRONTEND");     [ "$C" = "200" ] && ok "frontend $C" || bad "frontend $C"
+C=$(code "$API/health");   [ "$C" = "200" ] && ok "api/health $C" || bad "api/health $C"
+
+echo
+echo "==========================================================="
+echo -e "  ${GREEN}$PASS ok${NC} · ${YELLOW}$WARN aviso(s)${NC} · ${RED}$FAIL falha(s)${NC}"
+[ "$FAIL" -gt 0 ] && echo -e "  ${DIM}Falhas em 1 ou 2 = você fica sem acesso operacional à infra.${NC}"
+echo -e "  ${DIM}Avisos em 3 ou 4 não impedem deploy (é tudo server-side).${NC}"
+echo
+exit $([ "$FAIL" -gt 0 ] && echo 1 || echo 0)


### PR DESCRIPTION
## Contexto

Nasceu de um pedido para mover todos os tokens para um cofre em Docker, motivado por "estamos sem acesso CLI com credenciais válidas na Magalu". A validação mostrou que **as duas premissas estavam erradas** — e que migrar a cópia local dos segredos teria causado exatamente o ilhamento que se queria evitar.

## O que a investigação encontrou

**A credencial Magalu sempre foi válida.** O `mgc` só não estava no PATH (e estava em v0.53.0). Não havia credencial inválida.

**Não existe login persistido do `mgc` em máquina nenhuma.** O `auth.yaml` tem `access_token`, `refresh_token`, `access_key_id` e `secret_access_key` todos vazios; sem credencial explícita o CLI falha com `RefreshToken is not set`. O acesso "funcionava" no Windows apenas porque a API key era injetada por comando, lida de um arquivo de memória local do agente — que não viaja para outra máquina. Essa era a causa raiz do bloqueio no Mac.

**A fonte de verdade dos segredos é `/opt/tribultz/.env` na VM**, não a cópia local. O `.env.prod` local estava 3 meses defasado, sem `GITHUB_TOKEN`, `NEWS_PUBLISH_TOKEN`, `SENTRY_DSN` e `SENTRY_TRACES_SAMPLE_RATE`, e com HubSpot desligado enquanto a VM o tem ligado com token real.

**Deploy não depende de credencial local alguma** — frontend pelo `vercel[bot]` (GitHub App), backend pelo Actions com `MAGALU_SSH_KEY`. Sem credencial local perde-se acesso operacional, nunca a capacidade de deployar.

## O que entra

- **`tools/check_access.sh`** — valida SSH, mgc, gh, Vercel, drift do `.env.prod` e saúde da produção, com PASS/FAIL e a correção de cada falha. Não contém nem escreve segredos.
- **`docs/infra/secrets_inventory.md`** — onde cada segredo vive, como validar sem expor valores, onboarding de máquina nova (incl. Mac), e a armadilha dos dois tenants Magalu. Sem valores.
- **`docs/context/`** — 13 arquivos de conhecimento promovidos da memória local do agente (vocabulário fiscal, base legal, regras da contabilidade, referências de API, convenções, decisões de produto). Memória local vive fora do repo e não sai no clone: esse conhecimento seria perdido em silêncio na troca de máquina. `CLAUDE.md` aponta para lá.
- **`.gitignore`** — passa a cobrir backups de `.env` (`.env.prod.bak.*`, `.env.bak.*`), que contêm segredos de produção e escapavam da regra exata.
- **`.gitattributes`** — força LF em `*.sh`; com CRLF o script quebra no macOS.

## Verificação

`tools/check_access.sh` roda verde nas duas máquinas: **Windows** (10 ok / 1 aviso / 0 falhas) e **Mac** (10 ok / 1 aviso / 0 falhas). O aviso é o `gh` sem escopo `workflow`, conhecido e sem impacto em deploy.

Histórico do git auditado: nenhum segredo jamais foi commitado.

## Efeito colateral positivo

A produção tinha **uma única chave SSH autorizada** (só o Windows entrava). O Mac ganhou chave própria, adicionada sem revogar nada — ponto único de falha removido.

## Pendências registradas, intencionalmente sem ação

Por ordem vigente (não rotacionar credenciais enquanto o produto não escala), estas ficam documentadas e sem correção:

1. **Resend revogado (HTTP 401)** — e-mail transacional quebrado em produção com `EMAIL_VERIFICATION_ENABLED=true`. O secret `RESEND_API_KEY` no Actions foi atualizado em 27/mai, depois da chave morta: sugere rotação que nunca propagou para a VM.
2. **`GITHUB_TOKEN` de produção = OAuth pessoal do `gh`** (confirmado por hash, byte a byte).
3. **`gh` sem escopo `workflow`**.
4. **`refresh_token` do mgc exposto** em transcript de agente por um `mgc auth tenant set` sem redirecionamento.

## Revisão

Base `main`, sem tocar em `feat/311-ibscbs-crt-aware`. Só adiciona arquivos e 6 linhas ao `CLAUDE.md` — nenhum código de produto é alterado.