### PR TITLE
fix(billing): plan gate reconhece Grant Adapter (#487)

### DIFF
--- a/backend/app/api/plan_gate.py
+++ b/backend/app/api/plan_gate.py
@@ -12,6 +12,7 @@ from app.api.deps import get_current_user
 from app.database import get_db
 from app.models.auth import User
 from app.models.billing import Plan, Subscription, UsageTracking
+from app.models.founding_partner import resolve_effective_license
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def require_plan(*allowed_slugs: str) -> Callable:
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db),
     ) -> User:
-        sub, plan = _get_active_subscription(db, current_user)
+        plan = _get_effective_plan(db, current_user)
         slug = cast(str, plan.slug) if plan else None
 
         if slug not in allowed_slugs:
@@ -48,7 +49,7 @@ def check_usage_limit(usage_type: str) -> Callable:
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db),
     ) -> User:
-        sub, plan = _get_active_subscription(db, current_user)
+        plan = _get_effective_plan(db, current_user)
         if not plan:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -138,11 +139,32 @@ def increment_usage(db: Session, user_id: object, tenant_id: object, usage_type:
 
 
 def get_plan_slug(db: Session, user: User) -> str | None:
-    """Return the active plan slug for a user, or None if no active subscription."""
-    _, plan = _get_active_subscription(db, user)
+    """Return the effective plan slug for a user (Grant Adapter aware), or None."""
+    plan = _get_effective_plan(db, user)
     if plan is None:
         return None
     return str(plan.slug)
+
+
+def _get_effective_plan(db: Session, user: User) -> Any:
+    """Resolve o Plan efetivo do usuário — Grant ativo (ADR-0008, Grant Adapter)
+    tem precedência sobre a assinatura, mesmo ponto único de resolução já usado
+    no login (`auth.py`: ``resolve_effective_license``). Sem isso, um Early
+    Adopter com Grant ativo (sem Subscription — RNF002) nunca passava em
+    `require_plan`/`check_usage_limit`/`get_plan_slug`, apesar do JWT reportar
+    o plano correto (#487).
+
+    Ator ``partner`` (RFC-0026) não tem ``tenant_id`` — não há Grant possível,
+    devolve a assinatura como está (tipicamente None).
+    """
+    _sub, sub_plan = _get_active_subscription(db, user)
+    if user.tenant_id is None:
+        return sub_plan
+    base_slug = cast(str, sub_plan.slug) if sub_plan is not None else ""
+    effective_slug, source = resolve_effective_license(db, cast(Any, user.tenant_id), base_slug)
+    if source == "subscription":
+        return sub_plan
+    return db.execute(select(Plan).where(Plan.slug == effective_slug)).scalar_one_or_none()
 
 
 def _get_active_subscription(db: Session, user: User) -> tuple[Any, Any]:

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -408,7 +408,10 @@ class TestValidateXmlTrialAccess:
         mock_db = MagicMock()
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_usage
 
-        with patch("app.api.plan_gate._get_active_subscription", return_value=(MagicMock(), mock_plan)):
+        # Patch _get_effective_plan (não _get_active_subscription): desde #487
+        # o plan gate também resolve Grant ativo via query real, que quebraria
+        # este mock_db não configurado para essa segunda consulta.
+        with patch("app.api.plan_gate._get_effective_plan", return_value=mock_plan):
             dep = check_usage_limit("validations")
             with pytest.raises(HTTPException) as exc:
                 dep(current_user=mock_user, db=mock_db)
@@ -425,7 +428,7 @@ class TestValidateXmlTrialAccess:
         mock_db = MagicMock()
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_usage
 
-        with patch("app.api.plan_gate._get_active_subscription", return_value=(MagicMock(), mock_plan)):
+        with patch("app.api.plan_gate._get_effective_plan", return_value=mock_plan):
             dep = check_usage_limit("validations")
             result = dep(current_user=mock_user, db=mock_db)
             assert result is mock_user

--- a/backend/tests/test_credits.py
+++ b/backend/tests/test_credits.py
@@ -61,6 +61,15 @@ def client():
     app.dependency_overrides.pop(get_db, None)
 
 
+def _no_grant_result() -> MagicMock:
+    """resolve_effective_license (#487) faz um 2º execute() buscando EarlyGrant
+    ativo — sem grant, cai no plano da assinatura (comportamento pré-existente
+    destes testes). Mimetiza `select(EarlyGrant)...scalars().first() -> None`."""
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = None
+    return result
+
+
 def _stub_active_profissional(session: MagicMock) -> None:
     """Make plan_gate._get_active_subscription return ('active', 'profissional')."""
     sub = MagicMock(status="active", current_period_end=None)
@@ -99,6 +108,7 @@ def test_credit_balance_month_aggregation(client):
     # First execute() in plan_gate already consumed; chain side_effect for second:
     session.execute.side_effect = [
         session.execute.return_value,  # plan_gate subscription query
+        _no_grant_result(),             # plan_gate grant check (#487)
         agg_result,                    # credits aggregation query
     ]
 
@@ -125,7 +135,7 @@ def test_credit_balance_empty(client):
     _stub_active_profissional(session)
     empty_result = MagicMock()
     empty_result.mappings.return_value.all.return_value = []
-    session.execute.side_effect = [session.execute.return_value, empty_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),empty_result]
 
     resp = tc.get("/api/v1/credits/balance")
     assert resp.status_code == 200
