### PR TITLE
fix(ci): alerta por e-mail quando classtrib-sync falhar (#446)

### DIFF
--- a/.github/workflows/classtrib-sync.yml
+++ b/.github/workflows/classtrib-sync.yml
@@ -54,3 +54,43 @@ jobs:
             - (Follow-up) re-seed do DB `cclass_trib_items` (endpoint público `/classtrib`) — exige migration própria.
 
             Gerado por `.github/workflows/classtrib-sync.yml`.
+
+      # #446 — sem isto, uma falha (SVRS fora do ar, guard de diff abortando)
+      # passa despercebida: sem PR, sem e-mail, sem issue. Mesmo padrão de
+      # alerta via Resend já usado em monitor.yml.
+      - name: Alertar falha do sync (Resend)
+        if: failure()
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - << 'PY'
+          import os, json, urllib.request, urllib.error
+
+          key = os.environ["RESEND_API_KEY"]
+          run_url = os.environ.get("RUN_URL", "")
+
+          payload = json.dumps({
+            "from": "noreply@tribultz.com.br",
+            "to":   ["mickel@tribultz.com.br"],
+            "subject": "[ALERTA] cClassTrib Data Sync falhou",
+            "html": f"<h2>Sync diário da tabela cClassTrib falhou</h2>"
+                    f"<p>Sem re-sync, o motor de validação fiscal decai silenciosamente "
+                    f"(regras de cClassTrib, incl. Rejeição 1024, deixam de cobrir códigos novos da SVRS).</p>"
+                    f"<p><a href='{run_url}'>Ver execução no GitHub Actions</a></p>",
+          }).encode()
+
+          req = urllib.request.Request(
+            "https://api.resend.com/emails",
+            data=payload,
+            headers={
+              "Authorization": f"Bearer {key}",
+              "Content-Type":  "application/json",
+            },
+          )
+          try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+              print("Alert sent:", r.status)
+          except urllib.error.HTTPError as e:
+            print("Resend error:", e.read().decode())
+          PY


### PR DESCRIPTION
## Resumo

Fecha #446.

`.github/workflows/classtrib-sync.yml` roda diariamente e re-sincroniza a tabela oficial `cClassTrib` a partir da SVRS. A única saída visível era a PR de revisão em caso de **sucesso** — uma falha (SVRS fora do ar, guard de diff abortando por drop/queda abaixo do limite) passava totalmente despercebida: sem PR, sem e-mail, sem issue.

O próprio CLAUDE.md documenta que **"sem re-sync, o motor decai"** — as regras de cClassTrib (incl. Rejeição 1024) deixam de cobrir códigos novos. Uma falha persistente do job podia passar semanas sem detecção.

## Correção

Adicionado um step `if: failure()` ao job `sync`, reaproveitando **exatamente** o mesmo padrão de alerta via Resend já usado (e já provado funcionando em produção) em `monitor.yml` — sem inventar mecanismo novo, sem nova dependência.

## Critério de aceite (issue #446)

> Uma falha simulada de `resync_classtrib.py` resulta em notificação visível — e-mail ou issue — e não apenas em um "X" silencioso no histórico do Actions.

Verificado localmente (sem tocar a infra real do GitHub Actions): rodei `resync_classtrib.py` com um caminho inválido e confirmei que o script sai com código **1** (não-zero) — o que propaga corretamente para o step falhar no Actions e aciona o `if: failure()`. Não simulei a falha *dentro* de um run real do Actions (isso enviaria um e-mail de teste de verdade e criaria ruído desnecessário) — a lógica do alerta em si é uma reutilização estrutural do bloco já validado em produção em `monitor.yml`, não código novo.

## Test plan

- [x] YAML validado (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmado localmente que `resync_classtrib.py` sai com código não-zero em falha (testado com caminho de arquivo inválido)
- [x] Padrão do alerta é uma réplica estrutural do já usado em `monitor.yml` (mesma API Resend, mesmo secret `RESEND_API_KEY` já configurado no repo)