### PR TITLE
docs(marketing): objeção "TOTVS deixa customizar as regras" (#441)

### DIFF
--- a/docs/marketing/instrucoes-gpt-vendas.md
+++ b/docs/marketing/instrucoes-gpt-vendas.md
@@ -59,6 +59,7 @@ Direto e com senso de urgência, ancorado em **fato real**: "Rejeição 1024", "
 - **"Já tenho ERP/contador."** → "A Tribultz valida antes de emitir e gera o laudo que seu contador anexa. Tem API pra integrar ao ERP (Profissional+)."
 - **"Por que não exporta no grátis?"** → "Na tela você vê tudo de graça. O **documento auditável** que comprova perante o fisco é o que entregamos no plano pago."
 - **"Garante que não tomo multa?"** → "Não prometemos imunidade. Entregamos a validação e a **evidência auditável** que sustentam a correção — a decisão final é sua/do seu contador."
+- **"O TOTVS/meu ERP deixa eu customizar as regras. Vocês não?"** → "De propósito, não. As mesmas regras valem pra todo cliente — ninguém, nem a Tribultz, ajusta o motor caso a caso. É isso que torna o laudo uma **segunda opinião independente**: se desse pra configurar, deixava de valer como evidência imparcial perante o fisco."
 
 ## CTAs
 - Primário: **testar grátis** (cadastro).

--- a/docs/marketing/system-prompt-gpt-vendas.md
+++ b/docs/marketing/system-prompt-gpt-vendas.md
@@ -89,6 +89,10 @@ Agressivo e direto, ancorado em **fato regulatório real**:
 - *"Vocês garantem que não tomo multa?"* → "Não prometemos imunidade. Entregamos a
   validação e a **evidência auditável** que sustentam a correção — a decisão final
   é sua/do seu contador."
+- *"O TOTVS/meu ERP deixa eu customizar as regras. Vocês não?"* → "De propósito, não.
+  As mesmas regras valem pra todo cliente — ninguém, nem a Tribultz, ajusta o motor
+  caso a caso. É isso que torna o laudo uma **segunda opinião independente**: se
+  desse pra configurar, deixava de valer como evidência imparcial perante o fisco."
 
 # CTAs
 - Primário: **testar grátis** (cadastro/trial).


### PR DESCRIPTION
## Summary
Fecha #441.

Gap 3 (competitive/totvs.md): TOTVS tem "Configurador de Tributos"/"Cadastro de Regras Tributárias" ajustável pelo cliente; a Tribultz não replica de propósito (motor fixo é o que sustenta a evidência como "segunda opinião" independente, não configurável pelo próprio contribuinte). Isso é percebido como gap em vendas — esta PR fecha a lacuna de comunicação, não de produto.

## O que foi entregue
- Nova objeção de vendas espelhada em `docs/marketing/instrucoes-gpt-vendas.md` e `docs/marketing/system-prompt-gpt-vendas.md`, mesmo padrão das 4 objeções já existentes em cada arquivo.
- Claim aprovado registrado em `knowledge/marketing/claims.md` (Brain — [tribultz-brain#11](https://github.com/mickbap/tribultz-brain/pull/11), companion desta PR).

## Escopo
Não é mudança de produto/código (a própria issue já declara isso). Aplicação em material de vendas satisfaz o critério de aceite ("site OU material de vendas") — não toquei em copy do site, já que o GPT de vendas é onde a objeção real de "por que não customiza" aparece.

## Test plan
N/A — doc-only.