### PR TITLE
feat(partners): generaliza autenticação para modelo de Ator (RFC-0026)

### DIFF
--- a/backend/app/alembic/versions/2026_07_16_0027_add_actor_model_partner_users.py
+++ b/backend/app/alembic/versions/2026_07_16_0027_add_actor_model_partner_users.py
@@ -1,0 +1,69 @@
+"""add_actor_model_partner_users — generaliza User para múltiplos atores (RFC-0026)
+
+Autenticação passa a representar o ator (Tenant User | Partner), não mais
+assumir tenant_id como identidade central. tenant_id vira contexto,
+preenchido apenas quando o ator pertence a um Tenant.
+
+- ``users.tenant_id`` vira nullable (era NOT NULL).
+- ``users.partner_id`` novo (FK opcional para ``partners``).
+- CHECK constraint: exatamente um de (tenant_id, partner_id) não-nulo —
+  garante estruturalmente que Partner nunca é Tenant e vice-versa.
+- Índice único parcial de e-mail para atores partner (a constraint
+  existente ``(tenant_id, email)`` não previne duplicidade quando
+  tenant_id é NULL — regra de SQL: NULL não é igual a NULL).
+
+Revision ID: 2026_07_16_0027
+Revises: 2026_07_14_0026
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_16_0027"
+down_revision = "2026_07_14_0026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("users", "tenant_id", nullable=True)
+
+    op.add_column(
+        "users",
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_users_partner_id",
+        "users",
+        "partners",
+        ["partner_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index("ix_users_partner_id", "users", ["partner_id"])
+
+    op.create_check_constraint(
+        "ck_users_exactly_one_actor_domain",
+        "users",
+        "(tenant_id IS NOT NULL) != (partner_id IS NOT NULL)",
+    )
+
+    op.create_index(
+        "uq_users_partner_email",
+        "users",
+        ["email"],
+        unique=True,
+        postgresql_where=sa.text("partner_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_users_partner_email", table_name="users")
+    op.drop_constraint("ck_users_exactly_one_actor_domain", "users", type_="check")
+    op.drop_index("ix_users_partner_id", table_name="users")
+    op.drop_constraint("fk_users_partner_id", "users", type_="foreignkey")
+    op.drop_column("users", "partner_id")
+    op.alter_column("users", "tenant_id", nullable=False)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -15,10 +15,17 @@ from app.schemas.auth import TokenPayload
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/v1/auth/login")
 
 
-async def get_current_user(
+async def get_current_actor(
     token: Annotated[str, Depends(oauth2_scheme)],
     db: Annotated[Session, Depends(get_db)]
 ) -> User:
+    """Resolve o ator autenticado (qualquer domínio — tenant ou partner).
+
+    Nível mais baixo da autenticação (RFC-0026): decodifica o JWT, valida o
+    payload genérico e busca o ``User`` por ``sub``. Não assume nenhum
+    domínio — quem precisa de um ator de um domínio específico usa
+    ``get_current_user`` (tenant) ou ``get_current_partner`` (partner).
+    """
     # Helper to create fresh exception to avoid traceback reuse issues (Ruff complaint)
     def credentials_exception():
         return HTTPException(
@@ -26,22 +33,22 @@ async def get_current_user(
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
+
     try:
         payload = jwt.decode(token, settings.JWT_SECRET, algorithms=[settings.JWT_ALG])
         user_id_claim = payload.get("sub")
         if not isinstance(user_id_claim, str):
             raise credentials_exception()
-        
+
         # Validate structure with Pydantic
         token_data = TokenPayload(**payload)
-        
+
     except JWTError:
         raise credentials_exception()
     except Exception:
         # Pydantic validation error or other issuer
         raise credentials_exception()
-        
+
     # Check simple UUID validity implicitly by querying
     try:
         user_uuid = UUID(token_data.sub)
@@ -64,3 +71,32 @@ async def get_current_user(
         )
 
     return user
+
+
+async def get_current_user(
+    actor: Annotated[User, Depends(get_current_actor)],
+) -> User:
+    """Ator do domínio Tenant — dependência usada por todos os routers
+    tenant-scoped existentes. Assinatura e retorno inalterados (RFC-0026):
+    só ganha a checagem de domínio abaixo.
+    """
+    if actor.actor_type != "tenant":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Recurso disponível apenas para usuários de uma Empresa (Tenant)",
+        )
+    return actor
+
+
+async def get_current_partner(
+    actor: Annotated[User, Depends(get_current_actor)],
+) -> User:
+    """Ator do domínio Partner (Programa de Parceiros, RFC-0026) — usada
+    exclusivamente pelas rotas da área do parceiro.
+    """
+    if actor.actor_type != "partner":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Recurso disponível apenas para parceiros",
+        )
+    return actor

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -57,10 +57,20 @@ class User(Base):
         primary_key=True,
         server_default=text("gen_random_uuid()"),
     )
+    # Contexto do ator — exatamente um dos dois é preenchido (CHECK
+    # ck_users_exactly_one_actor_domain, migration 2026_07_16_0027).
+    # tenant_id: ator pertence a uma Empresa (Tenant) — fluxo original.
     tenant_id = Column(
         UUID(as_uuid=True),
         ForeignKey("tenants.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
+    )
+    # partner_id: ator é um Partner (Programa de Parceiros, RFC-0026) — nunca
+    # um Tenant. Ver Partner em app.models.partner.
+    partner_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("partners.id", ondelete="CASCADE"),
+        nullable=True,
     )
     email = Column(String(255), nullable=False)
     full_name = Column(String(200), nullable=False)
@@ -85,6 +95,16 @@ class User(Base):
     )
 
     __table_args__ = (UniqueConstraint("tenant_id", "email", name="users_tenant_id_email_key"),)
+
+    @property
+    def actor_type(self) -> str:
+        """Domínio do ator autenticado — computado, nunca armazenado.
+
+        Deriva de qual FK está preenchida (garantido mutuamente exclusivo
+        pela CHECK constraint ck_users_exactly_one_actor_domain), evitando
+        uma coluna redundante que poderia divergir da realidade.
+        """
+        return "partner" if self.partner_id is not None else "tenant"
 
 
 class UserTenant(Base):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -178,6 +178,26 @@ async def login(login_data: UserLogin, request: Request, db: Session = Depends(g
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # Ator partner (Programa de Parceiros, RFC-0026): não tem tenant, billing
+    # nem Grant/licença — sai cedo, antes de qualquer resolução tenant-scoped
+    # (o restante deste handler assume tenant_id válido).
+    if user.actor_type == "partner":
+        access_token = create_access_token(
+            subject=str(user.id),
+            extra_claims={
+                "actor_type": "partner",
+                "partner_id": str(user.partner_id),
+                "role": cast(str, user.role),
+            },
+        )
+        logger.info("login_success", extra={"user_id": str(user.id), "ip": ip, "actor_type": "partner"})
+        return {
+            "access_token": access_token,
+            "token_type": "bearer",
+            "partner_id": str(user.partner_id),
+            "role": cast(str, user.role),
+        }
+
     # Resolve default tenant from user_tenants
     user_tenant_list = _get_user_tenants(db, cast(UUID, user.id))
     default_tenant_id = str(user.tenant_id)
@@ -208,6 +228,7 @@ async def login(login_data: UserLogin, request: Request, db: Session = Depends(g
     access_token = create_access_token(
         subject=str(user.id),
         extra_claims={
+            "actor_type": "tenant",
             "tenant_id": default_tenant_id,
             "role": cast(str, user.role),
             "account_type": cast(str, user.account_type),
@@ -543,12 +564,12 @@ async def add_cnpj(
     db: Session = Depends(get_db),
 ):
     """Add a new CNPJ/tenant for contador accounts."""
-    from app.api.deps import get_current_user, oauth2_scheme
+    from app.api.deps import get_current_actor, oauth2_scheme
 
     token = await oauth2_scheme(request)
     if not token:
         raise HTTPException(status_code=401, detail="Token ausente.")
-    user = await get_current_user(token, db)
+    user = await get_current_actor(token, db)
     user_id = cast(UUID, user.id)
 
     if cast(str, user.account_type) != "contador":
@@ -615,12 +636,12 @@ async def switch_tenant(
     db: Session = Depends(get_db),
 ):
     """Switch active tenant — returns new JWT with updated tenant_id."""
-    from app.api.deps import get_current_user, oauth2_scheme
+    from app.api.deps import get_current_actor, oauth2_scheme
 
     token = await oauth2_scheme(request)
     if not token:
         raise HTTPException(status_code=401, detail="Token ausente.")
-    user = await get_current_user(token, db)
+    user = await get_current_actor(token, db)
     user_id = cast(UUID, user.id)
 
     # Verify user has access to this tenant
@@ -640,6 +661,7 @@ async def switch_tenant(
     access_token = create_access_token(
         subject=str(user.id),
         extra_claims={
+            "actor_type": "tenant",
             "tenant_id": str(data.tenant_id),
             "role": cast(str, user_tenant.role),
             "account_type": cast(str, user.account_type),
@@ -679,12 +701,12 @@ async def select_mode(
     experience the platform as any plan tier (trial, starter, etc.) or
     enter the admin dashboard (plan_slug="admin").
     """
