### PR TITLE
chore(infra): registra fingerprint da chave SSH do MacBook em KEY_FPS (#506)

### DIFF
--- a/tools/check_access.sh
+++ b/tools/check_access.sh
@@ -14,7 +14,8 @@ SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
 # Fingerprints das chaves autorizadas na VM (públicos — não são segredo).
 # Ao adicionar uma máquina, autorize a chave em ~/.ssh/authorized_keys na VM e liste aqui.
 KEY_FPS="SHA256:ydI3GwtHcGHjUvcCzFQgOp7zypbiVwqqiicGlhun7gg=tribultz-infra (Windows)
-SHA256:6DqZCh26dT2Ce0KPD8ZwMXPtZ9++3siBctZKD1E+8ig=tribultz-infra (Mac)"
+SHA256:6DqZCh26dT2Ce0KPD8ZwMXPtZ9++3siBctZKD1E+8ig=tribultz-infra (Mac)
+SHA256:9JtQfvh8yIebGMewdoenxW92w0XtRXJ/A8Ru9CYy9D0=tribultz-infra (MacBook Mickel)"
 API="https://api.tribultz.com.br"
 FRONTEND="https://tribultz.com.br"
 


### PR DESCRIPTION
Closes #506

Uma linha: adiciona a fingerprint pública da chave ed25519 do MacBook (`SHA256:9JtQfvh8yIebGMewdoenxW92w0XtRXJ/A8Ru9CYy9D0`) ao `KEY_FPS` do `tools/check_access.sh`, seguindo a instrução do próprio script.

## Verificação
Auditoria re-executada após a mudança:
```
✓ permissão da chave: 600
✓ chave reconhecida: tribultz-infra (MacBook Mickel)
✓ SSH conecta em ubuntu@201.54.20.18
```
O aviso "chave não listada em KEY_FPS" foi eliminado — `check_access.sh` agora fecha a seção SSH sem warnings.

Contexto: achado da auditoria de infra pós-deploy de 20/07/2026 (PR #505 / checklist do runbook).