### PR TITLE
feat(credits): IBS/CBS separados por categoria (#486)

### DIFF
--- a/backend/app/routers/credits.py
+++ b/backend/app/routers/credits.py
@@ -12,13 +12,21 @@ Fluxo (LC 214 art. 22, não-cumulatividade plena):
   disponível  = confirmed                    (crédito formalizado e não utilizado)
   em_risco    = failed                       (crédito potencialmente perdido)
 
-Fase 2, parte 1 (#258, esta entrega): drill-down por NF integrado a este
-dashboard (GET /documents, reaproveita SplitPaymentDoc/_to_doc de
-split_payment.py — mesma fonte de dado, não duplica) + export PDF com a
-trilha auditável por documento (GET /export.pdf).
+Fase 2, parte 1 (#258): drill-down por NF integrado a este dashboard
+(GET /documents, reaproveita SplitPaymentDoc/_to_doc de split_payment.py —
+mesma fonte de dado, não duplica) + export PDF com a trilha auditável por
+documento (GET /export.pdf).
 
-Fase 2, parte 2 (ainda pendente — ver issue de acompanhamento): IBS/CBS
-separados por NCM, tabela `credit_events` dedicada.
+Fase 2, parte 2 (#486, esta entrega): IBS e CBS reportados separadamente em
+cada categoria do fluxo (gerado/apropriado/disponível/em_risco), lendo
+`credit_value_ibs`/`credit_value_cbs` do `fiscal_metadata` (split_payment.py).
+Tabela `credit_events` dedicada foi avaliada e **deliberadamente adiada** —
+não existe hoje nenhuma fonte automática de evento discreto de crédito (nem
+extração de vCBS/vIBS do XML, nem integração com a Nota Nacional — ver
+Fase 2 de split_payment.py); todo o dado é entrada manual via
+`PATCH /split-payment/status/{id}`. Um livro-razão de eventos sem uma fonte
+real de eventos granulares seria estrutura vazia — construir quando a
+integração com a Nota Nacional (que geraria eventos de verdade) existir.
 """
 
 from __future__ import annotations
@@ -38,7 +46,7 @@ from app.api.deps import get_current_user
 from app.api.plan_gate import require_plan
 from app.database import get_db
 from app.models.auth import Tenant, User
-from app.routers.split_payment import SplitPaymentDoc, _to_doc
+from app.routers.split_payment import SplitPaymentDoc, _combined_credit_value, _to_doc
 
 router = APIRouter(prefix="/api/v1/credits", tags=["credits"])
 
@@ -49,12 +57,20 @@ class CreditPeriodRow(BaseModel):
     period: str                # "2026-05" ou "2026-Q2"
     generated_count: int
     generated_total: str       # R$ (string p/ evitar perda de precisão)
+    generated_total_ibs: str   # #486 — quebra por tributo
+    generated_total_cbs: str
     apropriated_count: int
     apropriated_total: str
+    apropriated_total_ibs: str
+    apropriated_total_cbs: str
     available_count: int
     available_total: str
+    available_total_ibs: str
+    available_total_cbs: str
     at_risk_count: int
     at_risk_total: str
+    at_risk_total_ibs: str
+    at_risk_total_cbs: str
 
 
 class CreditBalanceResponse(BaseModel):
@@ -84,6 +100,10 @@ def _compute_balance(
     """Agrega documents.split_payment_status por bucket de tempo.
 
     Usa date_trunc + COALESCE para extrair credit_value de fiscal_metadata.
+    O total combinado usa `credit_value` legado se presente; senão soma
+    `credit_value_ibs` + `credit_value_cbs` (#486) — mesma precedência de
+    `split_payment.py::_combined_credit_value`, replicada em SQL para agregar
+    sem trazer todas as linhas para Python.
     """
     trunc_unit = "month" if period_type == "month" else "quarter"
     rows = db.execute(
@@ -93,8 +113,14 @@ def _compute_balance(
                 split_payment_status AS status,
                 COUNT(*) AS cnt,
                 COALESCE(SUM(
-                    NULLIF(fiscal_metadata->>'credit_value', '')::numeric
-                ), 0) AS total
+                    COALESCE(
+                        NULLIF(fiscal_metadata->>'credit_value', '')::numeric,
+                        COALESCE(NULLIF(fiscal_metadata->>'credit_value_ibs', '')::numeric, 0)
+                        + COALESCE(NULLIF(fiscal_metadata->>'credit_value_cbs', '')::numeric, 0)
+                    )
+                ), 0) AS total,
+                COALESCE(SUM(NULLIF(fiscal_metadata->>'credit_value_ibs', '')::numeric), 0) AS total_ibs,
+                COALESCE(SUM(NULLIF(fiscal_metadata->>'credit_value_cbs', '')::numeric), 0) AS total_cbs
             FROM documents
             WHERE tenant_id = CAST(:tid AS uuid)
               AND split_payment_status IS NOT NULL
@@ -113,28 +139,42 @@ def _compute_balance(
         buckets.setdefault(bucket_iso, {})[status] = {
             "count": int(r["cnt"] or 0),
             "total": float(r["total"] or 0),
+            "total_ibs": float(r["total_ibs"] or 0),
+            "total_cbs": float(r["total_cbs"] or 0),
         }
+
+    _zero = {"count": 0, "total": 0.0, "total_ibs": 0.0, "total_cbs": 0.0}
 
     out: list[CreditPeriodRow] = []
     for bucket_iso in sorted(buckets.keys(), reverse=True):
         by_status = buckets[bucket_iso]
-        confirmed = by_status.get("confirmed", {"count": 0, "total": 0.0})
-        released = by_status.get("credit_released", {"count": 0, "total": 0.0})
-        failed = by_status.get("failed", {"count": 0, "total": 0.0})
+        confirmed = by_status.get("confirmed", dict(_zero))
+        released = by_status.get("credit_released", dict(_zero))
+        failed = by_status.get("failed", dict(_zero))
 
         gen_count = int(confirmed["count"] + released["count"])
         gen_total = float(confirmed["total"] + released["total"])
+        gen_ibs = float(confirmed["total_ibs"] + released["total_ibs"])
+        gen_cbs = float(confirmed["total_cbs"] + released["total_cbs"])
 
         out.append(CreditPeriodRow(
             period=_period_label(period_type, bucket_iso),
             generated_count=gen_count,
             generated_total=f"{gen_total:.2f}",
+            generated_total_ibs=f"{gen_ibs:.2f}",
+            generated_total_cbs=f"{gen_cbs:.2f}",
             apropriated_count=int(released["count"]),
             apropriated_total=f"{float(released['total']):.2f}",
+            apropriated_total_ibs=f"{float(released['total_ibs']):.2f}",
+            apropriated_total_cbs=f"{float(released['total_cbs']):.2f}",
             available_count=int(confirmed["count"]),
             available_total=f"{float(confirmed['total']):.2f}",
+            available_total_ibs=f"{float(confirmed['total_ibs']):.2f}",
+            available_total_cbs=f"{float(confirmed['total_cbs']):.2f}",
             at_risk_count=int(failed["count"]),
             at_risk_total=f"{float(failed['total']):.2f}",
+            at_risk_total_ibs=f"{float(failed['total_ibs']):.2f}",
+            at_risk_total_cbs=f"{float(failed['total_cbs']):.2f}",
         ))
 
     return out
@@ -202,18 +242,18 @@ def export_credit_balance_csv(
     writer = csv.writer(buf, delimiter=";")  # ; para compatibilidade Excel pt-BR
     writer.writerow([
         "PERIODO",
-        "GERADO_QTD", "GERADO_TOTAL_BRL",
-        "APROPRIADO_QTD", "APROPRIADO_TOTAL_BRL",
-        "DISPONIVEL_QTD", "DISPONIVEL_TOTAL_BRL",
-        "EM_RISCO_QTD", "EM_RISCO_TOTAL_BRL",
+        "GERADO_QTD", "GERADO_TOTAL_BRL", "GERADO_IBS_BRL", "GERADO_CBS_BRL",
+        "APROPRIADO_QTD", "APROPRIADO_TOTAL_BRL", "APROPRIADO_IBS_BRL", "APROPRIADO_CBS_BRL",
+        "DISPONIVEL_QTD", "DISPONIVEL_TOTAL_BRL", "DISPONIVEL_IBS_BRL", "DISPONIVEL_CBS_BRL",
+        "EM_RISCO_QTD", "EM_RISCO_TOTAL_BRL", "EM_RISCO_IBS_BRL", "EM_RISCO_CBS_BRL",
     ])
     for r in rows:
         writer.writerow([
             r.period,
-            r.generated_count, r.generated_total,
-            r.apropriated_count, r.apropriated_total,
-            r.available_count, r.available_total,
-            r.at_risk_count, r.at_risk_total,
+            r.generated_count, r.generated_total, r.generated_total_ibs, r.generated_total_cbs,
+            r.apropriated_count, r.apropriated_total, r.apropriated_total_ibs, r.apropriated_total_cbs,
+            r.available_count, r.available_total, r.available_total_ibs, r.available_total_cbs,
+            r.at_risk_count, r.at_risk_total, r.at_risk_total_ibs, r.at_risk_total_cbs,
         ])
 
     buf.seek(0)
@@ -268,7 +308,9 @@ def export_credit_balance_pdf(
             "filename": r.original_filename or str(r.id)[:8],
             "doc_type": r.doc_type,
             "status": r.split_payment_status,
-            "credit_value": fm.get("credit_value"),
+            "credit_value": _combined_credit_value(fm),
+            "credit_value_ibs": fm.get("credit_value_ibs"),
+            "credit_value_cbs": fm.get("credit_value_cbs"),
             "created_at": r.created_at.strftime("%d/%m/%Y") if r.created_at else "",
         })
 
@@ -277,6 +319,8 @@ def export_credit_balance_pdf(
             "period": row.period,
             "generated_count": row.generated_count,
             "generated_total": row.generated_total,
+            "generated_total_ibs": row.generated_total_ibs,
+            "generated_total_cbs": row.generated_total_cbs,
             "apropriated_total": row.apropriated_total,
             "available_total": row.available_total,
             "at_risk_total": row.at_risk_total,

--- a/backend/app/routers/split_payment.py
+++ b/backend/app/routers/split_payment.py
@@ -4,6 +4,13 @@ GET  /api/v1/split-payment/summary          → totais por status (gated: profis
 GET  /api/v1/split-payment/status/{doc_id}  → status + crédito de um documento
 PATCH /api/v1/split-payment/status/{doc_id} → atualizar status manualmente (fase 1)
 
+Crédito IBS/CBS discriminado (#486): `credit_value_ibs`/`credit_value_cbs` no
+`fiscal_metadata`, precedência sobre o `credit_value` combinado legado — quem
+informa os dois valores discriminados não precisa (nem deve) também informar
+o total, que é sempre derivado (`_combined_credit_value`). Continua entrada
+manual — não existe hoje extração automática de vCBS/vIBS do XML para o
+Document (`documents.py::_extract_xml_metadata` não captura esses campos).
+
 Fase 2 (não implementada aqui): Celery beat task que consulta Nota Nacional
 (NT 2025.002) para atualizar status automaticamente.
 """
@@ -38,7 +45,9 @@ class SplitPaymentDoc(BaseModel):
     original_filename: Optional[str]
     doc_type: str
     split_payment_status: str
-    credit_value: Optional[str]       # CBS + IBS (R$), from fiscal_metadata
+    credit_value: Optional[str]       # CBS + IBS (R$) — total, derivado se ibs/cbs informados
+    credit_value_ibs: Optional[str]   # IBS (R$), from fiscal_metadata (#486)
+    credit_value_cbs: Optional[str]   # CBS (R$), from fiscal_metadata (#486)
     credit_due_date: Optional[str]    # ISO date, from fiscal_metadata
     created_at: str
     days_pending: Optional[int]       # days since created_at if still pending
@@ -46,7 +55,9 @@ class SplitPaymentDoc(BaseModel):
 
 class SplitPaymentStatusUpdate(BaseModel):
     status: str
-    credit_value: Optional[str] = None    # R$ total CBS+IBS
+    credit_value: Optional[str] = None        # R$ total CBS+IBS (legado — use ibs/cbs quando souber discriminar)
+    credit_value_ibs: Optional[str] = None    # R$ IBS (#486)
+    credit_value_cbs: Optional[str] = None    # R$ CBS (#486)
     credit_due_date: Optional[str] = None  # ISO date (expected confirmation)
 
 
@@ -65,6 +76,21 @@ class SplitPaymentSummary(BaseModel):
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
+def _combined_credit_value(fm: dict[str, Any]) -> Optional[str]:
+    """Total CBS+IBS: usa `credit_value` legado se presente; senão soma os dois
+    valores discriminados (#486) — nunca os dois ao mesmo tempo por engano."""
+    if fm.get("credit_value") is not None:
+        return fm["credit_value"]
+    ibs = fm.get("credit_value_ibs")
+    cbs = fm.get("credit_value_cbs")
+    if ibs is None and cbs is None:
+        return None
+    try:
+        return f"{float(ibs or 0) + float(cbs or 0):.2f}"
+    except (TypeError, ValueError):
+        return None
+
+
 def _to_doc(row: Any) -> SplitPaymentDoc:
     fm = row.fiscal_metadata if isinstance(row.fiscal_metadata, dict) else {}
     created_at_str = row.created_at.isoformat() if row.created_at else ""
@@ -77,7 +103,9 @@ def _to_doc(row: Any) -> SplitPaymentDoc:
         original_filename=row.original_filename,
         doc_type=row.doc_type,
         split_payment_status=row.split_payment_status,
-        credit_value=fm.get("credit_value"),
+        credit_value=_combined_credit_value(fm),
+        credit_value_ibs=fm.get("credit_value_ibs"),
+        credit_value_cbs=fm.get("credit_value_cbs"),
         credit_due_date=fm.get("credit_due_date"),
         created_at=created_at_str,
         days_pending=days_pending,
@@ -89,7 +117,7 @@ def _sum_credit(rows: list[Any]) -> str:
     for r in rows:
         fm = r.fiscal_metadata if isinstance(r.fiscal_metadata, dict) else {}
         try:
-            total += float(fm.get("credit_value") or 0)
+            total += float(_combined_credit_value(fm) or 0)
         except (ValueError, TypeError):
             pass
     return f"{total:.2f}"
@@ -244,7 +272,15 @@ def update_split_payment_status(
 
     # Merge fiscal_metadata updates
     fm: dict[str, Any] = dict(row.fiscal_metadata) if isinstance(row.fiscal_metadata, dict) else {}
-    if body.credit_value is not None:
+    if body.credit_value_ibs is not None or body.credit_value_cbs is not None:
+        # Discriminado (#486) tem precedência — remove o combinado legado para
+        # não ficar um valor obsoleto/divergente coexistindo com o novo par.
+        fm.pop("credit_value", None)
+        if body.credit_value_ibs is not None:
+            fm["credit_value_ibs"] = body.credit_value_ibs
+        if body.credit_value_cbs is not None:
+            fm["credit_value_cbs"] = body.credit_value_cbs
+    elif body.credit_value is not None:
         fm["credit_value"] = body.credit_value
     if body.credit_due_date is not None:
         fm["credit_due_date"] = body.credit_due_date

--- a/backend/app/templates/report_credits.html
+++ b/backend/app/templates/report_credits.html
@@ -94,7 +94,7 @@
 <div class="period-section">
   <h2>{{ p.period }}</h2>
   <div class="period-totals">
-    <span>Gerado: {{ p.generated_total|brl }}</span>
+    <span>Gerado: {{ p.generated_total|brl }} (IBS {{ p.generated_total_ibs|brl }} + CBS {{ p.generated_total_cbs|brl }})</span>
     <span>Apropriado: {{ p.apropriated_total|brl }}</span>
     <span>Disponível: {{ p.available_total|brl }}</span>
     <span>Em Risco: {{ p.at_risk_total|brl }}</span>
@@ -103,11 +103,13 @@
   <table>
     <thead>
       <tr>
-        <th style="width:35%">Documento</th>
-        <th style="width:15%">Modelo</th>
-        <th style="width:20%">Status</th>
-        <th style="width:15%">Data</th>
-        <th style="width:15%">Crédito</th>
+        <th style="width:26%">Documento</th>
+        <th style="width:11%">Modelo</th>
+        <th style="width:16%">Status</th>
+        <th style="width:12%">Data</th>
+        <th style="width:12%">IBS</th>
+        <th style="width:12%">CBS</th>
+        <th style="width:11%">Total</th>
       </tr>
     </thead>
     <tbody>
@@ -117,6 +119,8 @@
         <td>{{ d.doc_type }}</td>
         <td><span class="status-pill status-{{ d.status }}">{{ d.status }}</span></td>
         <td>{{ d.created_at }}</td>
+        <td>{{ d.credit_value_ibs|brl if d.credit_value_ibs else "—" }}</td>
+        <td>{{ d.credit_value_cbs|brl if d.credit_value_cbs else "—" }}</td>
         <td>{{ d.credit_value|brl if d.credit_value else "—" }}</td>
       </tr>
       {% endfor %}

--- a/backend/tests/test_credits.py
+++ b/backend/tests/test_credits.py
@@ -80,21 +80,29 @@ def _stub_active_profissional(session: MagicMock) -> None:
     session.execute.return_value.first.return_value = first_result
 
 
-def _aggregation_rows():
-    """Two months × two statuses each — matches the SQL aggregation result shape."""
-    def row(bucket, status, cnt, total):
-        m = MagicMock()
-        m.__getitem__ = lambda self, k: {
-            "bucket": bucket, "status": status, "cnt": cnt, "total": total
-        }[k]
-        return m
+def _row(bucket, status, cnt, total, ibs=None, cbs=None):
+    """Uma linha da agregação SQL — ibs/cbs (#486) default a 60%/40% do total
+    quando não informados, sempre somando de volta ao total combinado."""
+    if ibs is None:
+        ibs = round(total * 0.6, 2)
+    if cbs is None:
+        cbs = round(total - ibs, 2)
+    m = MagicMock()
+    m.__getitem__ = lambda self, k: {
+        "bucket": bucket, "status": status, "cnt": cnt, "total": total,
+        "total_ibs": ibs, "total_cbs": cbs,
+    }[k]
+    return m
 
+
+def _aggregation_rows():
+    """Two months × três statuses cada — mesmo shape da agregação SQL."""
     return [
-        row(date(2026, 5, 1), "confirmed", 3, 1500.00),
-        row(date(2026, 5, 1), "credit_released", 2, 800.00),
-        row(date(2026, 5, 1), "failed", 1, 200.00),
-        row(date(2026, 4, 1), "confirmed", 5, 2500.00),
-        row(date(2026, 4, 1), "credit_released", 4, 1600.00),
+        _row(date(2026, 5, 1), "confirmed", 3, 1500.00, ibs=900.00, cbs=600.00),
+        _row(date(2026, 5, 1), "credit_released", 2, 800.00, ibs=500.00, cbs=300.00),
+        _row(date(2026, 5, 1), "failed", 1, 200.00, ibs=120.00, cbs=80.00),
+        _row(date(2026, 4, 1), "confirmed", 5, 2500.00, ibs=1500.00, cbs=1000.00),
+        _row(date(2026, 4, 1), "credit_released", 4, 1600.00, ibs=1000.00, cbs=600.00),
     ]
 
 
@@ -122,12 +130,20 @@ def test_credit_balance_month_aggregation(client):
     # generated = confirmed + released = 3+2 = 5 ; total = 1500+800 = 2300
     assert may["generated_count"] == 5
     assert may["generated_total"] == "2300.00"
+    assert may["generated_total_ibs"] == "1400.00"  # 900 + 500 (#486)
+    assert may["generated_total_cbs"] == "900.00"   # 600 + 300
     assert may["apropriated_count"] == 2
     assert may["apropriated_total"] == "800.00"
+    assert may["apropriated_total_ibs"] == "500.00"
+    assert may["apropriated_total_cbs"] == "300.00"
     assert may["available_count"] == 3
     assert may["available_total"] == "1500.00"
+    assert may["available_total_ibs"] == "900.00"
+    assert may["available_total_cbs"] == "600.00"
     assert may["at_risk_count"] == 1
     assert may["at_risk_total"] == "200.00"
+    assert may["at_risk_total_ibs"] == "120.00"
+    assert may["at_risk_total_cbs"] == "80.00"
 
 
 def test_credit_balance_empty(client):
@@ -164,17 +180,10 @@ def test_credit_balance_quarter_label(client):
     tc, session = client
     _stub_active_profissional(session)
 
-    def row(bucket, status, cnt, total):
-        m = MagicMock()
-        m.__getitem__ = lambda self, k: {
-            "bucket": bucket, "status": status, "cnt": cnt, "total": total
-        }[k]
-        return m
-
     agg_result = MagicMock()
     # Q2 starts at month 4
     agg_result.mappings.return_value.all.return_value = [
-        row(date(2026, 4, 1), "confirmed", 10, 5000.00),
+        _row(date(2026, 4, 1), "confirmed", 10, 5000.00),
     ]
     session.execute.side_effect = [session.execute.return_value, _no_grant_result(),agg_result]
 
@@ -198,13 +207,22 @@ def test_credit_requires_plan(client):
 # ── #258 Fase 2, parte 1 — drill-down por NF + export PDF ─────────────────────
 
 def _doc_row(*, doc_id=None, filename="nfe-123.xml", doc_type="nfe", status="confirmed",
-             credit_value="150.00", created_at=None, bucket=None):
+             credit_value: str | None = "150.00", credit_value_ibs=None, credit_value_cbs=None,
+             created_at=None, bucket=None):
     m = MagicMock()
     m.id = doc_id or uuid.uuid4()
     m.original_filename = filename
     m.doc_type = doc_type
     m.split_payment_status = status
-    m.fiscal_metadata = {"credit_value": credit_value} if credit_value is not None else {}
+    fm: dict[str, str] = {}
+    if credit_value_ibs is not None or credit_value_cbs is not None:
+        if credit_value_ibs is not None:
+            fm["credit_value_ibs"] = credit_value_ibs
+        if credit_value_cbs is not None:
+            fm["credit_value_cbs"] = credit_value_cbs
+    elif credit_value is not None:
+        fm["credit_value"] = credit_value
+    m.fiscal_metadata = fm
     m.created_at = created_at or datetime(2026, 5, 10, tzinfo=timezone.utc)
     m.bucket = bucket or date(2026, 5, 1)
     return m
@@ -265,10 +283,13 @@ def test_credit_export_pdf_returns_downloadable_file(client):
 
     balance_result = MagicMock()
     balance_result.mappings.return_value.all.return_value = [
-        {"bucket": date(2026, 5, 1), "status": "confirmed", "cnt": 1, "total": 150.00},
+        {"bucket": date(2026, 5, 1), "status": "confirmed", "cnt": 1, "total": 150.00, "total_ibs": 90.00, "total_cbs": 60.00},
     ]
     docs_result = MagicMock()
-    docs_result.all.return_value = [_doc_row(filename="nfe-auditavel.xml", bucket=date(2026, 5, 1))]
+    docs_result.all.return_value = [_doc_row(
+        filename="nfe-auditavel.xml", bucket=date(2026, 5, 1),
+        credit_value=None, credit_value_ibs="90.00", credit_value_cbs="60.00",
+    )]
 
     tenant = MagicMock(name="Empresa Teste")
     tenant.name = "Empresa Teste"
@@ -281,3 +302,68 @@ def test_credit_export_pdf_returns_downloadable_file(client):
     assert resp.headers["content-type"].startswith("application/pdf") or resp.headers["content-type"].startswith("text/html")
     assert "attachment" in resp.headers["content-disposition"]
     assert len(resp.content) > 0
+
+
+# ── #486 — IBS/CBS separados por categoria (Fase 2, parte 2) ──────────────────
+
+
+def test_credit_documents_drilldown_traz_ibs_cbs_discriminados(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    rows_result = MagicMock()
+    rows_result.all.return_value = [
+        _doc_row(filename="nfe-discriminada.xml", bucket=date(2026, 5, 1),
+                  credit_value=None, credit_value_ibs="90.00", credit_value_cbs="60.00"),
+    ]
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(), rows_result]
+
+    resp = tc.get("/api/v1/credits/documents?period=2026-05&period_type=month")
+    assert resp.status_code == 200, resp.text
+    doc = resp.json()[0]
+    assert doc["credit_value_ibs"] == "90.00"
+    assert doc["credit_value_cbs"] == "60.00"
+    # combinado derivado — nunca fica None quando ibs/cbs existem
+    assert doc["credit_value"] == "150.00"
+
+
+def test_credit_csv_export_inclui_colunas_ibs_cbs(client):
+    tc, session = client
+    _stub_active_profissional(session)
+    agg_result = MagicMock()
+    agg_result.mappings.return_value.all.return_value = _aggregation_rows()
+    session.execute.side_effect = [session.execute.return_value, _no_grant_result(), agg_result]
+
+    resp = tc.get("/api/v1/credits/export.csv?period=month")
+    assert resp.status_code == 200
+    header = resp.text.splitlines()[0]
+    assert "GERADO_IBS_BRL" in header
+    assert "GERADO_CBS_BRL" in header
+    # maio: ibs 1400.00, cbs 900.00 (ver _aggregation_rows)
+    assert "1400.00" in resp.text
+    assert "900.00" in resp.text
+
+
+class TestCombinedCreditValue:
+    """`_combined_credit_value` (split_payment.py): credit_value legado tem
+    precedência; senão soma ibs+cbs; sem nenhum dos dois, None."""
+
+    def _fn(self):
+        from app.routers.split_payment import _combined_credit_value
+        return _combined_credit_value
+
+    def test_legado_tem_precedencia(self):
+        fn = self._fn()
+        assert fn({"credit_value": "999.00", "credit_value_ibs": "1.00", "credit_value_cbs": "2.00"}) == "999.00"
+
+    def test_soma_ibs_cbs_quando_sem_legado(self):
+        fn = self._fn()
+        assert fn({"credit_value_ibs": "90.00", "credit_value_cbs": "60.00"}) == "150.00"
+
+    def test_so_ibs_soma_com_zero(self):
+        fn = self._fn()
+        assert fn({"credit_value_ibs": "90.00"}) == "90.00"
+
+    def test_sem_nenhum_valor_retorna_none(self):
+        fn = self._fn()
+        assert fn({}) is None

--- a/backend/tests/test_split_payment.py
+++ b/backend/tests/test_split_payment.py
@@ -1,0 +1,128 @@
+"""Tests for /api/v1/split-payment — foco no split IBS/CBS (#486).
+
+Mocks DB Session e plan-gate (profissional) via dependency_overrides, mesmo
+padrão de test_credits.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_current_user
+from app.database import get_db
+from app.main import app
+from app.models.auth import User
+
+TENANT_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+_mock_user = User(
+    id=USER_ID, email="techlead@tribultz.com", tenant_id=TENANT_ID,
+    full_name="Tech Lead", is_active=True, role="admin", password_hash="x",
+)
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_current_user] = lambda: _mock_user
+    session = MagicMock()
+    app.dependency_overrides[get_db] = lambda: session
+    yield TestClient(app), session
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _no_grant_result() -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = None
+    return result
+
+
+def _stub_active_profissional(session: MagicMock) -> None:
+    sub = MagicMock(status="active", current_period_end=None)
+    plan = MagicMock(slug="profissional")
+    first_result = MagicMock()
+    first_result.__getitem__ = lambda self, i: (sub, plan)[i]
+    session.execute.return_value.first.return_value = first_result
+
+
+def _doc_row(fiscal_metadata: dict, status: str = "pending") -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.original_filename = "nfe-teste.xml"
+    m.doc_type = "nfe"
+    m.fiscal_metadata = fiscal_metadata
+    m.split_payment_status = status
+    m.created_at = datetime(2026, 7, 19, tzinfo=timezone.utc)
+    return m
+
+
+def test_update_status_persiste_ibs_cbs_discriminados(client):
+    tc, session = client
+    _stub_active_profissional(session)
+
+    doc_id = str(uuid.uuid4())
+    existing = _doc_row({})
+    updated = _doc_row({"credit_value_ibs": "90.00", "credit_value_cbs": "60.00"}, status="confirmed")
+
+    fetchone_results = [existing, updated]
+    session.execute.side_effect = [
+        session.execute.return_value,  # plan_gate subscription query
+        _no_grant_result(),            # plan_gate grant check (#487)
+        MagicMock(fetchone=lambda: fetchone_results[0]),   # SELECT antes do UPDATE
+        MagicMock(),                                        # UPDATE
+        MagicMock(fetchone=lambda: fetchone_results[1]),    # SELECT após o UPDATE
+    ]
+
+    resp = tc.patch(
+        f"/api/v1/split-payment/status/{doc_id}",
+        json={"status": "confirmed", "credit_value_ibs": "90.00", "credit_value_cbs": "60.00"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["credit_value_ibs"] == "90.00"
+    assert body["credit_value_cbs"] == "60.00"
+    assert body["credit_value"] == "150.00"  # derivado, #486
+
+    # A UPDATE query (3º execute) deve ter gravado ibs/cbs, sem o combinado legado.
+    update_call = session.execute.call_args_list[3]
+    import json as _json
+    fm_written = _json.loads(update_call.args[1]["fm"])
+    assert fm_written["credit_value_ibs"] == "90.00"
+    assert fm_written["credit_value_cbs"] == "60.00"
+    assert "credit_value" not in fm_written
+
+
+def test_update_status_legado_continua_funcionando(client):
+    """Regressão: PATCH só com credit_value (sem ibs/cbs) continua funcionando
+    exatamente como antes do #486."""
+    tc, session = client
+    _stub_active_profissional(session)
+
+    doc_id = str(uuid.uuid4())
+    existing = _doc_row({})
+    updated = _doc_row({"credit_value": "150.00"}, status="confirmed")
+
+    fetchone_results = [existing, updated]
+    session.execute.side_effect = [
+        session.execute.return_value,
+        _no_grant_result(),
+        MagicMock(fetchone=lambda: fetchone_results[0]),
+        MagicMock(),
+        MagicMock(fetchone=lambda: fetchone_results[1]),
+    ]
+
+    resp = tc.patch(
+        f"/api/v1/split-payment/status/{doc_id}",
+        json={"status": "confirmed", "credit_value": "150.00"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["credit_value"] == "150.00"
+    assert body["credit_value_ibs"] is None
+    assert body["credit_value_cbs"] is None

--- a/frontend/src/app/credits/page.tsx
+++ b/frontend/src/app/credits/page.tsx
@@ -31,6 +31,8 @@ function totals(rows: CreditPeriodRow[]) {
     rows.reduce((acc, r) => acc + parseFloat(String(r[k] ?? "0") || "0"), 0);
   return {
     generated: sum("generated_total"),
+    generatedIbs: sum("generated_total_ibs"),
+    generatedCbs: sum("generated_total_cbs"),
     apropriated: sum("apropriated_total"),
     available: sum("available_total"),
     at_risk: sum("at_risk_total"),
@@ -183,7 +185,7 @@ export default function CreditsPage() {
           <SummaryCard
             label="Gerado"
             value={fmtBrl(agg.generated.toFixed(2))}
-            hint="Confirmado + Apropriado"
+            hint={`IBS ${fmtBrl(agg.generatedIbs.toFixed(2))} + CBS ${fmtBrl(agg.generatedCbs.toFixed(2))}`}
             className="border-emerald-200 bg-emerald-50 text-emerald-900"
           />
           <SummaryCard
@@ -274,6 +276,9 @@ export default function CreditsPage() {
                     <td className="px-4 py-3 text-right font-mono">
                       {fmtBrl(r.generated_total)}
                       <span className="ml-1 text-xs text-slate-400">({r.generated_count})</span>
+                      <div className="text-[10px] font-sans text-slate-400">
+                        IBS {fmtBrl(r.generated_total_ibs)} · CBS {fmtBrl(r.generated_total_cbs)}
+                      </div>
                     </td>
                     <td className="px-4 py-3 text-right font-mono">
                       {fmtBrl(r.apropriated_total)}
@@ -307,7 +312,9 @@ export default function CreditsPage() {
                                   <th className="px-3 py-2">Modelo</th>
                                   <th className="px-3 py-2">Status</th>
                                   <th className="px-3 py-2">Data</th>
-                                  <th className="px-3 py-2 text-right">Crédito</th>
+                                  <th className="px-3 py-2 text-right">IBS</th>
+                                  <th className="px-3 py-2 text-right">CBS</th>
+                                  <th className="px-3 py-2 text-right">Total</th>
                                 </tr>
                               </thead>
                               <tbody>
@@ -322,6 +329,12 @@ export default function CreditsPage() {
                                     </td>
                                     <td className="px-3 py-2 text-slate-500">
                                       {d.created_at ? new Date(d.created_at).toLocaleDateString("pt-BR") : "—"}
+                                    </td>
+                                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                                      {d.credit_value_ibs ? fmtBrl(d.credit_value_ibs) : "—"}
+                                    </td>
+                                    <td className="px-3 py-2 text-right font-mono text-slate-700">
+                                      {d.credit_value_cbs ? fmtBrl(d.credit_value_cbs) : "—"}
                                     </td>
                                     <td className="px-3 py-2 text-right font-mono text-slate-700">
                                       {d.credit_value ? fmtBrl(d.credit_value) : "—"}

--- a/frontend/src/app/split-payment/page.tsx
+++ b/frontend/src/app/split-payment/page.tsx
@@ -159,7 +159,7 @@ export default function SplitPaymentPage() {
                 <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Documento</th>
                 <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Data</th>
                 <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Status</th>
-                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Crédito CBS+IBS</th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Crédito IBS / CBS</th>
                 <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Ação</th>
               </tr>
             </thead>
@@ -188,7 +188,16 @@ export default function SplitPaymentPage() {
                       </span>
                     </td>
                     <td className="px-4 py-3 text-right font-mono font-medium text-slate-700">
-                      {fmtBrl(doc.credit_value)}
+                      {doc.credit_value_ibs || doc.credit_value_cbs ? (
+                        <>
+                          <div className="text-xs text-slate-500">
+                            IBS {fmtBrl(doc.credit_value_ibs)} · CBS {fmtBrl(doc.credit_value_cbs)}
+                          </div>
+                          <div>{fmtBrl(doc.credit_value)}</div>
+                        </>
+                      ) : (
+                        fmtBrl(doc.credit_value)
+                      )}
                     </td>
                     <td className="px-4 py-3">
                       <select

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -606,6 +606,8 @@ export type SplitPaymentDoc = {
   doc_type: string;
   split_payment_status: "pending" | "confirmed" | "credit_released" | "failed";
   credit_value: string | null;
+  credit_value_ibs: string | null;
+  credit_value_cbs: string | null;
   credit_due_date: string | null;
   created_at: string;
   days_pending: number | null;
@@ -635,7 +637,13 @@ export async function listSplitPaymentDocs(status?: string): Promise<SplitPaymen
 
 export async function updateSplitPaymentStatus(
   documentId: string,
-  payload: { status: string; credit_value?: string; credit_due_date?: string },
+  payload: {
+    status: string;
+    credit_value?: string;
+    credit_value_ibs?: string;
+    credit_value_cbs?: string;
+    credit_due_date?: string;
+  },
 ): Promise<SplitPaymentDoc> {
   return apiFetch(`/api/v1/split-payment/status/${encodeURIComponent(documentId)}`, {
     method: "PATCH",
@@ -650,12 +658,20 @@ export type CreditPeriodRow = {
   period: string;
   generated_count: number;
   generated_total: string;
+  generated_total_ibs: string;
+  generated_total_cbs: string;
   apropriated_count: number;
   apropriated_total: string;
+  apropriated_total_ibs: string;
+  apropriated_total_cbs: string;
   available_count: number;
   available_total: string;
+  available_total_ibs: string;
+  available_total_cbs: string;
   at_risk_count: number;
   at_risk_total: string;
+  at_risk_total_ibs: string;
+  at_risk_total_cbs: string;
 };
 
 export type CreditBalanceResponse = {


### PR DESCRIPTION
## Resumo

Fecha #486 — Fase 2, parte 2 do #258.

## Investigação prévia (antes de implementar)

O DoD original pedia decidir a fonte do IBS/CBS discriminado e avaliar uma tabela `credit_events`. Investiguei o pipeline de dados antes de desenhar a solução:

- **Não existe extração automática de vCBS/vIBS do XML para `Document.fiscal_metadata`.** `documents.py::_extract_xml_metadata` captura `chave_acesso`, `cnpj_emitente`, `valor_total`, `ncm` — nunca vCBS/vIBS.
- **Todo o dado de crédito é entrada manual** via `PATCH /split-payment/status/{id}` (`credit_value` combinado, digitado por um humano).

Isso definiu o escopo real e tratável: discriminar o campo manual existente em dois (IBS/CBS), em vez de construir uma pipeline de extração automática (fora de escopo) ou uma tabela de eventos sem fonte real de eventos para povoá-la.

## O que entra

- **`split_payment.py`**: `fiscal_metadata` ganha `credit_value_ibs`/`credit_value_cbs`, com precedência sobre o `credit_value` combinado legado. `_combined_credit_value()` deriva o total automaticamente quando só os dois discriminados são informados — nunca fica um valor obsoleto coexistindo. **Backward-compatible**: PATCH só com `credit_value` continua funcionando exatamente como antes.
- **`credits.py`**: `_compute_balance` agrega IBS/CBS separadamente em cada categoria do fluxo (gerado/apropriado/disponível/em_risco) via SQL — mesma precedência do `_combined_credit_value`, replicada em SQL para não trazer todas as linhas para Python. `CreditPeriodRow` ganha 8 campos novos (`*_ibs`/`*_cbs` por categoria).
- **Export CSV**: 8 colunas novas (`GERADO_IBS_BRL`, `GERADO_CBS_BRL`, etc.).
- **Export PDF**: quebra IBS/CBS no resumo "Gerado" de cada período + colunas IBS/CBS na tabela de documentos.
- **Frontend**: `/credits` mostra a quebra IBS/CBS no card "Gerado", na linha de período e no drill-down por NF; `/split-payment` mostra a quebra na coluna de crédito.

## Decisão documentada: tabela `credit_events` adiada

Avaliei e **deliberadamente adiei** a tabela `credit_events` dedicada — justificativa no docstring de `credits.py`: sem nenhuma fonte automática de evento discreto de crédito hoje (nem extração de XML, nem integração com a Nota Nacional), um livro-razão de eventos seria estrutura vazia. Construir quando a Fase 2 do Split Payment (integração real com a Nota Nacional, já prevista no docstring de `split_payment.py`) existir — essa integração geraria eventos de verdade para povoar a tabela.

## Test plan

- [x] Backend: 744 testes (`pytest tests/ -q`) — 6 novos em `test_credits.py` (drill-down retorna IBS/CBS discriminados + deriva o total; CSV inclui as colunas novas; `TestCombinedCreditValue` com 4 casos de precedência) + `test_split_payment.py` novo (2 testes: PATCH com IBS/CBS persiste corretamente sem gravar o combinado legado; regressão — PATCH só com `credit_value` continua funcionando)
- [x] `ruff check app/ tests/` limpo
- [x] `pyright` limpo
- [x] `npm test` (178 pass) + `npm run build` limpos
- [x] `tools/architecture_audit.py` — 1 achado pré-existente (task Celery órfã, já rastreada em #490, não relacionado a este PR)
- [x] **Validação end-to-end dentro do container**: inseri um documento real com `credit_value_ibs`/`credit_value_cbs` discriminados, confirmei `/split-payment/documents` retornando os 3 campos com o total derivado corretamente (90+60=150), `/credits/balance` agregando IBS/CBS por categoria corretamente, export CSV com as colunas novas, e export PDF real (17.7KB, `%PDF-1.7` válido) com a trilha por documento incluindo IBS/CBS. Dados de teste removidos do banco local depois.