### PR TITLE
docs(partners): proposta técnica — autenticação do parceiro

### DIFF
--- a/docs/sprints/2026-07-16_proposta_tecnica_auth_partner.md
+++ b/docs/sprints/2026-07-16_proposta_tecnica_auth_partner.md
@@ -1,0 +1,54 @@
+# Proposta técnica definitiva — autenticação do Partner (Programa de Parceiros, Fase 1)
+
+Data: 2026-07-16
+Escopo: **como** estender a infraestrutura de autenticação existente para um novo ator (`Partner`), sem criar Tenant artificial e sem alterar a semântica do domínio (RFC-0026, `tribultz-brain`, decide o **porquê**; este documento decide o **como** — ADR-0010).
+
+> **Não implementado ainda.** Aguardando aprovação antes de qualquer código.
+
+## Por que não dá pra reaproveitar sem mudança nenhuma
+
+Investigação no código real (`backend/app/api/deps.py`, `backend/app/routers/auth.py`, `backend/app/schemas/auth.py`):
+
+- `get_current_user` (dependência usada por todos os routers) decodifica o JWT e busca o `User` por `id` — **não olha `tenant_id` nesta camada**. Ou seja, o mecanismo central de sessão já é agnóstico de tenant.
+- `TokenPayload.tenant_id` é `str` **obrigatório** (não `Optional`) no schema Pydantic do payload do JWT. É o único ponto que **hoje** impede um usuário sem tenant de logar — a validação do payload rejeitaria o token.
+- `User.tenant_id` é `nullable=False` no banco — segundo ponto que precisa mudar.
+- O `/login` busca o usuário **só por e-mail**, sem filtrar por tenant (`select(User).where(User.email == login_data.email)`) — já é compatível com um ator sem tenant, zero mudança necessária aqui.
+- `role` já é um campo livre (`String(50)`, hoje com valores como `admin`/`contador`/`user`) — adicionar o valor `"partner"` é extensão natural de um padrão que já existe, não um conceito novo.
+
+## O que muda (mínimo necessário)
+
+1. **Migration**: `users.tenant_id` → nullable. Novo campo `users.partner_id` (UUID, nullable, FK `partners.id`, `ondelete=CASCADE`). Novo índice único parcial para e-mail entre parceiros (`UNIQUE (email) WHERE partner_id IS NOT NULL`) — a constraint atual `(tenant_id, email)` não pega duplicidade quando `tenant_id` é `NULL` (regra de SQL: `NULL != NULL`), então precisa de uma constraint própria pro caso de parceiro.
+2. **`TokenPayload.tenant_id`**: `str` → `Optional[str] = None`.
+3. **`auth.py` (login/registro):** branch explícito — se `user.partner_id` estiver setado (ator é parceiro), o JWT carrega `tenant_id: None`, `partner_id: <id>`, `role: "partner"`; caso contrário, comportamento **inalterado**.
+4. **Nova dependência** `get_current_partner` (mesmo padrão de `get_current_user`, só que também exige `role == "partner"` e `partner_id` não nulo) — usada exclusivamente pelas rotas novas da área do parceiro.
+5. **Fluxo de criação da conta**: reaproveita convite + primeiro acesso (link assinado → OTP → senha) já existentes — só muda o "o quê" está sendo criado (`User` com `partner_id`, sem `tenant_id`), não o "como" do fluxo.
+
+## O que **não** muda
+
+- Nenhum dos ~17 routers hoje tenant-scoped (`jobs`, `tasks`, `sped`, `compliance`, `audit`, `reports`, etc.) precisa de alteração de código. Auditei os usos de `current_user.tenant_id` neles: nenhum faz cast direto pra UUID sem tratamento (`cast(UUID, ...)`) que quebraria com `None` — todos usam `str(current_user.tenant_id)` (vira a string `"None"`, inofensivo) ou comparações de filtro (`WHERE tenant_id = None` retorna vazio, nunca vaza dado de outro tenant). Um ator parceiro batendo por engano nessas rotas recebe lista vazia, nunca dado de terceiro.
+- `Tenant` continua significando exclusivamente empresa-cliente. Nenhuma linha nova em `tenants` para representar um Partner.
+- `get_current_user`, `/login`, `/register` (fluxo de tenant) — zero mudança de comportamento para usuários existentes.
+
+## Reforço de defesa em profundidade (recomendado, não bloqueante)
+
+Como melhoria de robustez (não estritamente necessária pra correção, já que não há vazamento de dado possível): adicionar uma dependência `require_tenant_user` que os routers tenant-scoped podem adotar aos poucos, retornando 403 explícito em vez de lista vazia se um ator parceiro tentar acessá-los. Proponho tratar isso como item de follow-up, não bloqueador desta entrega.
+
+## Modelo de dados resultante
+
+```
+users
+  id              uuid PK
+  tenant_id       uuid FK tenants.id, NULLABLE  (era NOT NULL)
+  partner_id      uuid FK partners.id, NULLABLE (novo)
+  role            varchar(50)  -- ganha o valor "partner"
+  email, password_hash, full_name, is_active, ... (inalterados)
+
+  CHECK: exatamente um de (tenant_id, partner_id) deve ser não-nulo
+         (um User é de um Tenant OU de um Partner, nunca dos dois, nunca de nenhum)
+```
+
+O `CHECK constraint` acima é a garantia estrutural de que a separação de domínio (Partner não é Tenant) fica **impossível de violar por acidente**, não só por convenção de código.
+
+## Critério de aceite desta proposta
+
+Aprovada quando: (1) a migration acima fizer sentido; (2) o `CHECK constraint` for aceito como guardrail estrutural; (3) o item "defesa em profundidade" for aceito como follow-up, não bloqueador. Após aprovação, sigo com TDD (testes de isolamento partner↔tenant, testes de login/primeiro acesso reutilizando os fluxos existentes) antes da implementação em si.

