### PR TITLE
feat(admin): Cockpit Operacional do Programa Early Adopters (RFC-0024)

### DIFF
--- a/backend/app/alembic/versions/2026_07_19_0028_add_early_adopter_cockpit.py
+++ b/backend/app/alembic/versions/2026_07_19_0028_add_early_adopter_cockpit.py
@@ -1,0 +1,135 @@
+"""add_early_adopter_cockpit — Cockpit Operacional do Programa Early Adopters (RFC-0024)
+
+Estende a fundação do RFC-0017/ADR-0008 (``early_adopters``/``early_grants``, já em
+produção) com o que o cockpit precisa:
+
+- ``early_adopters``: cadastrais expandidos (cargo, cidade, uf, erp, qtd_cnpjs,
+  volume_nfe_mensal_aprox), ``proxima_acao``, ``owner_email`` (dono interno da
+  conta), ``recognition`` (early_adopter → founding_partner, RFC-0024) e os campos
+  de Conversão (Tela 02) — todos nullable/com default seguro, aditivos.
+- Reconcilia o enum ``origem`` para o conjunto da RFC-0024 (LinkedIn, Instagram,
+  Indicação, Cliente 6tech, Google, Site, Evento, Outro), migrando os valores
+  legados do RFC-0017 (microsoft_forms, contato_direto) para os mais próximos.
+- ``early_adopter_journey_events``: apenas eventos de jornada lançados manualmente
+  pelo Owner — os automáticos (1º login, XML recebido) são derivados ao vivo do
+  próprio sistema no endpoint de detalhe (RFC-0024, princípio "observar, não
+  replicar"), nunca duplicados aqui.
+- ``customer_evidence``: captura de Discovery (RFC-0019/ADR-0005) por
+  participante — nunca altera o Brain automaticamente.
+- ``early_adopter_tera``: registro manual do TERA (upload/link de PDF) — a
+  geração automática depende do RFC-0018, ainda não construído.
+- ``users.first_login_at``/``users.last_login_at``: necessários para popular
+  "Primeiro/Último login" da jornada sem tabela adicional (não existia nenhum
+  rastro de login persistido).
+
+Revision ID: 2026_07_19_0028
+Revises: 2026_07_16_0027
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_19_0028"
+down_revision = "2026_07_16_0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── users.first_login_at / last_login_at ───────────────────────────────
+    op.add_column("users", sa.Column("first_login_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True))
+
+    # ── early_adopters: cadastrais expandidos + próxima ação + owner + reconhecimento ──
+    op.add_column("early_adopters", sa.Column("cargo", sa.String(length=100), nullable=True))
+    op.add_column("early_adopters", sa.Column("cidade", sa.String(length=100), nullable=True))
+    op.add_column("early_adopters", sa.Column("uf", sa.String(length=2), nullable=True))
+    op.add_column("early_adopters", sa.Column("erp", sa.String(length=100), nullable=True))
+    op.add_column("early_adopters", sa.Column("qtd_cnpjs", sa.Integer(), nullable=True))
+    op.add_column("early_adopters", sa.Column("volume_nfe_mensal_aprox", sa.Integer(), nullable=True))
+    op.add_column("early_adopters", sa.Column("proxima_acao", sa.Text(), nullable=True))
+    op.add_column("early_adopters", sa.Column("owner_email", sa.String(length=255), nullable=True))
+    op.add_column(
+        "early_adopters",
+        sa.Column("recognition", sa.String(length=20), nullable=False, server_default="early_adopter"),
+    )
+
+    # ── Conversão (Tela 02) ──────────────────────────────────────────────────
+    op.add_column("early_adopters", sa.Column("conversion_interesse", sa.String(length=20), nullable=True))
+    op.add_column("early_adopters", sa.Column("conversion_motivo", sa.Text(), nullable=True))
+    op.add_column("early_adopters", sa.Column("conversion_plano_slug", sa.String(length=50), nullable=True))
+    op.add_column("early_adopters", sa.Column("conversion_data", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("early_adopters", sa.Column("conversion_valor_cents", sa.Integer(), nullable=True))
+    op.add_column("early_adopters", sa.Column("conversion_origem", sa.String(length=100), nullable=True))
+
+    # ── Reconciliação do enum origem (RFC-0017 → RFC-0024) ──────────────────
+    # Valores legados sem correspondência direta migram para "outro" — não há
+    # perda de sinal crítico (a empresa continua identificável pelos demais
+    # campos); poucas linhas existem em produção (feature em operação há <2 semanas).
+    op.execute("UPDATE early_adopters SET origem = 'outro' WHERE origem IN ('microsoft_forms', 'contato_direto')")
+
+    # ── early_adopter_journey_events (só eventos manuais) ───────────────────
+    op.create_table(
+        "early_adopter_journey_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("early_adopter_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("stage", sa.String(length=40), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("created_by_email", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["early_adopter_id"], ["early_adopters.id"], ondelete="CASCADE", name="fk_ea_journey_adopter_id"),
+    )
+    op.create_index("ix_ea_journey_adopter_id", "early_adopter_journey_events", ["early_adopter_id"])
+
+    # ── customer_evidence (Discovery — RFC-0019/ADR-0005) ───────────────────
+    op.create_table(
+        "customer_evidence",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("early_adopter_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tipo", sa.String(length=30), nullable=False),
+        sa.Column("texto", sa.Text(), nullable=False),
+        sa.Column("autor", sa.String(length=200), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["early_adopter_id"], ["early_adopters.id"], ondelete="CASCADE", name="fk_customer_evidence_adopter_id"),
+    )
+    op.create_index("ix_customer_evidence_adopter_id", "customer_evidence", ["early_adopter_id"])
+
+    # ── early_adopter_tera (registro manual — RFC-0018 fica para a geração) ──
+    op.create_table(
+        "early_adopter_tera",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("early_adopter_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("versao", sa.String(length=20), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="rascunho"),
+        sa.Column("responsavel", sa.String(length=200), nullable=True),
+        sa.Column("storage_key", sa.String(length=500), nullable=True),
+        sa.Column("pdf_link", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["early_adopter_id"], ["early_adopters.id"], ondelete="CASCADE", name="fk_ea_tera_adopter_id"),
+    )
+    op.create_index("ix_ea_tera_adopter_id", "early_adopter_tera", ["early_adopter_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ea_tera_adopter_id", table_name="early_adopter_tera")
+    op.drop_table("early_adopter_tera")
+    op.drop_index("ix_customer_evidence_adopter_id", table_name="customer_evidence")
+    op.drop_table("customer_evidence")
+    op.drop_index("ix_ea_journey_adopter_id", table_name="early_adopter_journey_events")
+    op.drop_table("early_adopter_journey_events")
+
+    for col in (
+        "conversion_origem", "conversion_valor_cents", "conversion_data",
+        "conversion_plano_slug", "conversion_motivo", "conversion_interesse",
+        "recognition", "owner_email", "proxima_acao", "volume_nfe_mensal_aprox",
+        "qtd_cnpjs", "erp", "uf", "cidade", "cargo",
+    ):
+        op.drop_column("early_adopters", col)
+
+    op.drop_column("users", "last_login_at")
+    op.drop_column("users", "first_login_at")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -84,6 +84,11 @@ class User(Base):
     email_verified = Column(Boolean, nullable=False, default=False)
     email_verification_token = Column(String(500), nullable=True)
     deleted_at = Column(DateTime(timezone=True), nullable=True)
+    # Marcados a cada login bem-sucedido (RFC-0024): alimentam "Primeiro/Último
+    # login" da jornada do cockpit Early Adopters sem tabela adicional.
+    # first_login_at grava só na transição NULL→preenchido; last_login_at sempre.
+    first_login_at = Column(DateTime(timezone=True), nullable=True)
+    last_login_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/app/models/founding_partner.py
+++ b/backend/app/models/founding_partner.py
@@ -1,11 +1,22 @@
-"""Founding Partners — camada de licenciamento (RFC-0017 + ADR-0008).
+"""Founding Partners — camada de licenciamento (RFC-0017 + ADR-0008) + Cockpit
+Operacional do Programa Early Adopters (RFC-0024).
 
-Duas entidades + um resolvedor:
+Entidades + um resolvedor:
 
 - ``EarlyAdopter`` — a empresa admitida no programa (RF001). "Founding Partner" é
-  o título de reconhecimento; a entidade técnica permanece Early Adopter.
+  o **reconhecimento** (`recognition`), não o nome do programa nem outra entidade;
+  a entidade técnica permanece Early Adopter.
 - ``EarlyGrant`` — a **autorização operacional**: concede um plano (Contador) por
   uma vigência, sem assinatura ASAAS. Nunca representa pagamento.
+- ``EarlyAdopterJourneyEvent`` — eventos de jornada lançados manualmente pelo
+  Owner (Tela 02). Os eventos automáticos (1º login, XML recebido) **não são
+  armazenados aqui** — são derivados ao vivo no endpoint de detalhe a partir do
+  próprio sistema (`users.first_login_at`/`last_login_at`, contagem de `Job`),
+  para honrar o princípio "observar, não replicar" (RFC-0024).
+- ``CustomerEvidence`` — captura de Discovery por participante (RFC-0019/ADR-0005):
+  este módulo nunca altera o Brain automaticamente; é só a superfície de captura.
+- ``EarlyAdopterTera`` — registro **manual** do TERA (upload/link de PDF); a
+  geração automática depende do RFC-0018, ainda não construído.
 - ``resolve_effective_license`` — o Grant Adapter (ADR-0008): no login,
   ``plan_slug = grant.plan_slug`` se houver Grant ativo, senão ``subscription``.
 
@@ -20,26 +31,69 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import cast
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, Text, func, select
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, func, select
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
 from app.database import Base
 
-# Enum de origem de aquisição (RFC-0017) — alimenta o Marketing Brain.
+# Enum de origem de aquisição — reconciliado na RFC-0024 (Tela 02). Valores
+# legados do RFC-0017 (microsoft_forms, contato_direto) foram migrados para
+# "outro" na migration 2026_07_19_0028; alimenta o Marketing Brain.
 EA_ORIGINS: tuple[str, ...] = (
-    "microsoft_forms",
-    "indicacao",
     "linkedin",
+    "instagram",
+    "indicacao",
+    "cliente_6tech",
+    "google",
     "site",
-    "contato_direto",
     "evento",
     "outro",
 )
 
 EA_STATUSES: tuple[str, ...] = ("active", "closed")
 GRANT_STATUSES: tuple[str, ...] = ("active", "revoked", "expired")
+
+# Reconhecimento (RFC-0024): status conquistado, permanente — não é etapa da
+# jornada. "founding_partner" quando atingir critério (reuniões, XML, validação,
+# melhorias, permanência como cliente); avaliação é manual pelo Owner.
+RECOGNITION_LEVELS: tuple[str, ...] = ("early_adopter", "founding_partner")
+
+# Jornada (RFC-0024, Tela 02) — eventos manuais; os automáticos (Primeiro login,
+# XML recebido) são derivados ao vivo, nunca gravados nesta tabela.
+JOURNEY_STAGES: tuple[str, ...] = (
+    "convite_enviado",
+    "formulario_recebido",
+    "selecionado",
+    "convite_acesso_enviado",
+    "primeiro_login",
+    "xml_recebido",
+    "tera_em_preparacao",
+    "tera_apresentado",
+    "reuniao_realizada",
+    "em_acompanhamento",
+    "convertido",
+    "encerrado",
+)
+
+# Customer Evidence (RFC-0024, guardrail RFC-0019/ADR-0005: Discovery, nunca Knowledge).
+EVIDENCE_TYPES: tuple[str, ...] = (
+    "problema_percebido",
+    "problema_confirmado",
+    "objecao",
+    "frase_marcante",
+    "momento_wow",
+    "momento_friccao",
+    "insight",
+    "hipotese",
+    "aprendizado",
+    "proximo_passo",
+)
+
+TERA_STATUSES: tuple[str, ...] = ("rascunho", "apresentado")
+
+CONVERSION_INTERESSE: tuple[str, ...] = ("sim", "nao", "pensando")
 
 # Plano concedido por padrão a um Founding Partner (RF003).
 DEFAULT_GRANT_PLAN = "contador"
@@ -59,10 +113,28 @@ class EarlyAdopter(Base):
     cnpj = Column(String(20), nullable=True)
     email = Column(String(255), nullable=False)
     responsavel = Column(String(200), nullable=True)
-    telefone = Column(String(32), nullable=True)
+    telefone = Column(String(32), nullable=True)  # exibido como "WhatsApp" na Tela 02
     origem = Column(String(32), nullable=False, server_default="outro")
     status = Column(String(16), nullable=False, server_default="active")
     observacoes = Column(Text, nullable=True)
+    # Cadastrais expandidos (RFC-0024, Tela 02).
+    cargo = Column(String(100), nullable=True)
+    cidade = Column(String(100), nullable=True)
+    uf = Column(String(2), nullable=True)
+    erp = Column(String(100), nullable=True)
+    qtd_cnpjs = Column(Integer, nullable=True)
+    volume_nfe_mensal_aprox = Column(Integer, nullable=True)
+    # Operação do cockpit (RFC-0024).
+    proxima_acao = Column(Text, nullable=True)
+    owner_email = Column(String(255), nullable=True)
+    recognition = Column(String(20), nullable=False, server_default="early_adopter")
+    # Conversão (Tela 02) — inicia o fluxo ASAAS existente, nunca substitui.
+    conversion_interesse = Column(String(20), nullable=True)
+    conversion_motivo = Column(Text, nullable=True)
+    conversion_plano_slug = Column(String(50), nullable=True)
+    conversion_data = Column(DateTime(timezone=True), nullable=True)
+    conversion_valor_cents = Column(Integer, nullable=True)
+    conversion_origem = Column(String(100), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
@@ -93,6 +165,55 @@ class EarlyGrant(Base):
     updated_at = Column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
     )
+
+
+class EarlyAdopterJourneyEvent(Base):
+    __tablename__ = "early_adopter_journey_events"
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    early_adopter_id = Column(
+        UUID(as_uuid=True), ForeignKey("early_adopters.id", ondelete="CASCADE"), nullable=False
+    )
+    stage = Column(String(40), nullable=False)
+    occurred_at = Column(DateTime(timezone=True), nullable=False)
+    note = Column(Text, nullable=True)
+    created_by_email = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+
+class CustomerEvidence(Base):
+    __tablename__ = "customer_evidence"
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    early_adopter_id = Column(
+        UUID(as_uuid=True), ForeignKey("early_adopters.id", ondelete="CASCADE"), nullable=False
+    )
+    tipo = Column(String(30), nullable=False)
+    texto = Column(Text, nullable=False)
+    autor = Column(String(200), nullable=True)
+    occurred_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+
+class EarlyAdopterTera(Base):
+    __tablename__ = "early_adopter_tera"
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    early_adopter_id = Column(
+        UUID(as_uuid=True), ForeignKey("early_adopters.id", ondelete="CASCADE"), nullable=False
+    )
+    versao = Column(String(20), nullable=False)
+    status = Column(String(20), nullable=False, server_default="rascunho")
+    responsavel = Column(String(200), nullable=True)
+    storage_key = Column(String(500), nullable=True)
+    pdf_link = Column(String(500), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
 
 def _aware(dt: datetime) -> datetime:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -178,6 +178,14 @@ async def login(login_data: UserLogin, request: Request, db: Session = Depends(g
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # Marca 1º/último login (RFC-0024): alimenta a jornada do cockpit Early
+    # Adopters sem tabela adicional — evento genérico de User, não exclusivo de EA.
+    _now = datetime.now(timezone.utc)
+    if user.first_login_at is None:
+        user.first_login_at = _now  # type: ignore[assignment]
+    user.last_login_at = _now  # type: ignore[assignment]
+    db.commit()
+
     # Ator partner (Programa de Parceiros, RFC-0026): não tem tenant, billing
     # nem Grant/licença — sai cedo, antes de qualquer resolução tenant-scoped
     # (o restante deste handler assume tenant_id válido).

--- a/backend/app/routers/founding_partners.py
+++ b/backend/app/routers/founding_partners.py
@@ -8,29 +8,43 @@ sendo a única origem de assinaturas pagas; o Grant é autorização excepcional
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import date, datetime, time, timezone
 from typing import Annotated, Any, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core.security import get_password_hash
 from app.database import get_db
 from app.models.auth import Tenant, User, UserTenant
-from app.models.billing import UsageTracking
+from app.models.billing import Payment, Plan, Subscription, UsageTracking
 from app.models.founding_partner import (
+    CONVERSION_INTERESSE,
     DEFAULT_GRANT_PLAN,
     EA_ORIGINS,
+    EVIDENCE_TYPES,
+    JOURNEY_STAGES,
+    RECOGNITION_LEVELS,
+    TERA_STATUSES,
+    CustomerEvidence,
     EarlyAdopter,
+    EarlyAdopterJourneyEvent,
+    EarlyAdopterTera,
     EarlyGrant,
     effective_grant_status,
 )
+from app.models.jobs import Job as JobModel
 from app.routers.admin import _audit, _require_superadmin
 from app.routers.auth import _cnpj_to_slug
+from app.services.asaas_service import asaas
+from app.tools import s3_tool
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/admin/founding-partners", tags=["founding-partners"])
 
@@ -71,17 +85,100 @@ def _ea_out(db: Session, ea: EarlyAdopter, grants: list[EarlyGrant]) -> dict[str
         "cnpj": ea.cnpj,
         "email": cast(str, ea.email),
         "responsavel": ea.responsavel,
-        "telefone": ea.telefone,
+        "telefone": ea.telefone,  # exibido como "WhatsApp" na Tela 02
+        "cargo": ea.cargo,
+        "cidade": ea.cidade,
+        "uf": ea.uf,
+        "erp": ea.erp,
+        "qtd_cnpjs": ea.qtd_cnpjs,
+        "volume_nfe_mensal_aprox": ea.volume_nfe_mensal_aprox,
         "origem": cast(str, ea.origem),
         "status": cast(str, ea.status),
         "observacoes": ea.observacoes,
+        "proxima_acao": ea.proxima_acao,
+        "owner_email": ea.owner_email,
+        "recognition": cast(str, ea.recognition),
+        "conversion": {
+            "interesse": ea.conversion_interesse,
+            "motivo": ea.conversion_motivo,
+            "plano_slug": ea.conversion_plano_slug,
+            "data": cast(datetime, ea.conversion_data).isoformat() if ea.conversion_data is not None else None,
+            "valor_cents": ea.conversion_valor_cents,
+            "origem": ea.conversion_origem,
+        },
         "created_at": cast(datetime, ea.created_at).isoformat(),
+        "updated_at": cast(datetime, ea.updated_at).isoformat(),
         # Licença efetiva resolvida (o que o Grant Adapter entregaria no login).
         "effective_plan": cast(str, active.plan_slug) if active is not None else None,
         "grant_ends_at": cast(datetime, active.ends_at).isoformat() if active is not None else None,
         "active_grant_id": str(active.id) if active is not None else None,
         "grants": [_grant_out(g) for g in mine],
     }
+
+
+def _journey_out(e: EarlyAdopterJourneyEvent) -> dict[str, Any]:
+    return {
+        "id": str(e.id),
+        "stage": cast(str, e.stage),
+        "occurred_at": cast(datetime, e.occurred_at).isoformat(),
+        "note": e.note,
+        "source": "manual",
+        "created_by_email": e.created_by_email,
+    }
+
+
+def _evidence_out(ev: CustomerEvidence) -> dict[str, Any]:
+    return {
+        "id": str(ev.id),
+        "tipo": cast(str, ev.tipo),
+        "texto": cast(str, ev.texto),
+        "autor": ev.autor,
+        "occurred_at": cast(datetime, ev.occurred_at).isoformat(),
+        "created_at": cast(datetime, ev.created_at).isoformat(),
+    }
+
+
+def _tera_out(t: EarlyAdopterTera) -> dict[str, Any]:
+    return {
+        "id": str(t.id),
+        "versao": cast(str, t.versao),
+        "status": cast(str, t.status),
+        "responsavel": t.responsavel,
+        "has_file": t.storage_key is not None,
+        "pdf_link": t.pdf_link,
+        "created_at": cast(datetime, t.created_at).isoformat(),
+    }
+
+
+def _auto_journey_events(db: Session, ea: EarlyAdopter) -> list[dict[str, Any]]:
+    """Eventos derivados AO VIVO do próprio sistema — nunca gravados (RFC-0024,
+    princípio "observar, não replicar"): 1º login (users.first_login_at) e XML
+    recebido (1º job de validate_xml do tenant)."""
+    events: list[dict[str, Any]] = []
+    user = db.execute(select(User).where(User.email == ea.email)).scalar_one_or_none()
+    if user is not None and user.first_login_at is not None:
+        events.append({
+            "id": None, "stage": "primeiro_login",
+            "occurred_at": cast(datetime, user.first_login_at).isoformat(),
+            "note": None, "source": "auto", "created_by_email": None,
+        })
+    xml_count = db.scalar(
+        select(func.count(JobModel.id)).where(JobModel.tenant_id == ea.tenant_id, JobModel.job_type == "validate_xml")
+    ) or 0
+    if xml_count > 0:
+        first_job = db.execute(
+            select(JobModel)
+            .where(JobModel.tenant_id == ea.tenant_id, JobModel.job_type == "validate_xml")
+            .order_by(JobModel.created_at.asc())
+            .limit(1)
+        ).scalar_one_or_none()
+        if first_job is not None:
+            events.append({
+                "id": None, "stage": "xml_recebido",
+                "occurred_at": cast(datetime, first_job.created_at).isoformat(),
+                "note": f"{xml_count} validação(ões) até agora", "source": "auto", "created_by_email": None,
+            })
+    return events
 
 
 def _revoke(db: Session, grant: EarlyGrant) -> None:
@@ -119,6 +216,40 @@ class EarlyAdopterUpdate(BaseModel):
     telefone: str | None = None
     origem: str | None = None
     observacoes: str | None = None
+    cargo: str | None = None
+    cidade: str | None = None
+    uf: str | None = None
+    erp: str | None = None
+    qtd_cnpjs: int | None = None
+    volume_nfe_mensal_aprox: int | None = None
+    proxima_acao: str | None = None
+    owner_email: str | None = None
+    recognition: str | None = None
+
+
+class JourneyEventCreate(BaseModel):
+    stage: str
+    occurred_at: datetime | None = None
+    note: str | None = None
+
+
+class EvidenceCreate(BaseModel):
+    tipo: str
+    texto: str
+    occurred_at: datetime | None = None
+    autor: str | None = None
+
+
+class ConversionInterestBody(BaseModel):
+    interesse: str
+    motivo: str | None = None
+
+
+class ConversionBody(BaseModel):
+    plan_slug: str
+    billing_type: str = "PIX"
+    motivo: str | None = None
+    origem: str | None = None
 
 
 # ── Provisionamento ──────────────────────────────────────────────────────────
@@ -282,11 +413,20 @@ def update_founding_partner(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Origem inválida: {body.origem}.")
         ea.origem = origem  # type: ignore[assignment]
         changed["origem"] = origem
-    for field in ("empresa", "responsavel", "telefone", "observacoes"):
+    if body.recognition is not None:
+        recognition = body.recognition.lower().strip()
+        if recognition not in RECOGNITION_LEVELS:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Reconhecimento inválido: {body.recognition}.")
+        ea.recognition = recognition  # type: ignore[assignment]
+        changed["recognition"] = recognition
+    for field in (
+        "empresa", "responsavel", "telefone", "observacoes", "cargo", "cidade", "uf",
+        "erp", "qtd_cnpjs", "volume_nfe_mensal_aprox", "proxima_acao", "owner_email",
+    ):
         val = getattr(body, field)
         if val is not None:
-            setattr(ea, field, val or None)
-            changed[field] = val or None
+            setattr(ea, field, val if val != "" else None)
+            changed[field] = val if val != "" else None
     _audit(db, _admin, "early_adopter.update", "early_adopter", ea.id, {"changed": changed})
     db.commit()
     grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
@@ -354,3 +494,309 @@ def close_founding_partner(
     grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
     db.refresh(ea)
     return _ea_out(db, ea, list(grants))
+
+
+# ── Tela 02 — Perfil do participante (RFC-0024) ─────────────────────────────
+
+
+@router.get("/{ea_id}")
+def get_founding_partner(
+    ea_id: UUID,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Perfil completo (Tela 02): cadastrais, jornada (manual + derivada ao vivo),
+    Customer Evidence, TERA e o snapshot do sistema que alimenta a jornada."""
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
+    manual_events = db.execute(
+        select(EarlyAdopterJourneyEvent).where(EarlyAdopterJourneyEvent.early_adopter_id == ea.id)
+    ).scalars().all()
+    evidences = db.execute(
+        select(CustomerEvidence).where(CustomerEvidence.early_adopter_id == ea.id).order_by(CustomerEvidence.occurred_at.desc())
+    ).scalars().all()
+    teras = db.execute(
+        select(EarlyAdopterTera).where(EarlyAdopterTera.early_adopter_id == ea.id).order_by(EarlyAdopterTera.created_at.desc())
+    ).scalars().all()
+    user = db.execute(select(User).where(User.email == ea.email)).scalar_one_or_none()
+
+    journey = [_journey_out(e) for e in manual_events] + _auto_journey_events(db, ea)
+    journey.sort(key=lambda x: cast(str, x["occurred_at"]))
+
+    out = _ea_out(db, ea, list(grants))
+    out["journey"] = journey
+    out["customer_evidence"] = [_evidence_out(e) for e in evidences]
+    out["tera"] = [_tera_out(t) for t in teras]
+    out["system"] = {
+        "user_id": str(user.id) if user is not None else None,
+        "first_login_at": cast(datetime, user.first_login_at).isoformat() if user is not None and user.first_login_at is not None else None,
+        "last_login_at": cast(datetime, user.last_login_at).isoformat() if user is not None and user.last_login_at is not None else None,
+    }
+    return out
+
+
+@router.post("/{ea_id}/journey", status_code=status.HTTP_201_CREATED)
+def add_journey_event(
+    ea_id: UUID,
+    body: JourneyEventCreate,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Lança um evento de jornada manual. Eventos automáticos (1º login, XML
+    recebido) NUNCA passam por aqui — são derivados ao vivo em `GET /{ea_id}`."""
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    stage = body.stage.strip()
+    if stage not in JOURNEY_STAGES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Etapa de jornada inválida: {stage}.")
+    event = EarlyAdopterJourneyEvent(
+        early_adopter_id=ea.id,
+        stage=stage,
+        occurred_at=body.occurred_at or datetime.now(timezone.utc),
+        note=(body.note or None),
+        created_by_email=cast(str, _admin.email),
+    )
+    db.add(event)
+    db.flush()
+    _audit(db, _admin, "early_adopter.journey_event", "early_adopter", ea.id, {"stage": stage})
+    db.commit()
+    db.refresh(event)
+    return _journey_out(event)
+
+
+@router.post("/{ea_id}/evidence", status_code=status.HTTP_201_CREATED)
+def add_customer_evidence(
+    ea_id: UUID,
+    body: EvidenceCreate,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Registra Customer Evidence (RFC-0019/ADR-0005: Discovery, nunca Knowledge
+    — não altera o Brain automaticamente; é só a superfície de captura)."""
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    tipo = body.tipo.strip()
+    if tipo not in EVIDENCE_TYPES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Tipo de evidência inválido: {tipo}.")
+    if not body.texto.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Texto é obrigatório.")
+    ev = CustomerEvidence(
+        early_adopter_id=ea.id,
+        tipo=tipo,
+        texto=body.texto.strip(),
+        autor=(body.autor or cast(str, _admin.email)),
+        occurred_at=body.occurred_at or datetime.now(timezone.utc),
+    )
+    db.add(ev)
+    db.flush()
+    _audit(db, _admin, "early_adopter.evidence_create", "early_adopter", ea.id, {"tipo": tipo})
+    db.commit()
+    db.refresh(ev)
+    return _evidence_out(ev)
+
+
+@router.post("/{ea_id}/tera", status_code=status.HTTP_201_CREATED)
+async def add_tera(
+    ea_id: UUID,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    versao: str = Form(...),
+    tera_status: str = Form("rascunho"),
+    responsavel: str | None = Form(None),
+    pdf_link: str | None = Form(None),
+    file: UploadFile | None = File(None),
+) -> dict[str, Any]:
+    """Registro MANUAL do TERA (v1, RFC-0024): upload de PDF e/ou link externo.
+    A geração automática de TERA depende do RFC-0018, ainda não construído."""
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    if not versao.strip():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Versão é obrigatória.")
+    if tera_status not in TERA_STATUSES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Status de TERA inválido: {tera_status}.")
+
+    storage_key: str | None = None
+    if file is not None:
+        raw = await file.read()
+        storage_key = f"documents/{ea.tenant_id}/tera/{uuid.uuid4()}.pdf"
+        s3_tool.put_object(
+            key=storage_key, data=raw, content_type="application/pdf",
+            metadata={"artifact_kind": "tera", "early_adopter_id": str(ea.id)},
+        )
+
+    tera = EarlyAdopterTera(
+        early_adopter_id=ea.id,
+        versao=versao.strip(),
+        status=tera_status,
+        responsavel=(responsavel or None),
+        storage_key=storage_key,
+        pdf_link=(pdf_link or None),
+    )
+    db.add(tera)
+    db.flush()
+    _audit(db, _admin, "early_adopter.tera_create", "early_adopter", ea.id, {"versao": versao, "status": tera_status})
+    db.commit()
+    db.refresh(tera)
+    return _tera_out(tera)
+
+
+@router.get("/tera/{tera_id}/download")
+def download_tera(
+    tera_id: UUID,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    tera = db.get(EarlyAdopterTera, tera_id)
+    if tera is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="TERA não encontrado.")
+    if tera.storage_key is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Este TERA não tem PDF enviado (só link).")
+    return {"download_url": s3_tool.get_object_url(cast(str, tera.storage_key))}
+
+
+@router.patch("/{ea_id}/conversion")
+def update_conversion_interest(
+    ea_id: UUID,
+    body: ConversionInterestBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Registra o interesse em continuar (Sim/Não/Pensando) sem iniciar ASAAS —
+    esse gatilho é exclusivo de `POST /{ea_id}/convert` ("Gerar assinatura ASAAS")."""
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+    interesse = body.interesse.strip().lower()
+    if interesse not in CONVERSION_INTERESSE:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Interesse inválido: {interesse}.")
+    ea.conversion_interesse = interesse  # type: ignore[assignment]
+    ea.conversion_motivo = (body.motivo or None)  # type: ignore[assignment]
+    _audit(db, _admin, "early_adopter.conversion_interest", "early_adopter", ea.id, {"interesse": interesse})
+    db.commit()
+    grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
+    db.refresh(ea)
+    return _ea_out(db, ea, list(grants))
+
+
+@router.post("/{ea_id}/convert")
+async def convert_founding_partner(
+    ea_id: UUID,
+    body: ConversionBody,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, Any]:
+    """Inicia a conversão em cliente pagante — reusa o fluxo ASAAS (mesmas
+    chamadas de `billing.py:upgrade_plan`: `asaas.create_customer` /
+    `asaas.create_subscription`). **Proibido gateway paralelo** (RFC-0024).
+
+    Não é literalmente `upgrade_plan`: um Early Adopter tipicamente não tem
+    NENHUMA Subscription prévia (Grant nunca cria Subscription — RNF002), então
+    `upgrade_plan` (que exige uma assinatura existente para substituir) não se
+    aplica aqui. Esta função cobre o caso "sem assinatura anterior"; se por
+    algum motivo já existir uma, ela é cancelada como no upgrade normal.
+    """
+    ea = db.get(EarlyAdopter, ea_id)
+    if ea is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Early Adopter não encontrado.")
+
+    target_plan = db.execute(
+        select(Plan).where(Plan.slug == body.plan_slug, Plan.is_active == True)  # noqa: E712
+    ).scalar_one_or_none()
+    if target_plan is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Plano não encontrado.")
+    if cast(int, target_plan.price_cents) == 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Conversão exige um plano pago.")
+
+    user = db.execute(select(User).where(User.email == ea.email)).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Usuário de login do Early Adopter não encontrado.")
+
+    existing_sub = db.execute(
+        select(Subscription).where(Subscription.user_id == user.id).order_by(Subscription.created_at.desc()).limit(1)
+    ).scalar_one_or_none()
+    customer_id = (
+        cast(str, existing_sub.asaas_customer_id)
+        if existing_sub is not None and existing_sub.asaas_customer_id is not None
+        else None
+    )
+    cnpj_value = cast(str, user.cnpj).strip() if user.cnpj is not None else ""
+    if not customer_id and len(cnpj_value.replace(".", "").replace("/", "").replace("-", "")) not in (11, 14):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Early Adopter sem CNPJ válido cadastrado — atualize antes de converter.")
+
+    if existing_sub is not None and cast(str, existing_sub.status) in ("active", "trial", "pending"):
+        old_asaas_id = cast(str, existing_sub.asaas_subscription_id) if existing_sub.asaas_subscription_id is not None else None
+        if old_asaas_id:
+            try:
+                await asaas.cancel_subscription(old_asaas_id)
+            except Exception:
+                logger.warning("Falha ao cancelar assinatura Asaas anterior na conversão: %s", old_asaas_id)
+        existing_sub.status = "cancelled"  # type: ignore[assignment]
+        existing_sub.cancelled_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+
+    value = cast(int, target_plan.price_cents) / 100.0
+    checkout_url = None
+    pix_qr_code = None
+    pix_copy_paste = None
+    try:
+        if not customer_id:
+            cust = await asaas.create_customer(
+                name=cast(str, user.full_name), email=cast(str, user.email),
+                cpf_cnpj=cnpj_value, phone=cast(str, user.phone) if user.phone is not None else "",
+            )
+            customer_id = cust["id"]
+        sub_resp = await asaas.create_subscription(
+            customer_id=customer_id, value=value, billing_type=body.billing_type.upper(),
+            description=f"Conversão Founding Partner — {cast(str, target_plan.name)}",
+        )
+        new_asaas_sub_id = sub_resp["id"]
+        sub_payments = await asaas.get_subscription_payments(new_asaas_sub_id)
+        if not sub_payments:
+            raise ValueError("Assinatura Asaas criada sem pagamento associado")
+        first_payment = sub_payments[0]
+        asaas_payment_id = first_payment["id"]
+        if body.billing_type.upper() == "PIX":
+            pix_data = await asaas.get_pix_qr_code(asaas_payment_id)
+            pix_qr_code = pix_data.get("encodedImage")
+            pix_copy_paste = pix_data.get("payload")
+        else:
+            checkout_url = asaas.get_checkout_url(asaas_payment_id)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Erro ao criar assinatura Asaas na conversão do Founding Partner")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Erro ao iniciar a assinatura. Tente novamente.")
+
+    new_sub = Subscription(
+        tenant_id=ea.tenant_id, user_id=user.id, plan_id=target_plan.id, status="pending",
+        asaas_customer_id=customer_id, asaas_subscription_id=new_asaas_sub_id,
+    )
+    db.add(new_sub)
+    db.flush()
+    db.add(Payment(
+        tenant_id=ea.tenant_id, subscription_id=new_sub.id, asaas_payment_id=asaas_payment_id,
+        amount_cents=cast(int, target_plan.price_cents), status="pending",
+        payment_method=body.billing_type.lower(), pix_qr_code=pix_qr_code, pix_copy_paste=pix_copy_paste,
+    ))
+
+    ea.conversion_interesse = "sim"  # type: ignore[assignment]
+    ea.conversion_motivo = (body.motivo or ea.conversion_motivo)  # type: ignore[assignment]
+    ea.conversion_plano_slug = cast(str, target_plan.slug)  # type: ignore[assignment]
+    ea.conversion_data = datetime.now(timezone.utc)  # type: ignore[assignment]
+    ea.conversion_valor_cents = cast(int, target_plan.price_cents)  # type: ignore[assignment]
+    ea.conversion_origem = (body.origem or ea.conversion_origem)  # type: ignore[assignment]
+    _audit(db, _admin, "early_adopter.convert", "early_adopter", ea.id, {"plan_slug": target_plan.slug, "subscription_id": str(new_sub.id)})
+    db.commit()
+    db.refresh(ea)
+    grants = db.execute(select(EarlyGrant).where(EarlyGrant.early_adopter_id == ea.id)).scalars().all()
+    return {
+        "early_adopter": _ea_out(db, ea, list(grants)),
+        "subscription_id": str(new_sub.id),
+        "checkout_url": checkout_url,
+        "pix_qr_code": pix_qr_code,
+        "pix_copy_paste": pix_copy_paste,
+    }

--- a/backend/tests/test_early_adopter_cockpit.py
+++ b/backend/tests/test_early_adopter_cockpit.py
@@ -1,0 +1,330 @@
+"""Cockpit Operacional do Programa Early Adopters (RFC-0024) — Tela 02.
+
+Cobre o que a RFC-0024 adiciona sobre a fundação já testada em
+test_founding_partners_admin.py (RFC-0017/ADR-0008): perfil detalhado (jornada
+auto+manual, Customer Evidence, TERA), próxima ação/owner/reconhecimento,
+interesse de conversão e o gatilho de conversão via ASAAS (mockado — nunca bate
+na API real do Asaas em teste).
+"""
+
+import os
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_password_hash
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.billing import Payment, Subscription
+
+anon = TestClient(app)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+
+def _pg_available() -> bool:
+    try:
+        with create_engine(DATABASE_URL).connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark_db = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    from app.api.deps import get_current_user
+
+    tenant = Tenant(name="Admin", slug=f"admin-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+    admin = User(
+        tenant_id=tenant.id, email=f"owner-{uuid.uuid4().hex[:8]}@tribultz.com.br",
+        full_name="Owner", password_hash=get_password_hash("x"), role="superadmin", email_verified=True,
+    )
+    session.add(admin)
+    session.flush()
+
+    def _db():
+        yield session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = lambda: admin
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _admit(client, cnpj: str | None = "11222333000181") -> dict:
+    email = f"ea-{uuid.uuid4().hex[:8]}@empresa.com"
+    hoje = date.today()
+    r = client.post("/api/v1/admin/founding-partners", json={
+        "empresa": "Cockpit Ltda", "email": email, "cnpj": cnpj,
+        "initial_password": "SenhaForte1", "responsavel": "Ana", "origem": "linkedin",
+        "grant": {"plan_slug": "contador", "starts_on": hoje.isoformat(), "ends_on": (hoje + timedelta(days=90)).isoformat()},
+    })
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+# ── Gate (sem DB) ─────────────────────────────────────────────────────────────
+
+_UUID = "00000000-0000-0000-0000-000000000000"
+NEW_ENDPOINTS = [
+    ("get", f"/api/v1/admin/founding-partners/{_UUID}", None),
+    ("post", f"/api/v1/admin/founding-partners/{_UUID}/journey", {"stage": "selecionado"}),
+    ("post", f"/api/v1/admin/founding-partners/{_UUID}/evidence", {"tipo": "insight", "texto": "x"}),
+    ("patch", f"/api/v1/admin/founding-partners/{_UUID}/conversion", {"interesse": "sim"}),
+    ("post", f"/api/v1/admin/founding-partners/{_UUID}/convert", {"plan_slug": "starter"}),
+    ("get", f"/api/v1/admin/founding-partners/tera/{_UUID}/download", None),
+]
+
+
+def test_novos_endpoints_registrados_e_superadmin_only():
+    for method, path, body in NEW_ENDPOINTS:
+        resp = getattr(anon, method)(path, json=body) if body is not None else anon.get(path)
+        assert resp.status_code != 404, f"{method} {path} não registrado"
+        assert resp.status_code in (401, 403), f"{method} {path} deveria bloquear anônimo ({resp.status_code})"
+
+
+# ── Tela 02 — perfil, jornada, evidence, TERA ──────────────────────────────────
+
+
+@pytestmark_db
+def test_detalhe_traz_jornada_evidence_tera_vazios(client, session):
+    ea = _admit(client)
+    r = client.get(f"/api/v1/admin/founding-partners/{ea['id']}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["journey"] == []
+    assert body["customer_evidence"] == []
+    assert body["tera"] == []
+    assert body["recognition"] == "early_adopter"
+    assert body["system"]["first_login_at"] is None
+
+
+@pytestmark_db
+def test_jornada_auto_primeiro_login_derivada_ao_vivo(client, session):
+    ea = _admit(client)
+    user = session.execute(select(User).where(User.email == ea["email"])).scalar_one()
+    user.first_login_at = datetime.now(timezone.utc)
+    session.commit()
+
+    r = client.get(f"/api/v1/admin/founding-partners/{ea['id']}")
+    stages = [e["stage"] for e in r.json()["journey"]]
+    assert "primeiro_login" in stages
+    auto = next(e for e in r.json()["journey"] if e["stage"] == "primeiro_login")
+    assert auto["source"] == "auto"
+    assert auto["id"] is None  # nunca persistido — derivado ao vivo
+
+
+@pytestmark_db
+def test_jornada_manual_registrada_e_valida_etapa(client, session):
+    ea = _admit(client)
+    r = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/journey", json={"stage": "selecionado", "note": "Reunião marcada"})
+    assert r.status_code == 201, r.text
+    assert r.json()["source"] == "manual"
+
+    bad = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/journey", json={"stage": "etapa_inexistente"})
+    assert bad.status_code == 400
+
+    detail = client.get(f"/api/v1/admin/founding-partners/{ea['id']}")
+    assert any(e["stage"] == "selecionado" for e in detail.json()["journey"])
+
+
+@pytestmark_db
+def test_customer_evidence_criada_e_valida_tipo(client, session):
+    ea = _admit(client)
+    r = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/evidence", json={
+        "tipo": "momento_wow", "texto": "Adorou o laudo em PDF",
+    })
+    assert r.status_code == 201, r.text
+    assert r.json()["tipo"] == "momento_wow"
+
+    bad = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/evidence", json={"tipo": "tipo_invalido", "texto": "x"})
+    assert bad.status_code == 400
+
+    empty_text = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/evidence", json={"tipo": "insight", "texto": "   "})
+    assert empty_text.status_code == 400
+
+
+@pytestmark_db
+def test_tera_registro_manual_via_link_sem_arquivo(client, session):
+    ea = _admit(client)
+    r = client.post(
+        f"/api/v1/admin/founding-partners/{ea['id']}/tera",
+        data={"versao": "v1", "tera_status": "rascunho", "pdf_link": "https://drive.example/tera-v1.pdf"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["has_file"] is False
+    assert body["pdf_link"] == "https://drive.example/tera-v1.pdf"
+
+    tera_id = body["id"]
+    dl = client.get(f"/api/v1/admin/founding-partners/tera/{tera_id}/download")
+    assert dl.status_code == 400, "TERA só com link (sem storage_key) não deve gerar URL presignada"
+
+
+@pytestmark_db
+def test_tera_status_invalido_rejeitado(client, session):
+    ea = _admit(client)
+    r = client.post(
+        f"/api/v1/admin/founding-partners/{ea['id']}/tera",
+        data={"versao": "v1", "tera_status": "publicado"},
+    )
+    assert r.status_code == 400
+
+
+# ── Cadastrais expandidos, próxima ação, owner, reconhecimento ────────────────
+
+
+@pytestmark_db
+def test_update_cadastrais_expandidos_e_reconhecimento(client, session):
+    ea = _admit(client)
+    r = client.patch(f"/api/v1/admin/founding-partners/{ea['id']}", json={
+        "cargo": "CFO", "cidade": "São Paulo", "uf": "SP", "erp": "Domínio",
+        "qtd_cnpjs": 3, "volume_nfe_mensal_aprox": 500,
+        "proxima_acao": "Ligar terça", "owner_email": "mickel@tribultz.com.br",
+        "recognition": "founding_partner",
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["cargo"] == "CFO"
+    assert body["uf"] == "SP"
+    assert body["qtd_cnpjs"] == 3
+    assert body["proxima_acao"] == "Ligar terça"
+    assert body["recognition"] == "founding_partner"
+
+
+@pytestmark_db
+def test_update_recognition_invalido_rejeitado(client, session):
+    ea = _admit(client)
+    r = client.patch(f"/api/v1/admin/founding-partners/{ea['id']}", json={"recognition": "vip"})
+    assert r.status_code == 400
+
+
+# ── Conversão ────────────────────────────────────────────────────────────────
+
+
+@pytestmark_db
+def test_conversion_interest_registrado_sem_asaas(client, session):
+    ea = _admit(client)
+    r = client.patch(f"/api/v1/admin/founding-partners/{ea['id']}/conversion", json={"interesse": "pensando", "motivo": "avaliando orçamento"})
+    assert r.status_code == 200, r.text
+    assert r.json()["conversion"]["interesse"] == "pensando"
+
+    bad = client.patch(f"/api/v1/admin/founding-partners/{ea['id']}/conversion", json={"interesse": "talvez"})
+    assert bad.status_code == 400
+
+
+@pytestmark_db
+def test_convert_sem_cnpj_bloqueado_antes_do_asaas(client, session, monkeypatch):
+    ea = _admit(client, cnpj=None)
+    create_customer = AsyncMock()
+    monkeypatch.setattr("app.routers.founding_partners.asaas.create_customer", create_customer)
+
+    r = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/convert", json={"plan_slug": "starter"})
+    assert r.status_code == 400
+    create_customer.assert_not_called()
+
+
+@pytestmark_db
+def test_convert_plano_gratuito_rejeitado(client, session):
+    ea = _admit(client)
+    r = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/convert", json={"plan_slug": "trial"})
+    assert r.status_code == 400
+
+
+@pytestmark_db
+def test_convert_reusa_asaas_cria_subscription_e_marca_conversao(client, session, monkeypatch):
+    ea = _admit(client)
+
+    monkeypatch.setattr(
+        "app.routers.founding_partners.asaas.create_customer",
+        AsyncMock(return_value={"id": "cus_mock_123"}),
+    )
+    monkeypatch.setattr(
+        "app.routers.founding_partners.asaas.create_subscription",
+        AsyncMock(return_value={"id": "sub_mock_456"}),
+    )
+    monkeypatch.setattr(
+        "app.routers.founding_partners.asaas.get_subscription_payments",
+        AsyncMock(return_value=[{"id": "pay_mock_789"}]),
+    )
+    monkeypatch.setattr(
+        "app.routers.founding_partners.asaas.get_pix_qr_code",
+        AsyncMock(return_value={"encodedImage": "base64img", "payload": "pix-copia-cola"}),
+    )
+
+    r = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/convert", json={
+        "plan_slug": "starter", "billing_type": "PIX", "motivo": "gostou do produto", "origem": "cockpit",
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["pix_qr_code"] == "base64img"
+    assert body["early_adopter"]["conversion"]["interesse"] == "sim"
+    assert body["early_adopter"]["conversion"]["plano_slug"] == "starter"
+
+    sub = session.execute(
+        select(Subscription).where(Subscription.id == uuid.UUID(body["subscription_id"]))
+    ).scalar_one()
+    assert sub.status == "pending"
+    assert sub.asaas_subscription_id == "sub_mock_456"
+    payment = session.execute(
+        select(Payment).where(Payment.subscription_id == sub.id)
+    ).scalar_one()
+    assert payment.amount_cents == 4990  # preço do plano "starter"
+
+
+@pytestmark_db
+def test_convert_nunca_cria_gateway_paralelo_so_chama_asaas(client, session, monkeypatch):
+    """Guardrail RFC-0024: 'proibido gateway paralelo' — garante que a conversão
+    só invoca o módulo `asaas`, nunca outro serviço de pagamento."""
+    ea = _admit(client)
+    calls: list[str] = []
+
+    async def _create_customer(**kw):
+        calls.append("create_customer")
+        return {"id": "cus_x"}
+
+    async def _create_subscription(**kw):
+        calls.append("create_subscription")
+        return {"id": "sub_x"}
+
+    async def _get_payments(sub_id):
+        calls.append("get_subscription_payments")
+        return [{"id": "pay_x"}]
+
+    async def _get_pix(payment_id):
+        calls.append("get_pix_qr_code")
+        return {"encodedImage": "img", "payload": "copia-cola"}
+
+    monkeypatch.setattr("app.routers.founding_partners.asaas.create_customer", _create_customer)
+    monkeypatch.setattr("app.routers.founding_partners.asaas.create_subscription", _create_subscription)
+    monkeypatch.setattr("app.routers.founding_partners.asaas.get_subscription_payments", _get_payments)
+    monkeypatch.setattr("app.routers.founding_partners.asaas.get_pix_qr_code", _get_pix)
+
+    r = client.post(f"/api/v1/admin/founding-partners/{ea['id']}/convert", json={"plan_slug": "starter"})
+    assert r.status_code == 200, r.text
+    assert calls == ["create_customer", "create_subscription", "get_subscription_payments", "get_pix_qr_code"]

--- a/backend/tests/test_founding_partners_admin.py
+++ b/backend/tests/test_founding_partners_admin.py
@@ -105,7 +105,7 @@ def test_fluxo_completo_grant(client, session):
     hoje = date(2026, 7, 8)
     # 1. Admite empresa já com Grant (Plano Contador, vigência).
     r = client.post("/api/v1/admin/founding-partners", json={
-        "empresa": "Contabilidade Duquesa", "email": email, "origem": "microsoft_forms",
+        "empresa": "Contabilidade Duquesa", "email": email, "origem": "indicacao",
         "initial_password": "SenhaForte1", "responsavel": "Kátia",
         "grant": {"plan_slug": "contador", "starts_on": hoje.isoformat(), "ends_on": (hoje + timedelta(days=30)).isoformat()},
     })

--- a/frontend/src/app/admin/founding-partners/[id]/page.tsx
+++ b/frontend/src/app/admin/founding-partners/[id]/page.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useAdminData, adminPost, adminRequest, adminUpload } from "@/lib/useAdminData";
+import { ORIGIN_LABEL, RECOGNITION_LABEL } from "../page";
+
+// Cockpit Operacional do Programa Early Adopters (RFC-0024) — Tela 02: perfil
+// do participante. Observa e organiza estados do sistema; não os replica.
+
+const JOURNEY_STAGES: [string, string][] = [
+  ["convite_enviado", "Convite enviado"],
+  ["formulario_recebido", "Formulário recebido"],
+  ["selecionado", "Selecionado"],
+  ["convite_acesso_enviado", "Convite de acesso enviado"],
+  ["primeiro_login", "Primeiro login"],
+  ["xml_recebido", "XML recebido"],
+  ["tera_em_preparacao", "TERA em preparação"],
+  ["tera_apresentado", "TERA apresentado"],
+  ["reuniao_realizada", "Reunião realizada"],
+  ["em_acompanhamento", "Em acompanhamento"],
+  ["convertido", "Convertido"],
+  ["encerrado", "Encerrado"],
+];
+const JOURNEY_LABEL = Object.fromEntries(JOURNEY_STAGES);
+
+const EVIDENCE_TYPES: [string, string][] = [
+  ["problema_percebido", "Problema percebido"],
+  ["problema_confirmado", "Problema confirmado"],
+  ["objecao", "Objeção"],
+  ["frase_marcante", "Frase marcante"],
+  ["momento_wow", "Momento WOW"],
+  ["momento_friccao", "Momento de fricção"],
+  ["insight", "Insight"],
+  ["hipotese", "Hipótese"],
+  ["aprendizado", "Aprendizado"],
+  ["proximo_passo", "Próximo passo"],
+];
+const EVIDENCE_LABEL = Object.fromEntries(EVIDENCE_TYPES);
+
+type Grant = { id: string; plan_slug: string; starts_at: string; ends_at: string; status: string };
+type JourneyEvent = { id: string | null; stage: string; occurred_at: string; note: string | null; source: "auto" | "manual"; created_by_email: string | null };
+type Evidence = { id: string; tipo: string; texto: string; autor: string | null; occurred_at: string; created_at: string };
+type Tera = { id: string; versao: string; status: string; responsavel: string | null; has_file: boolean; pdf_link: string | null; created_at: string };
+type Conversion = { interesse: string | null; motivo: string | null; plano_slug: string | null; data: string | null; valor_cents: number | null; origem: string | null };
+type Detail = {
+  id: string; empresa: string; cnpj: string | null; email: string; responsavel: string | null;
+  telefone: string | null; cargo: string | null; cidade: string | null; uf: string | null; erp: string | null;
+  qtd_cnpjs: number | null; volume_nfe_mensal_aprox: number | null; origem: string; status: string;
+  observacoes: string | null; proxima_acao: string | null; owner_email: string | null; recognition: string;
+  conversion: Conversion; effective_plan: string | null; grant_ends_at: string | null; active_grant_id: string | null;
+  grants: Grant[]; journey: JourneyEvent[]; customer_evidence: Evidence[]; tera: Tera[];
+  system: { user_id: string | null; first_login_at: string | null; last_login_at: string | null };
+};
+
+function fmt(d: string | null): string {
+  return d ? new Date(d).toLocaleString("pt-BR") : "—";
+}
+
+const inputCls = "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm";
+const cardCls = "rounded-xl border border-slate-200 p-4";
+
+export default function FoundingPartnerDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const { data, error, loading, reload } = useAdminData<Detail>(`/api/v1/admin/founding-partners/${id}`);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [editForm, setEditForm] = useState<Record<string, string>>({});
+  const [journeyOpen, setJourneyOpen] = useState(false);
+  const [journeyForm, setJourneyForm] = useState({ stage: JOURNEY_STAGES[0][0], note: "" });
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
+  const [evidenceForm, setEvidenceForm] = useState({ tipo: EVIDENCE_TYPES[0][0], texto: "" });
+  const [teraOpen, setTeraOpen] = useState(false);
+  const [teraForm, setTeraForm] = useState({ versao: "", tera_status: "rascunho", responsavel: "", pdf_link: "" });
+  const [teraFile, setTeraFile] = useState<File | null>(null);
+  const [convertOpen, setConvertOpen] = useState(false);
+  const [convertForm, setConvertForm] = useState({ plan_slug: "starter", billing_type: "PIX", motivo: "", origem: "cockpit" });
+  const [convertResult, setConvertResult] = useState<{ checkout_url: string | null; pix_qr_code: string | null; pix_copy_paste: string | null } | null>(null);
+
+  function openEdit() {
+    if (!data) return;
+    setEditForm({
+      empresa: data.empresa, responsavel: data.responsavel ?? "", telefone: data.telefone ?? "",
+      cargo: data.cargo ?? "", cidade: data.cidade ?? "", uf: data.uf ?? "", erp: data.erp ?? "",
+      qtd_cnpjs: data.qtd_cnpjs?.toString() ?? "", volume_nfe_mensal_aprox: data.volume_nfe_mensal_aprox?.toString() ?? "",
+      observacoes: data.observacoes ?? "", proxima_acao: data.proxima_acao ?? "", owner_email: data.owner_email ?? "",
+    });
+    setEditOpen(true);
+  }
+
+  async function saveEdit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy("edit");
+    try {
+      await adminRequest("PATCH", `/api/v1/admin/founding-partners/${id}`, {
+        empresa: editForm.empresa, responsavel: editForm.responsavel || null, telefone: editForm.telefone || null,
+        cargo: editForm.cargo || null, cidade: editForm.cidade || null, uf: editForm.uf || null, erp: editForm.erp || null,
+        qtd_cnpjs: editForm.qtd_cnpjs ? Number(editForm.qtd_cnpjs) : null,
+        volume_nfe_mensal_aprox: editForm.volume_nfe_mensal_aprox ? Number(editForm.volume_nfe_mensal_aprox) : null,
+        observacoes: editForm.observacoes || null, proxima_acao: editForm.proxima_acao || null,
+        owner_email: editForm.owner_email || null,
+      });
+      setEditOpen(false);
+      reload();
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : "Falha ao salvar.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function toggleRecognition() {
+    if (!data) return;
+    const next = data.recognition === "founding_partner" ? "early_adopter" : "founding_partner";
+    if (!window.confirm(`Marcar reconhecimento como "${RECOGNITION_LABEL[next]}"?`)) return;
+    setBusy("recognition");
+    try {
+      await adminRequest("PATCH", `/api/v1/admin/founding-partners/${id}`, { recognition: next });
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha ao atualizar reconhecimento.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function addJourney(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy("journey");
+    try {
+      await adminPost(`/api/v1/admin/founding-partners/${id}/journey`, {
+        stage: journeyForm.stage, note: journeyForm.note || null,
+      });
+      setJourneyForm({ stage: JOURNEY_STAGES[0][0], note: "" });
+      setJourneyOpen(false);
+      reload();
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : "Falha ao lançar evento.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function addEvidence(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy("evidence");
+    try {
+      await adminPost(`/api/v1/admin/founding-partners/${id}/evidence`, {
+        tipo: evidenceForm.tipo, texto: evidenceForm.texto,
+      });
+      setEvidenceForm({ tipo: EVIDENCE_TYPES[0][0], texto: "" });
+      setEvidenceOpen(false);
+      reload();
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : "Falha ao registrar evidência.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function addTera(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy("tera");
+    try {
+      const form = new FormData();
+      form.append("versao", teraForm.versao);
+      form.append("tera_status", teraForm.tera_status);
+      if (teraForm.responsavel) form.append("responsavel", teraForm.responsavel);
+      if (teraForm.pdf_link) form.append("pdf_link", teraForm.pdf_link);
+      if (teraFile) form.append("file", teraFile);
+      await adminUpload(`/api/v1/admin/founding-partners/${id}/tera`, form);
+      setTeraForm({ versao: "", tera_status: "rascunho", responsavel: "", pdf_link: "" });
+      setTeraFile(null);
+      setTeraOpen(false);
+      reload();
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : "Falha ao registrar TERA.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function downloadTera(teraId: string) {
+    try {
+      const r = await adminRequest<{ download_url: string }>("GET", `/api/v1/admin/founding-partners/tera/${teraId}/download`);
+      window.open(r.download_url, "_blank");
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha ao gerar link de download.");
+    }
+  }
+
+  async function setInterest(interesse: string) {
+    setBusy("interest");
+    try {
+      await adminRequest("PATCH", `/api/v1/admin/founding-partners/${id}/conversion`, { interesse });
+      reload();
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : "Falha ao registrar interesse.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function convert(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy("convert");
+    setConvertResult(null);
+    try {
+      const r = await adminRequest<{ checkout_url: string | null; pix_qr_code: string | null; pix_copy_paste: string | null }>(
+        "POST", `/api/v1/admin/founding-partners/${id}/convert`,
+        { plan_slug: convertForm.plan_slug, billing_type: convertForm.billing_type, motivo: convertForm.motivo || null, origem: convertForm.origem || null },
+      );
+      setConvertResult(r);
+      reload();
+    } catch (err) {
+      setMsg(err instanceof Error ? err.message : "Falha ao gerar assinatura ASAAS.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (loading) return <p className="text-sm text-slate-500">Carregando…</p>;
+  if (error || !data) return <p className="text-sm text-red-600">{error ?? "Não encontrado."}</p>;
+
+  const journeySorted = [...data.journey].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+
+  return (
+    <div>
+      <Link href="/admin/founding-partners" className="mb-3 inline-block text-xs text-slate-500 hover:underline">&larr; Founding Partners</Link>
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">{data.empresa}</h1>
+          <p className="text-sm text-slate-500">{data.email}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`rounded-full px-3 py-1 text-xs font-medium ${data.recognition === "founding_partner" ? "bg-amber-100 text-amber-700" : "bg-slate-100 text-slate-600"}`}>
+            {RECOGNITION_LABEL[data.recognition]}
+          </span>
+          <button onClick={toggleRecognition} disabled={busy === "recognition"} className="rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50">
+            {data.recognition === "founding_partner" ? "Reverter p/ Early Adopter" : "Marcar Founding Partner"}
+          </button>
+        </div>
+      </div>
+      {msg && <p className="mb-3 text-sm text-red-600">{msg}</p>}
+
+      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+        {/* Cadastrais */}
+        <section className={cardCls}>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-700">Cadastrais</h2>
+            <button onClick={openEdit} className="text-xs font-medium text-blue-700 hover:underline">Editar</button>
+          </div>
+          {!editOpen ? (
+            <dl className="grid grid-cols-2 gap-y-2 text-sm">
+              <dt className="text-slate-400">Responsável</dt><dd className="text-slate-700">{data.responsavel ?? "—"}</dd>
+              <dt className="text-slate-400">Cargo</dt><dd className="text-slate-700">{data.cargo ?? "—"}</dd>
+              <dt className="text-slate-400">WhatsApp</dt><dd className="text-slate-700">{data.telefone ?? "—"}</dd>
+              <dt className="text-slate-400">CNPJ</dt><dd className="text-slate-700">{data.cnpj ?? "—"}</dd>
+              <dt className="text-slate-400">Cidade/UF</dt><dd className="text-slate-700">{data.cidade ?? "—"}{data.uf ? `/${data.uf}` : ""}</dd>
+              <dt className="text-slate-400">ERP</dt><dd className="text-slate-700">{data.erp ?? "—"}</dd>
+              <dt className="text-slate-400">Qtd. CNPJs</dt><dd className="text-slate-700">{data.qtd_cnpjs ?? "—"}</dd>
+              <dt className="text-slate-400">Volume NF-e/mês</dt><dd className="text-slate-700">{data.volume_nfe_mensal_aprox ?? "—"}</dd>
+              <dt className="text-slate-400">Origem</dt><dd className="text-slate-700">{ORIGIN_LABEL[data.origem] ?? data.origem}</dd>
+              <dt className="text-slate-400">Owner</dt><dd className="text-slate-700">{data.owner_email ?? "—"}</dd>
+              <dt className="text-slate-400">Próxima ação</dt><dd className="text-slate-700">{data.proxima_acao ?? "—"}</dd>
+              <dt className="text-slate-400">Observações</dt><dd className="text-slate-700 col-span-1">{data.observacoes ?? "—"}</dd>
+            </dl>
+          ) : (
+            <form onSubmit={saveEdit} className="grid grid-cols-2 gap-2 text-sm">
+              {(["empresa", "responsavel", "cargo", "telefone", "cidade", "uf", "erp", "owner_email"] as const).map((f) => (
+                <input key={f} className={inputCls} placeholder={f} value={editForm[f] ?? ""} onChange={(e) => setEditForm({ ...editForm, [f]: e.target.value })} />
+              ))}
+              <input className={inputCls} type="number" placeholder="Qtd. CNPJs" value={editForm.qtd_cnpjs ?? ""} onChange={(e) => setEditForm({ ...editForm, qtd_cnpjs: e.target.value })} />
+              <input className={inputCls} type="number" placeholder="Volume NF-e/mês" value={editForm.volume_nfe_mensal_aprox ?? ""} onChange={(e) => setEditForm({ ...editForm, volume_nfe_mensal_aprox: e.target.value })} />
+              <textarea className={`${inputCls} col-span-2`} placeholder="Próxima ação" value={editForm.proxima_acao ?? ""} onChange={(e) => setEditForm({ ...editForm, proxima_acao: e.target.value })} />
+              <textarea className={`${inputCls} col-span-2`} placeholder="Observações" value={editForm.observacoes ?? ""} onChange={(e) => setEditForm({ ...editForm, observacoes: e.target.value })} />
+              <div className="col-span-2 flex gap-2">
+                <button type="submit" disabled={busy === "edit"} className="rounded-lg bg-[#2956E3] px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50">Salvar</button>
+                <button type="button" onClick={() => setEditOpen(false)} className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600">Cancelar</button>
+              </div>
+            </form>
+          )}
+        </section>
+
+        {/* Programa / Grant + sistema */}
+        <section className={cardCls}>
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Programa</h2>
+          <dl className="grid grid-cols-2 gap-y-2 text-sm">
+            <dt className="text-slate-400">Status</dt>
+            <dd><span className={`rounded-full px-2 py-0.5 text-xs font-medium ${data.status === "active" ? "bg-green-100 text-green-700" : "bg-slate-200 text-slate-600"}`}>{data.status === "active" ? "Ativo" : "Encerrado"}</span></dd>
+            <dt className="text-slate-400">Licença efetiva</dt>
+            <dd className="text-slate-700">{data.effective_plan ? `${data.effective_plan} · até ${fmt(data.grant_ends_at)}` : "sem concessão ativa"}</dd>
+            <dt className="text-slate-400">1º login</dt><dd className="text-slate-700">{fmt(data.system.first_login_at)}</dd>
+            <dt className="text-slate-400">Último login</dt><dd className="text-slate-700">{fmt(data.system.last_login_at)}</dd>
+          </dl>
+        </section>
+
+        {/* Jornada */}
+        <section className={`${cardCls} md:col-span-2`}>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-700">Jornada</h2>
+            <button onClick={() => setJourneyOpen((v) => !v)} className="text-xs font-medium text-blue-700 hover:underline">{journeyOpen ? "Fechar" : "Lançar evento"}</button>
+          </div>
+          {journeyOpen && (
+            <form onSubmit={addJourney} className="mb-4 grid grid-cols-1 gap-2 rounded-lg border border-slate-100 p-3 md:grid-cols-3">
+              <select className={inputCls} value={journeyForm.stage} onChange={(e) => setJourneyForm({ ...journeyForm, stage: e.target.value })}>
+                {JOURNEY_STAGES.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+              </select>
+              <input className={`${inputCls} md:col-span-1`} placeholder="Nota (opcional)" value={journeyForm.note} onChange={(e) => setJourneyForm({ ...journeyForm, note: e.target.value })} />
+              <button type="submit" disabled={busy === "journey"} className="rounded-lg bg-[#2956E3] px-3 py-2 text-xs font-medium text-white disabled:opacity-50">Lançar</button>
+            </form>
+          )}
+          <ol className="space-y-2">
+            {journeySorted.map((e, i) => (
+              <li key={e.id ?? `auto-${i}`} className="flex items-start gap-3 text-sm">
+                <span className={`mt-0.5 h-2 w-2 shrink-0 rounded-full ${e.source === "auto" ? "bg-green-500" : "bg-blue-500"}`} />
+                <div>
+                  <span className="font-medium text-slate-800">{JOURNEY_LABEL[e.stage] ?? e.stage}</span>
+                  <span className="ml-2 text-xs text-slate-400">{fmt(e.occurred_at)} · {e.source === "auto" ? "automático" : `manual${e.created_by_email ? ` (${e.created_by_email})` : ""}`}</span>
+                  {e.note && <p className="text-xs text-slate-500">{e.note}</p>}
+                </div>
+              </li>
+            ))}
+            {journeySorted.length === 0 && <p className="text-sm text-slate-400">Nenhum evento ainda.</p>}
+          </ol>
+        </section>
+
+        {/* Customer Evidence */}
+        <section className={cardCls}>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-700">Customer Evidence</h2>
+            <button onClick={() => setEvidenceOpen((v) => !v)} className="text-xs font-medium text-blue-700 hover:underline">{evidenceOpen ? "Fechar" : "Registrar"}</button>
+          </div>
+          <p className="mb-3 text-xs text-slate-400">Discovery — nunca altera o Brain automaticamente.</p>
+          {evidenceOpen && (
+            <form onSubmit={addEvidence} className="mb-4 space-y-2 rounded-lg border border-slate-100 p-3">
+              <select className={inputCls} value={evidenceForm.tipo} onChange={(e) => setEvidenceForm({ ...evidenceForm, tipo: e.target.value })}>
+                {EVIDENCE_TYPES.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+              </select>
+              <textarea className={inputCls} required placeholder="Texto" value={evidenceForm.texto} onChange={(e) => setEvidenceForm({ ...evidenceForm, texto: e.target.value })} />
+              <button type="submit" disabled={busy === "evidence"} className="rounded-lg bg-[#2956E3] px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50">Registrar</button>
+            </form>
+          )}
+          <ul className="space-y-2">
+            {data.customer_evidence.map((ev) => (
+              <li key={ev.id} className="rounded-lg bg-slate-50 p-2 text-sm">
+                <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-medium text-slate-600">{EVIDENCE_LABEL[ev.tipo] ?? ev.tipo}</span>
+                <p className="mt-1 text-slate-700">{ev.texto}</p>
+                <p className="text-xs text-slate-400">{fmt(ev.occurred_at)}{ev.autor ? ` · ${ev.autor}` : ""}</p>
+              </li>
+            ))}
+            {data.customer_evidence.length === 0 && <p className="text-sm text-slate-400">Nenhuma evidência ainda.</p>}
+          </ul>
+        </section>
+
+        {/* TERA */}
+        <section className={cardCls}>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-700">TERA</h2>
+            <button onClick={() => setTeraOpen((v) => !v)} className="text-xs font-medium text-blue-700 hover:underline">{teraOpen ? "Fechar" : "Registrar versão"}</button>
+          </div>
+          <p className="mb-3 text-xs text-slate-400">Registro manual (upload/link). Geração automática depende do RFC-0018.</p>
+          {teraOpen && (
+            <form onSubmit={addTera} className="mb-4 space-y-2 rounded-lg border border-slate-100 p-3">
+              <input className={inputCls} required placeholder="Versão (ex.: v1)" value={teraForm.versao} onChange={(e) => setTeraForm({ ...teraForm, versao: e.target.value })} />
+              <select className={inputCls} value={teraForm.tera_status} onChange={(e) => setTeraForm({ ...teraForm, tera_status: e.target.value })}>
+                <option value="rascunho">Rascunho</option>
+                <option value="apresentado">Apresentado</option>
+              </select>
+              <input className={inputCls} placeholder="Responsável" value={teraForm.responsavel} onChange={(e) => setTeraForm({ ...teraForm, responsavel: e.target.value })} />
+              <input className={inputCls} placeholder="Link do PDF (opcional)" value={teraForm.pdf_link} onChange={(e) => setTeraForm({ ...teraForm, pdf_link: e.target.value })} />
+              <input className={inputCls} type="file" accept="application/pdf" onChange={(e) => setTeraFile(e.target.files?.[0] ?? null)} />
+              <button type="submit" disabled={busy === "tera"} className="rounded-lg bg-[#2956E3] px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50">Registrar</button>
+            </form>
+          )}
+          <ul className="space-y-2">
+            {data.tera.map((t) => (
+              <li key={t.id} className="flex items-center justify-between rounded-lg bg-slate-50 p-2 text-sm">
+                <div>
+                  <span className="font-medium text-slate-800">{t.versao}</span>
+                  <span className="ml-2 rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-medium text-slate-600">{t.status === "apresentado" ? "Apresentado" : "Rascunho"}</span>
+                  <p className="text-xs text-slate-400">{fmt(t.created_at)}{t.responsavel ? ` · ${t.responsavel}` : ""}</p>
+                </div>
+                {t.has_file ? (
+                  <button onClick={() => downloadTera(t.id)} className="text-xs font-medium text-blue-700 hover:underline">Baixar</button>
+                ) : t.pdf_link ? (
+                  <a href={t.pdf_link} target="_blank" rel="noreferrer" className="text-xs font-medium text-blue-700 hover:underline">Abrir link</a>
+                ) : null}
+              </li>
+            ))}
+            {data.tera.length === 0 && <p className="text-sm text-slate-400">Nenhum TERA registrado ainda.</p>}
+          </ul>
+        </section>
+
+        {/* Conversão */}
+        <section className={`${cardCls} md:col-span-2`}>
+          <h2 className="mb-3 text-sm font-semibold text-slate-700">Conversão</h2>
+          <div className="mb-3 flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-slate-500">Interesse em continuar:</span>
+            {(["sim", "pensando", "nao"] as const).map((v) => (
+              <button key={v} onClick={() => setInterest(v)} disabled={busy === "interest"}
+                className={`rounded-full px-3 py-1 text-xs font-medium ${data.conversion.interesse === v ? "bg-blue-600 text-white" : "border border-slate-200 text-slate-600 hover:bg-slate-50"}`}>
+                {v === "sim" ? "Sim" : v === "nao" ? "Não" : "Pensando"}
+              </button>
+            ))}
+            {data.conversion.data && <span className="ml-2 text-xs text-slate-400">Convertido em {fmt(data.conversion.data)} · plano {data.conversion.plano_slug}</span>}
+          </div>
+
+          {!convertOpen ? (
+            <button onClick={() => setConvertOpen(true)} className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-medium text-white hover:opacity-90">
+              Gerar assinatura ASAAS
+            </button>
+          ) : (
+            <form onSubmit={convert} className="grid grid-cols-1 gap-2 rounded-lg border border-slate-100 p-3 md:grid-cols-2">
+              <select className={inputCls} value={convertForm.plan_slug} onChange={(e) => setConvertForm({ ...convertForm, plan_slug: e.target.value })}>
+                <option value="starter">Starter</option>
+                <option value="profissional">Profissional</option>
+                <option value="empresarial">Empresarial</option>
+                <option value="contador">Contador</option>
+              </select>
+              <select className={inputCls} value={convertForm.billing_type} onChange={(e) => setConvertForm({ ...convertForm, billing_type: e.target.value })}>
+                <option value="PIX">PIX</option>
+                <option value="BOLETO">Boleto</option>
+                <option value="CREDIT_CARD">Cartão de crédito</option>
+              </select>
+              <input className={`${inputCls} md:col-span-2`} placeholder="Motivo (opcional)" value={convertForm.motivo} onChange={(e) => setConvertForm({ ...convertForm, motivo: e.target.value })} />
+              <div className="md:col-span-2 flex gap-2">
+                <button type="submit" disabled={busy === "convert"} className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                  {busy === "convert" ? "Gerando…" : "Confirmar e iniciar assinatura ASAAS"}
+                </button>
+                <button type="button" onClick={() => setConvertOpen(false)} className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600">Cancelar</button>
+              </div>
+            </form>
+          )}
+
+          {convertResult && (
+            <div className="mt-3 rounded-lg bg-green-50 p-3 text-sm text-green-800">
+              <p className="font-medium">Assinatura iniciada.</p>
+              {convertResult.checkout_url && <a href={convertResult.checkout_url} target="_blank" rel="noreferrer" className="underline">Abrir checkout</a>}
+              {convertResult.pix_copy_paste && <p className="mt-1 break-all text-xs">PIX copia-e-cola: {convertResult.pix_copy_paste}</p>}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/founding-partners/page.tsx
+++ b/frontend/src/app/admin/founding-partners/page.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useAdminData, adminPost } from "@/lib/useAdminData";
 
-// Command Center dos Founding Partners (RFC-0017 + ADR-0008). O Grant concede o
-// Plano Contador por uma vigência, sem assinatura ASAAS — autorização operacional.
-const ORIGINS: { value: string; label: string }[] = [
-  { value: "microsoft_forms", label: "Microsoft Forms" },
-  { value: "indicacao", label: "Indicação" },
+// Cockpit Operacional do Programa Early Adopters (RFC-0024) — Tela 01. Sobre a
+// fundação RFC-0017/ADR-0008: o Grant concede o Plano Contador por uma
+// vigência, sem assinatura ASAAS — autorização operacional, nunca cobrança.
+export const ORIGINS: { value: string; label: string }[] = [
   { value: "linkedin", label: "LinkedIn" },
+  { value: "instagram", label: "Instagram" },
+  { value: "indicacao", label: "Indicação" },
+  { value: "cliente_6tech", label: "Cliente 6tech" },
+  { value: "google", label: "Google" },
   { value: "site", label: "Site" },
-  { value: "contato_direto", label: "Contato direto" },
   { value: "evento", label: "Evento" },
   { value: "outro", label: "Outro" },
 ];
-const ORIGIN_LABEL = Object.fromEntries(ORIGINS.map((o) => [o.value, o.label]));
+export const ORIGIN_LABEL = Object.fromEntries(ORIGINS.map((o) => [o.value, o.label]));
+export const RECOGNITION_LABEL: Record<string, string> = {
+  early_adopter: "Early Adopter",
+  founding_partner: "Founding Partner",
+};
 
 type Grant = {
   id: string;
@@ -23,7 +30,7 @@ type Grant = {
   ends_at: string;
   status: string;
 };
-type EarlyAdopter = {
+export type EarlyAdopter = {
   id: string;
   empresa: string;
   email: string;
@@ -34,6 +41,9 @@ type EarlyAdopter = {
   grant_ends_at: string | null;
   active_grant_id: string | null;
   grants: Grant[];
+  proxima_acao: string | null;
+  owner_email: string | null;
+  recognition: string;
 };
 type Resp = { total: number; items: EarlyAdopter[] };
 
@@ -49,7 +59,7 @@ const EMPTY = {
   cnpj: "",
   responsavel: "",
   telefone: "",
-  origem: "microsoft_forms",
+  origem: "linkedin",
   initial_password: "",
   starts_on: today(),
   ends_on: today(90),
@@ -217,32 +227,44 @@ export default function FoundingPartnersPage() {
                 <th className="px-4 py-3">Empresa</th>
                 <th className="px-4 py-3">Responsável</th>
                 <th className="px-4 py-3">Origem</th>
-                <th className="px-4 py-3">Licença efetiva</th>
-                <th className="px-4 py-3">Programa</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Próxima ação</th>
+                <th className="px-4 py-3">Owner</th>
                 <th className="px-4 py-3 text-right">Ações</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
               {data.items.map((ea) => (
                 <tr key={ea.id} className="hover:bg-slate-50">
-                  <td className="px-4 py-3 font-medium text-slate-900">{ea.empresa}<div className="text-xs text-slate-400">{ea.email}</div></td>
+                  <td className="px-4 py-3 font-medium text-slate-900">
+                    <Link href={`/admin/founding-partners/${ea.id}`} className="hover:underline">{ea.empresa}</Link>
+                    <div className="text-xs text-slate-400">{ea.email}</div>
+                    {ea.recognition === "founding_partner" && (
+                      <span className="mt-1 inline-block rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700">Founding Partner</span>
+                    )}
+                  </td>
                   <td className="px-4 py-3 text-slate-600">{ea.responsavel ?? "—"}</td>
                   <td className="px-4 py-3 text-slate-600">{ORIGIN_LABEL[ea.origem] ?? ea.origem}</td>
                   <td className="px-4 py-3">
-                    {ea.effective_plan ? (
-                      <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
-                        {ea.effective_plan} · até {new Date(ea.grant_ends_at as string).toLocaleDateString("pt-BR")}
-                      </span>
-                    ) : (
-                      <span className="text-slate-300">sem concessão ativa</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${ea.status === "active" ? "bg-green-100 text-green-700" : "bg-slate-200 text-slate-600"}`}>
+                    <div className={`mb-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${ea.status === "active" ? "bg-green-100 text-green-700" : "bg-slate-200 text-slate-600"}`}>
                       {ea.status === "active" ? "Ativo" : "Encerrado"}
-                    </span>
+                    </div>
+                    <div>
+                      {ea.effective_plan ? (
+                        <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                          {ea.effective_plan} · até {new Date(ea.grant_ends_at as string).toLocaleDateString("pt-BR")}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-slate-300">sem concessão ativa</span>
+                      )}
+                    </div>
                   </td>
+                  <td className="px-4 py-3 text-slate-600">{ea.proxima_acao ?? <span className="text-slate-300">—</span>}</td>
+                  <td className="px-4 py-3 text-slate-600">{ea.owner_email ?? <span className="text-slate-300">—</span>}</td>
                   <td className="px-4 py-3 text-right whitespace-nowrap">
+                    <Link href={`/admin/founding-partners/${ea.id}`} className="mr-2 rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50">
+                      Ver perfil
+                    </Link>
                     {ea.status === "active" && (
                       <>
                         {ea.active_grant_id ? (
@@ -263,7 +285,7 @@ export default function FoundingPartnersPage() {
                 </tr>
               ))}
               {data.items.length === 0 && (
-                <tr><td colSpan={6} className="px-4 py-8 text-center text-slate-400">Nenhum Founding Partner ainda.</td></tr>
+                <tr><td colSpan={7} className="px-4 py-8 text-center text-slate-400">Nenhum Founding Partner ainda.</td></tr>
               )}
             </tbody>
           </table>

--- a/frontend/src/lib/useAdminData.ts
+++ b/frontend/src/lib/useAdminData.ts
@@ -71,3 +71,18 @@ export async function adminRequest<T = unknown>(
   }
   return (await res.json().catch(() => ({}))) as T;
 }
+
+/** Mutação autenticada multipart/form-data (upload de arquivo). Sem Content-Type
+ * manual — o browser define o boundary. Retorna o JSON da resposta. */
+export async function adminUpload<T = unknown>(path: string, form: FormData): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${getToken()}` },
+    body: form,
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail ?? `Erro ${res.status}`);
+  }
+  return (await res.json().catch(() => ({}))) as T;
+}


### PR DESCRIPTION
## Resumo

Fecha #423.

A fundação (RFC-0017/ADR-0008 — `EarlyAdopter`, `EarlyGrant`, resolução de licença no login via `resolve_effective_license`) já estava em produção desde o PR #428. Esta entrega é o **cockpit operacional** da RFC-0024, construído sobre essa fundação — Tela 01 já existia (`admin/founding-partners`), o que faltava era a Tela 02 (perfil) e as capacidades operacionais em torno dela.

## O que entra

- **Tela 02** (`/admin/founding-partners/[id]`): cadastrais expandidos (cargo, cidade/UF, ERP, qtd. CNPJs, volume NF-e/mês), jornada, Customer Evidence, TERA, conversão.
- **Jornada — "observar, não replicar"**: eventos manuais (lançados pelo Owner) ficam em `early_adopter_journey_events`; os automáticos (**1º login**, **XML recebido**) são **derivados ao vivo** no `GET /{id}` a partir de `users.first_login_at`/`last_login_at` (novo) e da contagem de `Job` — nunca gravados como cópia. Validado end-to-end: logei de verdade como um Early Adopter de teste e confirmei o evento `primeiro_login` aparecer automaticamente, sem nenhuma escrita manual.
- **Customer Evidence**: captura por participante (10 tipos — problema percebido/confirmado, objeção, frase marcante, momento WOW/fricção, insight, hipótese, aprendizado, próximo passo). Guardrail RFC-0019/ADR-0005: nunca altera o Brain automaticamente — é só a superfície de captura.
- **TERA**: registro manual v1 (upload de PDF via S3/MinIO ou link externo). Geração automática fica para o RFC-0018 (ainda não construído).
- **Reconhecimento Founding Partner**: campo `recognition` (`early_adopter` → `founding_partner`), permanente, avaliação manual pelo Owner.
- **Conversão**: interesse (Sim/Não/Pensando) registrável sem tocar ASAAS; botão "Gerar assinatura ASAAS" reusa as mesmas chamadas de `billing.py:upgrade_plan` (`asaas.create_customer`/`create_subscription`) — **nunca um gateway paralelo**. Não é literalmente `upgrade_plan` porque um Early Adopter puro nunca tem Subscription prévia (Grant nunca cria Subscription, RNF002) — `upgrade_plan` exige uma assinatura existente para substituir, então esta função cobre o caso "sem assinatura anterior" com a mesma lógica ASAAS.
- **Enum de origem reconciliado** com a RFC-0024 (LinkedIn, Instagram, Indicação, Cliente 6tech, Google, Site, Evento, Outro) — valores legados do RFC-0017 (`microsoft_forms`, `contato_direto`) migrados para `outro` via `UPDATE` na migration.

## Migration

`2026_07_19_0028_add_early_adopter_cockpit`: estende `early_adopters` (aditivo, tudo nullable/com default seguro), cria `early_adopter_journey_events`, `customer_evidence`, `early_adopter_tera`, adiciona `users.first_login_at`/`last_login_at`.

## Test plan

- [x] Backend: 725 testes (`pytest tests/ -q`) — inclui `test_early_adopter_cockpit.py` (14 testes novos: detalhe, jornada auto+manual, evidência, TERA via link, cadastrais, reconhecimento, interesse de conversão, conversão via ASAAS **mockado** incluindo guardrail "nunca gateway paralelo") + `test_founding_partners_admin.py` ajustado (enum de origem)
- [x] `ruff check app/ tests/` limpo
- [x] `pyright` limpo
- [x] `npm test` (178 pass) + `npm run build` limpos
- [x] `tools/architecture_audit.py` — 1 achado pré-existente (task Celery órfã já documentada, não relacionado a este PR)
- [x] **Validação end-to-end via API real** (não só testes automatizados): login como superadmin, admissão de Early Adopter, PATCH de cadastrais, lançamento de evento de jornada manual, registro de Customer Evidence, registro de TERA via link, PATCH de interesse de conversão, e **login real como o Early Adopter de teste** confirmando o evento automático `primeiro_login` aparecer na jornada sem nenhuma escrita manual. Não testei interativamente no browser (clicar nos formulários) porque não há ferramenta de browser disponível neste ambiente — o `npm run build` valida os tipos/JSX da Tela 02 e a validação de API cobre a mesma superfície de dados que o frontend consome.

## Nota — flakiness de infra não relacionada

Durante os gates, `tests/test_billing_webhook.py` falhou (7 testes, "Connection to Redis lost"). Isolei com `git stash` contra `main` limpa: a falha é **idêntica sem nenhuma mudança minha**. Causa raiz: `REDIS_URL` do `.env` local aponta para o hostname interno do compose (`redis`), que resolve de forma instável quando o pytest roda no venv do host (fora de container) via proxy DNS do Docker Desktop. Com `REDIS_URL=redis://localhost:6379/0` explícito, os 725 testes passam em ~20s. Documentado em memória para não perder tempo re-diagnosticando em sessões futuras — não afeta CI (que provisiona Redis diretamente em `localhost`).