### PR TITLE
feat(ci): auditoria arquitetural contínua — severidade e integração ao CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,12 @@ jobs:
         run: |
           pytest -q
 
+      - name: Architecture Audit (informativo)
+        working-directory: backend
+        continue-on-error: true
+        run: |
+          python ../tools/architecture_audit.py
+
       - name: QA Gates (report)
         run: |
           python tools/qa_gates/run_gates.py --mode ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,11 @@ infra/             docker-compose.yml
 tools/qa_gates/    run_gates.py — QA automation
 tools/architecture_audit.py   Auditoria arquitetural (ADR-0013) — Crews sem classificação,
                                tasks Celery não registradas, tools órfãs, routers vs. CLAUDE.md,
-                               sincronia com o Brain. `cd backend && source .venv/bin/activate
-                               && python ../tools/architecture_audit.py`
+                               sincronia com o Brain. Achados com severidade (Crítico/Alto/Médio/
+                               Baixo — política em knowledge/process/architecture-audit-policy.md
+                               no Brain). Roda no CI (job backend-gates, após Pytest) em modo
+                               informativo — não bloqueia merge. Local: `cd backend && source
+                               .venv/bin/activate && python ../tools/architecture_audit.py`
 docs/sprints/      Histórico de sprints e relatórios de entrega
 docs/infra/operations_runbook.md   Arquitetura, fluxo de deploy/rollback, recuperação de
                                     ambiente, checklist de auditoria operacional

--- a/docs/sprints/2026-07-17_auditoria_continua_arquitetura.md
+++ b/docs/sprints/2026-07-17_auditoria_continua_arquitetura.md
@@ -1,0 +1,45 @@
+# Auditoria Contínua da Arquitetura — Ordem Técnica
+
+Data: 2026-07-17/18
+Contexto: sequência direta da institucionalização da governança arquitetural (ADR-0013, ver [relatório anterior](2026-07-17_governanca_arquitetural_adr0013.md)). Aquela ordem entregou a auditoria automatizada como ferramenta pontual; esta a transforma em processo contínuo — CI a cada PR, severidade explícita e revisão periódica da plataforma.
+
+## 1. Decisão — 3 entregas
+
+| Parte da ordem | Conteúdo | Onde vive |
+|---|---|---|
+| I — Integração ao CI | `tools/architecture_audit.py` roda no job `backend-gates`, depois de Ruff/Pyright/Pytest. **Modo informativo**: achados viram anotação `::warning::`/`::error::` no PR, mas não falham o build (`continue-on-error: true`). | `.github/workflows/ci.yml` (Produto) |
+| II — Classificação de severidade | Todo achado carrega Crítico/Alto/Médio/Baixo. Política com exemplos por nível registrada no Brain; `CATEGORY_SEVERITY` no script é a aplicação dela em código. | `knowledge/process/architecture-audit-policy.md` (Brain) + `tools/architecture_audit.py` (Produto) |
+| III — Revisão arquitetural periódica + evolução contínua | Cadência trimestral, usando o relatório da auditoria como ponto de partida obrigatório; escopo mínimo (inventário, Crews, Tasks Celery, APIs, integrações, cadeia LLM, deprecados, ADR-0013). Auditoria evolui conforme padrões recorrentes surgirem — não é lista fechada. | `knowledge/process/architecture-audit-policy.md` (Brain) |
+
+Bloqueio de merge por achado Crítico fica para depois de um período de estabilização — decisão de produto futura, não desta ordem.
+
+## 2. Severidade aplicada às 5 checagens existentes
+
+| Categoria | Severidade | Por quê |
+|---|---|---|
+| `crew-sem-classificacao` | Crítico | "Crew sem classificação institucional" (exemplo literal da ordem) |
+| `crew-fora-do-inventario-brain` | Crítico | "capacidade fora do inventário" |
+| `crew-documentada-inexistente` | Crítico | Brain referencia Crew que não existe no código — documentação inconsistente |
+| `router-documentado-inexistente` | Crítico | `CLAUDE.md` referencia router inexistente — referência quebrada |
+| `task-nao-registrada` | Alto | "Task Celery sem registro" (exemplo literal) |
+| `router-fora-da-doc` | Alto | "router não documentado" (exemplo literal) |
+| `celery-autodiscover-nao-encontrado` | Alto | estrutura esperada não encontrada — exige checagem manual, não é violação confirmada |
+| `claude-md-formato-inesperado` | Alto | idem — falha de introspecção, não achado confirmado |
+| `ferramenta-orfa` | Médio | "ferramenta potencialmente órfã" (exemplo literal) |
+
+Rodada atual (2026-07-17): 1 achado, `task-nao-registrada` (Alto) — `task_f_security_audit` fora do autodiscover, mesma pendência conhecida já registrada nos dois relatórios anteriores.
+
+## 3. Verificação
+
+- `python ../tools/architecture_audit.py` (local, venv ativo) — relatório com severidade, breakdown "(1 Alto)" no resultado final
+- Mesma rodada com `GITHUB_ACTIONS=true` — confirma emissão de anotação `::warning::` para o achado Alto
+- `ruff check app/ tests/ ../tools/` — limpo
+- `npx pyright@1.1.386 tools/architecture_audit.py` — 0 erros
+- `.github/workflows/ci.yml` — YAML validado (`yaml.safe_load`)
+- Brain: `python3 tools/lint_brain.py` — 0 erros (1 aviso pré-existente, `jsonschema` não instalado) · `python3 tools/build_index.py` — índice ressincronizado
+
+## Pendências conhecidas — fora do escopo desta ordem, registradas
+
+1. **`task_f_security_audit` continua fora do `beat_schedule`/`autodiscover_tasks`** — terceira vez que este relatório registra a mesma pendência; falta decisão de frequência.
+2. **Bloqueio de merge por Crítico** não está ativo — é evolução futura explícita da política, sem prazo definido.
+3. **Revisão arquitetural trimestral** ainda não tem primeira data agendada — a política define cadência e escopo, não quando começa o primeiro ciclo.

