### PR TITLE
chore(crews): renova cadeia de fallback LLM e fecha buraco de teste

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -77,10 +77,10 @@ class Settings(BaseSettings):
     # ── LLM / OpenRouter ─────────────────────────────────────
     OPENROUTER_API_KEY: str = ""
     OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
-    # Benchmark 08/04/2026 — cadeia de 6 tiers 100% free (ver llm_config.py)
-    LLM_FREE_PRIMARY: str = "openrouter/openai/gpt-oss-20b:free"
-    LLM_FREE_FALLBACK: str = "openrouter/openai/gpt-oss-120b:free"
-    # Timeout aumentado para acomodar 6 tiers com backoff (pior caso ~90s)
+    # Cadeia de fallback de 7 tiers 100% free vive em app/crews/llm_config.py
+    # (DEFAULT_FALLBACK_CHAIN) — não nestas settings, que não são lidas por
+    # nenhum código (LLM_FREE_PRIMARY/LLM_FREE_FALLBACK removidas em 17/07/2026).
+    # Timeout aumentado para acomodar 7 tiers com backoff (pior caso ~90s)
     CHATOPS_TIMEOUT_SECONDS: int = 120
     CREW_MEMORY_TTL_SECONDS: int = 2_592_000
 

--- a/backend/app/crews/llm_config.py
+++ b/backend/app/crews/llm_config.py
@@ -1,22 +1,33 @@
 """
 LLM configuration with tiered fallback for CrewAI agents.
 
-Benchmark realizado em 08/04/2026 contra OpenRouter free tier.
-Todos os modelos abaixo suportam tool calling e são 100% free.
+Benchmark original em 08/04/2026 contra OpenRouter free tier (T1, T4-T7
+abaixo sobrevivem desse benchmark). Revisão de disponibilidade em
+17/07/2026: 2 dos 7 modelos originais (arcee-ai/trinity-large-preview,
+openai/gpt-oss-120b) saíram do catálogo free do OpenRouter — toda vez que
+T1 falhava, a cadeia perdia tempo tentando 2 tiers mortos antes de chegar
+num vivo. Substituídos por T2/T3 novos: verificados **live + tool calling**
+via `GET /api/v1/models` do OpenRouter nesta data, mas sem benchmark de
+velocidade próprio (diferente de T1/T4-T7, que têm tempo medido).
 
 Cadeia de fallback (7 tiers, diversificação de providers):
-  T1  openai/gpt-oss-20b:free          3.4s  131K ctx  OpenAI  (US)     — mais rápido
-  T2  arcee-ai/trinity-large:free      8.3s  131K ctx  Arcee   (US)
-  T3  openai/gpt-oss-120b:free         9.6s  131K ctx  OpenAI  (US)     — maior
-  T4  nvidia/nemotron-3-super:free     11.6s 262K ctx  NVIDIA  (US)     — maior ctx
-  T5  google/gemma-4-31b:free          ~429  262K ctx  Google  (US/EU)  — qualidade
-  T6  meta-llama/llama-3.3-70b:free   ~429   65K ctx  Meta    (US)     — último recurso
-  T7  openrouter/free (router)          dyn   dyn      OpenRouter        — rede de segurança
+  T1  openai/gpt-oss-20b:free           3.4s  131K ctx  OpenAI  (US)     — mais rápido (bench 08/04/2026)
+  T2  qwen/qwen3-next-80b-a3b:free      —     262K ctx  Alibaba (CN)     — substituto de trinity-large (revisão 17/07/2026)
+  T3  nvidia/nemotron-3-ultra-550b:free —     1M  ctx   NVIDIA  (US)     — substituto de gpt-oss-120b, maior (revisão 17/07/2026)
+  T4  nvidia/nemotron-3-super:free      11.6s 262K ctx  NVIDIA  (US)     — maior ctx (bench 08/04/2026)
+  T5  google/gemma-4-31b:free           ~429  262K ctx  Google  (US/EU)  — qualidade (bench 08/04/2026)
+  T6  meta-llama/llama-3.3-70b:free    ~429   65K ctx  Meta    (US)     — último recurso (bench 08/04/2026)
+  T7  openrouter/free (router)           dyn   dyn      OpenRouter        — rede de segurança
 
 T5 e T6 ficam em 429 sob alta carga mas recuperam após backoff.
 T7 é o router free do OpenRouter: auto-seleciona um modelo free disponível
 filtrando por tool calling — resiliente à volatilidade do free tier.
 Nenhum modelo pago na cadeia — 100% free tier.
+
+O catálogo free do OpenRouter tem alta rotatividade — reconfirmar
+disponibilidade (`GET https://openrouter.ai/api/v1/models`, filtrar por
+`id` terminando em `:free` e `supported_parameters` incluindo `tools`)
+a cada trimestre ou ao notar 429/erro de modelo não encontrado recorrente.
 """
 
 from __future__ import annotations
