### PR TITLE
feat(partners): tela de criação de conta em /admin/partners

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -549,6 +549,8 @@ def _partner_out(db: Session, p: Partner) -> dict[str, Any]:
         "status": cast(str, p.status),
         "notes": p.notes,
         "companies": _safe_count(db, select(func.count(Tenant.id)).where(Tenant.partner_id == p.id)),
+        # Cadastro operacional (RFC-0026, ADR-0011) — se já tem conta de login.
+        "has_account": db.execute(select(User.id).where(User.partner_id == p.id)).scalar_one_or_none() is not None,
         "created_at": cast(datetime, p.created_at).isoformat(),
         "updated_at": cast(datetime, p.updated_at).isoformat(),
     }

--- a/backend/tests/test_partner_admin.py
+++ b/backend/tests/test_partner_admin.py
@@ -144,6 +144,7 @@ def test_crud_partner_e_codigo_unico(client, superadmin):
     pid = r.json()["id"]
     assert r.json()["code"] == code  # normalizado para uppercase
     assert r.json()["status"] == "active"
+    assert r.json()["has_account"] is False
     # código duplicado → 409
     assert client.post("/api/v1/admin/partners", json={"name": "Outro", "code": code}).status_code == 409
     # código inválido → 400
@@ -206,6 +207,11 @@ def test_create_partner_account_success(client, superadmin, session):
     assert user.tenant_id is None
     assert user.actor_type == "partner"
     assert user.role == "partner"
+
+    # GET /admin/partners reflete has_account (usado pela UI para decidir
+    # se mostra "criar conta" ou "conta já existe").
+    listed = client.get("/api/v1/admin/partners").json()["items"]
+    assert next(p for p in listed if p["id"] == str(partner.id))["has_account"] is True
 
 
 @pytestmark_db

--- a/frontend/src/app/admin/partners/page.tsx
+++ b/frontend/src/app/admin/partners/page.tsx
@@ -26,6 +26,7 @@ type Partner = {
   status: string;
   notes: string | null;
   companies: number;
+  has_account: boolean;
   created_at: string;
 };
 type Resp = { total: number; items: Partner[] };
@@ -96,6 +97,29 @@ export default function AdminPartnersPage() {
       reload();
     } catch (err) {
       window.alert(err instanceof Error ? err.message : "Falha na ação.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Cadastro operacional do parceiro (RFC-0026, ADR-0011). Sem convite/OTP —
+  // o admin define a senha inicial (mesmo padrão do Founding Partner).
+  async function createAccount(p: Partner) {
+    const email = window.prompt(`Criar conta para "${p.name}".\nE-mail:`, p.email ?? "");
+    if (!email) return;
+    const initialPassword = window.prompt("Senha inicial (mínimo 8 caracteres):");
+    if (!initialPassword) return;
+    setBusy(true);
+    try {
+      await adminPost(`/api/v1/admin/partners/${p.id}/account`, {
+        email: email.trim(),
+        full_name: p.name,
+        initial_password: initialPassword,
+      });
+      window.alert(`Conta criada para ${email.trim()}. Informe a senha inicial ao parceiro por um canal seguro.`);
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha ao criar conta.");
     } finally {
       setBusy(false);
     }
@@ -183,6 +207,7 @@ export default function AdminPartnersPage() {
                 <th className="px-4 py-3">Tipo</th>
                 <th className="px-4 py-3">Empresas</th>
                 <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Conta</th>
                 <th className="px-4 py-3 text-right">Ações</th>
               </tr>
             </thead>
@@ -198,10 +223,24 @@ export default function AdminPartnersPage() {
                       {p.status === "active" ? "Ativo" : "Inativo"}
                     </span>
                   </td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.has_account ? "bg-blue-100 text-blue-700" : "bg-slate-100 text-slate-500"}`}>
+                      {p.has_account ? "Criada" : "Sem conta"}
+                    </span>
+                  </td>
                   <td className="px-4 py-3 text-right">
                     <button onClick={() => edit(p)} className="mr-2 rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50">
                       Editar
                     </button>
+                    {!p.has_account && p.status === "active" && (
+                      <button
+                        onClick={() => createAccount(p)}
+                        disabled={busy}
+                        className="mr-2 rounded-lg border border-blue-200 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                      >
+                        Criar conta
+                      </button>
+                    )}
                     <button
                       onClick={() => toggleActive(p)}
                       disabled={busy}
@@ -213,7 +252,7 @@ export default function AdminPartnersPage() {
                 </tr>
               ))}
               {data.items.length === 0 && (
-                <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">Nenhum Partner cadastrado.</td></tr>
+                <tr><td colSpan={7} className="px-4 py-8 text-center text-slate-400">Nenhum Partner cadastrado.</td></tr>
               )}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
Terceira entrega do Programa de Parceiros, sobre o PR #460 (cadastro operacional via API): o Owner agora cria a conta do parceiro pela própria tela do admin, sem precisar de curl.

- **Backend**: `_partner_out` retorna `has_account` (bool) — computado via existência de `User.partner_id`.
- **Frontend**: nova coluna "Conta" + botão "Criar conta" (só para partners ativos sem conta) na página `/admin/partners`. Reaproveita o padrão já existente de `window.prompt()` sequencial (mesmo usado no fluxo de Grant dos Founding Partners) — sem modal novo, sem dependência nova.

## Testado de verdade no navegador
Sem chromium-cli disponível no ambiente, usei um script Playwright ad-hoc (headless Chromium) contra o dev server real: login → `/admin/partners` → cadastrar Partner de teste → clicar "Criar conta" → preencher os prompts → **confirmar visualmente** que a coluna muda de "Sem conta" para "Criada" e o botão some. Script e superadmin de teste foram descartados depois — nada disso vai para produção.

Achado no processo (ambiente de teste, não bug do app): o validador de e-mail do Pydantic (`EmailStr`) rejeita TLDs reservados como `.local` — só afetou minha conta de teste local.

## Test plan
- [x] Fluxo completo validado visualmente no navegador (Playwright, screenshots antes/depois).
- [x] Backend: 683/683, ruff limpo.
- [x] Frontend: 156/156, build limpo (exit 0).