--- a/docs/sprints/2026-07-16_proposta_tecnica_auth_partner.md
+++ b/docs/sprints/2026-07-16_proposta_tecnica_auth_partner.md
@@ -1,54 +1,80 @@
-# Proposta técnica definitiva — autenticação do Partner (Programa de Parceiros, Fase 1)
+# Proposta técnica definitiva — Autenticação de Atores (Programa de Parceiros, Fase 1)
 
-Data: 2026-07-16
-Escopo: **como** estender a infraestrutura de autenticação existente para um novo ator (`Partner`), sem criar Tenant artificial e sem alterar a semântica do domínio (RFC-0026, `tribultz-brain`, decide o **porquê**; este documento decide o **como** — ADR-0010).
+Data: 2026-07-16 · v2 (revisão pedida: generalizar para "ator", `tenant_id` vira contexto, não identidade)
+Escopo: **como** a autenticação passa a suportar múltiplos atores (`Tenant User`, `Partner`, futuros institucionais) sem exceção por ator e sem regressão. RFC-0026 (`tribultz-brain`) decide o **porquê**; este documento decide o **como** (ADR-0010).
 
 > **Não implementado ainda.** Aguardando aprovação antes de qualquer código.
 
-## Por que não dá pra reaproveitar sem mudança nenhuma
+## Achado que sustenta a proposta
 
-Investigação no código real (`backend/app/api/deps.py`, `backend/app/routers/auth.py`, `backend/app/schemas/auth.py`):
+`get_current_user` (`backend/app/api/deps.py`) decodifica o JWT e resolve **apenas** `sub` (id do `User`) — não usa `tenant_id`/`role` do payload para nada além de validar a forma. A autorização real de cada router vem do **objeto `User` carregado do banco**, não do JWT. Isso significa: a identidade principal do sistema **já é o `User`**, não o `Tenant` — só faltava o modelo deixar isso explícito.
 
