### PR TITLE
fix(ci): alerta Resend falhava silenciosamente por bloqueio Cloudflare (#509)

### DIFF
--- a/.github/workflows/classtrib-sync.yml
+++ b/.github/workflows/classtrib-sync.yml
@@ -86,11 +86,21 @@ jobs:
             headers={
               "Authorization": f"Bearer {key}",
               "Content-Type":  "application/json",
+              # Sem isto, o urllib manda "Python-urllib/3.x" como User-Agent — o WAF
+              # (Cloudflare) na frente da API do Resend bloqueia com 403 "error code:
+              # 1010" ("banned based on your browser's signature"). Confirmado em
+              # produção (2026-07-20): o alerta deste mesmo workflow nunca chegou a
+              # ser entregue na falha real do dia anterior, mesmo reportando sucesso
+              # no job — falha silenciosa do próprio mecanismo de último recurso.
+              "User-Agent": "tribultz-ci/1.0",
             },
           )
           try:
             with urllib.request.urlopen(req, timeout=10) as r:
               print("Alert sent:", r.status)
           except urllib.error.HTTPError as e:
-            print("Resend error:", e.read().decode())
+            # Antes só imprimia — o step reportava sucesso mesmo com a entrega
+            # falhando (mesmo incidente do 403/1010 acima). Falhar de verdade aqui
+            # é o que torna uma futura quebra do próprio alerta visível.
+            raise SystemExit(f"Resend error: {e.read().decode()}")
           PY

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -67,13 +67,23 @@ jobs:
             headers={
               "Authorization": f"Bearer {key}",
               "Content-Type":  "application/json",
+              # Sem isto, o urllib manda "Python-urllib/3.x" como User-Agent — o WAF
+              # (Cloudflare) na frente da API do Resend bloqueia com 403 "error code:
+              # 1010" ("banned based on your browser's signature"). Confirmado em
+              # produção (2026-07-20/21): o alerta nunca chegou a ser entregue, mesmo
+              # reportando sucesso no job — falha silenciosa do próprio mecanismo de
+              # último recurso.
+              "User-Agent": "tribultz-ci/1.0",
             },
           )
           try:
             with urllib.request.urlopen(req, timeout=10) as r:
               print("Alert sent:", r.status)
           except urllib.error.HTTPError as e:
-            print("Resend error:", e.read().decode())
+            # Antes só imprimia — o step reportava sucesso mesmo com a entrega
+            # falhando (mesmo incidente do 403/1010 acima). Falhar de verdade aqui
+            # é o que torna uma futura quebra do próprio alerta visível.
+            raise SystemExit(f"Resend error: {e.read().decode()}")
           PY
 
       - name: Log status (degraded warning)


### PR DESCRIPTION
## Summary
Fecha #509.

Durante a análise de infra de 21/07, encontrei que **tanto `monitor.yml` quanto `classtrib-sync.yml` falharam de verdade recentemente** (SVRS timeout ontem no sync; `storage: unreachable` duas vezes no health check), e em **ambos os casos** o step "Send alert email (Resend)" reportou sucesso (✓) mas o log mostrava `Resend error: error code: 1010` — o e-mail nunca chegou.

**Causa raiz confirmada e reproduzida localmente**: `error code: 1010` é formato do Cloudflare ("banned based on your browser's signature"), não da API do Resend. `urllib.request` sem `User-Agent` explícito manda `Python-urllib/3.x`, que o WAF na frente da API bloqueia.

```
# sem User-Agent → 403 "error code: 1010" (bloqueio Cloudflare)
# com User-Agent: "tribultz-ci/1.0" → 401 "missing_api_key" (resposta real da API)
```

## O que foi entregue
- `User-Agent` explícito no header da requisição, nos dois workflows.
- `except HTTPError: print(...)` → `except HTTPError: raise SystemExit(...)` — falha real de entrega agora aparece como falha do step, não sucesso silencioso (mesmo problema que permitiu essa falha passar despercebida desde sempre).

## Impacto
O mecanismo de alerta de último recurso (criado no #446 e copiado do padrão já existente em `monitor.yml`) **nunca entregou um e-mail sequer**, em nenhum dos dois workflows, desde que foi implementado. Achado só porque os dois workflows falharam de verdade essa semana.

## Test plan
- [x] YAML válido nos dois arquivos (`yaml.safe_load`)
- [x] Sintaxe Python do heredoc validada (`compile()`)
- [x] Causa raiz reproduzida localmente (User-Agent com/sem)
- [ ] Após merge: disparar `workflow_dispatch` em `classtrib-sync.yml` ou `monitor.yml` numa condição de falha real e confirmar "Alert sent: 2xx" no log — vou fazer isso no pós-deploy