### PR TITLE
docs(infra): consolidação final pós-incidente — auditoria completa + runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,16 @@ frontend/          Next.js app (app router)
   src/components/  UI: AppShell, Sidebar, EvidenceList, JsonViewer, Toast
 
 backend/           FastAPI
-  app/routers/     audit, auth, chat, health, jobs, tasks, validate, validation, admin (BFF
-                   superadmin + ações auditadas), classtrib, ncm_suggest, public_api, calculadora
-  app/crews/       CrewAI chatops crew + tools
-  app/tasks/       Celery tasks (validate, report, simulation, reconciliation, hubspot)
+  app/routers/     28 routers (auditado 16/07/2026) — admin, audit, auth, billing, calculadora,
+                   classtrib, compliance, credits, documents, exceptions, feedback,
+                   founding_partners, health, jobs, lgpd, ncm_suggest, news, public, public_api,
+                   reports, simulator, sped, split_payment, support, tasks, validate,
+                   validate_xml, validation. Chat não é mais endpoint REST — virou crew CrewAI
+                   (app/crews/chatops_crew.py) desde a migration 2026_04_11_0010.
+  app/crews/       CrewAI crews (chatops, devops, security audit)
+  app/tasks/       10 tasks Celery (validate, report, simulation, reconciliation, hubspot,
+                   security_audit — órfã, sem beat/autodiscover, ver runbook —, billing, sped,
+                   compliance, crm)
   app/tools/       ERP connector, HubSpot, Postgres, S3, validation
   tests/           pytest
 
@@ -39,6 +45,8 @@ database/          README — schema é 100% Alembic (backend/app/alembic); sche
 infra/             docker-compose.yml
 tools/qa_gates/    run_gates.py — QA automation
 docs/sprints/      Histórico de sprints e relatórios de entrega