@@ -137,7 +147,7 @@ def test_credit_csv_export(client):
     _stub_active_profissional(session)
     agg_result = MagicMock()
     agg_result.mappings.return_value.all.return_value = _aggregation_rows()
-    session.execute.side_effect = [session.execute.return_value, agg_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),agg_result]
 
     resp = tc.get("/api/v1/credits/export.csv?period=month")
     assert resp.status_code == 200
@@ -166,7 +176,7 @@ def test_credit_balance_quarter_label(client):
     agg_result.mappings.return_value.all.return_value = [
         row(date(2026, 4, 1), "confirmed", 10, 5000.00),
     ]
-    session.execute.side_effect = [session.execute.return_value, agg_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),agg_result]
 
     resp = tc.get("/api/v1/credits/balance?period=quarter")
     assert resp.status_code == 200
@@ -174,10 +184,11 @@ def test_credit_balance_quarter_label(client):
 
 
 def test_credit_requires_plan(client):
-    """User sem subscription → 403."""
+    """User sem subscription e sem grant → 403."""
     tc, session = client
-    # Override the subscription query: return None
+    # Sem subscription (1ª query) e sem grant ativo (2ª query, #487)
     session.execute.return_value.first.return_value = None
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result()]
 
     resp = tc.get("/api/v1/credits/balance")
     assert resp.status_code == 403
@@ -208,7 +219,7 @@ def test_credit_documents_drilldown_filters_by_period(client):
         _doc_row(filename="nfe-maio.xml", bucket=date(2026, 5, 1)),
         _doc_row(filename="nfe-abril.xml", bucket=date(2026, 4, 1)),
     ]
-    session.execute.side_effect = [session.execute.return_value, rows_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),rows_result]
 
     resp = tc.get("/api/v1/credits/documents?period=2026-05&period_type=month")
     assert resp.status_code == 200, resp.text
@@ -226,7 +237,7 @@ def test_credit_documents_drilldown_quarter_label(client):
     rows_result.all.return_value = [
         _doc_row(filename="nfe-q2.xml", bucket=date(2026, 4, 1)),
     ]
-    session.execute.side_effect = [session.execute.return_value, rows_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),rows_result]
 
     resp = tc.get("/api/v1/credits/documents?period=2026-Q2&period_type=quarter")
     assert resp.status_code == 200
@@ -239,7 +250,7 @@ def test_credit_documents_drilldown_empty_period(client):
 
     rows_result = MagicMock()
     rows_result.all.return_value = [_doc_row(bucket=date(2026, 5, 1))]
-    session.execute.side_effect = [session.execute.return_value, rows_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),rows_result]
 
     resp = tc.get("/api/v1/credits/documents?period=2026-06&period_type=month")
     assert resp.status_code == 200
@@ -262,7 +273,7 @@ def test_credit_export_pdf_returns_downloadable_file(client):
     tenant = MagicMock(name="Empresa Teste")
     tenant.name = "Empresa Teste"
 
-    session.execute.side_effect = [session.execute.return_value, balance_result, docs_result]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(),balance_result, docs_result]
     session.get.return_value = tenant
 
     resp = tc.get("/api/v1/credits/export.pdf?period=month&months_back=6")

