### PR TITLE
feat(partners): cadastro operacional do parceiro

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -6,11 +6,12 @@ from typing import Annotated, Any, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.core.security import get_password_hash
 from app.database import get_db
 from app.models.admin_audit import AdminAuditLog
 from app.models.api_key import ApiKey
@@ -578,6 +579,12 @@ class SetPartnerBody(BaseModel):
     partner_id: UUID | None = None
 
 
+class PartnerAccountCreateBody(BaseModel):
+    email: EmailStr
+    full_name: str
+    initial_password: str
+
+
 def _validate_code_unique(db: Session, raw: str, exclude_id: UUID | None = None) -> str:
     code = normalize_partner_code(raw)
     if code is None:
@@ -709,6 +716,58 @@ def admin_set_partner_active(
     )
     db.commit()
     return {"id": str(partner.id), "status": new_status}
+
+
+@router.post("/partners/{partner_id}/account", status_code=status.HTTP_201_CREATED)
+def admin_create_partner_account(
+    partner_id: UUID,
+    body: PartnerAccountCreateBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Cria a conta de login do Partner (RFC-0026, ADR-0011 — Programa de Parceiros, Fase 1).
+
+    Mesmo padrão do Founding Partner (_provision_tenant_and_user): admin
+    provisiona com senha inicial — sem convite/e-mail automático (não existe
+    hoje no código). ``User.partner_id`` é setado, ``tenant_id`` fica NULL —
+    o CHECK constraint do banco (migration 2026_07_16_0027) garante que essa
+    separação nunca é violada. Um Partner tem no máximo uma conta nesta fase.
+    """
+    partner = db.get(Partner, partner_id)
+    if partner is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner não encontrado.")
+    if cast(str, partner.status) != "active":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Partner inativo não pode receber conta.")
+    if len(body.initial_password) < 8:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Senha inicial deve ter no mínimo 8 caracteres.")
+    if not body.full_name.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nome é obrigatório.")
+
+    existing_account = db.execute(
+        select(User).where(User.partner_id == partner.id)
+    ).scalar_one_or_none()
+    if existing_account is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Este Partner já possui uma conta.")
+
+    # Login busca por e-mail globalmente (scalar_one_or_none) — e-mail precisa
+    # ser único entre TODOS os atores, não só entre partners.
+    if db.execute(select(User).where(User.email == body.email)).scalar_one_or_none() is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Este e-mail já está em uso.")
+
+    user = User(
+        partner_id=partner.id,
+        email=body.email,
+        full_name=body.full_name.strip(),
+        password_hash=get_password_hash(body.initial_password),
+        role="partner",
+        email_verified=True,
+    )
+    db.add(user)
+    db.flush()
+    _audit(db, _admin, "partner.create_account", "partner", partner.id, {"user_id": str(user.id), "email": body.email})
+    db.commit()
+    db.refresh(user)
+    return {"user_id": str(user.id), "partner_id": str(partner.id), "email": cast(str, user.email)}
 
 
 @router.post("/tenants/{tenant_id}/partner")

--- a/backend/tests/test_partner_admin.py
+++ b/backend/tests/test_partner_admin.py
@@ -30,6 +30,7 @@ PARTNER_MUTATIONS = [
     ("patch", f"/api/v1/admin/partners/{_UUID}", {"name": "Y"}),
     ("post", f"/api/v1/admin/partners/{_UUID}/active", {"is_active": False}),
     ("post", f"/api/v1/admin/tenants/{_UUID}/partner", {"partner_id": None}),
+    ("post", f"/api/v1/admin/partners/{_UUID}/account", {"email": "x@x.com", "full_name": "X", "initial_password": "password123"}),
 ]
 
 
@@ -90,6 +91,22 @@ def client_fixture(session):
     app.dependency_overrides[get_db] = override_get_db
     yield TestClient(app)
     app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiters():
+    """Evita 429 em /login entre arquivos de teste (mesmo padrão de test_auth.py)."""
+    from app.routers.auth import _login_limiter, _register_limiter, _forgot_limiter
+
+    prefixes = ["ratelimit:login:", "ratelimit:register:", "ratelimit:resend:", "ratelimit:forgot:"]
+    for rl in (_login_limiter, _register_limiter, _forgot_limiter):
+        rl._memory_store.clear()
+    redis_conn = _login_limiter.redis
+    if redis_conn is not None:
+        for prefix in prefixes:
+            redis_conn.delete(f"{prefix}testclient")
+            redis_conn.delete(f"{prefix}127.0.0.1")
+            redis_conn.delete(f"{prefix}unknown")
 
 
 @pytest.fixture(name="superadmin")
@@ -155,3 +172,120 @@ def test_atribuicao_manual_e_filtro(client, superadmin, session):
     assert r.status_code == 200
     items = r.json()["items"]
     assert any(it["id"] == str(tenant.id) and it["partner_name"] == "INSI" for it in items)
+
+
+# ── Cadastro de conta do Partner (RFC-0026, Fase 1) ───────────────────────────
+# Mesmo padrão do Founding Partner (_provision_tenant_and_user): admin cria a
+# conta com senha inicial — sem convite/e-mail automático (não existe no
+# código hoje; ver docs/sprints/2026-07-16_programa_parceiros_fundacao_auth.md).
+
+def _make_partner(session, code_prefix="ACC"):
+    partner = Partner(type="accountant", name="Dra. Kátia Pollon", code=f"{code_prefix}{uuid.uuid4().hex[:5].upper()}")
+    session.add(partner)
+    session.flush()
+    return partner
+
+
+@pytestmark_db
+def test_create_partner_account_success(client, superadmin, session):
+    from sqlalchemy import select as sa_select
+
+    partner = _make_partner(session)
+    email = f"katia-{uuid.uuid4().hex[:6]}@example.com"
+    r = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": email, "full_name": "Dra. Kátia Pollon", "initial_password": "senhaforte123"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["email"] == email
+    assert body["partner_id"] == str(partner.id)
+
+    user = session.execute(sa_select(User).where(User.email == email)).scalar_one()
+    assert user.partner_id == partner.id
+    assert user.tenant_id is None
+    assert user.actor_type == "partner"
+    assert user.role == "partner"
+
+
+@pytestmark_db
+def test_create_partner_account_short_password_rejected(client, superadmin, session):
+    partner = _make_partner(session, "SHORT")
+    r = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": f"x-{uuid.uuid4().hex[:6]}@example.com", "full_name": "X", "initial_password": "1234567"},
+    )
+    assert r.status_code == 400
+
+
+@pytestmark_db
+def test_create_partner_account_duplicate_email_rejected(client, superadmin, session):
+    """E-mail já usado por qualquer ator (tenant ou partner) — login é global por e-mail;
+    duas contas com o mesmo e-mail quebrariam o login (scalar_one_or_none)."""
+    existing_tenant = Tenant(name="Empresa X", slug=f"empresa-{uuid.uuid4().hex[:8]}")
+    session.add(existing_tenant)
+    session.flush()
+    taken_email = f"taken-{uuid.uuid4().hex[:6]}@example.com"
+    session.add(User(
+        tenant_id=existing_tenant.id, email=taken_email, full_name="Alguém",
+        password_hash=get_password_hash("x"), role="user", email_verified=True,
+    ))
+    session.flush()
+
+    partner = _make_partner(session, "DUP")
+    r = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": taken_email, "full_name": "Dra. Kátia Pollon", "initial_password": "senhaforte123"},
+    )
+    assert r.status_code == 409
+
+
+@pytestmark_db
+def test_create_partner_account_already_exists_rejected(client, superadmin, session):
+    partner = _make_partner(session, "TWICE")
+    first_email = f"first-{uuid.uuid4().hex[:6]}@example.com"
+    r1 = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": first_email, "full_name": "Dra. Kátia Pollon", "initial_password": "senhaforte123"},
+    )
+    assert r1.status_code == 201, r1.text
+
+    r2 = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": f"second-{uuid.uuid4().hex[:6]}@example.com", "full_name": "Dra. Kátia Pollon", "initial_password": "senhaforte123"},
+    )
+    assert r2.status_code == 409
+
+
+@pytestmark_db
+def test_create_partner_account_inactive_partner_rejected(client, superadmin, session):
+    partner = _make_partner(session, "INACT")
+    partner.status = "inactive"  # type: ignore[assignment]
+    session.flush()
+    r = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": f"x-{uuid.uuid4().hex[:6]}@example.com", "full_name": "X", "initial_password": "senhaforte123"},
+    )
+    assert r.status_code == 400
+
+
+@pytestmark_db
+def test_partner_account_can_actually_login(client, superadmin, session):
+    """Ponta a ponta: a conta criada aqui usa o mesmo /login de todo mundo."""
+    partner = _make_partner(session, "LOGIN")
+    email = f"login-{uuid.uuid4().hex[:6]}@example.com"
+    r = client.post(
+        f"/api/v1/admin/partners/{partner.id}/account",
+        json={"email": email, "full_name": "Dra. Kátia Pollon", "initial_password": "senhaforte123"},
+    )
+    assert r.status_code == 201, r.text
+
+    login = client.post("/api/v1/auth/login", json={"email": email, "password": "senhaforte123"})
+    assert login.status_code == 200
+    from jose import jwt
+
+    from app.config import settings
+
+    claims = jwt.decode(login.json()["access_token"], settings.JWT_SECRET, algorithms=[settings.JWT_ALG])
+    assert claims["actor_type"] == "partner"
+    assert claims["partner_id"] == str(partner.id)


### PR DESCRIPTION
## Summary
Segunda entrega do Programa de Parceiros (RFC-0026/ADR-0011), depois da fundação de autenticação (#459): `POST /api/v1/admin/partners/{partner_id}/account` — admin cria a conta de login de um Partner existente.

**Achado que moldou esta implementação**: o fluxo "convite → link assinado → OTP → senha" descrito nos docs do Brain (Early Adopters) é **aspiracional** — não existe no código hoje. O que existe de verdade (`founding_partners.py::_provision_tenant_and_user`) é mais simples: admin define uma senha inicial diretamente. Espelhei esse padrão real, não o idealizado.

## Guardrails
- Partner precisa estar ativo (400 caso contrário).
- Um Partner tem no máximo uma conta nesta fase (409 se já existir).
- E-mail único entre **todos** os atores — não só entre partners. O `/login` busca por e-mail globalmente com `scalar_one_or_none()`; duas contas com o mesmo e-mail quebrariam o login com `MultipleResultsFound`. Validado com teste dedicado.
- Senha mínima de 8 caracteres (mesmo critério do Founding Partner).
- Toda criação é auditada.

## Test plan
- [x] 11 testes novos: gate superadmin, sucesso (confirma `partner_id` setado, `tenant_id` NULL, `actor_type == "partner"`), senha curta, e-mail duplicado cross-domínio, conta duplicada, partner inativo, e **login ponta a ponta** confirmando `actor_type=partner` no JWT retornado pelo `/login` real.
- [x] Suite completa: 683/683.
- [x] `ruff check`: limpo.
- [x] `pyright`: limpo nos arquivos tocados.

## Fora deste PR
Dashboard do parceiro (frontend), extensão do Command Center, convite por e-mail automatizado (se decidido depois).