### PR TITLE
fix(seo): OG images e logo via ImageResponse, menu mobile, cookie banner LGPD e FAQ visível (#502)

### DIFF
--- a/frontend/src/app/blog/[slug]/opengraph-image.tsx
+++ b/frontend/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,23 @@
+import { ImageResponse } from "next/og";
+import { getPostBySlug } from "@/lib/blog";
+import { OgTemplate, OG_SIZE } from "@/components/seo/ogTemplate";
+
+export const alt = "Artigo do blog Tribultz sobre a Reforma Tributária";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+
+  return new ImageResponse(
+    (
+      <OgTemplate
+        badge={post?.category ?? "Blog"}
+        title={post?.title ?? "Blog Tribultz — Reforma Tributária na prática"}
+        subtitle="Blog Tribultz · Reforma Tributária"
+      />
+    ),
+    size,
+  );
+}

--- a/frontend/src/app/blog/[slug]/page.tsx
+++ b/frontend/src/app/blog/[slug]/page.tsx
@@ -40,7 +40,8 @@ export async function generateMetadata({
       publishedTime: post.publishedAt,
       modifiedTime: post.updatedAt,
       authors: [post.author.name],
-      ...(post.coverImage ? { images: [post.coverImage] } : {}),
+      // og:image vem do arquivo opengraph-image.tsx deste segmento; os
+      // coverImage do frontmatter apontam para PNGs que não existem (#502).
     },
   };
 }

--- a/frontend/src/app/logo.png/route.tsx
+++ b/frontend/src/app/logo.png/route.tsx
@@ -1,0 +1,20 @@
+import { ImageResponse } from "next/og";
+import { TribultzMark } from "@/components/seo/ogTemplate";
+
+/**
+ * Serve a marca oficial em /logo.png (512×512) — URL referenciada pelo
+ * JSON-LD Organization da home. Gerada em build (force-static) a partir da
+ * mesma geometria SVG do TribultzLogo, sem asset binário no repositório.
+ */
+export const dynamic = "force-static";
+
+export function GET() {
+  return new ImageResponse(
+    (
+      <div style={{ display: "flex", width: "100%", height: "100%" }}>
+        <TribultzMark size={512} />
+      </div>
+    ),
+    { width: 512, height: 512 },
+  );
+}

--- a/frontend/src/app/opengraph-image.tsx
+++ b/frontend/src/app/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { ImageResponse } from "next/og";
+import { OgTemplate, OG_SIZE } from "@/components/seo/ogTemplate";
+
+export const alt = "Tribultz — Validação CBS/IBS e compliance da Reforma Tributária (LC 214)";
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <OgTemplate
+        badge="LC 214"
+        title="IBS e CBS sem erro. Sem multa. Sem susto."
+        subtitle="Validação CBS/IBS · cClassTrib · Evite a Rejeição 1024"
+      />
+    ),
+    size,
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -26,6 +26,33 @@ const WA_URL = `https://wa.me/${WA_NUMBER}?text=${WA_MSG}`;
 const WA_REJEICAO = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent("Olá! Estou com Rejeição 1024 na NF-e (cClassTrib incorreto) e preciso de ajuda urgente.")}`;
 const WA_ERP = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent("Olá! Preciso integrar CBS/IBS ao meu ERP (TOTVS/SAP/Omie/Linx) e quero entender como a Tribultz pode ajudar.")}`;
 