@@ -68,17 +79,17 @@ TIER_GPT_OSS_20B = ModelTier(
     backoff_base=2.0,
 )
 
-TIER_TRINITY_LARGE = ModelTier(
-    name="trinity-large",
-    model_id="openrouter/arcee-ai/trinity-large-preview:free",
+TIER_QWEN3_NEXT_80B = ModelTier(
+    name="qwen3-next-80b",
+    model_id="openrouter/qwen/qwen3-next-80b-a3b-instruct:free",
     is_free=True,
     max_retries=2,
     backoff_base=2.0,
 )
 
-TIER_GPT_OSS_120B = ModelTier(
-    name="gpt-oss-120b",
-    model_id="openrouter/openai/gpt-oss-120b:free",
+TIER_NEMOTRON_ULTRA = ModelTier(
+    name="nemotron-3-ultra-550b",
+    model_id="openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
     is_free=True,
     max_retries=2,
     backoff_base=2.0,
@@ -121,10 +132,11 @@ TIER_FREE_ROUTER = ModelTier(
 )
 
 # Cadeia padrão — ordem por confiabilidade observada no benchmark
+# (T2/T3 revisados em 17/07/2026 — ver docstring do módulo)
 DEFAULT_FALLBACK_CHAIN: list[ModelTier] = [
     TIER_GPT_OSS_20B,      # primário: mais rápido (3.4s), confiável
-    TIER_TRINITY_LARGE,    # 2º: 8.3s, provider alternativo
-    TIER_GPT_OSS_120B,     # 3º: 9.6s, maior e mais capaz
+    TIER_QWEN3_NEXT_80B,   # 2º: provider alternativo (Alibaba/Qwen)
+    TIER_NEMOTRON_ULTRA,   # 3º: maior e mais capaz (1M ctx)
     TIER_NEMOTRON_SUPER,   # 4º: 11.6s, 262K ctx, NVIDIA
     TIER_GEMMA4_31B,       # 5º: alta qualidade, pode 429
     TIER_LLAMA33_70B,      # 6º: último recurso, provado em PT-BR
@@ -133,7 +145,7 @@ DEFAULT_FALLBACK_CHAIN: list[ModelTier] = [
 
 # Aliases para compatibilidade retroativa
 FREE_PRIMARY = TIER_GPT_OSS_20B
-FREE_FALLBACK = TIER_GPT_OSS_120B
+FREE_FALLBACK = TIER_QWEN3_NEXT_80B
 
 
 def _get_api_key() -> str:

--- a/backend/tests/crews/test_crm_engagement_crew.py
+++ b/backend/tests/crews/test_crm_engagement_crew.py
@@ -1,0 +1,119 @@
+"""Tests for CRMEngagementCrew (dunning/win-back emails) — zero coverage before this file.
+
+Crew.kickoff is monkeypatched globally (crewai.Crew) for the run() tests —
+same seam used in test_chatops_resilience.py and test_security_crew.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from crewai import LLM, Crew
+
+from app.crews.crm_engagement_crew import _EVENT_GUIDANCE, CRMEngagementCrew
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-123")
+
+
+def _make_crew(event_type: str = "payment_overdue") -> CRMEngagementCrew:
+    return CRMEngagementCrew(
+        user_id="user-1",
+        tenant_id="tenant-1",
+        event_type=event_type,
+        to_email="cliente@example.com",
+        user_name="Maria Silva",
+        company_name="Empresa Exemplo Ltda",
+        transaction_id="tx-crm-test",
+    )
+
+
+# ── Event guidance ─────────────────────────────────────────────
+
+
+class TestEventGuidance:
+    def test_payment_overdue_and_win_back_have_distinct_copy(self):
+        overdue = _EVENT_GUIDANCE["payment_overdue"]
+        cancelled = _EVENT_GUIDANCE["subscription_cancelled"]
+        assert overdue["tone"] != cancelled["tone"]
+        assert overdue["subject_hint"] != cancelled["subject_hint"]
+
+    def test_known_event_types_select_matching_guidance(self):
+        assert _make_crew("payment_overdue")._guidance == _EVENT_GUIDANCE["payment_overdue"]
+        assert (
+            _make_crew("subscription_cancelled")._guidance
+            == _EVENT_GUIDANCE["subscription_cancelled"]
+        )
+
+    def test_unknown_event_type_falls_back_to_payment_overdue(self):
+        crew = _make_crew("some_unmapped_event")
+        assert crew._guidance == _EVENT_GUIDANCE["payment_overdue"]
+
+
+# ── _build_crew wiring ──────────────────────────────────────────
+
+
+class TestBuildCrewWiring:
+    def test_three_agents_three_tasks_in_order(self):
+        llm = LLM(model="openrouter/test:free", api_key="test-key-123")
+        crew = _make_crew()._build_crew(llm)
+        assert [a.role for a in crew.agents] == [
+            "CRM Analyst",
+            "Email Copywriter",
+            "CRM Executor",
+        ]
+        assert len(crew.tasks) == 3
+
+    def test_analyst_has_only_context_tool(self):
+        llm = LLM(model="openrouter/test:free", api_key="test-key-123")
+        crew = _make_crew()._build_crew(llm)
+        analyst = crew.agents[0]
+        assert [t.name for t in analyst.tools] == ["get_customer_context"]
+
+    def test_executor_has_email_and_hubspot_tools(self):
+        llm = LLM(model="openrouter/test:free", api_key="test-key-123")
+        crew = _make_crew()._build_crew(llm)
+        executor = crew.agents[2]
+        assert [t.name for t in executor.tools] == ["send_email", "hubspot_log_note"]
+
+    def test_copywriter_has_no_tools(self):
+        llm = LLM(model="openrouter/test:free", api_key="test-key-123")
+        crew = _make_crew()._build_crew(llm)
+        assert crew.agents[1].tools == []
+
+    def test_task_dependency_chain(self):
+        """compose depends on analyze; send depends on compose."""
+        llm = LLM(model="openrouter/test:free", api_key="test-key-123")
+        crew = _make_crew()._build_crew(llm)
+        task_analyze, task_compose, task_send = crew.tasks
+        assert task_compose.context == [task_analyze]
+        assert task_send.context == [task_compose]
+
+    def test_crew_has_no_memory(self):
+        """CRM crew is one-shot — docstring says 'No memory'."""
+        llm = LLM(model="openrouter/test:free", api_key="test-key-123")
+        crew = _make_crew()._build_crew(llm)
+        assert crew.memory is False
+
+
+# ── run() ────────────────────────────────────────────────────────
+
+
+class TestRun:
+    def test_success_returns_completed_status(self, monkeypatch):
+        monkeypatch.setattr(Crew, "kickoff", lambda self: '{"email_sent": true, "hubspot_logged": true}')
+        crew = _make_crew("subscription_cancelled")
+        result = crew.run()
+        assert result["status"] == "crew_completed"
+        assert result["event_type"] == "subscription_cancelled"
+        assert "email_sent" in result["output"]
+
+    def test_llm_unavailable_returns_llm_unavailable_status(self, monkeypatch):
+        def _always_fail(self):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(Crew, "kickoff", _always_fail)
+        crew = _make_crew()
+        result = crew.run()
+        assert result == {"status": "llm_unavailable", "event_type": "payment_overdue"}

--- a/backend/tests/crews/test_crm_engagement_crew.py
+++ b/backend/tests/crews/test_crm_engagement_crew.py
@@ -69,13 +69,13 @@ class TestBuildCrewWiring:
         llm = LLM(model="openrouter/test:free", api_key="test-key-123")
         crew = _make_crew()._build_crew(llm)
         analyst = crew.agents[0]
-        assert [t.name for t in analyst.tools] == ["get_customer_context"]
+        assert [t.name for t in analyst.tools or []] == ["get_customer_context"]
 
     def test_executor_has_email_and_hubspot_tools(self):
         llm = LLM(model="openrouter/test:free", api_key="test-key-123")
         crew = _make_crew()._build_crew(llm)
         executor = crew.agents[2]
-        assert [t.name for t in executor.tools] == ["send_email", "hubspot_log_note"]
+        assert [t.name for t in executor.tools or []] == ["send_email", "hubspot_log_note"]
 
     def test_copywriter_has_no_tools(self):
         llm = LLM(model="openrouter/test:free", api_key="test-key-123")

--- a/backend/tests/crews/test_llm_config.py
+++ b/backend/tests/crews/test_llm_config.py
@@ -6,8 +6,8 @@ from app.crews.llm_config import (
     FREE_FALLBACK,
     FREE_PRIMARY,
     TIER_GPT_OSS_20B,
-    TIER_GPT_OSS_120B,
-    TIER_TRINITY_LARGE,
+    TIER_NEMOTRON_ULTRA,
+    TIER_QWEN3_NEXT_80B,
     TIER_NEMOTRON_SUPER,
     TIER_GEMMA4_31B,
     TIER_LLAMA33_70B,
@@ -44,8 +44,8 @@ class TestModelTiers:
     def test_default_chain_order(self):
         assert DEFAULT_FALLBACK_CHAIN == [
             TIER_GPT_OSS_20B,
-            TIER_TRINITY_LARGE,
-            TIER_GPT_OSS_120B,
+            TIER_QWEN3_NEXT_80B,
+            TIER_NEMOTRON_ULTRA,
             TIER_NEMOTRON_SUPER,
             TIER_GEMMA4_31B,
             TIER_LLAMA33_70B,
@@ -143,8 +143,8 @@ class TestExecuteWithFallback:
 
         result, tier, elapsed = execute_with_fallback(fn)
         assert result == "fallback_ok"
-        # Second tier in chain is TIER_TRINITY_LARGE
-        assert tier == TIER_TRINITY_LARGE
+        # Second tier in chain is TIER_QWEN3_NEXT_80B
+        assert tier == TIER_QWEN3_NEXT_80B
         # PRIMARY (gpt-oss-20b) has max_retries=2, so 2 attempts + 1 on tier 2 = 3
         assert call_count == TIER_GPT_OSS_20B.max_retries + 1
 

--- a/backend/tests/crews/test_security_crew.py
+++ b/backend/tests/crews/test_security_crew.py
@@ -1,0 +1,93 @@
+"""Tests for the Security Crew (SOC + CloudSec + SRE) — zero coverage before this file.
+
+Crew.kickoff is monkeypatched globally (crewai.Crew) so real Agent/Task
+construction (YAML-driven) runs for real, but no network call happens —
+mirrors the seam already used in test_chatops_resilience.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from crewai import Crew
+
+from app.crews.security_crew import TribultzSecurityCrew, _parse_output
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key-123")
+
+
+# ── _parse_output ────────────────────────────────────────────────
+
+
+class TestParseOutput:
+    def test_plain_json_object(self):
+        assert _parse_output('{"report_markdown": "ok"}') == {"report_markdown": "ok"}
+
+    def test_json_object_in_code_fence(self):
+        raw = '```json\n{"alerts_found": 2}\n```'
+        assert _parse_output(raw) == {"alerts_found": 2}
+
+    def test_json_array_in_code_fence_wraps_in_alerts_key(self):
+        raw = '```json\n[{"severity": "high"}]\n```'
+        assert _parse_output(raw) == {"alerts": [{"severity": "high"}]}
+
+    def test_non_json_falls_back_to_report_markdown(self):
+        raw = "# Relatorio\nTudo certo."
+        assert _parse_output(raw) == {"report_markdown": raw}
+
+    def test_malformed_json_in_fence_falls_back(self):
+        raw = "```json\n{not valid json}\n```"
+        assert _parse_output(raw) == {"report_markdown": raw}
+
+
+# ── TribultzSecurityCrew ───────────────────────────────────────────
+
+
+class TestAnalyzeAccess:
+    def test_returns_parsed_soc_output(self, monkeypatch):
+        monkeypatch.setattr(
+            Crew, "kickoff", lambda self: '{"alerts_found": 0, "summary": "sem anomalias"}'
+        )
+        crew = TribultzSecurityCrew(tenant_id="tenant-1")
+        result = crew.analyze_access(log_data="[]")
+        assert result == {"alerts_found": 0, "summary": "sem anomalias"}
+
+
+class TestAuditStorage:
+    def test_returns_parsed_cloudsec_output(self, monkeypatch):
+        monkeypatch.setattr(
+            Crew,
+            "kickoff",
+            lambda self: '{"summary": {"total": 7, "pass": 7, "fail": 0, "score_pct": 100}}',
+        )
+        crew = TribultzSecurityCrew(tenant_id="tenant-1")
+        result = crew.audit_storage(storage_config="{}")
+        assert result["summary"]["score_pct"] == 100
+
+
+class TestExecutiveReport:
+    def test_returns_parsed_markdown_report(self, monkeypatch):
+        monkeypatch.setattr(Crew, "kickoff", lambda self: "# Resumo Executivo\nTudo em dia.")
+        crew = TribultzSecurityCrew(tenant_id="tenant-1")
+        result = crew.executive_report(
+            soc_alerts="[]", cloudsec_audit="{}", report_period="2026-06-01 to 2026-07-01"
+        )
+        assert "Resumo Executivo" in result["report_markdown"]
+
+
+class TestExecuteFallbackExhausted:
+    def test_llm_unavailable_returns_error_dict(self, monkeypatch):
+        """Crew.kickoff always raising exhausts every tier (no backoff — non-transient
+        error) and _execute must degrade to an error dict, never raise to the caller."""
+
+        def _always_fail(self):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(Crew, "kickoff", _always_fail)
+        crew = TribultzSecurityCrew(tenant_id="tenant-1")
+        result = crew.analyze_access(log_data="[]")
+        assert result == {
+            "error": "Todos os modelos de IA estao temporariamente indisponiveis.",
+        }


### PR DESCRIPTION
## Summary

Parte de uma avaliação das capacidades dos CrewAgents (chatops, security, nfe_validation, crm_engagement) pedida nesta sessão. Este PR cobre os 2 achados de baixo risco, mecânicos; a análise de manter/remover crews órfãs (chatops, devops, nfe_validation) fica para decisão separada, sem código pendente aqui.

1. **Cadeia de fallback LLM desatualizada** — benchmarcada em 08/04/2026. Verificação ao vivo hoje contra `GET /api/v1/models` do OpenRouter: 2 dos 7 tiers saíram do catálogo free (`arcee-ai/trinity-large-preview`, `openai/gpt-oss-120b`). Substituídos por `qwen/qwen3-next-80b-a3b-instruct` e `nvidia/nemotron-3-ultra-550b-a55b` — confirmados live + tool-calling, sem benchmark de velocidade próprio (diferente dos tiers originais, que mantêm o tempo medido). Removidas também `LLM_FREE_PRIMARY`/`LLM_FREE_FALLBACK` de `config.py` — settings mortas, nunca lidas por nenhum código.
2. **Buraco de teste** — `security_crew.py` e `crm_engagement_crew.py` tinham zero teste. Adiciona 20 testes novos (9 + 11).

## Test plan
- [x] `python -m pytest tests/ -q` — 705 passed
- [x] `ruff check app/ tests/` — limpo
- [x] `npx pyright@1.1.386 app/` — 0 erros