### PR TITLE
chore(ci): remove andaime de teste do alerta (#509)

### DIFF
--- a/.github/workflows/classtrib-sync.yml
+++ b/.github/workflows/classtrib-sync.yml
@@ -9,11 +9,6 @@ on:
   schedule:
     - cron: "0 8 * * *"   # diário, 08:00 UTC
   workflow_dispatch:
-    inputs:
-      test_alert:
-        description: "TEMPORÁRIO (#509) — força falha só pra validar o envio real do alerta. Reverter após uso."
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -35,11 +30,6 @@ jobs:
 
       - name: Install deps (httpx)
         run: pip install httpx
-
-      # TEMPORÁRIO (#509) — remover após validar o envio real do alerta.
-      - name: "[TESTE #509] Forçar falha para validar o alerta"
-        if: ${{ inputs.test_alert == true }}
-        run: exit 1
 
       - name: Re-sync cClassTrib (SVRS) → JSON
         run: python backend/scripts/resync_classtrib.py


### PR DESCRIPTION
## Summary
Fecha #509.

Validação real concluída: disparei \`workflow_dispatch\` do \`classtrib-sync.yml\` com \`test_alert=true\` (run [29858386026](https://github.com/mickbap/tribultz/actions/runs/29858386026)) — a falha forçada disparou o step de alerta, que agora retornou **"Alert sent: 200"** (entrega real confirmada com o secret de CI de verdade, não mais bloqueada pelo Cloudflare).

Esta PR remove o input temporário (\`test_alert\`) e o step de teste introduzidos no #511, agora que a validação foi feita.

## Test plan
- [x] YAML válido
- [x] Diff é reversão limpa exata do que o #511 adicionou
- [x] Confirmado com o teste real: "Alert sent: 200" no log da run 29858386026