### PR TITLE
fix(infra): renomeia rede interna internal→tribultz no docker-compose.prod.yml

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -25,7 +25,7 @@ x-common: &common
     PYTHONUNBUFFERED: "1"        # único override — não sobrescreve vars do .env
   restart: unless-stopped
   networks:
-    - internal
+    - tribultz
   # CIS Docker Benchmark 5.25 — previne escalada de privilégios via setuid/setgid
   security_opt:
     - no-new-privileges:true
@@ -157,7 +157,7 @@ services:
 
 # ── Redes ─────────────────────────────────────────────────────────────────────
 networks:
-  internal:
+  tribultz:
     driver: bridge
 
 # ── Volumes ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- A VM de produção (`/opt/tribultz`) tinha uma mudança **não commitada** neste arquivo: a rede interna do compose de prod foi renomeada de `internal` para `tribultz` diretamente na VM, provavelmente para resolver DNS interno entre containers, e nunca foi trazida para o repositório.
- Risco real: `deploy.sh` roda `git -C "$DEPLOY_DIR" pull --ff-only` a cada deploy. Com um arquivo tracked divergente no working tree da VM, o próximo deploy que tocar em `infra/docker-compose.prod.yml` (mesmo que em outra linha) falha nesse passo — travando o rollout.
- Este PR traz a mudança já aplicada na VM para o repo, para que `git status` na VM fique limpo e os próximos `git pull --ff-only` funcionem sem conflito.

## Test plan
- [x] Diff comparado byte a byte com a mudança já rodando na VM (mesmo hash de blob antes/depois: `b68fcc7..a76c0b1`)
- [ ] Após merge: reconciliar o working tree da VM (`git checkout -- infra/docker-compose.prod.yml` ou equivalente) para que ela fique com working tree limpo antes do próximo deploy automático
