### PR TITLE
feat(credits): drill-down por NF + export PDF auditável (#258 Fase 2)

### DIFF
--- a/backend/app/routers/credits.py
+++ b/backend/app/routers/credits.py
@@ -12,15 +12,21 @@ Fluxo (LC 214 art. 22, não-cumulatividade plena):
   disponível  = confirmed                    (crédito formalizado e não utilizado)
   em_risco    = failed                       (crédito potencialmente perdido)
 
-Fase 2 (futuro): drill-down por NF, PDF, IBS/CBS separados por NCM,
-breakdown automático a partir de fiscal_metadata enriquecido.
+Fase 2, parte 1 (#258, esta entrega): drill-down por NF integrado a este
+dashboard (GET /documents, reaproveita SplitPaymentDoc/_to_doc de
+split_payment.py — mesma fonte de dado, não duplica) + export PDF com a
+trilha auditável por documento (GET /export.pdf).
+
+Fase 2, parte 2 (ainda pendente — ver issue de acompanhamento): IBS/CBS
+separados por NCM, tabela `credit_events` dedicada.
 """
 
 from __future__ import annotations
 
 import csv
 import io
-from typing import Literal
+from collections.abc import Sequence
+from typing import Any, Literal, cast
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
@@ -31,7 +37,8 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_current_user
 from app.api.plan_gate import require_plan
 from app.database import get_db
-from app.models.auth import User
+from app.models.auth import Tenant, User
+from app.routers.split_payment import SplitPaymentDoc, _to_doc
 
 router = APIRouter(prefix="/api/v1/credits", tags=["credits"])
 
@@ -133,6 +140,33 @@ def _compute_balance(
     return out
 
 
+def _documents_with_bucket(
+    db: Session,
+    tenant_id: str,
+    period_type: PeriodGranularity,
+    months_back: int,
+) -> Sequence[Any]:
+    """Documentos rastreados no Split Payment, com o bucket de período de cada
+    um — base tanto do drill-down (`GET /documents`) quanto do PDF auditável.
+    Reaproveita a mesma janela/condição de `_compute_balance`, só sem agregar.
+    """
+    trunc_unit = "month" if period_type == "month" else "quarter"
+    return db.execute(
+        text(f"""
+            SELECT
+                id, original_filename, doc_type, fiscal_metadata,
+                split_payment_status, created_at,
+                date_trunc('{trunc_unit}', created_at)::date AS bucket
+            FROM documents
+            WHERE tenant_id = CAST(:tid AS uuid)
+              AND split_payment_status IS NOT NULL
+              AND created_at >= (now() - (:months_back || ' months')::interval)
+            ORDER BY created_at DESC
+        """),
+        {"tid": tenant_id, "months_back": months_back},
+    ).all()
+
+
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
 @router.get(
@@ -187,5 +221,89 @@ def export_credit_balance_csv(
     return StreamingResponse(
         iter([buf.getvalue()]),
         media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get(
+    "/documents",
+    response_model=list[SplitPaymentDoc],
+    summary="Documentos (NFs) que compõem o crédito de um período — drill-down",
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def get_credit_documents(
+    period: str = Query(..., description="Rótulo do período, ex.: '2026-07' (mês) ou '2026-Q3' (trimestre)"),
+    period_type: PeriodGranularity = Query("month"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[SplitPaymentDoc]:
+    """Rastreabilidade por NF (#258): qual documento compõe o saldo de um
+    período específico da tela `/credits`. Reaproveita `_to_doc`/`SplitPaymentDoc`
+    de `split_payment.py` — mesma fonte de dado, não duplica.
+    """
+    rows = _documents_with_bucket(db, str(current_user.tenant_id), period_type, months_back=36)
+    matching = [r for r in rows if _period_label(period_type, r.bucket.isoformat()) == period]
+    return [_to_doc(r) for r in matching]
+
+
+@router.get(
+    "/export.pdf",
+    summary="Exporta saldo de crédito em PDF com trilha auditável por NF",
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def export_credit_balance_pdf(
+    period: PeriodGranularity = Query("month"),
+    months_back: int = Query(12, ge=1, le=36),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> StreamingResponse:
+    balance_rows = _compute_balance(db, str(current_user.tenant_id), period, months_back)
+    doc_rows = _documents_with_bucket(db, str(current_user.tenant_id), period, months_back)
+
+    docs_by_period: dict[str, list[dict[str, Any]]] = {}
+    for r in doc_rows:
+        label = _period_label(period, r.bucket.isoformat())
+        fm = r.fiscal_metadata if isinstance(r.fiscal_metadata, dict) else {}
+        docs_by_period.setdefault(label, []).append({
+            "filename": r.original_filename or str(r.id)[:8],
+            "doc_type": r.doc_type,
+            "status": r.split_payment_status,
+            "credit_value": fm.get("credit_value"),
+            "created_at": r.created_at.strftime("%d/%m/%Y") if r.created_at else "",
+        })
+
+    periods_payload = [
+        {
+            "period": row.period,
+            "generated_count": row.generated_count,
+            "generated_total": row.generated_total,
+            "apropriated_total": row.apropriated_total,
+            "available_total": row.available_total,
+            "at_risk_total": row.at_risk_total,
+            "documents": docs_by_period.get(row.period, []),
+        }
+        for row in balance_rows
+    ]
+
+    tenant = db.get(Tenant, current_user.tenant_id)
+    from app.services.pdf_service import generate_credit_report_pdf
+
+    result = generate_credit_report_pdf(
+        company_name=cast(str, tenant.name) if tenant is not None else "",
+        cnpj=cast(str, current_user.cnpj) if current_user.cnpj is not None else "",
+        period_type=period,
+        periods=periods_payload,
+    )
+
+    pdf_bytes = result["bytes"]
+    content_type = "application/pdf"
+    filename = f"credito-ibs-cbs-{period}.pdf"
+    if pdf_bytes[:15] == b"<!DOCTYPE html>":
+        content_type = "text/html; charset=utf-8"
+        filename = f"credito-ibs-cbs-{period}.html"
+
+    return StreamingResponse(
+        iter([pdf_bytes]),
+        media_type=content_type,
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -128,6 +128,64 @@ def generate_validation_report_pdf(
     }
 
 
+def generate_credit_report_pdf(
+    *,
+    company_name: str,
+    cnpj: str,
+    period_type: str,
+    periods: list[dict],
+    storage_key: str = "",
+) -> dict:
+    """Render the credit dashboard (#258) as a PDF with per-document (NF) audit
+    trail — cada período traz a lista de documentos que compõem o saldo.
+
+    Returns a dict with keys: bytes, storage_key, file_size.
+    Falls back to HTML-only if WeasyPrint is not installed.
+    """
+    template = _jinja_env.get_template("report_credits.html")
+    now = _generated_at_brasilia()
+
+    def _sum(key: str) -> float:
+        total = 0.0
+        for p in periods:
+            try:
+                total += float(p.get(key, 0) or 0)
+            except (TypeError, ValueError):
+                pass
+        return total
+
+    html = template.render(
+        company_name=company_name,
+        cnpj=cnpj,
+        period_type="Mensal" if period_type == "month" else "Trimestral",
+        generated_at=now,
+        periods=periods,
+        total_generated=_sum("generated_total"),
+        total_apropriated=_sum("apropriated_total"),
+        total_available=_sum("available_total"),
+        total_at_risk=_sum("at_risk_total"),
+    )
+
+    try:
+        from weasyprint import HTML
+        pdf_bytes: bytes = HTML(string=html).write_pdf()  # type: ignore[assignment]
+        logger.info("Credit report PDF generated (%d bytes)", len(pdf_bytes))
+        if storage_key:
+            _persist_to_s3(storage_key, pdf_bytes, "application/pdf")
+    except (ImportError, OSError):
+        logger.warning("WeasyPrint unavailable (missing GTK/system libs), returning HTML fallback")
+        pdf_bytes = html.encode("utf-8")
+        if storage_key:
+            html_key = storage_key.replace(".pdf", ".html") if storage_key.endswith(".pdf") else storage_key + ".html"
+            _persist_to_s3(html_key, pdf_bytes, "text/html")
+
+    return {
+        "bytes": pdf_bytes,
+        "storage_key": storage_key,
+        "file_size": len(pdf_bytes),
+    }
+
+
 def generate_batch_report_pdf(
     *,
     company_name: str,

--- a/backend/app/templates/report_credits.html
+++ b/backend/app/templates/report_credits.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Relatório de Crédito IBS/CBS — Tribultz</title>
+  <style>
+    @page {
+      size: A4;
+      margin: 2cm;
+      @bottom-center { content: "Tribultz — Relatório de Crédito IBS/CBS — Página " counter(page) " de " counter(pages); font-size: 8pt; color: #666; }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10pt; color: #1e293b; line-height: 1.5; }
+    .header { border-bottom: 3px solid #2563eb; padding-bottom: 12pt; margin-bottom: 16pt; }
+    .header h1 { font-size: 18pt; color: #2563eb; margin-bottom: 4pt; }
+    .header .subtitle { font-size: 10pt; color: #64748b; }
+    .meta-grid { display: flex; flex-wrap: wrap; gap: 8pt; margin-bottom: 16pt; }
+    .meta-item { flex: 1 1 30%; }
+    .meta-item .label { font-size: 8pt; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5pt; }
+    .meta-item .value { font-size: 11pt; font-weight: 600; }
+    .summary-cards { display: flex; gap: 8pt; margin-bottom: 16pt; }
+    .card { flex: 1; border: 1px solid #e2e8f0; border-radius: 4pt; padding: 8pt; text-align: center; }
+    .card .card-label { font-size: 8pt; color: #94a3b8; text-transform: uppercase; }
+    .card .card-value { font-size: 13pt; font-weight: 700; color: #1e293b; }
+    .card-generated .card-value { color: #059669; }
+    .card-apropriated .card-value { color: #2563eb; }
+    .card-available .card-value { color: #b45309; }
+    .card-risk .card-value { color: #dc2626; }
+    .period-section { margin-bottom: 18pt; page-break-inside: avoid; }
+    .period-section h2 { font-size: 12pt; color: #1e293b; background: #f1f5f9; padding: 6pt 8pt; border-radius: 3pt; margin-bottom: 6pt; }
+    .period-totals { display: flex; gap: 12pt; font-size: 8.5pt; color: #64748b; margin-bottom: 6pt; padding: 0 2pt; }
+    table { width: 100%; border-collapse: collapse; font-size: 8.5pt; margin-bottom: 8pt; }
+    th { background: #f8fafc; color: #475569; font-weight: 600; text-align: left; padding: 5pt 6pt; border-bottom: 2px solid #cbd5e1; }
+    td { padding: 4pt 6pt; border-bottom: 1px solid #e2e8f0; }
+    tr:nth-child(even) td { background: #f8fafc; }
+    .status-pill { display: inline-block; padding: 1pt 6pt; border-radius: 8pt; font-size: 7.5pt; font-weight: 600; }
+    .status-confirmed, .status-credit_released { background: #dcfce7; color: #166534; }
+    .status-pending { background: #fef3c7; color: #92400e; }
+    .status-failed { background: #fef2f2; color: #991b1b; }
+    .no-docs { font-size: 8.5pt; color: #94a3b8; padding: 4pt 2pt; }
+    .footer { margin-top: 24pt; padding-top: 8pt; border-top: 1px solid #e2e8f0; font-size: 8pt; color: #94a3b8; text-align: center; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <div style="display:flex; align-items:center; gap:10pt; margin-bottom:4pt;">
+    <span style="font-size:20pt; font-weight:900; color:#2563eb; letter-spacing:-1pt;">Tribultz</span>
+    <span style="font-size:9pt; color:#94a3b8; border-left:1px solid #cbd5e1; padding-left:10pt;">Plataforma de Conformidade Fiscal</span>
+  </div>
+  <h1>Relatório de Crédito IBS/CBS — Trilha Auditável</h1>
+  <div class="subtitle">LC 214/2025 art. 22 · Não-cumulatividade plena</div>
+</div>
+
+<div class="meta-grid">
+  <div class="meta-item">
+    <div class="label">Empresa</div>
+    <div class="value">{{ company_name }}</div>
+  </div>
+  <div class="meta-item">
+    <div class="label">CNPJ</div>
+    <div class="value">{{ cnpj }}</div>
+  </div>
+  <div class="meta-item">
+    <div class="label">Granularidade</div>
+    <div class="value">{{ period_type }}</div>
+  </div>
+  <div class="meta-item">
+    <div class="label">Gerado em</div>
+    <div class="value">{{ generated_at }}</div>
+  </div>
+</div>
+
+<div class="summary-cards">
+  <div class="card card-generated">
+    <div class="card-label">Gerado</div>
+    <div class="card-value">{{ total_generated|brl }}</div>
+  </div>
+  <div class="card card-apropriated">
+    <div class="card-label">Apropriado</div>
+    <div class="card-value">{{ total_apropriated|brl }}</div>
+  </div>
+  <div class="card card-available">
+    <div class="card-label">Disponível</div>
+    <div class="card-value">{{ total_available|brl }}</div>
+  </div>
+  <div class="card card-risk">
+    <div class="card-label">Em Risco</div>
+    <div class="card-value">{{ total_at_risk|brl }}</div>
+  </div>
+</div>
+
+{% for p in periods %}
+<div class="period-section">
+  <h2>{{ p.period }}</h2>
+  <div class="period-totals">
+    <span>Gerado: {{ p.generated_total|brl }}</span>
+    <span>Apropriado: {{ p.apropriated_total|brl }}</span>
+    <span>Disponível: {{ p.available_total|brl }}</span>
+    <span>Em Risco: {{ p.at_risk_total|brl }}</span>
+  </div>
+  {% if p.documents %}
+  <table>
+    <thead>
+      <tr>
+        <th style="width:35%">Documento</th>
+        <th style="width:15%">Modelo</th>
+        <th style="width:20%">Status</th>
+        <th style="width:15%">Data</th>
+        <th style="width:15%">Crédito</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for d in p.documents %}
+      <tr>
+        <td>{{ d.filename }}</td>
+        <td>{{ d.doc_type }}</td>
+        <td><span class="status-pill status-{{ d.status }}">{{ d.status }}</span></td>
+        <td>{{ d.created_at }}</td>
+        <td>{{ d.credit_value|brl if d.credit_value else "—" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="no-docs">Nenhum documento rastreado neste período.</p>
+  {% endif %}
+</div>
+{% endfor %}
+
+<div class="footer">
+  Relatório gerado automaticamente pela plataforma Tribultz — tribultz.com.br<br>
+  LC 214/2025 art. 22 · Trilha auditável para fiscalização
+</div>
+
+</body>
+</html>

--- a/backend/tests/test_credits.py
+++ b/backend/tests/test_credits.py
@@ -6,7 +6,7 @@ Mocks DB Session and plan-gate (profissional) via dependency_overrides.
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -182,3 +182,91 @@ def test_credit_requires_plan(client):
     resp = tc.get("/api/v1/credits/balance")
     assert resp.status_code == 403
     assert "profissional" in resp.json()["detail"].lower()
+
+
+# ── #258 Fase 2, parte 1 — drill-down por NF + export PDF ─────────────────────
+
+def _doc_row(*, doc_id=None, filename="nfe-123.xml", doc_type="nfe", status="confirmed",
+             credit_value="150.00", created_at=None, bucket=None):
+    m = MagicMock()
+    m.id = doc_id or uuid.uuid4()
+    m.original_filename = filename
+    m.doc_type = doc_type
+    m.split_payment_status = status
+    m.fiscal_metadata = {"credit_value": credit_value} if credit_value is not None else {}
+    m.created_at = created_at or datetime(2026, 5, 10, tzinfo=timezone.utc)
+    m.bucket = bucket or date(2026, 5, 1)
+    return m
+
+
+def test_credit_documents_drilldown_filters_by_period(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    rows_result = MagicMock()
+    rows_result.all.return_value = [
+        _doc_row(filename="nfe-maio.xml", bucket=date(2026, 5, 1)),
+        _doc_row(filename="nfe-abril.xml", bucket=date(2026, 4, 1)),
+    ]
+    session.execute.side_effect = [session.execute.return_value, rows_result]
+
+    resp = tc.get("/api/v1/credits/documents?period=2026-05&period_type=month")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["original_filename"] == "nfe-maio.xml"
+    assert body[0]["credit_value"] == "150.00"
+
+
+def test_credit_documents_drilldown_quarter_label(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    rows_result = MagicMock()
+    rows_result.all.return_value = [
+        _doc_row(filename="nfe-q2.xml", bucket=date(2026, 4, 1)),
+    ]
+    session.execute.side_effect = [session.execute.return_value, rows_result]
+
+    resp = tc.get("/api/v1/credits/documents?period=2026-Q2&period_type=quarter")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_credit_documents_drilldown_empty_period(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    rows_result = MagicMock()
+    rows_result.all.return_value = [_doc_row(bucket=date(2026, 5, 1))]
+    session.execute.side_effect = [session.execute.return_value, rows_result]
+
+    resp = tc.get("/api/v1/credits/documents?period=2026-06&period_type=month")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_credit_export_pdf_returns_downloadable_file(client):
+    """PDF ou fallback HTML (WeasyPrint pode não estar disponível no ambiente de
+    teste) — o endpoint deve sempre devolver um arquivo anexável com trilha por NF."""
+    tc, session = client
+    _stub_active_profissional(session)
+
+    balance_result = MagicMock()
+    balance_result.mappings.return_value.all.return_value = [
+        {"bucket": date(2026, 5, 1), "status": "confirmed", "cnt": 1, "total": 150.00},
+    ]
+    docs_result = MagicMock()
+    docs_result.all.return_value = [_doc_row(filename="nfe-auditavel.xml", bucket=date(2026, 5, 1))]
+
+    tenant = MagicMock(name="Empresa Teste")
+    tenant.name = "Empresa Teste"
+
+    session.execute.side_effect = [session.execute.return_value, balance_result, docs_result]
+    session.get.return_value = tenant
+
+    resp = tc.get("/api/v1/credits/export.pdf?period=month&months_back=6")
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("application/pdf") or resp.headers["content-type"].startswith("text/html")
+    assert "attachment" in resp.headers["content-disposition"]
+    assert len(resp.content) > 0

--- a/frontend/src/app/credits/page.tsx
+++ b/frontend/src/app/credits/page.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { Skeleton } from "@/components/common/Skeleton";
 import { Toast } from "@/components/common/Toast";
-import { downloadCreditCsv, getCreditBalance } from "@/lib/api";
-import type { CreditBalanceResponse, CreditPeriodRow } from "@/lib/api";
+import { downloadCreditCsv, downloadCreditPdf, getCreditBalance, getCreditDocuments } from "@/lib/api";
+import type { CreditBalanceResponse, CreditPeriodRow, SplitPaymentDoc } from "@/lib/api";
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "Pendente",
+  confirmed: "Confirmado",
+  credit_released: "Apropriado",
+  failed: "Falhou",
+};
+
+const STATUS_CLASS: Record<string, string> = {
+  pending: "bg-amber-100 text-amber-700",
+  confirmed: "bg-emerald-100 text-emerald-700",
+  credit_released: "bg-tribultz-100 text-tribultz-700",
+  failed: "bg-red-100 text-red-700",
+};
 
 function fmtBrl(v: string): string {
   const n = parseFloat(v);
@@ -47,11 +61,16 @@ export default function CreditsPage() {
   const [period, setPeriod] = useState<"month" | "quarter">("month");
   const [data, setData] = useState<CreditBalanceResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [downloading, setDownloading] = useState(false);
+  const [downloading, setDownloading] = useState<"csv" | "pdf" | null>(null);
   const [toast, setToast] = useState<{ tone: "success" | "error"; message: string } | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [docsByPeriod, setDocsByPeriod] = useState<Record<string, SplitPaymentDoc[]>>({});
+  const [docsLoading, setDocsLoading] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
+    setExpanded(null);
+    setDocsByPeriod({});
     getCreditBalance(period, 12)
       .then(setData)
       .catch(() => setToast({ tone: "error", message: "Erro ao carregar saldo de crédito" }))
@@ -59,7 +78,7 @@ export default function CreditsPage() {
   }, [period]);
 
   async function handleExportCsv(): Promise<void> {
-    setDownloading(true);
+    setDownloading("csv");
     try {
       const blob = await downloadCreditCsv(period, 12);
       const url = URL.createObjectURL(blob);
@@ -74,7 +93,49 @@ export default function CreditsPage() {
     } catch {
       setToast({ tone: "error", message: "Erro ao exportar CSV" });
     } finally {
-      setDownloading(false);
+      setDownloading(null);
+    }
+  }
+
+  async function handleExportPdf(): Promise<void> {
+    setDownloading("pdf");
+    try {
+      const { blob, isHtmlFallback } = await downloadCreditPdf(period, 12);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `credito-ibs-cbs-${period}.${isHtmlFallback ? "html" : "pdf"}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setToast({
+        tone: "success",
+        message: isHtmlFallback ? "Relatório exportado (HTML — gerador de PDF indisponível no servidor)" : "PDF exportado",
+      });
+    } catch {
+      setToast({ tone: "error", message: "Erro ao exportar PDF" });
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  async function toggleExpand(row: CreditPeriodRow): Promise<void> {
+    if (expanded === row.period) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(row.period);
+    if (docsByPeriod[row.period]) return;
+    setDocsLoading(row.period);
+    try {
+      const docs = await getCreditDocuments(row.period, period);
+      setDocsByPeriod((prev) => ({ ...prev, [row.period]: docs }));
+    } catch {
+      setToast({ tone: "error", message: "Erro ao carregar documentos do período" });
+      setExpanded(null);
+    } finally {
+      setDocsLoading(null);
     }
   }
 
@@ -91,14 +152,24 @@ export default function CreditsPage() {
             documentos rastreados em Split Payment.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => void handleExportCsv()}
-          disabled={downloading || rows.length === 0}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
-        >
-          {downloading ? "Exportando…" : "Exportar CSV"}
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void handleExportCsv()}
+            disabled={downloading !== null || rows.length === 0}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            {downloading === "csv" ? "Exportando…" : "Exportar CSV"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleExportPdf()}
+            disabled={downloading !== null || rows.length === 0}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            {downloading === "pdf" ? "Exportando…" : "Exportar PDF (trilha auditável)"}
+          </button>
+        </div>
       </header>
 
       {loading ? (
@@ -187,29 +258,84 @@ export default function CreditsPage() {
                 <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-red-700">
                   Em Risco
                 </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  NFs
+                </th>
               </tr>
             </thead>
             <tbody>
               {rows.map((r) => (
-                <tr key={r.period} className="border-t border-slate-100">
-                  <td className="px-4 py-3 font-medium text-slate-800">{r.period}</td>
-                  <td className="px-4 py-3 text-right font-mono">
-                    {fmtBrl(r.generated_total)}
-                    <span className="ml-1 text-xs text-slate-400">({r.generated_count})</span>
-                  </td>
-                  <td className="px-4 py-3 text-right font-mono">
-                    {fmtBrl(r.apropriated_total)}
-                    <span className="ml-1 text-xs text-slate-400">({r.apropriated_count})</span>
-                  </td>
-                  <td className="px-4 py-3 text-right font-mono">
-                    {fmtBrl(r.available_total)}
-                    <span className="ml-1 text-xs text-slate-400">({r.available_count})</span>
-                  </td>
-                  <td className="px-4 py-3 text-right font-mono">
-                    {fmtBrl(r.at_risk_total)}
-                    <span className="ml-1 text-xs text-slate-400">({r.at_risk_count})</span>
-                  </td>
-                </tr>
+                <Fragment key={r.period}>
+                  <tr
+                    className="cursor-pointer border-t border-slate-100 hover:bg-slate-50"
+                    onClick={() => void toggleExpand(r)}
+                  >
+                    <td className="px-4 py-3 font-medium text-slate-800">{r.period}</td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {fmtBrl(r.generated_total)}
+                      <span className="ml-1 text-xs text-slate-400">({r.generated_count})</span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {fmtBrl(r.apropriated_total)}
+                      <span className="ml-1 text-xs text-slate-400">({r.apropriated_count})</span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {fmtBrl(r.available_total)}
+                      <span className="ml-1 text-xs text-slate-400">({r.available_count})</span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono">
+                      {fmtBrl(r.at_risk_total)}
+                      <span className="ml-1 text-xs text-slate-400">({r.at_risk_count})</span>
+                    </td>
+                    <td className="px-4 py-3 text-right text-xs font-medium text-tribultz-600">
+                      {expanded === r.period ? "Ocultar ▲" : "Ver NFs ▼"}
+                    </td>
+                  </tr>
+                  {expanded === r.period && (
+                    <tr className="border-t border-slate-100 bg-slate-50/60">
+                      <td colSpan={6} className="px-4 py-3">
+                        {docsLoading === r.period ? (
+                          <Skeleton className="h-10 w-full" />
+                        ) : (docsByPeriod[r.period]?.length ?? 0) === 0 ? (
+                          <p className="py-2 text-xs text-slate-400">Nenhum documento rastreado neste período.</p>
+                        ) : (
+                          <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+                            <table className="w-full text-xs">
+                              <thead>
+                                <tr className="bg-slate-50 text-left text-[11px] uppercase tracking-wide text-slate-400">
+                                  <th className="px-3 py-2">Documento</th>
+                                  <th className="px-3 py-2">Modelo</th>
+                                  <th className="px-3 py-2">Status</th>
+                                  <th className="px-3 py-2">Data</th>
+                                  <th className="px-3 py-2 text-right">Crédito</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {docsByPeriod[r.period]?.map((d) => (
+                                  <tr key={d.document_id} className="border-t border-slate-100">
+                                    <td className="px-3 py-2 text-slate-700">{d.original_filename ?? d.document_id.slice(0, 8)}</td>
+                                    <td className="px-3 py-2 text-slate-500">{d.doc_type}</td>
+                                    <td className="px-3 py-2">
+                                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASS[d.split_payment_status] ?? "bg-slate-100 text-slate-600"}`}>
+                                        {STATUS_LABEL[d.split_payment_status] ?? d.split_payment_status}
+                                      </span>
+                                    </td>
+                                    <td className="px-3 py-2 text-slate-500">
+                                      {d.created_at ? new Date(d.created_at).toLocaleDateString("pt-BR") : "—"}
+                                    </td>
+                                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                                      {d.credit_value ? fmtBrl(d.credit_value) : "—"}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               ))}
             </tbody>
           </table>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -684,3 +684,30 @@ export async function downloadCreditCsv(
   if (!res.ok) throw new Error(`API ${res.status}`);
   return res.blob();
 }
+
+// ── Credits — drill-down por NF + export PDF (#258 Fase 2, parte 1) ─────────
+
+export async function getCreditDocuments(
+  period: string,
+  periodType: "month" | "quarter" = "month",
+): Promise<SplitPaymentDoc[]> {
+  return apiFetch(
+    `/api/v1/credits/documents?period=${encodeURIComponent(period)}&period_type=${periodType}`,
+  );
+}
+
+export async function downloadCreditPdf(
+  period: "month" | "quarter" = "month",
+  monthsBack: number = 12,
+): Promise<{ blob: Blob; isHtmlFallback: boolean }> {
+  const res = await fetch(
+    `${API_BASE}/api/v1/credits/export.pdf?period=${period}&months_back=${monthsBack}`,
+    {
+      headers: { Authorization: `Bearer ${getToken()}`, "X-Tenant-Id": getTenantId() },
+      cache: "no-store",
+    },
+  );
+  if (!res.ok) throw new Error(`API ${res.status}`);
+  const contentType = res.headers.get("content-type") ?? "";
+  return { blob: await res.blob(), isHtmlFallback: contentType.includes("text/html") };
+}


### PR DESCRIPTION
## Resumo

Segue #258 (não fecha totalmente — ver "Escopo declarado" abaixo).

A Fase 1 (PR #263, saldo agregado por período + CSV) já estava em produção, mas nunca teve uma issue de acompanhamento dedicada para o gap que a própria PR declarou (Não-escopo: drill-down por NF, export PDF, IBS/CBS separados, tabela `credit_events`). Esta entrega fecha os dois itens mais citados no próprio issue como diferencial ("trilha auditável para fiscalização"):

- **`GET /api/v1/credits/documents`**: drill-down por NF integrado ao `/credits` — reaproveita `SplitPaymentDoc`/`_to_doc` de `split_payment.py` (mesma fonte de dado, não duplica nada). Na UI, cada linha de período agora expande mostrando os documentos que compõem aquele saldo (status, valor de crédito, data).
- **`GET /api/v1/credits/export.pdf`**: relatório em PDF (Jinja2 + WeasyPrint, mesmo padrão de `report_validation.html`/`report_batch.html`) com a trilha auditável **por documento dentro de cada período** — não só o agregado que o CSV já oferecia. Fallback gracioso para HTML quando WeasyPrint não está disponível no ambiente (mesmo padrão já usado em `generate_validation_report_pdf`).

## Escopo declarado como fora desta entrega

- **IBS/CBS separados por NCM**: hoje o saldo é um total combinado (`credits.py` já documentava isso como Fase 2 desde a entrega original). Não mudei isso aqui.
- **Tabela `credit_events` dedicada**: o dashboard continua derivando tudo de `documents.split_payment_status` + `fiscal_metadata`. Sem tabela nova nesta entrega.

Vou abrir a issue de acompanhamento dedicada para os dois itens acima logo em seguida, mesmo padrão de #478/#480/#482/#484.

## Achado colateral (fora de escopo, não corrigido aqui)

Ao testar o fluxo real, descobri que `require_plan(...)` (`app/api/plan_gate.py::_get_active_subscription`) consulta **somente** `Subscription`+`Plan` no banco — não considera o `EarlyGrant`/`resolve_effective_license` (Grant Adapter, RFC-0017/ADR-0008). Ou seja, hoje um Early Adopter com Grant ativo (ex.: Plano Contador) provavelmente **não** consegue acessar endpoints gated por `require_plan` (`/credits`, `/split-payment`, etc.), mesmo com o JWT reportando `plan_slug: "contador"`. Não investiguei a fundo nem mexi nisso — é uma trilha separada da #258, mas registro aqui para não se perder; posso abrir issue se fizer sentido.

## Test plan

- [x] Backend: 729 testes (`pytest tests/ -q`) — 4 testes novos em `test_credits.py` (drill-down filtra por período, rótulo de trimestre, período vazio, export PDF retorna arquivo anexável PDF ou fallback HTML)
- [x] `ruff check app/ tests/` limpo
- [x] `pyright` limpo
- [x] `npm test` (178 pass) + `npm run build` limpos
- [x] `tools/architecture_audit.py` — 1 achado pré-existente (task Celery órfã já documentada, não relacionado a este PR)
- [x] **Validação end-to-end via API real dentro do container**: inseri 3 documentos sintéticos com `split_payment_status` no Postgres local, autentiquei com JWT real e testei `/balance` (agregação correta: 150.75+80.00=230.75 gerado), `/documents` (drill-down retornou as 3 NFs certas), e `/export.pdf` — **gerou um PDF real e válido (18KB, `%PDF-1.7`, verificado com `file`)** dentro do container Linux, onde as dependências de sistema do WeasyPrint estão presentes (diferente do host Mac, que cai no fallback HTML — ambos os caminhos ficaram cobertos). Dados de teste removidos do banco local depois. Não testei interativamente no browser (clicar no drill-down/botão PDF) — sem ferramenta de browser disponível neste ambiente; o `npm run build` valida os tipos/JSX da UI nova e a validação de API cobre a mesma superfície de dados que ela consome.