+docs/infra/operations_runbook.md   Arquitetura, fluxo de deploy/rollback, recuperação de
+                                    ambiente, checklist de auditoria operacional
 ```
 
 ## Convenções

--- a/docs/infra/operations_runbook.md
+++ b/docs/infra/operations_runbook.md
@@ -1,0 +1,107 @@
+# Runbook Operacional — Tribultz
+
+> Consolidação pós-incidente (09/07–16/07/2026). Fonte de verdade operacional do
+> repositório `tribultz`. Decisões de negócio/processo vivem no `tribultz-brain`
+> (`knowledge/operations/`); este documento é a camada de execução técnica.
+
+## Arquitetura atual
+
+```
+                    ┌─────────────┐
+                    │   GitHub    │
+                    │    main     │
+                    └──────┬──────┘
+              ┌────────────┼────────────┐
+              ▼                         ▼
+    ┌───────────────────┐    ┌────────────────────┐
+    │  Vercel (GitHub    │    │  GitHub Actions     │
+    │  App integration)  │    │  deploy-prod.yml    │
+    │  → frontend        │    │  → SSH → VM Magalu  │
+    └───────────────────┘    └──────────┬──────────┘
+                                         ▼
+                              ┌─────────────────────┐
+                              │ VM tribultz-api      │
+                              │ (Ubuntu 24.04,       │
+                              │  Magalu br-se1)      │
+                              │ docker-compose.prod  │
+                              │ → api/worker/beat/   │
+                              │   redis              │
+                              └──────────┬───────────┘
+                                         ▼
+                          PostgreSQL (Magalu DBaaS, externo)
+                          Object Storage (Magalu S3, externo)
+```
+
+- **Frontend**: Next.js, deploy via integração GitHub App da Vercel (não passa pelo workflow `deploy-prod.yml`).
+- **Backend**: FastAPI + Celery/Redis em containers Docker na VM; Postgres e Object Storage são serviços gerenciados externos (DBaaS/S3), não containers.
+- **CI**: `ci.yml` (backend-gates + frontend-build) roda em todo PR/push.
+
+## Fluxo de deploy (backend)
+
+Gatilho: push em `main` que toca `backend/**` ou `infra/**`, ou `workflow_dispatch` manual.
+
+1. `.github/workflows/deploy-prod.yml` faz checkout, configura chave SSH temporária (secret `MAGALU_SSH_KEY`), conecta em `ubuntu@<MAGALU_SSH_HOST>`.
+2. Executa `sudo bash /opt/tribultz/infra/scripts/deploy.sh` na VM, que roda **sequencialmente** (`set -euo pipefail` — para no primeiro erro):
+   1. `git pull --ff-only` (aborta com erro se houver mudança local não commitada no working tree da VM — ver "Regra de origem" abaixo)
+   2. `docker compose build --pull`
+   3. `alembic upgrade head` (idempotente)
+   4. Restart `api` com `--no-deps`, aguarda `healthy`, valida `/health` via HTTP
+   5. Restart `worker`
+   6. Restart `beat`
+3. Rollback automático por serviço se o health check falhar (restaura snapshot de imagem `:rollback` salvo antes do build).
+
+**Tempo de referência** (deploy controlado, 16/07/2026, run [`29467289172`](https://github.com/mickbap/tribultz/actions/runs/29467289172), commit `bafcdf6`, sem mudança de código): pull 1s → build 2s (cache, sem mudança) → migração 2s (no-op) → API healthy 14s → worker 9s → beat 5s. **Total: 33s**.
+
+## Rollback
+
+- **Automático por serviço**: se o health check de `api` falhar após um deploy, `deploy.sh` restaura a imagem `:rollback` (snapshot salvo antes do build) e reinicia o serviço.
+- **Rollback de código**: `git -C /opt/tribultz revert HEAD && bash infra/scripts/deploy.sh --skip-pull` (instrução já impressa pelo próprio script em caso de falha).
+- **Migração**: `infra/scripts/db-migrate.sh --prod` faz backup `pg_dump` antes de qualquer `alembic upgrade head` fora do fluxo padrão do deploy.
+
+## Regra de origem de mudanças (adotada em 16/07/2026)
+
+> **Produção nunca deve conter alteração que não exista no Git.** Toda mudança
+> operacional nasce do repositório — nunca é feita direto na VM.
+
+**Motivo**: um incidente real (16/07/2026) mostrou o custo dessa violação — `infra/docker-compose.prod.yml` foi editado diretamente na VM (rede renomeada `internal`→`tribultz`, provavelmente para resolver DNS interno) sem nunca ser commitado. Isso **quebrou um deploy automático real** (run `29464934375`, PR #453): `deploy.sh` abortou no passo `git pull --ff-only` com `Your local changes... would be overwritten by merge`. Nenhum container chegou a ser tocado (o script parou antes do build) — mas o deploy automático falhou até a divergência ser trazida para o repo via PR e o working tree da VM ser reconciliado manualmente (`git checkout -- <arquivo> && sudo git pull --ff-only`).
+
+**Como aplicar:**
+- Qualquer mudança de configuração de infra (compose, nginx, firewall, etc.) vira PR no repo primeiro. A VM só recebe via `git pull`.
+- Se uma mudança emergencial precisar ser feita direto na VM (ex.: indisponibilidade), ela **deve** ser trazida ao repo via PR na sequência imediata — nunca deixada solta no working tree.
+- `tools/check_access.sh` e este runbook devem ser consultados antes de qualquer deploy manual.
+
+## Recuperação de ambiente (bootstrap de máquina nova)
+
+Runbook completo de onboarding (SSH, `mgc`, `gh`, Vercel, `.env.prod`) em `docs/infra/secrets_inventory.md` (seção "Onboarding em máquina nova"). Resumo:
+
+1. Chave SSH própria da máquina, autorizada na VM a partir de uma máquina que já tenha acesso (nunca sobrescrever chave existente).
+2. `mgc` CLI + `mgc auth login` (sessão OAuth) — atenção à armadilha dos dois tenants Magalu (ver `secrets_inventory.md`).
+3. `.env.prod` sempre puxado da VM (`/opt/tribultz/.env`, fonte de verdade) — nunca copiado de outra máquina.
+4. `gh auth login`, `vercel login`.
+5. Validar tudo com `bash tools/check_access.sh` antes de depender da máquina.
+
+Bootstrap de infra do zero (VM nova): `infra/scripts/magalu-init.sh` — instala Docker, UFW, fail2ban, nginx, certbot, roda migrations e sobe o stack.
+
+## Checklist de auditoria operacional
+
+Rodar antes de considerar a infraestrutura saudável:
+
+- [ ] `bash tools/check_access.sh` — SSH, `mgc`, `gh`, Vercel, drift do `.env.prod`, produção no ar.
+- [ ] `git status` limpo tanto no repo local quanto em `/opt/tribultz` na VM (via SSH).
+- [ ] `docker compose -f infra/docker-compose.prod.yml ps` na VM — todos os serviços `Up`/`healthy`.
+- [ ] `curl https://api.tribultz.com.br/health/deep` — todos os subsistemas `ok`.
+- [ ] `apt list --upgradable` na VM + `/var/run/reboot-required` — sem reboot pendente crítico.
+- [ ] Alembic head na VM == head do repo (`alembic current` dentro do container `api`).
+- [ ] Último run de `deploy-prod.yml` (`gh run list --workflow=deploy-prod.yml`) com `conclusion: success`.
+
+## Ambientes
+
+Não existe ambiente de **staging** — só `local` (Docker Compose do desenvolvedor, Postgres/Redis/MinIO containerizados) e `produção` (VM Magalu, Postgres/S3 gerenciados). Diferenças **intencionais** (arquitetura, não drift):
+
+| | Local | Produção |
+|---|---|---|
+| Postgres | Container `postgres:16-alpine` | Magalu DBaaS (gerenciado, externo) |
+| Object Storage | MinIO container | Magalu Object Storage (S3, externo) |
+| Rebuild de imagem | Manual (`docker compose build`/`--build`) | Automático a cada deploy (`build --pull` no `deploy.sh`) |
+| Rede Docker | `tribultz` (bridge) | `tribultz` (bridge) — unificada em 16/07/2026, ver histórico |
+| Migração | `migrate` (serviço one-shot no compose) | `alembic upgrade head` como passo do `deploy.sh` |

--- a/docs/sprints/2026-07-16_auditoria_infraestrutura_completa.md
+++ b/docs/sprints/2026-07-16_auditoria_infraestrutura_completa.md
@@ -1,0 +1,75 @@
+# Auditoria Completa de Infraestrutura — Encerramento do Incidente 09/07–16/07/2026
+
+Data: 2026-07-16
+Contexto: Etapa 1 da consolidação pós-incidente (ver `docs/sprints/2026-07-15_infra_dev_env_mac_migration.md` para a fase de acesso/dev-env; issue [#432](https://github.com/mickbap/tribultz/issues/432) — Owner Workstation Recovery).
+
+## 1. Deploy
+
+- **Backend**: `deploy-prod.yml` → SSH → `deploy.sh` na VM. Deploy controlado disparado manualmente em 16/07 (run [`29467289172`](https://github.com/mickbap/tribultz/actions/runs/29467289172)): **sucesso total, 33s** (pull 1s, build 2s, migração 2s, API healthy 14s, worker 9s, beat 5s).
+- **Achado real**: o deploy automático anterior (run `29464934375`, merge do PR #453) **falhou** — não por firewall/SSH (a causa histórica de #436), mas porque `git pull --ff-only` encontrou uma mudança local não commitada na VM (`infra/docker-compose.prod.yml`) e abortou **antes de tocar em qualquer container** (`set -euo pipefail` funcionou como esperado — falha segura, sem impacto em produção). Corrigido na hora via reconciliação manual do working tree + o próprio PR #453. Deploy seguinte (acima) confirma a cadeia saudável de ponta a ponta.
+- **Frontend**: Vercel via GitHub App — deploys recentes todos `Ready` (confirmado em sessão anterior).
+
+## 2. Rollback
+
+- `deploy.sh` salva snapshot `:rollback` de cada imagem antes do build; restaura automaticamente se o health check pós-restart falhar.
+- Não exercido nesta consolidação (nenhum deploy falhou depois de reconciliada a VM) — mecanismo íntegro por inspeção de código, não testado em produção real neste ciclo.
+
+## 3. Git
+
+- `main` e a VM (`/opt/tribultz`) **reconciliados**: mesmo commit (`bafcdf6` após o deploy de validação), `git status` limpo nos dois lados.
+- Ownership misto identificado no `.git` da VM (`FETCH_HEAD` de `root`, resto de `ubuntu` — resultado de o `deploy.sh` rodar via `sudo`) — sem impacto funcional, registrado para conhecimento.
+
+## 4. Docker / Compose
+
+- Local (Mac): imagens rebuildadas, stack completo (`db`/`redis`/`minio`/`api`/`worker`/`beat`) saudável.
+- Produção: imagens sempre reconstruídas a cada deploy (`build --pull` no `deploy.sh`) — não sofre o problema de cache do ambiente local.
+- Rede do compose de produção unificada (`internal`→`tribultz`, PR #453) — sem mais divergência entre o que roda e o que está no repo.
+
+## 5. GitHub Actions
+
+- `ci.yml` (backend-gates + frontend-build): verde nos últimos PRs.
+- `deploy-prod.yml`: confirmado funcional (ver seção 1).
+- `monitor.yml`, `classtrib-sync.yml`, `soro-blog-sync.yml`: não auditados nesta rodada (fora do escopo do incidente).
+
+## 6. Vercel
+
+- CLI autenticado, projeto resolve, deploys `Ready`. Next.js 16.2.10 já na última versão.
+- **Pendência conhecida, não nova**: issue [#435](https://github.com/mickbap/tribultz/issues/435) — auto-deploy da Vercel via GitHub App ainda não revalidado desde o incidente de 09-10/07 (publicação naquele momento foi manual via `vercel deploy --prod`). Não foi possível confirmar nesta sessão se o gatilho automático (push→produção) já voltou sozinho ou segue exigindo o passo manual — **recomendo validar com um push real e observar se a Vercel publica sozinha**, antes de fechar #435.
+
+## 7. Magalu (VM)
+
+- Kernel atualizado (reboot coordenado, 16/07), sem reboot pendente, sem OOM em 30 dias, disco com folga.
+- `/health/deep` (local e externo): todos os subsistemas `ok`.
+
+## 8. Command Center, Founding Partners, Partner Attribution (auditoria de código)
+
+**Implementados de verdade, não só documentados:**
+- Command Center: `backend/app/routers/admin.py` (739 linhas) + `founding_partners.py` (356 linhas), 8 páginas em `frontend/src/app/admin/`.
+- Founding Partners / Grant Adapter (ADR-0008): `backend/app/models/founding_partner.py` — `EarlyGrant`, `resolve_effective_license`, consumido em `auth.py` no login.
+- Partner Attribution (RFC-0025): `backend/app/models/partner.py`, captura `?partner=`/`?ref=` em `frontend/src/app/register/page.tsx`.
+- **31 testes** cobrindo os três fluxos (`test_admin_access.py`, `test_partner_admin.py`, `test_founding_partners_admin.py`, `test_partner_code.py`). Nenhum TODO/FIXME/mock encontrado.
+
+## 9. TERA — achado relevante
+
+**Não implementado.** RFC-0018 (tribultz-brain) está com status `proposed`. No código do produto, "TERA" existe **somente como copy de marketing** na landing `/founding-partners` (duas strings estáticas). Não há Fiscal Readiness Index, endpoint, service, model ou teste. Isso é relevante porque TERA é a prioridade #3 declarada para depois desta consolidação — vale registrar que ainda é 100% trabalho futuro, não uma funcionalidade pausada por causa do incidente.
+
+## 10. APIs, Workers, Schedules — inventário
+
+- **28 routers** ativos (lista cresceu desde a documentada no `CLAUDE.md` — ver Etapa 5/achado de doc desatualizada). Router `chat` não existe mais (virou crew CrewAI, não endpoint REST).
+- **10 tasks Celery**, **6 schedules** no beat (`expire-trials-hourly`, `warn-trial-expiring`, `reset-usage-monthly`, `classtrib-sync-weekly`, `compliance-monthly-scores`, `crm-audit-daily`).
+- **Achado real**: `task_f_security_audit.py` está **órfã** — não aparece em `autodiscover_tasks`, sem entrada em `beat_schedule`, não referenciada em lugar nenhum. Definida mas nunca executada por nada. Recomendo abrir issue própria para decidir: registrar no beat, ou remover se obsoleta.
+
+## Achados que exigem decisão (não corrigidos nesta auditoria — fora do pedido de "só medir/registrar")
+
+1. `task_f_security_audit.py` órfã.
+2. `CLAUDE.md` com lista de routers desatualizada (seção "Estrutura do projeto").
+3. Issue #435 (auto-deploy Vercel) não revalidada nesta sessão.
+
+## Pendências conhecidas — registradas, sem intervenção (decisão explícita já tomada)
+
+- Chave Resend revogada (HTTP 401).
+- `GITHUB_TOKEN` de produção é o OAuth pessoal do usuário.
+- `gh` CLI sem escopo `workflow`.
+- Inventário completo de credenciais: `docs/infra/secrets_inventory.md`.
+
+Nenhuma ação foi tomada nessas pendências, por ordem vigente documentada em `docs/context/feedback_no_token_rotation.md`.


### PR DESCRIPTION
## Summary
Fecha a Etapa 1-5 da ordem de consolidação de infraestrutura (issue #432):
- **Auditoria completa** (`docs/sprints/2026-07-16_auditoria_infraestrutura_completa.md`): deploy, rollback, git, docker, compose, GitHub Actions, Vercel, Magalu, Command Center, Founding Partners, Partner Attribution, TERA, APIs/workers/schedules.
- **Deploy controlado** validado ponta a ponta: 33s, run [`29467289172`](https://github.com/mickbap/tribultz/actions/runs/29467289172), sucesso.
- **Runbook operacional novo** (`docs/infra/operations_runbook.md`): arquitetura, fluxo de deploy/rollback, política "mudança nasce do repo, nunca da VM", comparação local vs. produção, checklist de auditoria.
- **CLAUDE.md**: lista de routers/tasks corrigida (estava desatualizada — 28 routers hoje, `chat` virou crew CrewAI).

## Achados relevantes (registrados, não corrigidos neste PR)
- `task_f_security_audit.py` está órfã (sem beat schedule, sem autodiscover).
- TERA (RFC-0018) ainda não implementado no código — só copy de marketing na landing.
- Issue #435 (auto-deploy Vercel) não revalidada nesta sessão.
- Pendências de credenciais (Resend, GITHUB_TOKEN, escopo workflow) seguem sem ação por decisão vigente.

Sem mudança de código de produto — só documentação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)