--- a/backend/tests/test_plan_gate.py
+++ b/backend/tests/test_plan_gate.py
@@ -1,0 +1,170 @@
+"""Plan Gate — Grant Adapter aware (#487).
+
+`require_plan`/`check_usage_limit`/`get_plan_slug` devem reconhecer um Grant
+ativo (ADR-0008) com a mesma precedência já usada no login (`auth.py`) — sem
+isso, um Early Adopter com Grant (sem Subscription — RNF002) sempre recebia
+403 em qualquer endpoint gated, apesar do JWT reportar o plano correto.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.api.plan_gate import check_usage_limit, get_plan_slug, require_plan
+from app.core.security import get_password_hash
+from app.models.auth import Tenant, User
+from app.models.billing import Plan, Subscription
+from app.models.founding_partner import EarlyAdopter, EarlyGrant
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+
+def _pg_available() -> bool:
+    try:
+        with create_engine(DATABASE_URL).connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _tenant_and_user(session, email: str) -> tuple[Tenant, User]:
+    tenant = Tenant(name="Empresa Teste", slug=f"t-{uuid.uuid4().hex[:10]}")
+    session.add(tenant)
+    session.flush()
+    user = User(
+        tenant_id=tenant.id, email=email, full_name="Teste",
+        password_hash=get_password_hash("x"), email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+    return tenant, user
+
+
+def _add_subscription(session, tenant: Tenant, user: User, plan_slug: str) -> None:
+    plan = session.execute(select(Plan).where(Plan.slug == plan_slug)).scalar_one()
+    session.add(Subscription(tenant_id=tenant.id, user_id=user.id, plan_id=plan.id, status="active"))
+    session.flush()
+
+
+def _add_grant(session, tenant: Tenant, plan_slug: str = "contador") -> None:
+    ea = EarlyAdopter(tenant_id=tenant.id, empresa="Empresa Teste", email="ea@teste.com")
+    session.add(ea)
+    session.flush()
+    hoje = date.today()
+    session.add(EarlyGrant(
+        early_adopter_id=ea.id, tenant_id=tenant.id, plan_slug=plan_slug,
+        starts_at=hoje - timedelta(days=1), ends_at=hoje + timedelta(days=30),
+        status="active",
+    ))
+    session.flush()
+
+
+def test_early_adopter_com_grant_ativo_acessa_endpoint_gated_sem_subscription(session):
+    """Núcleo do #487: Grant ativo, ZERO Subscription — antes retornava 403 sempre."""
+    tenant, user = _tenant_and_user(session, f"ea-{uuid.uuid4().hex[:8]}@empresa.com")
+    _add_grant(session, tenant, plan_slug="contador")
+
+    check = require_plan("contador", "empresarial", "profissional")
+    result = check(current_user=user, db=session)  # não levanta HTTPException
+    assert result is user
+
+
+def test_early_adopter_com_grant_bloqueado_fora_do_plano_do_grant(session):
+    tenant, user = _tenant_and_user(session, f"ea-{uuid.uuid4().hex[:8]}@empresa.com")
+    _add_grant(session, tenant, plan_slug="starter")  # fora dos planos aceitos abaixo
+
+    check = require_plan("contador", "empresarial", "profissional")
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        check(current_user=user, db=session)
+    assert exc.value.status_code == 403
+
+
+def test_usuario_pagante_sem_grant_continua_funcionando(session):
+    """Regressão: só Subscription, sem Grant — comportamento pré-existente intacto."""
+    tenant, user = _tenant_and_user(session, f"pay-{uuid.uuid4().hex[:8]}@empresa.com")
+    _add_subscription(session, tenant, user, plan_slug="profissional")
+
+    check = require_plan("contador", "empresarial", "profissional")
+    assert check(current_user=user, db=session) is user
+
+
+def test_grant_tem_precedencia_sobre_subscription(session):
+    """Mesma precedência do login (ADR-0008): Grant ativo > assinatura."""
+    tenant, user = _tenant_and_user(session, f"both-{uuid.uuid4().hex[:8]}@empresa.com")
+    _add_subscription(session, tenant, user, plan_slug="starter")
+    _add_grant(session, tenant, plan_slug="contador")
+
+    assert get_plan_slug(session, user) == "contador"
+
+
+def test_sem_grant_e_sem_subscription_bloqueado(session):
+    _tenant, user = _tenant_and_user(session, f"none-{uuid.uuid4().hex[:8]}@empresa.com")
+
+    check = require_plan("contador", "empresarial", "profissional")
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        check(current_user=user, db=session)
+    assert exc.value.status_code == 403
+
+
+def test_check_usage_limit_reconhece_grant():
+    """check_usage_limit também deve resolver o Plan via Grant (max_validations etc.)."""
+    engine2 = create_engine(DATABASE_URL)
+    Session2 = sessionmaker(autocommit=False, autoflush=False, bind=engine2)
+    conn = engine2.connect()
+    txn = conn.begin()
+    session = Session2(bind=conn)
+    try:
+        tenant, user = _tenant_and_user(session, f"usage-{uuid.uuid4().hex[:8]}@empresa.com")
+        _add_grant(session, tenant, plan_slug="contador")  # ilimitado (max_validations=None)
+
+        check = check_usage_limit("validations")
+        assert check(current_user=user, db=session) is user
+    finally:
+        session.close()
+        txn.rollback()
+        conn.close()
+
+
+def test_actor_partner_sem_tenant_nao_quebra(session):
+    """Ator partner (RFC-0026) não tem tenant_id — _get_effective_plan não deve
+    tentar resolver Grant (que exige tenant_id) e deve só refletir a ausência
+    de plano, sem lançar exceção inesperada."""
+    from app.models.partner import Partner
+
+    partner = Partner(name="Parceiro Teste", code=f"TEST{uuid.uuid4().hex[:6].upper()}")
+    session.add(partner)
+    session.flush()
+    user = User(
+        partner_id=partner.id, email=f"partner-{uuid.uuid4().hex[:8]}@teste.com",
+        full_name="Ator Partner", password_hash=get_password_hash("x"), email_verified=True,
+        role="partner",
+    )
+    session.add(user)
+    session.flush()
+
+    assert get_plan_slug(session, user) is None

