### PR TITLE
fix(audit): apresentar timestamps em America/Sao_Paulo (laudo PDF + frontend)

### DIFF
--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -5,12 +5,28 @@ from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from jinja2 import Environment, FileSystemLoader
 
 logger = logging.getLogger(__name__)
 
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+# Armazenamento permanece UTC (datetime.now(timezone.utc)) — conversão para
+# America/Sao_Paulo acontece só na borda de apresentação do laudo, nunca no
+# storage. Ver knowledge/engineering/tempo-e-auditoria.md no Brain.
+BRASILIA_TZ = ZoneInfo("America/Sao_Paulo")
+
+
+def _format_brasilia(instant_utc: datetime) -> str:
+    """Converte um instante UTC aware para string de exibição em America/Sao_Paulo."""
+    return instant_utc.astimezone(BRASILIA_TZ).strftime("%d/%m/%Y %H:%M horário de Brasília")
+
+
+def _generated_at_brasilia() -> str:
+    return _format_brasilia(datetime.now(timezone.utc))
+
 
 _jinja_env = Environment(
     loader=FileSystemLoader(str(TEMPLATES_DIR)),
@@ -64,7 +80,7 @@ def generate_validation_report_pdf(
     Falls back to HTML-only if WeasyPrint is not installed.
     """
     template = _jinja_env.get_template("report_validation.html")
-    now = datetime.now(timezone.utc).strftime("%d/%m/%Y %H:%M UTC")
+    now = _generated_at_brasilia()
 
     # Categorize findings by severity
     errors = [f for f in findings if f.get("severity") == "ERROR"]
@@ -128,7 +144,7 @@ def generate_batch_report_pdf(
     Returns a dict with keys: bytes, storage_key, file_size.
     """
     template = _jinja_env.get_template("report_batch.html")
-    now = datetime.now(timezone.utc).strftime("%d/%m/%Y %H:%M UTC")
+    now = _generated_at_brasilia()
 
     # Summary stats
     total = len(invoices)

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -7,7 +7,13 @@ import uuid
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.services.pdf_service import generate_validation_report_pdf, generate_batch_report_pdf
+from datetime import datetime, timezone
+
+from app.services.pdf_service import (
+    generate_validation_report_pdf,
+    generate_batch_report_pdf,
+    _format_brasilia,
+)
 
 
 client = TestClient(app)
@@ -93,6 +99,48 @@ class TestPdfServiceValidation:
         h2 = hashlib.sha256(canonical.encode()).hexdigest()
         assert h1 == h2
         assert len(h1) == 64  # SHA-256 hex length
+
+
+class TestPdfServiceTimezone:
+    """#419 — laudo PDF apresenta horário de Brasília, não UTC.
+
+    Storage continua UTC aware (datetime.now(timezone.utc)) — só a borda de
+    apresentação converte, conforme knowledge/engineering/tempo-e-auditoria.md.
+    """
+
+    def test_utc_instant_converts_to_sao_paulo_deterministically(self):
+        # 2026-06-15 12:00 UTC -> horário de verão não se aplica no Brasil
+        # desde 2019; America/Sao_Paulo é UTC-3 o ano inteiro -> 09:00.
+        instant = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+        assert _format_brasilia(instant) == "15/06/2026 09:00 horário de Brasília"
+
+    def test_label_says_brasilia_not_utc(self):
+        instant = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        result = _format_brasilia(instant)
+        assert "horário de Brasília" in result
+        assert "UTC" not in result
+
+    def test_date_rolls_back_across_midnight_boundary(self):
+        # 2026-03-01 02:00 UTC -> 2026-02-28 23:00 em São Paulo (UTC-3):
+        # o dia muda, não só a hora — é exatamente o bug que o laudo tinha.
+        instant = datetime(2026, 3, 1, 2, 0, tzinfo=timezone.utc)
+        assert _format_brasilia(instant) == "28/02/2026 23:00 horário de Brasília"
+
+    def test_validation_pdf_report_shows_brasilia_label(self):
+        result = generate_validation_report_pdf(
+            company_name="Empresa Teste LTDA",
+            cnpj=CNPJ,
+            reference_period="2026-03",
+            job_id=JOB_ID,
+            findings=[],
+            overall_status="CONFORME",
+        )
+        # HTML fallback (sem WeasyPrint) ou PDF real — ambos carregam o texto
+        # gerado pelo template; se for HTML puro dá pra inspecionar direto.
+        data = result["bytes"]
+        if data.startswith(b"<!DOCTYPE"):
+            assert "horário de Brasília".encode("utf-8") in data
+            assert b"UTC" not in data
 
 
 class TestPdfServiceBatch:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/blogFiscalLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts src/lib/deadlineCountdown.test.ts",
+    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/blogFiscalLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts src/lib/deadlineCountdown.test.ts src/lib/formatDateTimeBR.test.ts",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "content:lint": "tsx scripts/content-lint.ts",
     "content:lint:fix": "tsx scripts/content-lint.ts --fix",

--- a/frontend/src/app/admin/audit/page.tsx
+++ b/frontend/src/app/admin/audit/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { useAdminData } from "@/lib/useAdminData";
 
 type AuditEntry = {
@@ -48,7 +49,7 @@ export default function AdminAuditPage() {
             <tbody className="divide-y divide-slate-100">
               {data.items.map((e) => (
                 <tr key={e.id} className="hover:bg-slate-50">
-                  <td className="whitespace-nowrap px-4 py-3 text-slate-500">{new Date(e.created_at).toLocaleString("pt-BR")}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-slate-500">{formatDateTimeBR(e.created_at)}</td>
                   <td className="px-4 py-3 text-slate-700">{e.actor_email}</td>
                   <td className="px-4 py-3 font-medium text-slate-900">{ACTION_LABEL[e.action] ?? e.action}</td>
                   <td className="px-4 py-3 text-slate-600">

--- a/frontend/src/app/audit/page.tsx
+++ b/frontend/src/app/audit/page.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
 import { getAudits } from "@/lib/api";
 import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { AuditLog } from "@/lib/types";
 
 function AuditContent() {
@@ -110,7 +111,7 @@ function AuditContent() {
               <tbody>
                 {filtered.map((item) => (
                   <tr key={item.id} className="border-b border-slate-100">
-                    <td className="px-2 py-2 text-slate-600">{new Date(item.createdAt).toLocaleString()}</td>
+                    <td className="px-2 py-2 text-slate-600">{formatDateTimeBR(item.createdAt)}</td>
                     <td className="px-2 py-2 font-medium text-slate-800">{item.action}</td>
                     <td className="px-2 py-2 text-slate-600">{item.jobId ?? "-"}</td>
                     <td className="px-2 py-2">

--- a/frontend/src/app/closing/page.tsx
+++ b/frontend/src/app/closing/page.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
 import { getAudits, getJobs, listExceptionRequests } from "@/lib/api";
 import { createClosingSnapshot } from "@/lib/closing/aggregate";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { AuditLog, ExceptionRequest, Job } from "@/lib/types";
 
 export default function ClosingPage() {
@@ -35,7 +36,7 @@ export default function ClosingPage() {
         <h1 className="text-2xl font-bold text-slate-900">Painel de Fechamento</h1>
         <p className="text-sm text-slate-500">Janela de 7 dias com consolidação de jobs, auditoria e exceções.</p>
         <p className="text-xs text-slate-400">
-          Janela ativa: {new Date(snapshot.since).toLocaleString()} até {new Date(snapshot.until).toLocaleString()}
+          Janela ativa: {formatDateTimeBR(snapshot.since)} até {formatDateTimeBR(snapshot.until)}
         </p>
       </header>
 
@@ -88,7 +89,7 @@ export default function ClosingPage() {
                     </Link>
                     <span className="text-xs text-slate-500">{row.status}</span>
                   </div>
-                  <p className="text-xs text-slate-500">{new Date(row.createdAt).toLocaleString()}</p>
+                  <p className="text-xs text-slate-500">{formatDateTimeBR(row.createdAt)}</p>
                 </li>
               ))}
             </ul>
@@ -110,7 +111,7 @@ export default function ClosingPage() {
               {snapshot.recentAuditRows.map((row) => (
                 <li key={row.id} className="rounded border border-slate-100 p-2">
                   <p className="text-sm font-medium text-slate-800">{row.action}</p>
-                  <p className="text-xs text-slate-500">{new Date(row.createdAt).toLocaleString()}</p>
+                  <p className="text-xs text-slate-500">{formatDateTimeBR(row.createdAt)}</p>
                   <div className="mt-1 flex flex-wrap gap-3">
                     <Link href={`/audit?audit_id=${encodeURIComponent(row.id)}`} className="text-xs text-tribultz-700 hover:underline">
                       Ver audit

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
 import { ComplianceScore, getAudits, getComplianceScore, getJobs, getSplitPaymentSummary, listExceptionRequests } from "@/lib/api";
 import type { SplitPaymentSummary } from "@/lib/api";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { AuditLog, ExceptionRequest, Finding, Job } from "@/lib/types";
 import { getAccountType, getTenantId, getTenants, type StoredTenant } from "@/lib/storage";
 
@@ -359,7 +360,7 @@ export default function DashboardPage() {
                     <Link href={`/jobs/${job.id}`} className="text-sm font-medium text-tribultz-700 hover:underline">
                       {job.id}
                     </Link>
-                    <p className="text-xs text-slate-500">{new Date(job.createdAt).toLocaleString()}</p>
+                    <p className="text-xs text-slate-500">{formatDateTimeBR(job.createdAt)}</p>
                   </div>
                   <StatusBadge status={job.status} />
                 </li>
@@ -388,7 +389,7 @@ export default function DashboardPage() {
                       Ver na auditoria
                     </Link>
                   </div>
-                  <p className="text-xs text-slate-500">{new Date(audit.createdAt).toLocaleString()}</p>
+                  <p className="text-xs text-slate-500">{formatDateTimeBR(audit.createdAt)}</p>
                 </li>
               ))}
             </ul>

--- a/frontend/src/app/documents/page.tsx
+++ b/frontend/src/app/documents/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { listDocuments, getDocumentDownloadUrl, type DocumentResponse } from "@/lib/api";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 
 export default function DocumentsPage() {
   const [docs, setDocs] = useState<DocumentResponse[]>([]);
@@ -62,7 +63,7 @@ export default function DocumentsPage() {
                     {doc.original_filename ?? doc.storage_key.split("/").pop()}
                   </p>
                   <p className="text-xs text-slate-500">
-                    {doc.doc_type} • {doc.content_type ?? ""} • {new Date(doc.created_at).toLocaleString()}
+                    {doc.doc_type} • {doc.content_type ?? ""} • {formatDateTimeBR(doc.created_at)}
                   </p>
                 </div>
                 <button

--- a/frontend/src/app/exceptions/page.tsx
+++ b/frontend/src/app/exceptions/page.tsx
@@ -5,6 +5,7 @@ import { JsonViewer } from "@/components/common/JsonViewer";
 import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
 import { decideExceptionRequest, listExceptionRequests } from "@/lib/api";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { ExceptionRequest } from "@/lib/types";
 
 export default function ExceptionsPage() {
@@ -102,7 +103,7 @@ export default function ExceptionsPage() {
                     <td className="px-2 py-2 font-mono text-xs">{item.job_id}</td>
                     <td className="px-2 py-2 font-mono text-xs">{item.finding_id}</td>
                     <td className="px-2 py-2">{item.status}</td>
-                    <td className="px-2 py-2 text-slate-600">{new Date(item.created_at).toLocaleString()}</td>
+                    <td className="px-2 py-2 text-slate-600">{formatDateTimeBR(item.created_at)}</td>
                     <td className="px-2 py-2">
                       <button
                         type="button"

--- a/frontend/src/app/jobs/[id]/page.tsx
+++ b/frontend/src/app/jobs/[id]/page.tsx
@@ -13,6 +13,7 @@ import { RegimeComparison } from "@/components/jobs/RegimeComparison";
 import { getDocumentDownloadUrl, getJob, listDocuments } from "@/lib/api";
 import type { DocumentResponse } from "@/lib/api";
 import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { Job, Finding } from "@/lib/types";
 
 /**
@@ -163,11 +164,11 @@ export default function JobDetailPage() {
             </div>
             <div>
               <p className="text-xs uppercase text-slate-500">Criado em</p>
-              <p className="mt-1 text-slate-700">{new Date(job.createdAt).toLocaleString()}</p>
+              <p className="mt-1 text-slate-700">{formatDateTimeBR(job.createdAt)}</p>
             </div>
             <div>
               <p className="text-xs uppercase text-slate-500">Atualizado em</p>
-              <p className="mt-1 text-slate-700">{new Date(job.updatedAt).toLocaleString()}</p>
+              <p className="mt-1 text-slate-700">{formatDateTimeBR(job.updatedAt)}</p>
             </div>
           </section>
 
@@ -242,7 +243,7 @@ export default function JobDetailPage() {
                       <p className="truncate font-medium text-slate-800">
                         XML corrigido — {doc.original_filename ?? doc.storage_key.split("/").pop()}
                       </p>
-                      <p className="text-xs text-slate-500">Criado em: {new Date(doc.created_at).toLocaleString()}</p>
+                      <p className="text-xs text-slate-500">Criado em: {formatDateTimeBR(doc.created_at)}</p>
                     </div>
                     <button
                       type="button"

--- a/frontend/src/app/jobs/page.tsx
+++ b/frontend/src/app/jobs/page.tsx
@@ -7,6 +7,7 @@ import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
 import { getJobs } from "@/lib/api";
 import { exportEvidenceZipAndDownload } from "@/lib/export/evidenceExportUi";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { Job, JobStatus } from "@/lib/types";
 
 type PeriodFilter = "24h" | "7d" | "30d" | "all";
@@ -159,7 +160,7 @@ export default function JobsPage() {
                     <td className="px-2 py-2">
                       <StatusBadge status={job.status} />
                     </td>
-                    <td className="px-2 py-2 text-slate-500">{new Date(job.createdAt).toLocaleString()}</td>
+                    <td className="px-2 py-2 text-slate-500">{formatDateTimeBR(job.createdAt)}</td>
                     <td className="px-2 py-2">
                       <div className="flex flex-wrap items-center gap-3">
                         <Link href={`/jobs/${job.id}`} className="text-tribultz-700 hover:underline">

--- a/frontend/src/app/report/page.tsx
+++ b/frontend/src/app/report/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { listReports, getReportDownloadUrl, ReportListItem } from "@/lib/api";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 
 export default function ReportPage() {
   const [reports, setReports] = useState<ReportListItem[]>([]);
@@ -114,7 +115,7 @@ export default function ReportPage() {
                     {r.job_id ? r.job_id.slice(0, 8) + "…" : "—"}
                   </td>
                   <td className="px-4 py-3 text-slate-600">
-                    {new Date(r.created_at).toLocaleString("pt-BR")}
+                    {formatDateTimeBR(r.created_at)}
                   </td>
                   <td className="px-4 py-3 text-slate-600">
                     {r.file_size != null ? (r.file_size / 1024).toFixed(1) + " KB" : "—"}

--- a/frontend/src/app/settings/api/page.tsx
+++ b/frontend/src/app/settings/api/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Toast } from "@/components/common/Toast";
 import { API_BASE } from "@/lib/api";
+import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { getToken, getTenantId } from "@/lib/storage";
 
 interface ApiKey {
@@ -187,7 +188,7 @@ export default function ApiSettingsPage() {
                   </td>
                   <td className="px-5 py-3 text-xs text-slate-400">
                     {k.last_used_at
-                      ? new Date(k.last_used_at).toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" })
+                      ? formatDateTimeBR(k.last_used_at)
                       : "Nunca usado"}
                   </td>
                   <td className="px-5 py-3">

--- a/frontend/src/lib/formatDateTimeBR.test.ts
+++ b/frontend/src/lib/formatDateTimeBR.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatDateTimeBR } from "./formatDateTimeBR";
+
+test("#419 formatDateTimeBR: instante UTC vira horário de Brasília (UTC-3, sem DST)", () => {
+  assert.equal(formatDateTimeBR("2026-06-15T12:00:00.000Z"), "15/06/2026, 09:00");
+});
+
+test("#419 formatDateTimeBR: aceita Date além de string ISO", () => {
+  assert.equal(
+    formatDateTimeBR(new Date("2026-06-15T12:00:00.000Z")),
+    "15/06/2026, 09:00",
+  );
+});
+
+test("#419 formatDateTimeBR: dia muda na conversão (não só a hora) — o bug original", () => {
+  assert.equal(formatDateTimeBR("2026-03-01T02:00:00.000Z"), "28/02/2026, 23:00");
+});
+
+test("#419 formatDateTimeBR: determinístico independente do TZ do processo", () => {
+  const original = process.env.TZ;
+  try {
+    process.env.TZ = "America/Los_Angeles";
+    assert.equal(formatDateTimeBR("2026-06-15T12:00:00.000Z"), "15/06/2026, 09:00");
+  } finally {
+    process.env.TZ = original;
+  }
+});

--- a/frontend/src/lib/formatDateTimeBR.ts
+++ b/frontend/src/lib/formatDateTimeBR.ts
@@ -1,0 +1,20 @@
+/**
+ * Formata data/hora sempre em America/Sao_Paulo ("horário de Brasília"),
+ * independente do fuso do navegador ou do runner de testes — #419.
+ * Storage (API) permanece UTC; esta função só converte na borda de
+ * apresentação (ver knowledge/engineering/tempo-e-auditoria.md no Brain).
+ */
+const formatter = new Intl.DateTimeFormat("pt-BR", {
+  timeZone: "America/Sao_Paulo",
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+export function formatDateTimeBR(input: string | number | Date): string {
+  const date = input instanceof Date ? input : new Date(input);
+  return formatter.format(date);
+}


### PR DESCRIPTION
## Summary
Closes #419. Primeira execução sob o regime Product-First (ADR-0014/0015) — Issue P0 escolhida pela matriz de priorização como quick win inicial.

Storage permanece 100% UTC-aware (52× `datetime.now(timezone.utc)`, 0 naive, 0 `utcnow()` — sem regressão). O gap era só na apresentação, conforme `knowledge/engineering/tempo-e-auditoria.md` no Brain.

- **Backend**: `pdf_service.py` carimbava "UTC" no laudo — o pior lugar pro erro estar (evidência auditável). Agora converte para `America/Sao_Paulo` (`zoneinfo`) e rotula "horário de Brasília". Função pura `_format_brasilia(instant_utc)` extraída para ser testável sem depender do relógio do sistema.
- **Frontend**: 15 ocorrências de `new Date(...).toLocaleString()` sem `timeZone` (renderizava no fuso do navegador) em 10 telas de auditoria/laudo/admin, migradas para um util único `formatDateTimeBR()` (`Intl.DateTimeFormat` com `timeZone: "America/Sao_Paulo"` fixo).

## Test plan
- [x] 4 testes novos no backend — instante UTC fixo → string SP determinística, incluindo o caso de a **data** mudar na conversão (o bug original: `2026-03-01T02:00Z` → `28/02/2026 23:00`)
- [x] 4 testes novos no frontend — mesmo padrão + prova de que o resultado independe de `process.env.TZ`
- [x] `pytest -q` — 686 passed · `ruff check` limpo · `pyright` 0 erros
- [x] `npm test` — 160 passed · `npm run build` limpo · `npm run lint` sem regressão nos arquivos tocados (warnings pré-existentes em outros arquivos, não relacionados)
- [x] `python ../tools/architecture_audit.py` — sem regressão