### PR TITLE
test(ci): input temporário pra validar envio real do alerta (#509)

### DIFF
--- a/.github/workflows/classtrib-sync.yml
+++ b/.github/workflows/classtrib-sync.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: "0 8 * * *"   # diário, 08:00 UTC
   workflow_dispatch:
+    inputs:
+      test_alert:
+        description: "TEMPORÁRIO (#509) — força falha só pra validar o envio real do alerta. Reverter após uso."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -30,6 +35,11 @@ jobs:
 
       - name: Install deps (httpx)
         run: pip install httpx
+
+      # TEMPORÁRIO (#509) — remover após validar o envio real do alerta.
+      - name: "[TESTE #509] Forçar falha para validar o alerta"
+        if: ${{ inputs.test_alert == true }}
+        run: exit 1
 
       - name: Re-sync cClassTrib (SVRS) → JSON
         run: python backend/scripts/resync_classtrib.py


### PR DESCRIPTION
## Summary
Companion do #509/#510 — o fix do User-Agent já foi mergeado, mas não consigo replicar o envio real localmente (o secret \`RESEND_API_KEY\` de CI não está acessível fora do GitHub Actions). Esta PR adiciona um input temporário (\`test_alert\`, default \`false\`) que força uma falha controlada **antes** do sync de verdade rodar, só pra exercitar o step de alerta com o secret real.

**Plano**: mergear → disparar \`workflow_dispatch\` com \`test_alert=true\` → confirmar "Alert sent: 2xx" no log → abrir PR removendo este input de teste.

Não toca a lógica de sync/PR real — a falha forçada acontece antes do \`Re-sync cClassTrib\`, então nada de dado fiscal é tocado.

## Test plan
- [x] YAML válido
- [ ] Após merge: `workflow_dispatch` com `test_alert=true` confirma envio real