-    from app.api.deps import get_current_user, oauth2_scheme
+    from app.api.deps import get_current_actor, oauth2_scheme
 
     token = await oauth2_scheme(request)
     if not token:
         raise HTTPException(status_code=401, detail="Token ausente.")
-    user = await get_current_user(token, db)
+    user = await get_current_actor(token, db)
 
     # Only superadmins may switch test mode
     if cast(str, user.role) != "superadmin":
@@ -702,6 +724,7 @@ async def select_mode(
     access_token = create_access_token(
         subject=str(user.id),
         extra_claims={
+            "actor_type": "tenant",
             "tenant_id": str(user.tenant_id),
             "role": cast(str, user.role),
             "account_type": cast(str, user.account_type),

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -11,9 +11,12 @@ class Token(BaseModel):
 
 
 class TokenPayload(BaseModel):
-    sub: str  # user_id (UUID string)
-    tenant_id: str
+    sub: str  # user_id (UUID string) — âncora de identidade, qualquer ator
+    actor_type: str  # "tenant" | "partner" — domínio do ator (RFC-0026)
     role: str
+    # Contextuais: exatamente um preenchido, conforme actor_type.
+    tenant_id: Optional[str] = None
+    partner_id: Optional[str] = None
     exp: int
     iat: int
 

--- a/backend/tests/test_partner_auth.py
+++ b/backend/tests/test_partner_auth.py
@@ -1,0 +1,235 @@
+"""Modelo de Ator (RFC-0026) — Partner como ator autenticável.
+
+Cobre: login do parceiro (sem crash no fluxo tenant-only), isolamento
+cruzado (partner não acessa rota tenant-scoped e vice-versa), e a
+CHECK constraint que garante tenant_id XOR partner_id no banco.
+"""
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from app.api.deps import get_current_partner, get_current_user
+from app.core.security import get_password_hash
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.partner import Partner
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiters():
+    from app.routers.auth import _login_limiter, _register_limiter, _forgot_limiter
+
+    prefixes = ["ratelimit:login:", "ratelimit:register:", "ratelimit:resend:", "ratelimit:forgot:"]
+    for rl in (_login_limiter, _register_limiter, _forgot_limiter):
+        rl._memory_store.clear()
+    redis_conn = _login_limiter.redis
+    if redis_conn is not None:
+        for prefix in prefixes:
+            redis_conn.delete(f"{prefix}testclient")
+            redis_conn.delete(f"{prefix}127.0.0.1")
+            redis_conn.delete(f"{prefix}unknown")
+
+
+@pytest.fixture
+def test_tenant(session):
+    tenant = Tenant(name="Test Tenant", slug=f"test-tenant-{uuid.uuid4()}")
+    session.add(tenant)
+    session.commit()
+    session.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def test_tenant_user(session, test_tenant):
+    user = User(
+        email=f"user-{uuid.uuid4()}@test.com",
+        full_name="Test Tenant User",
+        password_hash=get_password_hash("password123"),
+        tenant_id=test_tenant.id,
+        role="admin",
+        email_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def test_partner(session):
+    partner = Partner(type="accountant", name="Dra. Kátia Pollon", code=f"KATIA{uuid.uuid4().hex[:6].upper()}")
+    session.add(partner)
+    session.commit()
+    session.refresh(partner)
+    return partner
+
+
+@pytest.fixture
+def test_partner_user(session, test_partner):
+    user = User(
+        email=f"partner-{uuid.uuid4()}@test.com",
+        full_name="Dra. Kátia Pollon",
+        password_hash=get_password_hash("password123"),
+        partner_id=test_partner.id,
+        role="partner",
+        email_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+# ── actor_type ────────────────────────────────────────────────
+
+def test_actor_type_tenant(test_tenant_user):
+    assert test_tenant_user.actor_type == "tenant"
+
+
+def test_actor_type_partner(test_partner_user):
+    assert test_partner_user.actor_type == "partner"
+
+
+# ── CHECK constraint (banco) ─────────────────────────────────
+
+def test_user_requires_exactly_one_actor_domain(session, test_tenant, test_partner):
+    """Nem os dois, nem nenhum — a integridade é estrutural, não só de código."""
+    both = User(
+        email=f"both-{uuid.uuid4()}@test.com",
+        full_name="Invalid",
+        password_hash=get_password_hash("x"),
+        tenant_id=test_tenant.id,
+        partner_id=test_partner.id,
+        role="user",
+    )
+    session.add(both)
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+    neither = User(
+        email=f"neither-{uuid.uuid4()}@test.com",
+        full_name="Invalid",
+        password_hash=get_password_hash("x"),
+        role="user",
+    )
+    session.add(neither)
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+
+def test_partner_email_uniqueness_enforced(session, test_partner):
+    """A constraint (tenant_id, email) não pega duplicidade com tenant_id NULL —
+    o índice único parcial precisa cobrir isso."""
+    email = f"dup-{uuid.uuid4()}@test.com"
+    session.add(User(
+        email=email, full_name="A", password_hash=get_password_hash("x"),
+        partner_id=test_partner.id, role="partner",
+    ))
+    session.commit()
+
+    session.add(User(
+        email=email, full_name="B", password_hash=get_password_hash("x"),
+        partner_id=test_partner.id, role="partner",
+    ))
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+
+# ── Login ────────────────────────────────────────────────────
+
+def _decode(token: str) -> dict:
+    """response_model=Token filtra o corpo HTTP — os claims reais só existem
+    dentro do JWT. Decodificar é a única forma correta de verificá-los."""
+    from jose import jwt
+
+    from app.config import settings
+
+    return jwt.decode(token, settings.JWT_SECRET, algorithms=[settings.JWT_ALG])
+
+
+def test_login_partner_success(client, test_partner_user, test_partner):
+    """Não deve crashar tentando resolver tenant/billing/Grant (que não existem)."""
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": test_partner_user.email, "password": "password123"},
+    )
+    assert response.status_code == 200
+    claims = _decode(response.json()["access_token"])
+    assert claims["actor_type"] == "partner"
+    assert claims["partner_id"] == str(test_partner.id)
+    assert claims["role"] == "partner"
+    assert claims.get("tenant_id") is None
+
+
+def test_login_tenant_still_works(client, test_tenant_user, test_tenant):
+    """Regressão — fluxo tenant existente inalterado."""
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": test_tenant_user.email, "password": "password123"},
+    )
+    assert response.status_code == 200
+    claims = _decode(response.json()["access_token"])
+    assert claims["actor_type"] == "tenant"
+    assert claims["tenant_id"] == str(test_tenant.id)
+
+
+# ── Isolamento cruzado ───────────────────────────────────────
+# Exercita get_current_user/get_current_partner diretamente (nível de
+# dependência), sem depender de rotas de sondagem montadas no app real.
+
+async def test_partner_actor_rejected_by_get_current_user(test_partner_user):
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(actor=test_partner_user)
+    assert exc_info.value.status_code == 403
+
+
+async def test_tenant_actor_rejected_by_get_current_partner(test_tenant_user):
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_partner(actor=test_tenant_user)
+    assert exc_info.value.status_code == 403
+
+
+async def test_tenant_actor_accepted_by_get_current_user(test_tenant_user):
+    result = await get_current_user(actor=test_tenant_user)
+    assert result is test_tenant_user
+
+
+async def test_partner_actor_accepted_by_get_current_partner(test_partner_user):
+    result = await get_current_partner(actor=test_partner_user)
+    assert result is test_partner_user

--- a/docs/sprints/2026-07-16_programa_parceiros_fundacao_auth.md
+++ b/docs/sprints/2026-07-16_programa_parceiros_fundacao_auth.md
@@ -1,0 +1,41 @@
+# Programa de Parceiros — Fundação de Autenticação
+
+Data: 2026-07-16
+PR: [#459](https://github.com/mickbap/tribultz/pull/459) — aberto, aguardando review
+Governança: [RFC-0026](https://github.com/mickbap/tribultz-brain/blob/main/knowledge/rfcs/RFC-0026-programa-de-parceiros.md) (`tribultz-brain`)
+
+## Resumo executivo
+
+Primeira entrega de código do Programa de Parceiros: a plataforma agora sabe autenticar um **parceiro** (ex.: Dra. Kátia Pollon) como ator próprio, sem confundi-lo com uma empresa-cliente (Tenant) e sem exigir uma tela nova de login separada. É a base sobre a qual o cadastro do parceiro, o dashboard dele e a extensão do Command Center serão construídos nas próximas etapas — nenhum desses três ainda existe.
+
+**Nenhuma informação financeira, comissão ou pagamento foi implementada.** Fora de escopo por decisão explícita, conforme RFC-0026.
+
+## O que muda, na prática
+
+Hoje, todo login na Tribultz assume implicitamente "isso é alguém de uma empresa cliente". Essa entrega generaliza esse conceito: o sistema de login passa a reconhecer **dois tipos de ator** — quem é de uma empresa (como sempre foi) e quem é um parceiro (novo). Um parceiro poderá usar exatamente o mesmo fluxo de convite, criação de senha e login que qualquer outro usuário já usa hoje — não é um sistema paralelo, é o mesmo sistema reconhecendo um novo tipo de conta.
+
+Guardrail preservado: um Partner **nunca** vira uma empresa-cliente, e vice-versa. O banco de dados agora **impede estruturalmente** que essa distinção seja violada por acidente (não é só uma regra de código, é uma restrição no próprio banco).
+
+## Validação
+
+- 14 testes novos, cobrindo: o parceiro conseguindo logar sem quebrar nada; um parceiro não conseguindo acessar áreas de empresa-cliente (e vice-versa); a restrição do banco funcionando.
+- Suite completa do backend: **677 de 677 testes passando** — ou seja, nada que já existia foi afetado.
+- Um problema real foi encontrado e corrigido **durante** a implementação (não estava previsto na proposta técnica original): três endpoints antigos chamavam uma função interna de um jeito que quebraria com essa mudança. A ferramenta de checagem de tipos (pyright) pegou isso antes de virar bug em produção; foi corrigido no mesmo PR.
+
+## O que ainda falta (não está nesta entrega)
+
+1. **Criar a conta do parceiro de fato** — hoje a plataforma sabe autenticar um parceiro, mas ainda não existe a tela/fluxo pra convidar um novo parceiro e ele criar a senha.
+2. **Dashboard do parceiro** — a área onde ele vê seu código, link e empresas indicadas.
+3. **Extensão do Command Center** — visão do Owner sobre todos os parceiros e a evolução das indicações.
+
+## Decisão de processo que vale registrar
+
+Esta entrega passou por duas rodadas de revisão arquitetural antes de virar código:
+1. Primeira proposta previa criar uma "empresa" fictícia no banco só para o parceiro poder logar — foi corretamente barrada por misturar dois conceitos que deveriam ficar separados.
+2. Segunda proposta generalizava a solução, mas ainda tratava "tenant" como o conceito central — foi refinada para que o **ator autenticado** (seja ele qual for) vire o conceito central, e "empresa" passe a ser só um contexto usado quando aplicável.
+
+O modelo que entrou em código é o da segunda rodada — pensado para caber o próximo tipo de ator que a Tribultz precisar (ex.: parceiros institucionais maiores) sem precisar redesenhar de novo.
+
+## Próximo passo
+
+PR #459 aguardando review antes do merge. Após aprovado, sigo para o fluxo de criação de conta do parceiro (Etapa seguinte da Fase 1).

--- a/docs/sprints/2026-07-16_programa_parceiros_fundacao_auth.md
+++ b/docs/sprints/2026-07-16_programa_parceiros_fundacao_auth.md
@@ -10,6 +10,28 @@ Primeira entrega de código do Programa de Parceiros: a plataforma agora sabe au
 
 **Nenhuma informação financeira, comissão ou pagamento foi implementada.** Fora de escopo por decisão explícita, conforme RFC-0026.
 
+> **Leitura oficial deste PR:** não é só a documentação de uma feature do Programa de Parceiros — é uma evolução da arquitetura de autenticação da Tribultz, com validade permanente para qualquer ator futuro.
+
+## Decisão arquitetural consolidada
+
+> A autenticação da Tribultz autentica identidades.
+> A autorização define contexto e permissões.
+> Novos domínios reutilizam a mesma infraestrutura de autenticação.
+
+Este passa a ser o princípio oficial para toda evolução futura da autenticação da plataforma — não um detalhe de implementação do Programa de Parceiros.
+
+## Benefícios obtidos
+
+- Eliminação do Tenant artificial (a primeira proposta previa criar uma "empresa" fictícia só para o parceiro logar — descartada).
+- Reutilização integral da infraestrutura de autenticação existente — nenhum sistema paralelo.
+- Compatibilidade total com os usuários e tenants atuais — zero regressão (677/677 testes).
+- Base preparada para novos atores institucionais futuros, sem necessidade de redesenho.
+- Redução de dívida técnica futura: a próxima vez que a plataforma precisar de um novo tipo de ator, o modelo já existe.
+
+## O que NÃO muda (para evitar interpretação futura equivocada)
+
+Permanecem **inalterados**: fluxo de login, convite, primeiro acesso, OTP, recuperação de senha, auditoria, sessão, usuários atuais, tenants atuais. Esta entrega **estende** a autenticação para um novo domínio de ator — não **substitui** nem **modifica** o comportamento existente para quem já usa a plataforma hoje.
+
 ## O que muda, na prática
 
 Hoje, todo login na Tribultz assume implicitamente "isso é alguém de uma empresa cliente". Essa entrega generaliza esse conceito: o sistema de login passa a reconhecer **dois tipos de ator** — quem é de uma empresa (como sempre foi) e quem é um parceiro (novo). Um parceiro poderá usar exatamente o mesmo fluxo de convite, criação de senha e login que qualquer outro usuário já usa hoje — não é um sistema paralelo, é o mesmo sistema reconhecendo um novo tipo de conta.
@@ -22,11 +44,17 @@ Guardrail preservado: um Partner **nunca** vira uma empresa-cliente, e vice-vers
 - Suite completa do backend: **677 de 677 testes passando** — ou seja, nada que já existia foi afetado.
 - Um problema real foi encontrado e corrigido **durante** a implementação (não estava previsto na proposta técnica original): três endpoints antigos chamavam uma função interna de um jeito que quebraria com essa mudança. A ferramenta de checagem de tipos (pyright) pegou isso antes de virar bug em produção; foi corrigido no mesmo PR.
 
-## O que ainda falta (não está nesta entrega)
+## Escopo delimitado — este PR NÃO implementa
 
-1. **Criar a conta do parceiro de fato** — hoje a plataforma sabe autenticar um parceiro, mas ainda não existe a tela/fluxo pra convidar um novo parceiro e ele criar a senha.
-2. **Dashboard do parceiro** — a área onde ele vê seu código, link e empresas indicadas.
-3. **Extensão do Command Center** — visão do Owner sobre todos os parceiros e a evolução das indicações.
+- Cadastro operacional do parceiro (convite, criação de conta de verdade).
+- Dashboard do parceiro.
+- Comissão.
+- Carteira financeira.
+- Pagamentos.
+- Relatórios comerciais.
+- Command Center expandido (visão de parceiros/indicações).
+
+Todos pertencem às próximas etapas do Programa de Parceiros — nenhum está bloqueado por esta entrega, mas nenhum está pronto ainda.
 
 ## Decisão de processo que vale registrar
 


### PR DESCRIPTION
## Summary
Implementa a fundação de autenticação aprovada em `docs/sprints/2026-07-16_proposta_tecnica_auth_partner.md` (v2 — modelo de Ator). Primeira peça de código do Programa de Parceiros (RFC-0026, `tribultz-brain`).

- **Migration**: `users.tenant_id` nullable + `users.partner_id` novo + `CHECK` constraint (`tenant_id` XOR `partner_id`) + índice único parcial de e-mail para atores partner.
- **`User.actor_type`**: propriedade computada, nunca armazenada.
- **`TokenPayload`**: generalizado — `actor_type` obrigatório, `tenant_id`/`partner_id` contextuais.
- **`api/deps.py`**: `get_current_actor` (genérico) → `get_current_user` (mesma assinatura/retorno, ganha checagem de domínio) → `get_current_partner` (nova). **Zero mudança nos ~17 routers tenant-scoped existentes.**
- **`auth.py`**: login sai cedo para atores partner (evita crash tentando resolver Grant/billing que não existem para eles). Corrigidas 3 chamadas diretas a `get_current_user(token, db)` que bypassavam o DI do FastAPI — achado via pyright durante a implementação, não durante a proposta.

## Test plan
- [x] 14 testes novos (`test_partner_auth.py`): `actor_type`, CHECK constraint, unicidade de e-mail entre parceiros, login partner sem crash, regressão login tenant, isolamento cruzado (partner→tenant 403, tenant→partner 403).
- [x] Suite completa: **677/677**.
- [x] `ruff check app/ tests/`: limpo.
- [x] `pyright` nos arquivos tocados: 0 erros (achou e corrigiu as 3 chamadas quebradas).

## Fora deste PR
Fluxo de criação de conta do parceiro (convite/OTP/senha), dashboard do parceiro, extensão do Command Center — próximas etapas da Fase 1.