+/**
+ * Fonte única do FAQ: alimenta a seção visível E o JSON-LD FAQPage abaixo.
+ * O Google exige que o conteúdo do schema esteja visível na página (#502).
+ */
+const FAQ_ITEMS = [
+  {
+    q: "O que é a Rejeição 1024 na NF-e com CBS/IBS?",
+    a: "A Rejeição 1024 ocorre quando o cClassTrib informado na NF-e é incompatível com o CST do produto, tornando-se o erro mais comum desde janeiro/2026. A Tribultz valida essa compatibilidade automaticamente antes da emissão e indica a correção necessária.",
+  },
+  {
+    q: "Quando começam as penalidades por erro em CBS/IBS?",
+    a: "As penalidades efetivas por erros de CBS/IBS em NF-e começam em agosto/2026, encerrando o período educacional da Receita Federal. Empresas com cClassTrib incorreto ficarão sujeitas a autuações e multas.",
+  },
+  {
+    q: "Como classificar o NCM correto para o cClassTrib na Reforma Tributária?",
+    a: "O cClassTrib é determinado pelo capítulo NCM e pelo regime tributário aplicável (padrão, reduzido, cesta básica, imune, etc). A Tribultz valida a compatibilidade CST × cClassTrib (a fonte da Rejeição 1024) e calcula CBS/IBS com evidência auditável da base legal; a sugestão automática de cClassTrib a partir do NCM está em ativação e deve ser validada.",
+  },
+  {
+    q: "Como integrar CBS/IBS no TOTVS, SAP, Omie ou Linx?",
+    a: "A Tribultz exporta o catálogo de produtos validado nos formatos TOTVS Protheus, SAP Business One, Omie, Linx e CSV genérico, prontos para importação direta no ERP sem alterações manuais.",
+  },
+  {
+    q: "O que é o split payment e quando entra em vigor?",
+    a: "O split payment é o mecanismo de retenção automática de IBS/CBS no momento do pagamento (Pix, boleto, transferência bancária), previsto para entrar em vigor em 2027. Impacta diretamente o capital de giro — empresas devem modelar o impacto antes do prazo.",
+  },
+];
+
 const JSON_LD = {
   "@context": "https://schema.org",
   "@graph": [
@@ -47,33 +74,11 @@ const JSON_LD = {
     },
     {
       "@type": "FAQPage",
-      "mainEntity": [
-        {
-          "@type": "Question",
-          "name": "O que é a Rejeição 1024 na NF-e com CBS/IBS?",
-          "acceptedAnswer": { "@type": "Answer", "text": "A Rejeição 1024 ocorre quando o cClassTrib informado na NF-e é incompatível com o CST do produto, tornando-se o erro mais comum desde janeiro/2026. A Tribultz valida essa compatibilidade automaticamente antes da emissão e indica a correção necessária." },
-        },
-        {
-          "@type": "Question",
-          "name": "Quando começam as penalidades por erro em CBS/IBS?",
-          "acceptedAnswer": { "@type": "Answer", "text": "As penalidades efetivas por erros de CBS/IBS em NF-e começam em agosto/2026, encerrando o período educacional da Receita Federal. Empresas com cClassTrib incorreto ficarão sujeitas a autuações e multas." },
-        },
-        {
-          "@type": "Question",
-          "name": "Como classificar o NCM correto para o cClassTrib na Reforma Tributária?",
-          "acceptedAnswer": { "@type": "Answer", "text": "O cClassTrib é determinado pelo capítulo NCM e pelo regime tributário aplicável (padrão, reduzido, cesta básica, imune, etc). A Tribultz valida a compatibilidade CST × cClassTrib (a fonte da Rejeição 1024) e calcula CBS/IBS com evidência auditável da base legal; a sugestão automática de cClassTrib a partir do NCM está em ativação e deve ser validada." },
-        },
-        {
-          "@type": "Question",
-          "name": "Como integrar CBS/IBS no TOTVS, SAP, Omie ou Linx?",
-          "acceptedAnswer": { "@type": "Answer", "text": "A Tribultz exporta o catálogo de produtos validado nos formatos TOTVS Protheus, SAP Business One, Omie, Linx e CSV genérico, prontos para importação direta no ERP sem alterações manuais." },
-        },
-        {
-          "@type": "Question",
-          "name": "O que é o split payment e quando entra em vigor?",
-          "acceptedAnswer": { "@type": "Answer", "text": "O split payment é o mecanismo de retenção automática de IBS/CBS no momento do pagamento (Pix, boleto, transferência bancária), previsto para entrar em vigor em 2027. Impacta diretamente o capital de giro — empresas devem modelar o impacto antes do prazo." },
-        },
-      ],
+      "mainEntity": FAQ_ITEMS.map((item) => ({
+        "@type": "Question",
+        "name": item.q,
+        "acceptedAnswer": { "@type": "Answer", "text": item.a },
+      })),
     },
   ],
 };