--- a/backend/tests/test_reports_s18.py
+++ b/backend/tests/test_reports_s18.py
@@ -68,7 +68,10 @@ def _mock_plan():
 @pytest.fixture()
 def client_auth():
     app.dependency_overrides[get_current_user] = _override_current_user
-    with patch("app.api.plan_gate._get_active_subscription", return_value=(MagicMock(), _mock_plan())):
+    # Patch _get_effective_plan (não _get_active_subscription): desde #487 o
+    # plan gate também resolve Grant ativo (resolve_effective_license), que
+    # faria uma 2ª query real contra o mock_db não configurado para isso.
+    with patch("app.api.plan_gate._get_effective_plan", return_value=_mock_plan()):
         yield TestClient(app)
     app.dependency_overrides.pop(get_current_user, None)
 


### PR DESCRIPTION
## Resumo

Fecha #487.

**Causa raiz**: `backend/app/api/plan_gate.py::_get_active_subscription` consultava exclusivamente `Subscription`+`Plan` no banco — nunca considerava `EarlyGrant`/`resolve_effective_license` (Grant Adapter, ADR-0008). O login já resolvia o plano corretamente (`auth.py:224-226`), mas os três pontos de enforcement (`require_plan`, `check_usage_limit`, `get_plan_slug`) ignoravam isso e voltavam direto ao banco — todo Early Adopter com Grant ativo (Plano Contador, sem Subscription por design — RNF002) recebia 403 em qualquer endpoint gated (`/credits`, `/split-payment`, `/validate/xml`, `/api-keys`, etc — 28 routers).

## Correção

Novo helper `_get_effective_plan(db, user)`: resolve o `Plan` efetivo reaproveitando `resolve_effective_license` — a mesma função e precedência (Grant ativo > assinatura) já usada no login. Os três pontos de enforcement passam a usar esse único helper em vez de `_get_active_subscription` direto.

## DoD (issue #487)

- [x] **Confirmado que o bug nunca afetou produção** — consultei `early_adopters`/`early_grants` em produção antes de começar: zero registros. Nenhum Early Adopter real foi bloqueado até agora.
- [x] `require_plan`/`get_plan_slug`/`check_usage_limit` consideram Grant ativo, mesma precedência do login
- [x] Teste cobrindo Early Adopter (só Grant, sem Subscription) acessando endpoint gated com sucesso
- [x] Regressão: usuário pagante (só Subscription, sem Grant) continua funcionando normalmente

## Test plan

- [x] Backend: 736 testes (`pytest tests/ -q`) — `test_plan_gate.py` novo (7 testes: Grant sem Subscription passa, Grant fora do plano aceito bloqueia, pagante sem Grant funciona normalmente, Grant tem precedência sobre Subscription quando ambos existem, sem nenhum dos dois bloqueia, `check_usage_limit` reconhece Grant, ator `partner` sem `tenant_id` não quebra). 3 arquivos de teste existentes ajustados (`test_billing.py`, `test_credits.py`, `test_reports_s18.py`) — patchavam `_get_active_subscription` diretamente ou fixavam sequências rígidas de `db.execute()`; atualizados para o novo helper/consulta extra.
- [x] `ruff check app/ tests/` limpo
- [x] `pyright` limpo
- [x] **Validação end-to-end dentro do container**: criei um Early Adopter real com Grant ativo (Plano Contador) e zero Subscription, logei de verdade, e `GET /api/v1/credits/balance` retornou **200** (antes desta correção: 403). Dados de teste removidos depois.