--- a/docs/sprints/2026-07-17_governanca_arquitetural_adr0013.md
+++ b/docs/sprints/2026-07-17_governanca_arquitetural_adr0013.md
@@ -1,0 +1,54 @@
+# Governança Arquitetural — ADR-0013 (Ordem Técnica de Institucionalização)
+
+Data: 2026-07-17/18
+Contexto: sequência direta da Ordem Técnica das Crews (ver [relatório anterior](2026-07-17_governanca_crews_ordem_unificada.md)). Aquela ordem resolveu um caso concreto (5 Crews sem estado institucional); esta generaliza a solução — governança arquitetural deixa de depender de decisão pontual e passa a ter processo, inventário e auditoria automatizada permanentes.
+
+## 1. Decisão — 5 partes, uma ordem única
+
+| Parte | Conteúdo | Onde vive |
+|---|---|---|
+| I | **Política de Depreciação** — ciclo obrigatório de 4 estados (Ativa/Deprecada/Descontinuada/Removida) + processo obrigatório antes de qualquer remoção. Nasceu do caso ChatOps: decisão de produto e remoção de código ficaram ~3 meses desalinhadas. | `knowledge/process/deprecation-policy.md` (Brain) |
+| II | **Inventário Arquitetural** — registro único de toda capacidade permanente (auth, motor determinístico, Crews, Celery, APIs, integrações, componentes removidos). Nunca apaga linha, só muda estado. | `knowledge/engineering/architecture-inventory.md` (Brain) |
+| III | **Auditoria arquitetural automatizada** — `tools/architecture_audit.py`, roda contra o estado real do repo (não depende de memória de quem audita). | `tools/architecture_audit.py` (Produto) |
+| IV | **ADR-0013** — consolida os 7 princípios que já governavam a arquitetura (governança precede implementação; identidade≠contexto; motor determinístico é fonte oficial; Crew tem ciclo de vida; remoção segue processo; governança é auditável; critério técnico é objetivo). Não introduz princípio novo, só torna explícito o que já era seguido. | `knowledge/decisions/2026-07-18-principios-permanentes-da-arquitetura.md` (Brain) |
+| V | **Definition of Ready + template de ADR** — toda ordem técnica futura confronta inventário, política de depreciação, ADR-0013 e classificação de Crews *antes* de começar; template de ADR ganha campo obrigatório "Natureza" (cria/altera/depreca/remove capacidade). | `knowledge/process/definition-of-ready.md` + `knowledge/decisions/README.md` (Brain) |
+
+## 2. O que a auditoria automatizada checa
+
+`tools/architecture_audit.py` roda 5 verificações contra o repo real, sem depender de memória de quem audita:
+
+1. Crews sem header `Status:` no docstring (classificação institucional)
+2. Tasks Celery definidas em `app/tasks/` mas ausentes de `autodiscover_tasks`
+3. Ferramentas em `app/crews/tools/` sem nenhum import fora do próprio arquivo
+4. Routers reais (`app/routers/`) vs. lista documentada no `CLAUDE.md`
+5. Sincronia Brain × produto — Crews existentes vs. inventário em `knowledge/engineering/crews.md` (pula com aviso se `../tribultz-brain` não existir; ausência do Brain não bloqueia a auditoria)
+
+Projetada para futura integração ao CI — não integrada nesta entrega (não bloqueia a ordem, conforme especificado).
+
+## 3. Achado real (rodada de 2026-07-17)
+
+```
+[OK] Crews sem classificação institucional
+[1 achado] Tasks Celery ausentes de autodiscover_tasks
+  - task_f_security_audit.py define uma task mas o módulo não está em autodiscover_tasks
+[OK] Ferramentas órfãs em app/crews/tools/
+[OK] Routers reais vs. CLAUDE.md
+[OK] Sincronia Brain × produto (Crews)
+```
+
+Único achado real: `task_f_security_audit` fora do autodiscover — já documentado como pendência conhecida (decisão de frequência/cadência, não de escopo; ver pendência #1 do relatório de Crews). Zero falso positivo depois de 2 rodadas de calibração do regex de sincronia com o Brain (`Descontinuada` é exceção válida — a Política de Depreciação exige nunca apagar a linha do inventário).
+
+## 4. Deploys e verificação
+
+| PR | Repo | Conteúdo | Verificação |
+|---|---|---|---|
+| [tribultz-brain#4](https://github.com/mickbap/tribultz-brain/pull/4) | Brain | Partes I, II, IV, V | `lint_brain.py` (0 erros) + `build_index.py` (106 docs sincronizados) — repo sem CI/deploy, merge direto |
+| [tribultz#470](https://github.com/mickbap/tribultz/pull/470) | Produto | Parte III (`architecture_audit.py`) | `ruff` limpo, `pyright` 0 erros, 682 testes (`pytest`, nenhum código de `app/` tocado) — [CI verde](https://github.com/mickbap/tribultz/actions/runs/29624159503) |
+
+Ambos merged em 2026-07-17 (mesma sessão da Ordem Técnica das Crews).
+
+## Pendências conhecidas — fora do escopo desta ordem, registradas
+
+1. **`task_f_security_audit` continua fora do `beat_schedule`/`autodiscover_tasks`** — mesma pendência já registrada no relatório de Crews; falta decisão de frequência antes de ativar.
+2. **Auditoria não integrada ao CI** — hoje roda manualmente (`cd backend && source .venv/bin/activate && python ../tools/architecture_audit.py`); integração futura, não bloqueada por nada técnico.
+3. **DoR v2 e template de ADR com campo "Natureza"** valem a partir de agora — ordens técnicas já em andamento antes de 2026-07-17 não são retroativamente exigidas a se conformar.

--- a/tools/architecture_audit.py
+++ b/tools/architecture_audit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Auditoria arquitetural automatizada — ADR-0013 / Ordem Técnica de
-institucionalização da governança (2026-07-18).
+institucionalização da governança (2026-07-18) + Ordem Técnica de Auditoria
+Contínua da Arquitetura (2026-07-18).
 
 Verifica, contra o estado real do repositório (não contra memória de quem
 audita):
@@ -12,16 +13,24 @@ audita):
     código — best-effort, pulado com aviso se ../tribultz-brain não existir
     (a ausência do Brain não bloqueia a auditoria)
 
+Cada achado carrega uma severidade (Crítico/Alto/Médio/Baixo) — a política
+que define essa classificação vive em
+knowledge/process/architecture-audit-policy.md no Brain; CATEGORY_SEVERITY
+abaixo é a aplicação dela em código. Hoje a auditoria roda em modo
+informativo no CI (não bloqueia merge nem quando encontra Crítico) — ver a
+seção "Integração ao CI" da política.
+
 Uso:
     cd backend && source .venv/bin/activate && python ../tools/architecture_audit.py
 
-Saída: relatório em texto no stdout. Exit code 0 se zero achados, 1 se houver
-qualquer achado (para uso futuro em CI — ver docstring do módulo, PARTE III
-da Ordem Técnica: a ausência de integração ao CI não bloqueia esta entrega).
+Saída: relatório em texto no stdout (mais anotações ::warning::/::error:: do
+GitHub Actions quando GITHUB_ACTIONS=true). Exit code 0 se zero achados, 1 se
+houver qualquer achado.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -30,6 +39,31 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND = REPO_ROOT / "backend"
 BRAIN_ROOT = REPO_ROOT.parent / "tribultz-brain"
+
+SEVERITY_CRITICO = "Crítico"
+SEVERITY_ALTO = "Alto"
+SEVERITY_MEDIO = "Médio"
+SEVERITY_BAIXO = "Baixo"
+
+# Fonte da política: knowledge/process/architecture-audit-policy.md (Brain).
+# Categoria sem entrada aqui cai em SEVERITY_MEDIO (default seguro em
+# check_severity — nem alarme demais, nem passa despercebido).
+CATEGORY_SEVERITY: dict[str, str] = {
+    "crew-sem-classificacao": SEVERITY_CRITICO,
+    "crew-fora-do-inventario-brain": SEVERITY_CRITICO,
+    "crew-documentada-inexistente": SEVERITY_CRITICO,
+    "router-documentado-inexistente": SEVERITY_CRITICO,
+    "task-nao-registrada": SEVERITY_ALTO,
+    "router-fora-da-doc": SEVERITY_ALTO,
+    "celery-autodiscover-nao-encontrado": SEVERITY_ALTO,
+    "claude-md-formato-inesperado": SEVERITY_ALTO,
+    "ferramenta-orfa": SEVERITY_MEDIO,
+    "brain-nao-encontrado": SEVERITY_BAIXO,
+}
+
+
+def severity_of(category: str) -> str:
+    return CATEGORY_SEVERITY.get(category, SEVERITY_MEDIO)
 
 
 @dataclass(frozen=True)
@@ -256,7 +290,15 @@ CHECKS = [
 ]
 
 
+def _emit_gha_annotation(finding: Finding) -> None:
+    level = "error" if severity_of(finding.category) == SEVERITY_CRITICO else "warning"
+    title = f"[{severity_of(finding.category)}] {finding.category}"
+    message = finding.message.replace("\n", " ").replace("::", ": ")
+    print(f"::{level} title={title}::{message}")
+
+
 def main() -> int:
+    in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
     all_findings: list[Finding] = []
     print("=" * 70)
     print("Auditoria Arquitetural — Tribultz (ADR-0013)")
@@ -268,12 +310,23 @@ def main() -> int:
         status = "OK" if not findings else f"{len(findings)} achado(s)"
         print(f"\n[{status}] {title}")
         for f in findings:
-            print(f"  - ({f.category}) {f.message}")
+            print(f"  - [{severity_of(f.category)}] ({f.category}) {f.message}")
+            if in_ci:
+                _emit_gha_annotation(f)
 
     print("\n" + "=" * 70)
     real_findings = [f for f in all_findings if f.category not in ("brain-nao-encontrado",)]
     if real_findings:
-        print(f"RESULTADO: {len(real_findings)} achado(s) que exigem atenção.")
+        by_severity: dict[str, int] = {}
+        for f in real_findings:
+            sev = severity_of(f.category)
+            by_severity[sev] = by_severity.get(sev, 0) + 1
+        breakdown = ", ".join(
+            f"{by_severity[s]} {s}"
+            for s in (SEVERITY_CRITICO, SEVERITY_ALTO, SEVERITY_MEDIO, SEVERITY_BAIXO)
+            if s in by_severity
+        )
+        print(f"RESULTADO: {len(real_findings)} achado(s) que exigem atenção ({breakdown}).")
         return 1
     print("RESULTADO: nenhum achado. Arquitetura consistente com o inventário.")
     return 0


### PR DESCRIPTION
## Summary
Ordem Técnica "Auditoria Contínua da Arquitetura" — lado produto, par de [tribultz-brain#5](https://github.com/mickbap/tribultz-brain/pull/5).

- `tools/architecture_audit.py`: severidade (Crítico/Alto/Médio/Baixo) por categoria de achado (`CATEGORY_SEVERITY`), aplicando a política registrada em `knowledge/process/architecture-audit-policy.md` no Brain. Anotações `::warning::`/`::error::` do GitHub Actions quando `GITHUB_ACTIONS=true`.
- `.github/workflows/ci.yml`: novo step "Architecture Audit (informativo)" no job `backend-gates`, após Pytest. `continue-on-error: true` — não bloqueia merge (bloqueio por achado Crítico fica para depois de um período de estabilização, decisão futura).
- `CLAUDE.md`: documenta severidade e execução no CI.
- `docs/sprints/`: dois relatórios para o time de produto — fechamento do ADR-0013 (Parte III, já mergeada em #470) e desta ordem.

Rodada atual: 1 achado (Alto) — `task_f_security_audit` fora do autodiscover, pendência já conhecida (documentada em relatórios anteriores).

## Test plan
- [x] `python ../tools/architecture_audit.py` (local e com `GITHUB_ACTIONS=true` simulado) — severidade e anotação corretas
- [x] `ruff check app/ tests/ ../tools/` — limpo
- [x] `npx pyright@1.1.386 tools/architecture_audit.py` — 0 erros
- [x] `pytest -q` — 682 passed
- [x] YAML do `ci.yml` validado (`yaml.safe_load`)