@@ -446,6 +451,29 @@ export default function HomePage() {
           <div className="mx-auto max-w-6xl px-4 md:px-6">
             <h2 className="mb-8 text-2xl font-bold text-[#24292E]">Últimas novidades</h2>
             <NewsFeed />
+          </div>
+        </section>
+
+        {/* FAQ — conteúdo visível espelha o JSON-LD FAQPage (fonte: FAQ_ITEMS) */}
+        <section className="py-24" style={{ background: "#F8FAFC" }} id="faq">
+          <div className="mx-auto max-w-3xl px-4 md:px-6">
+            <span className="text-xs font-semibold uppercase tracking-widest text-[#2044C7]">FAQ</span>
+            <h2 className="mb-10 mt-3 text-4xl font-extrabold leading-tight tracking-tight text-[#24292E]">
+              Perguntas frequentes
+            </h2>
+            <div className="flex flex-col gap-4">
+              {FAQ_ITEMS.map((item) => (
+                <details key={item.q} className="group rounded-2xl border border-slate-200 bg-white p-6">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-base font-bold text-[#24292E]">
+                    {item.q}
+                    <span className="text-[#2956E3] transition-transform group-open:rotate-45" aria-hidden="true">
+                      +
+                    </span>
+                  </summary>
+                  <p className="mt-4 text-sm leading-relaxed text-[#334155]">{item.a}</p>
+                </details>
+              ))}
+            </div>
           </div>
         </section>
 

--- a/frontend/src/components/common/CookieConsent.tsx
+++ b/frontend/src/components/common/CookieConsent.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
   CONSENT_OPEN_EVENT,
-  REFUSE_REDIRECT_URL,
   getStoredConsent,
   setConsent,
 } from "@/lib/consent";
@@ -16,7 +15,8 @@ import {
  * - Pode ser reaberto a qualquer momento pelo link "Preferências de cookies"
  *   no rodapé (via evento `CONSENT_OPEN_EVENT`).
  * - "Aceitar": concede o analytics_storage e fecha.
- * - "Recusar": mantém o analytics negado e leva o usuário para fora do site.
+ * - "Recusar": mantém o analytics negado e fecha — a navegação segue normal
+ *   (LGPD art. 8º §3º: o consentimento deve ser livre, nunca condição de acesso).
  */
 export default function CookieConsent() {
   const [visible, setVisible] = useState(false);
@@ -42,7 +42,6 @@ export default function CookieConsent() {
   function refuse() {
     setConsent("denied");
     setVisible(false);
-    window.location.href = REFUSE_REDIRECT_URL;
   }
 
   return (
@@ -56,8 +55,7 @@ export default function CookieConsent() {
         <p className="text-sm text-slate-600">
           Usamos cookies essenciais para o funcionamento da plataforma e, com seu
           consentimento, cookies de análise (Google Analytics) para entender o uso e
-          melhorar o produto. Ao recusar, você será redirecionado para fora do site.
-          Veja a{" "}
+          melhorar o produto. Veja a{" "}
           <Link href="/cookies" className="font-medium text-blue-600 underline hover:text-blue-700">
             Política de Cookies
           </Link>
@@ -69,7 +67,7 @@ export default function CookieConsent() {
             onClick={refuse}
             className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
           >
-            Recusar e sair
+            Recusar
           </button>
           <button
             type="button"

--- a/frontend/src/components/public/PublicNavbar.tsx
+++ b/frontend/src/components/public/PublicNavbar.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { PublicNavbarMobileMenu } from "./PublicNavbarMobileMenu";
+import { PUBLIC_NAV_LINKS } from "./publicNavLinks";
 
 function TribultzLogo({ dark = false }: { dark?: boolean }) {
   const textColor = dark ? "#FFFFFF" : "#24292E";
@@ -17,42 +19,32 @@ export { TribultzLogo };
 export function PublicNavbar() {
   return (
     <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/92 backdrop-blur-md backdrop-saturate-150">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 md:px-6" style={{ height: 64 }}>
+      <div className="relative mx-auto flex max-w-6xl items-center justify-between px-4 py-3 md:px-6" style={{ height: 64 }}>
         <Link href="/" aria-label="Tribultz">
           <TribultzLogo />
         </Link>
 
         <nav className="hidden items-center gap-7 text-sm md:flex" aria-label="Navegação pública">
-          <Link href="/diagnostico" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-            Diagnóstico Gratuito
-          </Link>
-          <Link href="/calculadora" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-            Calculadora CBS/IBS
-          </Link>
-          <Link href="/simulador" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-            Simulador de Impacto
-          </Link>
-          <Link href="/pricing" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-            Planos
-          </Link>
-          <Link href="/founding-partners" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-            Founding Partners
-          </Link>
-          <Link href="/blog" className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-            Blog
-          </Link>
+          {PUBLIC_NAV_LINKS.map((link) => (
+            <Link key={link.href} href={link.href} className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
+              {link.label}
+            </Link>
+          ))}
           <Link href="/login" className="font-medium text-slate-500 transition-colors hover:text-slate-800">
             Entrar
           </Link>
         </nav>
 
-        <Link
-          href="/register"
-          className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#2044C7]"
-          style={{ boxShadow: "0 8px 24px rgba(41,86,227,0.20)" }}
-        >
-          Criar conta grátis
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/register"
+            className="whitespace-nowrap rounded-lg bg-[#2956E3] px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-[#2044C7] md:px-4 md:text-sm"
+            style={{ boxShadow: "0 8px 24px rgba(41,86,227,0.20)" }}
+          >
+            Criar conta grátis
+          </Link>
+          <PublicNavbarMobileMenu />
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/components/public/PublicNavbarMobileMenu.tsx
+++ b/frontend/src/components/public/PublicNavbarMobileMenu.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { PUBLIC_NAV_LINKS } from "./publicNavLinks";
+
+/** Menu hambúrguer do header público — visível só abaixo de md (#502). */
+export function PublicNavbarMobileMenu() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="md:hidden">
+      <button
+        type="button"
+        aria-label={open ? "Fechar menu de navegação" : "Abrir menu de navegação"}
+        aria-expanded={open}
+        aria-controls="public-mobile-nav"
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-10 w-10 items-center justify-center rounded-lg text-slate-700 hover:bg-slate-100"
+      >
+        {open ? (
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        ) : (
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+            <path d="M4 7h16M4 12h16M4 17h16" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <nav
+          id="public-mobile-nav"
+          aria-label="Navegação pública"
+          className="absolute inset-x-0 top-full border-b border-slate-200 bg-white shadow-lg"
+        >
+          <div className="mx-auto flex max-w-6xl flex-col px-4 py-2">
+            {PUBLIC_NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setOpen(false)}
+                className="border-b border-slate-100 py-3 text-sm font-medium text-slate-700 hover:text-[#2956E3]"
+              >
+                {link.label}
+              </Link>
+            ))}
+            <Link
+              href="/login"
+              onClick={() => setOpen(false)}
+              className="py-3 text-sm font-medium text-slate-500 hover:text-slate-800"
+            >
+              Entrar
+            </Link>
+          </div>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/public/publicNavLinks.ts
+++ b/frontend/src/components/public/publicNavLinks.ts
@@ -1,0 +1,9 @@
+/** Links do header público — fonte única para o desktop (PublicNavbar) e o menu mobile. */
+export const PUBLIC_NAV_LINKS = [
+  { href: "/diagnostico", label: "Diagnóstico Gratuito" },
+  { href: "/calculadora", label: "Calculadora CBS/IBS" },
+  { href: "/simulador", label: "Simulador de Impacto" },
+  { href: "/pricing", label: "Planos" },
+  { href: "/founding-partners", label: "Founding Partners" },
+  { href: "/blog", label: "Blog" },
+] as const;

--- a/frontend/src/components/seo/ogTemplate.tsx
+++ b/frontend/src/components/seo/ogTemplate.tsx
@@ -1,0 +1,83 @@
+/**
+ * Template compartilhado das imagens Open Graph (1200×630) geradas via
+ * ImageResponse/Satori. Usado por `app/opengraph-image.tsx` (site) e
+ * `app/blog/[slug]/opengraph-image.tsx` (por post).
+ *
+ * Satori só suporta flexbox — todo container com múltiplos filhos precisa
+ * de display:flex explícito.
+ */
+
+export const OG_SIZE = { width: 1200, height: 630 };
+
+/** Marca Tribultz (mesma geometria do TribultzLogo em PublicNavbar). */
+export function TribultzMark({ size = 72 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 40 40" width={size} height={size}>
+      <rect x="2" y="2" width="36" height="36" rx="9" fill="#2956E3" />
+      <path d="M11 14 H29 M20 14 V32" stroke="#FFFFFF" strokeWidth="4" strokeLinecap="round" />
+      <circle cx="29" cy="32" r="2.5" fill="#FFD600" />
+    </svg>
+  );
+}
+
+export function OgTemplate({
+  badge,
+  title,
+  subtitle,
+}: {
+  badge: string;
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "64px 72px",
+        background: "linear-gradient(135deg, #2956E3 0%, #1a328b 100%)",
+        color: "#FFFFFF",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+        <TribultzMark size={64} />
+        <span style={{ fontSize: 40, fontWeight: 800, letterSpacing: -1 }}>Tribultz</span>
+        <span
+          style={{
+            marginLeft: 16,
+            padding: "6px 18px",
+            borderRadius: 999,
+            background: "rgba(255,255,255,0.14)",
+            border: "1px solid rgba(255,255,255,0.25)",
+            fontSize: 24,
+            fontWeight: 600,
+          }}
+        >
+          {badge}
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          fontSize: title.length > 70 ? 52 : 62,
+          fontWeight: 800,
+          lineHeight: 1.15,
+          letterSpacing: -1,
+          maxWidth: 1020,
+        }}
+      >
+        {title}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: 28, color: "rgba(255,255,255,0.82)" }}>{subtitle}</span>
+        <span style={{ fontSize: 28, fontWeight: 700, color: "#FFD600" }}>tribultz.com.br</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/consent.ts
+++ b/frontend/src/lib/consent.ts
@@ -11,12 +11,6 @@ export const CONSENT_STORAGE_KEY = "tribultz-cookie-consent";
 /** Evento disparado pelo link do rodapé para reabrir o banner de preferências. */
 export const CONSENT_OPEN_EVENT = "tribultz:cookie-preferences";
 
-/**
- * Para onde o usuário é enviado ao recusar os cookies (sai do site).
- * Altere esta URL caso queira outro destino.
- */
-export const REFUSE_REDIRECT_URL = "https://6tech.net.br";
-
 export type ConsentChoice = "granted" | "denied";
 
 type GtagFn = (...args: unknown[]) => void;


### PR DESCRIPTION
Closes #502

Implementa os 4 fixes P0 da auditoria SEO/design (follow-ups P1/P2 em #503).

## Mudanças

### 1. Open Graph images (antes: nenhuma existia; coverImage do blog → 404)
- `app/opengraph-image.tsx` — OG 1200×630 gerada em build via `ImageResponse`, aplicada a todas as rotas públicas por cascata
- `app/blog/[slug]/opengraph-image.tsx` — OG dinâmica por post (título + categoria)
- `components/seo/ogTemplate.tsx` — template Satori compartilhado com a marca
- `blog/[slug]/page.tsx` — deixa de emitir as `coverImage` quebradas do frontmatter

### 2. `/logo.png` (antes: 404, referenciado pelo JSON-LD Organization)
- `app/logo.png/route.tsx` — route handler `force-static` servindo a marca oficial 512×512 via `ImageResponse`, sem asset binário no repo (mesma geometria SVG do `TribultzLogo`)

### 3. Navegação mobile (antes: links `hidden` sem hambúrguer — só o CTA acessível)
- `PublicNavbarMobileMenu.tsx` — hambúrguer client-side com `aria-expanded`/`aria-controls`, painel com os 7 links
- `publicNavLinks.ts` — fonte única dos links (desktop + mobile)
- CTA do header com `whitespace-nowrap` + tamanho reduzido em mobile (não quebra mais em 2 linhas)

### 4. Cookie banner (antes: "Recusar e sair" redirecionava para fora do site)
- "Recusar" nega analytics e fecha o banner — usuário permanece no site (LGPD art. 8º §3º: consentimento livre não pode condicionar acesso)
- Removidos `REFUSE_REDIRECT_URL` e a frase coercitiva do texto

### 5. FAQ visível (antes: JSON-LD FAQPage sem conteúdo na página — viola diretrizes Google)
- Seção `#faq` na home com accordions `<details>` — `FAQ_ITEMS` é fonte única do visível E do schema (paridade 1:1 garantida por construção)

## Verificação
- `npm test --silent`: **188/188 pass**
- `npm run build`: ✓ (64/64 páginas estáticas; rotas `/logo.png` e `/opengraph-image` no manifest)
- Dev server: `og:image` 200 `image/png` na home; OG do post 200; `/logo.png` 200 com pixels da marca conferidos (`#2956E3`/branco/`#FFD600`); paridade FAQ schema↔visível 5/5; "Recusar" mantém `location` no site com `consent=denied` persistido; hambúrguer abre painel com os 7 links (`aria-expanded=true`)