### PR TITLE
chore(deps): executa Categoria A + institucionaliza auditoria de dependências

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
       PYTHONUNBUFFERED: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Setup Python (pin)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12.6"
           cache: "pip"
@@ -68,17 +68,17 @@ jobs:
             backend/pyproject.toml
 
       - name: Setup Node (pin) # needed for pyright via npx
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: "22.12.0"
 
       - name: Install backend deps
         working-directory: backend
         run: |
-          python -m pip install --upgrade pip uv
+          python -m pip install --upgrade pip "uv==0.11.29"
           if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
           if [ -f pyproject.toml ]; then uv pip install --system -e ".[dev]" || uv pip install --system -e "."; fi
-          uv pip install --system "ruff==0.6.9" "pytest==8.3.3"
+          uv pip install --system "ruff==0.15.22" "pytest==8.3.3"
 
       - name: CrewAI import sanity
         working-directory: backend
@@ -131,8 +131,8 @@ jobs:
           S3_ACCESS_KEY: test_key
           S3_SECRET_KEY: test_secret
         run: |
-          npx --yes pyright@1.1.386 --version
-          npx --yes pyright@1.1.386
+          npx --yes pyright@1.1.411 --version
+          npx --yes pyright@1.1.411
 
       - name: DB migrate (alembic)
         working-directory: backend
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload QA report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: qa_gates_report
           path: reports/qa_gates_report.md
@@ -173,10 +173,10 @@ jobs:
       NEXT_PUBLIC_API_BASE_URL: "http://localhost:8000"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node (pin)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: "22.12.0"
           cache: "npm"

--- a/.github/workflows/classtrib-sync.yml
+++ b/.github/workflows/classtrib-sync.yml
@@ -22,9 +22,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -35,7 +35,7 @@ jobs:
         run: python backend/scripts/resync_classtrib.py
 
       - name: Abrir PR de revisão
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: classtrib-sync/auto
           title: "chore(data): atualização da tabela cClassTrib (SVRS)"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,218 @@