-- `get_current_user` (dependência usada por todos os routers) decodifica o JWT e busca o `User` por `id` — **não olha `tenant_id` nesta camada**. Ou seja, o mecanismo central de sessão já é agnóstico de tenant.
-- `TokenPayload.tenant_id` é `str` **obrigatório** (não `Optional`) no schema Pydantic do payload do JWT. É o único ponto que **hoje** impede um usuário sem tenant de logar — a validação do payload rejeitaria o token.
-- `User.tenant_id` é `nullable=False` no banco — segundo ponto que precisa mudar.
-- O `/login` busca o usuário **só por e-mail**, sem filtrar por tenant (`select(User).where(User.email == login_data.email)`) — já é compatível com um ator sem tenant, zero mudança necessária aqui.
-- `role` já é um campo livre (`String(50)`, hoje com valores como `admin`/`contador`/`user`) — adicionar o valor `"partner"` é extensão natural de um padrão que já existe, não um conceito novo.
+## 1. Modelo final do JWT
 
-## O que muda (mínimo necessário)
-
-1. **Migration**: `users.tenant_id` → nullable. Novo campo `users.partner_id` (UUID, nullable, FK `partners.id`, `ondelete=CASCADE`). Novo índice único parcial para e-mail entre parceiros (`UNIQUE (email) WHERE partner_id IS NOT NULL`) — a constraint atual `(tenant_id, email)` não pega duplicidade quando `tenant_id` é `NULL` (regra de SQL: `NULL != NULL`), então precisa de uma constraint própria pro caso de parceiro.
-2. **`TokenPayload.tenant_id`**: `str` → `Optional[str] = None`.
-3. **`auth.py` (login/registro):** branch explícito — se `user.partner_id` estiver setado (ator é parceiro), o JWT carrega `tenant_id: None`, `partner_id: <id>`, `role: "partner"`; caso contrário, comportamento **inalterado**.
-4. **Nova dependência** `get_current_partner` (mesmo padrão de `get_current_user`, só que também exige `role == "partner"` e `partner_id` não nulo) — usada exclusivamente pelas rotas novas da área do parceiro.
-5. **Fluxo de criação da conta**: reaproveita convite + primeiro acesso (link assinado → OTP → senha) já existentes — só muda o "o quê" está sendo criado (`User` com `partner_id`, sem `tenant_id`), não o "como" do fluxo.
-
-## O que **não** muda
-
-- Nenhum dos ~17 routers hoje tenant-scoped (`jobs`, `tasks`, `sped`, `compliance`, `audit`, `reports`, etc.) precisa de alteração de código. Auditei os usos de `current_user.tenant_id` neles: nenhum faz cast direto pra UUID sem tratamento (`cast(UUID, ...)`) que quebraria com `None` — todos usam `str(current_user.tenant_id)` (vira a string `"None"`, inofensivo) ou comparações de filtro (`WHERE tenant_id = None` retorna vazio, nunca vaza dado de outro tenant). Um ator parceiro batendo por engano nessas rotas recebe lista vazia, nunca dado de terceiro.
-- `Tenant` continua significando exclusivamente empresa-cliente. Nenhuma linha nova em `tenants` para representar um Partner.
-- `get_current_user`, `/login`, `/register` (fluxo de tenant) — zero mudança de comportamento para usuários existentes.
-
-## Reforço de defesa em profundidade (recomendado, não bloqueante)
-
-Como melhoria de robustez (não estritamente necessária pra correção, já que não há vazamento de dado possível): adicionar uma dependência `require_tenant_user` que os routers tenant-scoped podem adotar aos poucos, retornando 403 explícito em vez de lista vazia se um ator parceiro tentar acessá-los. Proponho tratar isso como item de follow-up, não bloqueador desta entrega.
-
-## Modelo de dados resultante
-
-```
-users
-  id              uuid PK
-  tenant_id       uuid FK tenants.id, NULLABLE  (era NOT NULL)
-  partner_id      uuid FK partners.id, NULLABLE (novo)
-  role            varchar(50)  -- ganha o valor "partner"
-  email, password_hash, full_name, is_active, ... (inalterados)
-
-  CHECK: exatamente um de (tenant_id, partner_id) deve ser não-nulo
-         (um User é de um Tenant OU de um Partner, nunca dos dois, nunca de nenhum)
+```json
+{
+  "sub": "<user.id>",
+  "actor_type": "tenant" | "partner",
+  "role": "<user.role>",
+  "tenant_id": "<tenant.id> | null",
+  "partner_id": "<partner.id> | null",
+  "exp": 0,
+  "iat": 0
+}
 ```
 
-O `CHECK constraint` acima é a garantia estrutural de que a separação de domínio (Partner não é Tenant) fica **impossível de violar por acidente**, não só por convenção de código.
+- `sub` continua a âncora de identidade — inalterado para todo usuário existente.
+- `actor_type` é novo: declara **que tipo** de ator está autenticado. Não substitui `role` (que continua sendo o papel dentro do contexto do ator — `admin`/`contador`/`user` para tenant, futuramente algo para partner se necessário); `actor_type` é ortogonal — declara o **domínio**, `role` declara a **permissão**.
+- `tenant_id`/`partner_id` são **contextuais**: exatamente um dos dois é preenchido, conforme `actor_type`. Futuro ator institucional adicionaria seu próprio campo contextual (ex.: `institution_id`) sem tocar nos demais.
+- `TokenPayload` (Pydantic) generaliza: `actor_type` obrigatório; `tenant_id`/`partner_id` opcionais (`Optional[str] = None`).
+
+## 2. Modelo final do contexto autenticado
+
+```
+get_current_actor(token, db) -> User
+    # nível mais baixo: decodifica JWT, valida TokenPayload genérico,
+    # busca User por sub, checa is_active/deleted_at.
+    # É o que get_current_user faz HOJE — só generaliza o schema validado.
+
+get_current_user(actor: User = Depends(get_current_actor)) -> User
+    # MANTÉM nome, assinatura e tipo de retorno atuais.
+    # Ganha uma checagem nova: actor.actor_type == "tenant" (equivalente a
+    # actor.tenant_id is not None), senão 403 explícito.
+    # Todo router existente que já usa Depends(get_current_user) continua
+    # funcionando sem NENHUMA mudança de código — só fica mais estrito:
+    # um ator partner batendo aqui agora recebe 403 em vez de lista vazia
+    # (é uma correção de robustez, não uma regressão).
+
+get_current_partner(actor: User = Depends(get_current_actor)) -> User
+    # nova, simétrica: exige actor.actor_type == "partner", senão 403.
+    # Usada só pelas rotas novas da área do parceiro.
+```
+
+`actor_type` é uma **propriedade computada** no model `User` (`"partner" if partner_id else "tenant"`) — não é uma coluna redundante no banco, evita divergência entre coluna e realidade.
+
+Nenhuma duplicação de infraestrutura: `get_current_user` e `get_current_partner` são as duas finas camadas sobre o mesmo `get_current_actor` — um único mecanismo de sessão, dois filtros de contexto.
+
+## 3. Impacto nos routers existentes
+
+**Zero mudança de código** nos ~17 routers hoje tenant-scoped (`jobs`, `tasks`, `sped`, `compliance`, `audit`, `reports`, `documents`, `exceptions`, `feedback`, `credits`, `support`, `validate`, `validation`, `validate_xml`, `split_payment`, `public_api`, `auth`) — todos continuam com `Depends(get_current_user)`, mesma assinatura, mesmo tipo de retorno (`User`). O único efeito observável: um ator `partner` que tentasse acessá-los recebe **403 explícito** em vez do comportamento anterior (lista vazia, pela ausência de `tenant_id` — já auditado antes: nenhum desses routers faz cast direto que quebraria, então isso é estritamente uma melhoria, não uma regressão).
+
+**Regressão para usuários existentes:** nenhuma. Todo `User` hoje já tem `tenant_id` preenchido → `actor_type` computado é sempre `"tenant"` → `get_current_user` continua aceitando exatamente como hoje.
+
+## 4. Estratégia de migração
+
+1. **Migration**: `users.tenant_id` → nullable. Novo `users.partner_id` (UUID, nullable, FK `partners.id`, `ondelete=CASCADE`). `CHECK` constraint: exatamente um de (`tenant_id`, `partner_id`) não-nulo — garante estruturalmente que todo `User` tem exatamente um domínio, nunca os dois, nunca nenhum. Índice único parcial `UNIQUE (email) WHERE partner_id IS NOT NULL` (a constraint atual `(tenant_id, email)` não previne duplicidade quando `tenant_id` é `NULL`, por semântica de SQL).
+2. **`User` model**: propriedade computada `actor_type`.
+3. **`schemas/auth.py`**: generalizar `TokenPayload` (`actor_type` obrigatório, `tenant_id`/`partner_id` opcionais).
+4. **`api/deps.py`**: introduzir `get_current_actor`; redefinir `get_current_user` como camada fina sobre ele (compat); adicionar `get_current_partner`.
+5. **`routers/auth.py`**: login/criação de conta passam a montar o JWT com `actor_type` + o campo contextual certo. Fluxo de criação de conta do Partner reaproveita convite/primeiro acesso/OTP/senha já existentes.
+6. **Nenhuma mudança** nos demais routers.
+7. **Testes (antes da implementação, TDD):**
+   - Regressão: usuário tenant existente loga e acessa tudo exatamente como hoje.
+   - Ator partner recebe 403 explícito em rota tenant-scoped.
+   - Ator tenant recebe 403 explícito em rota partner-scoped (`get_current_partner`).
+   - `CHECK constraint` rejeita `User` com os dois campos ou nenhum preenchido.
+   - Fluxo completo do Partner: convite → primeiro acesso → OTP → senha → login → dashboard só-leitura.
 
 ## Critério de aceite desta proposta
 
-Aprovada quando: (1) a migration acima fizer sentido; (2) o `CHECK constraint` for aceito como guardrail estrutural; (3) o item "defesa em profundidade" for aceito como follow-up, não bloqueador. Após aprovação, sigo com TDD (testes de isolamento partner↔tenant, testes de login/primeiro acesso reutilizando os fluxos existentes) antes da implementação em si.
+Aprovada quando: (1) o modelo de JWT/contexto acima fizer sentido; (2) a estratégia de compatibilidade (`get_current_user` inalterado por fora, mais estrito por dentro) for aceita; (3) a migration/CHECK constraint forem aceitas. Após aprovação, sigo com TDD antes da implementação em si.


### PR DESCRIPTION
## Summary
Proposta técnica definitiva pedida antes de alterar o modelo de autenticação (ordem de governança do Programa de Parceiros). Responde "como" sem tocar no "porquê" (RFC-0026, tribultz-brain).

**Correção em relação à minha proposta anterior**: nada de Tenant artificial para representar Partner — Tenant continua significando exclusivamente empresa-cliente.

**Achado central**: `get_current_user` não depende de `tenant_id`; o único bloqueio real é `TokenPayload.tenant_id` ser `str` obrigatório (não `Optional`) e `User.tenant_id` ser `NOT NULL`. Login já busca só por e-mail, sem filtro de tenant — zero mudança necessária ali.

**Mudança mínima proposta**: `User.tenant_id` nullable + `User.partner_id` novo + `TokenPayload.tenant_id` opcional + `CHECK` constraint garantindo `tenant_id` XOR `partner_id` (nunca os dois, nunca nenhum) — guardrail estrutural, não só de convenção.

**Auditei os ~17 routers tenant-scoped existentes** um a um: nenhum quebra com `tenant_id = None` (nenhum cast direto pra UUID sem tratamento) — pior caso é lista vazia, nunca vazamento de dado de outro tenant.

**Não implementado.** Aguardando aprovação antes de qualquer código, como pedido.