### PR TITLE
fix(auth): /login e /switch-tenant descartavam role/tenant_id/tenants na resposta

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -5,9 +5,31 @@ from uuid import UUID
 from pydantic import BaseModel, EmailStr, field_validator
 
 
+class TenantInfo(BaseModel):
+    id: UUID
+    name: str
+    slug: str
+    is_default: bool = False
+
+
 class Token(BaseModel):
+    """response_model de /login e /switch-tenant.
+
+    Precisa declarar TODO campo que os handlers colocam no dict de retorno —
+    response_model descarta silenciosamente qualquer chave extra não listada
+    aqui (FastAPI serializa através do schema). Os opcionais cobrem os 3
+    formatos de resposta: login tenant, login partner e switch-tenant.
+    """
+
     access_token: str
     token_type: str
+    role: Optional[str] = None
+    tenant_id: Optional[str] = None
+    tenant_name: Optional[str] = None
+    partner_id: Optional[str] = None
+    account_type: Optional[str] = None
+    plan_slug: Optional[str] = None
+    tenants: Optional[list[TenantInfo]] = None
 
 
 class TokenPayload(BaseModel):
@@ -102,13 +124,6 @@ class UserRegister(BaseModel):
                 "Consentimento LGPD obrigatório para cadastro."
             )
         return v
-
-
-class TenantInfo(BaseModel):
-    id: UUID
-    name: str
-    slug: str
-    is_default: bool = False
 
 
 class UserRead(BaseModel):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -120,6 +120,28 @@ def test_login_success(client, test_user, test_tenant):
     assert data["token_type"] == "bearer"
 
 
+def test_login_response_body_includes_role_and_tenant(client, test_user, test_tenant):
+    """Regressão: response_model=Token só declarava access_token/token_type e
+    descartava silenciosamente role/tenant_id/tenants — o handler retornava
+    esses campos, mas o FastAPI filtrava tudo que não estava no schema. Isso
+    quebrava toda UI client-side que lê o corpo do /login (link Admin,
+    redirect de superadmin, nome do tenant ativo) mesmo com o JWT correto."""
+    response = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": test_user.email,
+            "password": "password123",
+            "tenant_slug": test_tenant.slug
+        }
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["role"] == "admin"
+    assert data["tenant_id"] == str(test_tenant.id)
+    assert data["account_type"] == "empresa"
+    assert "tenants" in data  # test_user não tem linha em user_tenants; lista vazia é válida aqui
+
+
 def test_login_wrong_password(client, test_user, test_tenant):
     response = client.post(
         "/api/v1/auth/login",


### PR DESCRIPTION
## Summary

Bug de produção que afeta **todo login** desde 12/02/2026, encontrado ao investigar por que o link "Admin" não aparecia para uma conta `superadmin`.

- `Token` (o `response_model` de `/login` e `/switch-tenant`) só declara `access_token` e `token_type`.
- Os handlers retornam um dict bem maior — `role`, `tenant_id`, `account_type`, `plan_slug`, `tenants`, `tenant_name`, `partner_id` — mas o FastAPI serializa a resposta **através** do `response_model` e descarta silenciosamente qualquer chave não declarada nele.
- O JWT em si sempre carregou as claims certas (por isso toda autorização server-side sempre funcionou normalmente — `_require_superadmin`, `/admin/me` etc. decodificam o token, não o corpo da resposta).
- Mas todo **estado client-side** que lê o corpo do `/login` ficava quebrado silenciosamente:
  - `role` sempre cai no fallback `"user"` → link "Admin" nunca aparece, mesmo para superadmin.
  - Redirect de superadmin para `/select-mode` nunca dispara (checa `login.role === "superadmin"`).
  - `tenant_id` sempre `""`, `tenants` sempre `[]` → "Tenant ativo:" fica em branco no dashboard.
  - `account_type` sempre cai no fallback `"empresa"` — quebra a UI de contas `"contador"` (banner errado, sem link "Gerenciar CNPJs").

## Fix

`Token` ganha os campos que os handlers já retornavam, todos `Optional` (cobre os 3 formatos de resposta: login tenant, login partner, switch-tenant) — sem mudança nenhuma no frontend, que já esperava exatamente esses campos opcionais no tipo `LoginResponse`.

## Test plan
- [x] Novo teste `test_login_response_body_includes_role_and_tenant` trava o formato da resposta (não só decodifica o JWT, como os testes existentes faziam — por isso ninguém tinha pego isso antes)
- [x] `python -m pytest tests/ -q` — 684 passed (683 + 1 novo), zero regressão
- [x] `ruff check app/ tests/` — limpo
- [x] `npx pyright@1.1.386 app/` — 0 erros