### PR TITLE
feat(split-payment): simulação fundamentada no Ato Conjunto RFB/CGIBS nº 2/2026 (#440)

### DIFF
--- a/frontend/src/app/simulador/client.tsx
+++ b/frontend/src/app/simulador/client.tsx
@@ -291,6 +291,28 @@ export function SimuladorClient() {
                 </div>
               </div>
 
+              {/* Split Payment — simulação fundamentada no Ato Conjunto RFB/CGIBS nº 2/2026 */}
+              <div className="rounded-2xl border border-indigo-200 bg-indigo-50 p-5">
+                <p className="mb-1 text-[11px] font-bold uppercase tracking-wider text-indigo-500">
+                  Split Payment — o que seria segregado automaticamente
+                </p>
+                <p className="text-2xl font-extrabold text-indigo-900 md:text-3xl">{fmtR$(result.regime_novo.total)}</p>
+                <p className="mt-2 text-xs leading-relaxed text-indigo-700">
+                  A partir de 2027 (fase B2B voluntária, cronograma declarado — ainda não vigente),
+                  esse valor de CBS + IBS poderia ser segregado automaticamente no pagamento e
+                  recolhido direto ao governo, sem passar pelo caixa da empresa, via Plataforma
+                  Pública do Split Payment. No <strong>Modelo Inteligente</strong> descrito no
+                  Manual de Integração, o valor segregado é exatamente o CBS/IBS já destacado no
+                  documento fiscal vinculado ao pagamento — o mesmo número calculado acima.
+                </p>
+                <p className="mt-2 text-[11px] leading-relaxed text-indigo-400">
+                  Fonte: Ato Conjunto RFB/CGIBS nº 2/2026 (27/05/2026, DOU 03/06/2026) — Manual de
+                  Integração e Swagger da Plataforma Pública do Split Payment, publicados em{" "}
+                  consumo.tributos.gov.br. Simulação ilustrativa da Tribultz — não é integração
+                  operacional com a Plataforma Pública nem disponibilidade antecipada de produto.
+                </p>
+              </div>
+
               {/* Delta */}
               <div className={`flex flex-col gap-1 rounded-2xl border p-5 sm:flex-row sm:items-center sm:justify-between ${deltaBg} ${deltaBorder}`}>
                 <div>

--- a/frontend/src/app/split-payment/page.tsx
+++ b/frontend/src/app/split-payment/page.tsx
@@ -79,6 +79,9 @@ export default function SplitPaymentPage() {
         <p className="text-sm text-slate-500">
           Rastreabilidade de crédito CBS/IBS por NF — LC 214 art. 22. O crédito só é liberado após confirmação do pagamento do imposto.
         </p>
+        <p className="mt-1 text-xs text-slate-400">
+          O mecanismo de segregação automática (Plataforma Pública do Split Payment) entra em vigor a partir de 2027, fase B2B voluntária — Ato Conjunto RFB/CGIBS nº 2/2026 (Manual de Integração e Swagger, consumo.tributos.gov.br). Este painel rastreia o crédito manualmente até lá.
+        </p>
       </header>
 
       {summary ? (


### PR DESCRIPTION
## Summary
Fecha #440.

**Governança**: issue nasceu antes do funil Discovery→Customer Evidence→RFC (#444). Checado: zero Customer Evidence real em todo o programa (mesmo achado do #439, hoje mais cedo). Diferente do #439, esta issue não é "construir integração porque a TOTVS tem" — é citar uma especificação oficial já pública (Ato Conjunto RFB/CGIBS nº 2/2026) em conteúdo/simulação existente, sem prometer produto que não existe. Decisão explícita do usuário: prosseguir mesmo sem Customer Evidence, dado o escopo baixo-risco e o mérito próprio (rigor de conteúdo, não corrida competitiva).

**Achado que ajustou o escopo**: a premissa original ("`/split-payment` é só conteúdo educativo") está parcialmente desatualizada — o #486 (mergeado hoje mais cedo) já entregou um dashboard funcional real de rastreamento de crédito IBS/CBS. Ajustei para uma nota de contexto mínima ali, e concentrei a simulação fundamentada no `/simulador`, que de fato não tinha nenhuma menção a Split Payment.

## O que foi entregue
- **`/simulador`**: novo card no resultado citando o CBS+IBS já calculado como o valor que seria segregado automaticamente via Plataforma Pública do Split Payment — **Modelo Inteligente** (valor segregado = exatamente o CBS/IBS já destacado no documento fiscal, sem recálculo pelo governo). Fonte citada: Ato Conjunto RFB/CGIBS nº 2/2026 (27/05/2026, DOU 03/06/2026), Manual de Integração + Swagger (consumo.tributos.gov.br) — datas já rastreadas em `docs/context/reference_nt2025002_apis.md`.
- **`/split-payment`**: nota de contexto mínima no header citando a mesma fonte, sem alterar a UX do dashboard funcional.
- Guardrails da própria issue respeitados: **nenhuma alteração de cálculo/motor** (reusa `regime_novo.total`, já retornado pela API existente) e **nenhuma antecipação de disponibilidade** ("ainda não vigente", "não é integração operacional... nem disponibilidade antecipada de produto", explícito no texto).

## Test plan
- [x] `npm test` — 188 passed, sem regressão
- [x] `npm run build` — limpo
- [x] `npm run dev` + `curl` em `/simulador` e `/split-payment` — ambos 200, sem crash