### PR TITLE
fix(auth): /switch-tenant não devolvia role/account_type na resposta

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -677,6 +677,8 @@ async def switch_tenant(
         "token_type": "bearer",
         "tenant_id": str(data.tenant_id),
         "tenant_name": cast(str, tenant.name) if tenant else "",
+        "role": cast(str, user_tenant.role),
+        "account_type": cast(str, user.account_type),
     }
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 
 from app.database import get_db
 from app.main import app
-from app.models.auth import Tenant, User
+from app.models.auth import Tenant, User, UserTenant
 from app.core.security import get_password_hash
 
 # Use the environment variable for DB connection (standard for CI/Docker)
@@ -140,6 +140,39 @@ def test_login_response_body_includes_role_and_tenant(client, test_user, test_te
     assert data["tenant_id"] == str(test_tenant.id)
     assert data["account_type"] == "empresa"
     assert "tenants" in data  # test_user não tem linha em user_tenants; lista vazia é válida aqui
+
+
+def test_switch_tenant_response_includes_role_for_new_tenant(client, session, test_user, test_tenant):
+    """Regressão: /switch-tenant nunca devolvia role/account_type no corpo —
+    o frontend (Topbar.tsx) só atualizava tenant_id/token e dava reload, então
+    um usuário com role diferente em cada tenant (comum: admin numa empresa,
+    contador levado por /settings noutra) ficava com o role antigo em cache
+    até fazer logout/login de novo."""
+    other_tenant = Tenant(name="Outro Tenant", slug=f"other-{test_tenant.slug}")
+    session.add(other_tenant)
+    session.flush()
+    session.add_all([
+        UserTenant(user_id=test_user.id, tenant_id=test_tenant.id, role="admin", is_default=True),
+        UserTenant(user_id=test_user.id, tenant_id=other_tenant.id, role="contador", is_default=False),
+    ])
+    session.commit()
+
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": test_user.email, "password": "password123", "tenant_slug": test_tenant.slug},
+    )
+    assert login.status_code == 200
+
+    response = client.post(
+        "/api/v1/auth/switch-tenant",
+        json={"tenant_id": str(other_tenant.id)},
+        headers={"Authorization": f"Bearer {login.json()['access_token']}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["role"] == "contador"  # role do vínculo com other_tenant, não o role original
+    assert data["account_type"] == "empresa"
+    assert data["tenant_name"] == "Outro Tenant"
 
 
 def test_login_wrong_password(client, test_user, test_tenant):

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -5,6 +5,8 @@ import {
   getAccountType,
   getTenantId,
   getTenants,
+  setAccountType,
+  setRole,
   setTenantId,
   setToken,
   type StoredTenant,
@@ -64,6 +66,8 @@ export function Topbar({ onOpenMenu, stateVersion }: TopbarProps) {
         const data = await res.json();
         setTenantId(tenantId);
         setToken(data.access_token);
+        if (data.role) setRole(data.role);
+        if (data.account_type) setAccountType(data.account_type);
         window.dispatchEvent(new Event("tribultz-settings-updated"));
         window.location.reload();
       }


### PR DESCRIPTION
## Summary

Achado durante validação completa de todas as rotas de login (usuário pagante em cada plano, Partner revenda, Founding Partner, admin/superadmin) pedida após o fix do #464.

- Mesma classe de bug do #464: `/switch-tenant` nunca incluía `role`/`account_type` no dict de retorno (só `access_token`/`token_type`/`tenant_id`/`tenant_name`).
- `Topbar.tsx` (que dá `window.location.reload()` logo depois de trocar de tenant) só atualizava `tenantId`/`token` no localStorage — nunca `role`/`accountType`.
- Efeito: um usuário com `role` diferente entre tenants (ex.: `admin` na empresa principal, `contador` num CNPJ adicionado via `/settings` → `POST /auth/add-cnpj`, que força `role="contador"` no novo vínculo) ficava com o `role` da conta ANTERIOR em cache até fazer logout/login completo — a sidebar podia mostrar permissões erradas para o tenant atual.

## Fix
- `switch_tenant` (backend/app/routers/auth.py) agora devolve `role` (do `UserTenant` do tenant de destino, o mesmo já usado pra montar o JWT) e `account_type`.
- `Topbar.tsx` chama `setRole`/`setAccountType` com os valores da resposta antes do reload.

## Test plan
- [x] Novo teste `test_switch_tenant_response_includes_role_for_new_tenant` — usuário com `role="admin"` no tenant A e `role="contador"` no tenant B, confirma que o switch devolve o role do tenant B
- [x] `python -m pytest tests/ -q` — 685 passed
- [x] `ruff check app/ tests/` — limpo
- [x] `npx pyright@1.1.386 app/` — 0 erros
- [x] `npm test` (frontend) — 156 passed
- [x] `npm run build` (frontend) — build limpo
- [x] Validação end-to-end via navegador real (Playwright, ambiente local): login pagante em todos os planos (trial/starter/profissional/empresarial/contador), contador multi-CNPJ com switch-tenant, Partner revenda, Founding Partner, superadmin → `/select-mode` → Command Center — todos corretos
- [x] Fluxo de cadastro real (CNPJ real validado via BrasilAPI) → verificação de e-mail → login — ponta a ponta
- [x] Fluxo de troca de senha (forgot → reset via API e via UI real) → login com senha nova — ponta a ponta
- [x] Confirmado: sidebar nunca aparece em rota protegida sem token (redirect pro /login em todos os casos testados)