### PR TITLE
feat(register): campo digitável de Código de Referência + drill-down (#488)

### DIFF
--- a/frontend/src/app/admin/partners/page.tsx
+++ b/frontend/src/app/admin/partners/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useAdminData, adminPost, adminRequest } from "@/lib/useAdminData";
 
 // Proveniência comercial (RFC-0025). Partner = origem, NUNCA comissão/contrato/financeiro.
@@ -31,6 +31,15 @@ type Partner = {
 };
 type Resp = { total: number; items: Partner[] };
 
+type ReferredTenant = {
+  id: string;
+  name: string;
+  is_active: boolean;
+  users: number;
+  created_at: string;
+};
+type TenantsResp = { total: number; items: ReferredTenant[] };
+
 const EMPTY = { type: "other", name: "", company: "", email: "", phone: "", code: "", notes: "" };
 
 export default function AdminPartnersPage() {
@@ -39,6 +48,28 @@ export default function AdminPartnersPage() {
   const [editing, setEditing] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [referredByPartner, setReferredByPartner] = useState<Record<string, ReferredTenant[]>>({});
+  const [referredLoading, setReferredLoading] = useState<string | null>(null);
+
+  async function toggleExpand(p: Partner): Promise<void> {
+    if (expanded === p.id) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(p.id);
+    if (referredByPartner[p.id]) return;
+    setReferredLoading(p.id);
+    try {
+      const resp = await adminRequest<TenantsResp>("GET", `/api/v1/admin/tenants?partner_id=${p.id}&limit=200`);
+      setReferredByPartner((prev) => ({ ...prev, [p.id]: resp.items }));
+    } catch {
+      window.alert("Falha ao carregar empresas indicadas.");
+      setExpanded(null);
+    } finally {
+      setReferredLoading(null);
+    }
+  }
 
   function edit(p: Partner) {
     setEditing(p.id);
@@ -213,43 +244,91 @@ export default function AdminPartnersPage() {
             </thead>
             <tbody className="divide-y divide-slate-100">
               {data.items.map((p) => (
-                <tr key={p.id} className="hover:bg-slate-50">
-                  <td className="px-4 py-3 font-mono text-xs text-slate-700">{p.code}</td>
-                  <td className="px-4 py-3 font-medium text-slate-900">{p.name}</td>
-                  <td className="px-4 py-3 text-slate-600">{TYPE_LABEL[p.type] ?? p.type}</td>
-                  <td className="px-4 py-3 text-slate-700">{p.companies}</td>
-                  <td className="px-4 py-3">
-                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.status === "active" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
-                      {p.status === "active" ? "Ativo" : "Inativo"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.has_account ? "bg-blue-100 text-blue-700" : "bg-slate-100 text-slate-500"}`}>
-                      {p.has_account ? "Criada" : "Sem conta"}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <button onClick={() => edit(p)} className="mr-2 rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50">
-                      Editar
-                    </button>
-                    {!p.has_account && p.status === "active" && (
+                <Fragment key={p.id}>
+                  <tr className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-mono text-xs text-slate-700">{p.code}</td>
+                    <td className="px-4 py-3 font-medium text-slate-900">{p.name}</td>
+                    <td className="px-4 py-3 text-slate-600">{TYPE_LABEL[p.type] ?? p.type}</td>
+                    <td className="px-4 py-3">
                       <button
-                        onClick={() => createAccount(p)}
-                        disabled={busy}
-                        className="mr-2 rounded-lg border border-blue-200 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                        onClick={() => void toggleExpand(p)}
+                        className="rounded-full border border-slate-200 px-2 py-0.5 text-xs font-medium text-slate-700 hover:bg-slate-100"
+                        disabled={p.companies === 0}
                       >
-                        Criar conta
+                        {p.companies} {expanded === p.id ? "▲" : p.companies > 0 ? "▼" : ""}
                       </button>
-                    )}
-                    <button
-                      onClick={() => toggleActive(p)}
-                      disabled={busy}
-                      className={`rounded-lg px-3 py-1 text-xs font-medium disabled:opacity-50 ${p.status === "active" ? "border border-red-200 text-red-600 hover:bg-red-50" : "border border-green-200 text-green-700 hover:bg-green-50"}`}
-                    >
-                      {p.status === "active" ? "Desativar" : "Reativar"}
-                    </button>
-                  </td>
-                </tr>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.status === "active" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}>
+                        {p.status === "active" ? "Ativo" : "Inativo"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${p.has_account ? "bg-blue-100 text-blue-700" : "bg-slate-100 text-slate-500"}`}>
+                        {p.has_account ? "Criada" : "Sem conta"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button onClick={() => edit(p)} className="mr-2 rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50">
+                        Editar
+                      </button>
+                      {!p.has_account && p.status === "active" && (
+                        <button
+                          onClick={() => createAccount(p)}
+                          disabled={busy}
+                          className="mr-2 rounded-lg border border-blue-200 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                        >
+                          Criar conta
+                        </button>
+                      )}
+                      <button
+                        onClick={() => toggleActive(p)}
+                        disabled={busy}
+                        className={`rounded-lg px-3 py-1 text-xs font-medium disabled:opacity-50 ${p.status === "active" ? "border border-red-200 text-red-600 hover:bg-red-50" : "border border-green-200 text-green-700 hover:bg-green-50"}`}
+                      >
+                        {p.status === "active" ? "Desativar" : "Reativar"}
+                      </button>
+                    </td>
+                  </tr>
+                  {expanded === p.id && (
+                    <tr className="bg-slate-50/60">
+                      <td colSpan={7} className="px-4 py-3">
+                        {referredLoading === p.id ? (
+                          <p className="text-xs text-slate-400">Carregando…</p>
+                        ) : (referredByPartner[p.id]?.length ?? 0) === 0 ? (
+                          <p className="text-xs text-slate-400">Nenhuma empresa indicada por este Partner ainda.</p>
+                        ) : (
+                          <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+                            <table className="w-full text-xs">
+                              <thead>
+                                <tr className="bg-slate-50 text-left text-[11px] uppercase tracking-wide text-slate-400">
+                                  <th className="px-3 py-2">Empresa</th>
+                                  <th className="px-3 py-2">Status</th>
+                                  <th className="px-3 py-2">Usuários</th>
+                                  <th className="px-3 py-2">Cadastrada em</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {referredByPartner[p.id]?.map((t) => (
+                                  <tr key={t.id} className="border-t border-slate-100">
+                                    <td className="px-3 py-2 font-medium text-slate-800">{t.name}</td>
+                                    <td className="px-3 py-2">
+                                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${t.is_active ? "bg-green-100 text-green-700" : "bg-slate-200 text-slate-600"}`}>
+                                        {t.is_active ? "Ativa" : "Inativa"}
+                                      </span>
+                                    </td>
+                                    <td className="px-3 py-2 text-slate-600">{t.users}</td>
+                                    <td className="px-3 py-2 text-slate-500">{new Date(t.created_at).toLocaleDateString("pt-BR")}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               ))}
               {data.items.length === 0 && (
                 <tr><td colSpan={7} className="px-4 py-8 text-center text-slate-400">Nenhum Partner cadastrado.</td></tr>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -295,7 +295,7 @@ export default function RegisterPage() {
         <p className="mt-1 text-sm font-medium text-tribultz-700">Garanta sua conformidade fiscal antes que a reforma tributária te pegue de surpresa.</p>
         {partnerCode && (
           <p className="mt-2 inline-block rounded-full bg-tribultz-50 px-3 py-1 text-xs font-medium text-tribultz-700">
-            Indicação: <span className="font-mono">{partnerCode}</span>
+            Indicação detectada no link: <span className="font-mono">{partnerCode}</span>
           </p>
         )}
 
@@ -412,6 +412,21 @@ export default function RegisterPage() {
               </div>
             </fieldset>
           )}
+
+          <label className="block text-sm">
+            <span className="mb-1 block text-slate-600">Código de Referência (opcional)</span>
+            <input
+              type="text"
+              value={partnerCode}
+              onChange={(e) => setPartnerCode(e.target.value.toUpperCase())}
+              placeholder="Ex.: KATIA"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono uppercase placeholder:font-sans placeholder:normal-case"
+              maxLength={32}
+            />
+            <span className="mt-1 block text-xs text-slate-400">
+              Foi indicado por um parceiro Tribultz? Informe o código que ele compartilhou com você.
+            </span>
+          </label>
 
           <label className="flex items-start gap-2 text-sm">
             <input type="checkbox" checked={lgpdConsent} onChange={(e) => setLgpdConsent(e.target.checked)} className="mt-1 h-4 w-4 rounded border-slate-300" />


### PR DESCRIPTION
## Resumo

Fecha #488, escopo real da "Ordem Executiva — Implementação do Programa de Referência (MVP)" recebida hoje (P0).

**Contexto importante**: antes de implementar, investiguei e confirmei que a fundação já existe — RFC-0025 (Partner Attribution v1, #424, PR #425), **validada em produção em 16/07/2026**, 3 dias antes desta ordem. Modelo `Partner` (id, código único, nome, status, created_at), vínculo permanente `Tenant.partner_id`, admin CRUD, e captura automática no `/register` via `partner_code` — tudo já implementado e testado. **Confirmado em produção: zero parceiros cadastrados** — a Dra. Katia nunca foi registrada, e mesmo se fosse, não haveria como compartilhar um código digitável (só funcionava via link `?partner=CODIGO`).

Este PR fecha as **2 lacunas reais** identificadas (sem tocar em nenhum contrato de backend — zero arquivo `.py` mudou):

1. **`/register`**: adiciona um `<input>` editável "Código de Referência (opcional)", pré-preenchido quando a URL já traz `?partner=`/`?ref=` mas agora digitável por qualquer pessoa que tenha recebido o código verbalmente/por WhatsApp. Usa o mesmo campo `partner_code` que o backend já aceita e processa (`UserRegister.partner_code` → `_attach_partner_from_code`) — nenhuma mudança de contrato.
2. **`/admin/partners`**: a contagem "Empresas" agora expande (clique) num drill-down mostrando a lista real de empresas indicadas (nome, status, nº de usuários, data de cadastro) — reaproveita `GET /admin/tenants?partner_id=` já existente, sem duplicar lógica.

## Fora de escopo (intencional)

- Cadastrar a Dra. Katia como parceira — fica para o time de produto fazer via `/admin/partners` quando quiser (já confirmado com o usuário).
- Geração automática de código — o modelo já foi desenhado para o admin escolher o código (`KATIA`, `DRAKATIA` etc. são exemplos de escolha humana, não geração), consistente com RFC-0025.
- Comissões, pagamentos, ranking, dashboards avançados, cupons, múltiplos níveis — explicitamente fora de escopo tanto na ordem quanto no RFC-0025 original.

## Test plan

- [x] `npm test` (178 pass, sem novos testes de componente — convenção do repo não testa páginas admin diretamente, só módulos `lib/`; o contrato de backend reaproveitado já tem cobertura em `test_partner_admin.py`) + `npm run build` limpos
- [x] **Validação end-to-end via API real** (sem ferramenta de browser disponível neste ambiente): registrei uma empresa nova com `partner_code: "SEEDPARTNER"` (simulando exatamente o que o campo digitável envia) → vínculo automático confirmado; `GET /admin/tenants?partner_id=<id>` retornou a empresa corretamente, no formato exato que o novo drill-down do frontend consome. Dados de teste removidos do banco local depois.
- [x] Nenhum arquivo backend (`.py`) foi alterado — zero risco de regressão de contrato; toda a lógica reaproveitada já está coberta pelos testes existentes de RFC-0025.