+name: Dependency Audit
+
+# Auditoria contínua de dependências — institucionalizada pela Ordem Técnica
+# "Execução da Categoria A e Institucionalização da Auditoria de Dependências"
+# (2026-07-18), complemento da Auditoria de Dependências manual de 2026-07-18
+# (docs/sprints/2026-07-18_atualizacao_continua_dependencias.md).
+#
+# Roda pip-audit (backend) + npm audit (frontend) toda semana; na primeira
+# segunda-feira do mês, roda também a comparação de versões instaladas vs.
+# estáveis disponíveis e o inventário de imagens Docker / GitHub Actions.
+# Produz sempre um relatório em artifact. Nunca abre Pull Request — quando
+# há vulnerabilidade Alta/Crítica sem nenhuma versão de correção publicada,
+# abre (ou comenta, se já existir) uma Issue.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # toda segunda-feira, 06:00 UTC — foco em CVEs
+    - cron: "0 6 1 * *"   # dia 1 de cada mês, 06:00 UTC — revisão completa
+  workflow_dispatch:
+    inputs:
+      full_review:
+        description: "Forçar revisão completa (versões + infraestrutura), não só CVEs"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: dependency-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Determinar modo (semanal=CVEs / mensal=revisão completa)
+        id: mode
+        run: |
+          if [ "${{ github.event.schedule }}" = "0 6 1 * *" ] || [ "${{ inputs.full_review }}" = "true" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Python (pin)
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12.6"
+
+      - name: Setup Node (pin)
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.12.0"
+
+      - name: Instalar dependências do backend + pip-audit
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip "uv==0.11.29"
+          uv pip install --system -r requirements.txt
+          uv pip install --system pip-audit
+
+      - name: pip-audit (backend)
+        working-directory: backend
+        run: |
+          pip-audit -r requirements.txt --format json > /tmp/pip-audit.json || true
+          pip-audit -r requirements.txt > /tmp/pip-audit.txt || true
+
+      - name: Instalar dependências do frontend
+        working-directory: frontend
+        run: npm ci
+
+      - name: npm audit (frontend)
+        working-directory: frontend
+        run: |
+          npm audit --json > /tmp/npm-audit.json || true
+          npm audit > /tmp/npm-audit.txt || true
+
+      - name: Comparação de versões — backend (revisão completa)
+        if: steps.mode.outputs.full == 'true'
+        working-directory: backend
+        run: |
+          python3 -m pip list --outdated --format json > /tmp/pip-outdated.json || echo "[]" > /tmp/pip-outdated.json
+          python3 - <<'PY'
+          import json
+          data = json.load(open("/tmp/pip-outdated.json"))
+          with open("/tmp/versions.md", "w") as f:
+              f.write("## Comparação de versões — Backend (pip)\n\n")
+              if not data:
+                  f.write("Nenhuma dependência instalada com atualização pendente.\n\n")
+              for d in data:
+                  f.write(f"- **{d['name']}**: {d['version']} → {d['latest_version']}\n")
+              f.write("\n")
+          PY
+
+      - name: Comparação de versões — frontend (revisão completa)
+        if: steps.mode.outputs.full == 'true'
+        working-directory: frontend
+        run: |
+          npm outdated --json > /tmp/npm-outdated.json 2>/dev/null || echo "{}" > /tmp/npm-outdated.json
+          python3 - <<'PY'
+          import json
+          try:
+              data = json.load(open("/tmp/npm-outdated.json"))
+          except json.JSONDecodeError:
+              data = {}
+          with open("/tmp/versions.md", "a") as f:
+              f.write("## Comparação de versões — Frontend (npm)\n\n")
+              if not data:
+                  f.write("Nenhuma dependência instalada com atualização pendente.\n\n")
+              for name, info in data.items():
+                  f.write(f"- **{name}**: {info.get('current')} → {info.get('latest')}\n")
+              f.write("\n")
+          PY
+
+      - name: Infraestrutura — imagens Docker e GitHub Actions (revisão completa)
+        if: steps.mode.outputs.full == 'true'
+        run: |
+          {
+            echo "## Infraestrutura"
+            echo ""
+            echo "### Imagens Docker em uso (infra/docker-compose.yml)"
+            grep -ohE 'image:.*' infra/docker-compose.yml | sed 's/^/- /'
+            echo ""
+            echo "### GitHub Actions em uso (.github/workflows/)"
+            grep -rohE 'uses: [A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[A-Za-z0-9._-]+' .github/workflows/*.yml | sed 's/^/- /' | sort -u
+            echo ""
+          } >> /tmp/versions.md
+
+      - name: Montar relatório
+        run: |
+          {
+            echo "# Relatório de Auditoria de Dependências — $(date -u +%Y-%m-%d)"
+            echo ""
+            echo "Modo: $( [ '${{ steps.mode.outputs.full }}' = 'true' ] && echo 'Revisão completa (mensal)' || echo 'Segurança (semanal)' )"
+            echo ""
+            echo "## Backend — pip-audit"
+            echo '```'
+            cat /tmp/pip-audit.txt
+            echo '```'
+            echo ""
+            echo "## Frontend — npm audit"
+            echo '```'
+            cat /tmp/npm-audit.txt
+            echo '```'
+            if [ -f /tmp/versions.md ]; then
+              echo ""
+              cat /tmp/versions.md
+            fi
+          } > /tmp/dependency-audit-report.md
+          cat /tmp/dependency-audit-report.md
+
+      - name: Upload relatório
+        uses: actions/upload-artifact@v7
+        with:
+          name: dependency-audit-report
+          path: /tmp/dependency-audit-report.md
+          retention-days: 90
+
+      - name: Verificar vulnerabilidade Alta/Crítica sem correção publicada
+        id: unfixed
+        run: |
+          python3 - <<'PY'
+          import json
+
+          lines = []
+
+          try:
+              pip_data = json.load(open("/tmp/pip-audit.json"))
+          except Exception:
+              pip_data = {"dependencies": []}
+          for dep in pip_data.get("dependencies", []):
+              for v in dep.get("vulns", []):
+                  if not v.get("fix_versions"):
+                      ids = ", ".join(v.get("aliases") or [v["id"]])
+                      lines.append(f"- **{dep['name']} {dep['version']}** (pip-audit): {ids} — nenhuma versão de correção publicada")
+
+          try:
+              npm_data = json.load(open("/tmp/npm-audit.json"))
+          except Exception:
+              npm_data = {"vulnerabilities": {}}
+          for name, v in (npm_data.get("vulnerabilities") or {}).items():
+              severity = v.get("severity")
+              if severity in ("high", "critical") and v.get("fixAvailable") is False:
+                  lines.append(f"- **{name}** (npm, {severity}): sem fix disponível em nenhuma versão")
+
+          with open("/tmp/unfixed.md", "w") as f:
+              f.write("\n".join(lines))
+
+          print(f"count={len(lines)}")
+          PY
+          {
+            echo "count<<EOF_UNFIXED"
+            python3 -c "print(len(open('/tmp/unfixed.md').read().splitlines()))"
+            echo "EOF_UNFIXED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Abrir/atualizar Issue (vulnerabilidade sem correção conhecida)
+        if: steps.unfixed.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            cat /tmp/unfixed.md
+            echo ""
+            echo "Relatório completo (pip-audit + npm audit) no artifact \`dependency-audit-report\` deste run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > /tmp/issue-body.md
+          TITLE="Auditoria de Dependências: vulnerabilidade sem correção conhecida"
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file /tmp/issue-body.md
+          else
+            gh issue create --title "$TITLE" --label "security" --body-file /tmp/issue-body.md
+          fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout (para referência do commit)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Resolver flags do deploy.sh
         id: flags

--- a/.github/workflows/publish-news.yml
+++ b/.github/workflows/publish-news.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           # 0 = histórico completo. Necessário para workflow_dispatch poder
           # re-publicar entradas a partir de SHAs antigos (caso contrário
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/soro-blog-sync.yml
+++ b/.github/workflows/soro-blog-sync.yml
@@ -20,9 +20,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -37,7 +37,7 @@ jobs:
         run: npx tsx scripts/soro-sync.ts
 
       - name: Abrir PR de revisão
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: soro-sync/auto
           title: "chore(blog): novos artigos do Soro para revisão"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Motor determinístico que verifica notas fiscais contra regras CBS/IBS e gera ev
 | Frontend | Next.js 16, React 19, TypeScript 5, Tailwind CSS 3, tsx --test |
 | Backend | FastAPI, SQLAlchemy, Alembic, Python 3.12 |
 | AI/Agents | CrewAI 1.10 (CRM Engagement em produção; Security Crew interna; NFe Validation dormante — ver `knowledge/engineering/crews.md` no Brain), LiteLLM |
-| Workers | Celery 5.4 + Redis 7 (task queue / beat scheduler) |
+| Workers | Celery 5.6 + Redis 7 (task queue / beat scheduler) |
 | Database | PostgreSQL 16 (multi-tenant, UUID PKs, tenant_id FK em todas as tabelas) |
 | Storage | MinIO (S3-compatible) |
 | Infra | Docker Compose (db, redis, minio, api, worker, beat) |
@@ -66,7 +66,7 @@ docs/infra/operations_runbook.md   Arquitetura, fluxo de deploy/rollback, recupe
 - **Testes backend**: `cd backend && source .venv/bin/activate && python -m pytest tests/ -q`
 - **Lint backend**: `ruff check app/ tests/`
 - **Build frontend**: `cd frontend && npm run build`
-- **Type check backend**: `npx pyright@1.1.386`
+- **Type check backend**: `npx pyright@1.1.411`
 
 ## Gates (obrigatório antes de PR)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.139.2
-uvicorn[standard]==0.34.0
+uvicorn[standard]==0.51.0
 pydantic[email]==2.11.10
 pydantic-settings==2.10.1
 sqlalchemy==2.0.51
@@ -12,7 +12,7 @@ python-multipart==0.0.32
 boto3==1.43.50
 redis==5.2.1
 httpx==0.28.1
-celery==5.4.0
+celery==5.6.3
 gunicorn==23.0.0
 sentry-sdk[fastapi]==2.66.0
 weasyprint==63.1

--- a/docs/sprints/2026-07-18_execucao_categoria_a_dependencias.md
+++ b/docs/sprints/2026-07-18_execucao_categoria_a_dependencias.md
@@ -1,0 +1,67 @@
+# Execução da Categoria A e Institucionalização da Auditoria de Dependências
+
+Data: 2026-07-18
+Contexto: Ordem Técnica de execução direta, sequência da [Auditoria de Dependências](2026-07-18_atualizacao_continua_dependencias.md) de mais cedo hoje. Executa **só** os itens classificados como Categoria A naquele relatório, audita o pipeline de PDF, e institucionaliza o monitoramento contínuo (workflow automatizado + política no Brain). Categoria B e C permanecem congeladas, como a ordem exigiu.
+
+Execução feita **diretamente por mim, sem subagentes em background** — lição do incidente da sessão anterior, em que um agente sem isolamento executou mudanças não autorizadas. Cada item abaixo foi aplicado e validado individualmente antes do próximo.
+
+## 1. Categoria A — aplicada e validada item por item
+
+| Item | De → Para | Validação |
+|---|---|---|
+| `uv` (CI) | 0.9.30 → 0.11.29 | ruff + pyright + pytest (682) + auditoria arquitetural |
+| `ruff` (pin no CI) | 0.6.9 → 0.15.22 | idem — `ruff check` limpo com a versão nova |
+| `pyright` (CI + `CLAUDE.md`) | 1.1.386 → 1.1.411 | idem — 0 erros com a versão nova |
+| `celery` | 5.4.0 → 5.6.3 | ruff/pyright/pytest + **smoke test real**: rebuild do container `worker`, conectou no Redis real, registrou as 14 tasks, `beat` iniciou o scheduler normalmente |
+| `uvicorn` | 0.34.0 → 0.51.0 | ruff/pyright/pytest + **smoke test real**: API subiu no Docker, `/health` respondeu `{"status":"ok"}` |
+| GitHub Actions (5 workflows) | `checkout` v4/v5→v7, `setup-python` v5→v6, `setup-node` v4/v5→v7, `upload-artifact` v5→v7, `peter-evans/create-pull-request` v6→v8 | Versões confirmadas via API do GitHub (`gh api repos/.../releases/latest`) antes de aplicar; YAML validado nos 5 arquivos |
+| MinIO (tag) | `:latest` → `RELEASE.2025-09-07T16-13-09Z` | Confirmado via Docker Hub que essa É a imagem que `:latest` resolve hoje (MinIO não publica imagem nova desde set/2025, apesar de ter GitHub Releases mais recentes sem imagem Docker correspondente). Container recriado, `healthy`, `/minio/health/live` → 200 |
+| Frontend (build final) | — | `npm run build` limpo + 156 testes passando (nenhuma dependência de frontend mudou nesta ordem — só a versão das Actions que rodam o job) |
+
+**Correção ao relatório anterior**: `pydantic`/`pydantic-settings` **não foram atualizados**. O relatório de auditoria os classificou como "Atualização recomendada" (2.11.10→2.13.4 / 2.10.1→2.14.2) comparando só números de versão. Inspecionando o `METADATA` real do wheel do CrewAI 1.10.1, ele trava `pydantic~=2.11.9` e `pydantic-settings~=2.10.1` — as versões já instaladas **já são o teto máximo** dentro dessa trava (confirmado via `pip index versions`: 2.11.10 é o último patch da série 2.11.x, 2.10.1 é o último da série 2.10.x). Atualizar quebraria o pin institucional do CrewAI, que é Categoria B nesta ordem — fora de escopo. Não há ação possível aqui sem primeiro decidir sobre o CrewAI. Isso virou lição registrada na política do Brain (ver §4).
+
+## 2. Auditoria funcional do pipeline de PDF (WeasyPrint)
+
+Únicos dois pontos de chamada no código: `backend/app/services/pdf_service.py` (`generate_validation_report_pdf` e `generate_batch_report_pdf`). Inspecionado linha a linha:
+
+- `HTML(string=html).write_pdf()` — **sem** `url_fetcher` customizado, **sem** `presentational_hints=True` (usa o default `False` da lib).
+- Os dois templates (`report_validation.html`, `report_batch.html`) são **100% CSS inline** — nenhuma referência a `<img>`, `<link>`, `@import` ou `url()` externo em nenhum dos dois.
+- Todo dado dinâmico é interpolado via Jinja2 com `Environment(autoescape=True)`, **sem nenhum `|safe`/`Markup()`** em lugar nenhum — nem no serviço, nem nos templates.
+
+**Parecer técnico:**
+
+| CVE | Classificação | Justificativa |
+|---|---|---|
+| CVE-2025-68616 (SSRF via redirect no `default_url_fetcher`) | **Mitigado pela ausência de superfície** | O código vulnerável existe na lib instalada, mas nunca é exercido: não há nenhuma URL externa nos templates para o fetcher buscar, e nenhum dado dinâmico vira URL fetchável (tudo é texto autoescapado). Ainda assim, recomenda-se o bump de versão (Categoria B) como defesa em profundidade — um template futuro poderia introduzir uma referência externa sem que quem escrever lembre desta análise. |
+| CVE-2026-49452 (CSS injection via `presentational_hints=True`) | **Não aplicável** | O parâmetro nunca é passado como `True` em nenhum dos dois call sites — o vetor exige exatamente essa configuração, que o código não usa. |
+
+## 3. Automação — `.github/workflows/dependency-audit.yml`
+
+Workflow novo, testado localmente (YAML validado, todo bloco bash com `bash -n`, scripts Python testados contra `pip-audit`/`npm audit` reais do repo):
+
+- **Semanal** (segunda-feira): `pip-audit` + `npm audit`.
+- **Mensal** (dia 1): a mesma varredura **mais** comparação de versões (`pip list --outdated`, `npm outdated`) e inventário de imagens Docker + GitHub Actions em uso.
+- Relatório sempre sobe como artifact (`dependency-audit-report`, retenção 90 dias).
+- **Nunca abre PR.** Abre (ou comenta, se já existir) uma Issue com label `security` só quando há vulnerabilidade **Alta/Crítica sem nenhuma versão de correção publicada** — testado contra os dados reais de hoje: dispararia para `weasyprint` (CVE-2026-49452, sem fix), `chromadb` (CVE-2026-45829, sem fix) e `ecdsa` (CVE-2024-23342, sem fix por decisão do mantenedor). As 2 vulnerabilidades moderadas do `next`/`postcss` corretamente **não** disparam (severidade abaixo do limiar).
+- `workflow_dispatch` com input `full_review` para rodar a revisão completa sob demanda.
+
+## 4. Política permanente (Brain)
+
+[`knowledge/process/dependency-audit-policy.md`](https://github.com/mickbap/tribultz-brain/pull/6) — classificação A/B/C com critério verificável, a armadilha pydantic×crewai documentada como lição permanente, e a cadência de revisão manual (mensal/trimestral/semestral) espelhando a Auditoria Arquitetural.
+
+## 5. Verificação final
+
+- `ruff check app/ tests/ ../tools/` — limpo (versão 0.15.22)
+- `npx pyright@1.1.411` — 0 erros
+- `pytest -q` — 682 passed
+- `python ../tools/architecture_audit.py` — mesmo achado conhecido (`task_f_security_audit`), nenhuma regressão
+- Docker Compose: `api`, `worker`, `beat`, `minio` recriados e saudáveis; `/health` (API) e `/minio/health/live` (MinIO) respondendo
+- Frontend: `npm run build` limpo, `npm test --silent` — 156 passed
+- YAML dos 6 workflows (5 alterados + 1 novo) validado com `yaml.safe_load`
+
+## Pendências conhecidas — fora do escopo desta ordem, registradas
+
+1. **Categoria B congelada** (CrewAI, LiteLLM, WeasyPrint, bcrypt, gunicorn, alinhamento pytest) — aguarda branch própria + validação funcional dedicada por item, conforme a própria ordem exige.
+2. **Categoria C congelada** (redis-py 8, TypeScript 7, Tailwind 4, ESLint 10) — aguarda RFC própria por item.
+3. **`task_f_security_audit` continua fora do autodiscover** — mesma pendência registrada nos três relatórios anteriores desta sequência.
+4. **Abertura automática de Issue** só será validada de verdade na primeira execução real do workflow em produção (semanal/mensal ou `workflow_dispatch` manual) — a lógica foi testada contra dados reais localmente, mas a chamada à API de Issues do GitHub em si não pôde ser exercida fora do runner.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -50,8 +50,13 @@ services:
       retries: 5
 
   # ── MinIO (S3-compatible storage) ─────────────────────────
+  # Tag fixada (era :latest — build não-reprodutível, achado da auditoria de
+  # dependências 2026-07-18). RELEASE.2025-09-07T16-13-09Z é a mesma imagem
+  # que :latest resolve hoje (confirmado via Docker Hub — MinIO não publica
+  # imagem nova desde então). Atualizar deliberadamente via PR quando uma
+  # release nova for avaliada, não por pull automático.
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     networks: [tribultz]
     env_file:


### PR DESCRIPTION
## Summary
Ordem Técnica "Execução da Categoria A e Institucionalização da Auditoria de Dependências" — par de [tribultz-brain#6](https://github.com/mickbap/tribultz-brain/pull/6).

Executa **exclusivamente** os itens Categoria A do [relatório de auditoria de dependências](docs/sprints/2026-07-18_atualizacao_continua_dependencias.md) — Categoria B (CrewAI, LiteLLM, WeasyPrint, bcrypt, gunicorn) e C (redis-py 8, TypeScript 7, Tailwind 4, ESLint 10) permanecem **congeladas**, como a ordem exige.

- `uv` 0.9.30→0.11.29, `ruff` (CI) 0.6.9→0.15.22, `pyright` 1.1.386→1.1.411
- `celery` 5.4.0→5.6.3, `uvicorn` 0.34.0→0.51.0
- GitHub Actions padronizadas nos 5 workflows
- MinIO: tag `:latest` → `RELEASE.2025-09-07T16-13-09Z` (mesma imagem que `:latest` já resolve hoje)
- Novo `.github/workflows/dependency-audit.yml`: `pip-audit`+`npm audit` semanal, revisão completa mensal, nunca abre PR, abre Issue só quando há vuln Alta/Crítica sem fix publicado
- Auditoria funcional do pipeline de PDF (WeasyPrint) — parecer técnico no relatório anexo

**Correção importante**: `pydantic`/`pydantic-settings` **não foram tocados** — o `METADATA` real do wheel do CrewAI 1.10.1 trava `pydantic~=2.11.9`/`pydantic-settings~=2.10.1`, e as versões instaladas já são o teto dessa trava. O relatório de auditoria original os classificou como seguros comparando só números de versão via PyPI, sem checar essa constraint transitiva. Registrado como lição permanente na política do Brain.

Execução feita diretamente por mim, sem subagentes em background, cada item validado individualmente antes do próximo — ver relatório completo em `docs/sprints/2026-07-18_execucao_categoria_a_dependencias.md`.

## Test plan
- [x] `ruff check app/ tests/ ../tools/` — limpo
- [x] `npx pyright@1.1.411` — 0 erros
- [x] `pytest -q` — 682 passed
- [x] `python ../tools/architecture_audit.py` — sem regressão
- [x] Docker Compose real: `api` (`/health` → ok), `worker` (conecta Redis, registra 14 tasks), `beat`, `minio` (`/minio/health/live` → 200) — todos healthy após rebuild
- [x] Frontend: `npm run build` limpo, `npm test --silent` — 156 passed
- [x] YAML dos 6 workflows validado (`yaml.safe_load` + `bash -n` em cada bloco `run:`)
- [x] Scripts do `dependency-audit.yml` testados contra `pip-audit`/`npm audit` reais do repo