### PR TITLE
feat(dashboard): relatório agregado de padrão de risco por tenant/período (#442)

### DIFF
--- a/backend/app/alembic/versions/2026_07_21_0029_add_jobs_tenant_created_at_index.py
+++ b/backend/app/alembic/versions/2026_07_21_0029_add_jobs_tenant_created_at_index.py
@@ -1,0 +1,27 @@
+"""add_jobs_tenant_created_at_index — suporte ao relatório de padrão de risco (#442)
+
+O endpoint GET /api/v1/compliance/risk-patterns agrega findings de `jobs.result`
+(JSONB) por tenant + janela de data (jsonb_array_elements + GROUP BY). Sem
+índice em (tenant_id, created_at), o filtro de período faz sequential scan
+sobre `created_at` depois do índice de tenant_id — igual ao que já acontecia
+(sem índice) no fallback realtime de compliance.py. Aditivo, idempotente.
+
+Revision ID: 2026_07_21_0029
+Revises: 2026_07_19_0028
+Create Date: 2026-07-21
+"""
+
+from alembic import op
+
+revision = "2026_07_21_0029"
+down_revision = "2026_07_19_0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE INDEX IF NOT EXISTS idx_jobs_tenant_created_at ON jobs(tenant_id, created_at)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_jobs_tenant_created_at")

--- a/backend/app/routers/compliance.py
+++ b/backend/app/routers/compliance.py
@@ -6,7 +6,7 @@ GET /api/v1/compliance/score/history — histórico dos últimos 12 meses
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, Query
@@ -15,10 +15,18 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.api.plan_gate import require_plan
 from app.database import get_db
 from app.models.auth import User
 
 router = APIRouter(prefix="/api/v1/compliance", tags=["compliance"])
+
+# Job types cujo `result` tem o formato plano `{"findings": [...]}` usado pela
+# agregação de risk-patterns. SPED (`sped_validation`) guarda achados em
+# `result.produtos`, formato diferente — fica de fora, não quebra a query
+# (o filtro job_type já exclui, e o guard jsonb_typeof abaixo é redundância
+# defensiva contra qualquer job_type futuro com `result` sem findings).
+_RISK_PATTERN_JOB_TYPES = ("validate_xml", "task_a_validate_cbs_ibs")
 
 
 # ── Schemas ───────────────────────────────────────────────────────────────────
@@ -42,6 +50,25 @@ class ComplianceHistory(BaseModel):
     nfs_total: int
     findings_error: int
     credit_at_risk: float
+
+
+class RiskPatternRule(BaseModel):
+    rule_id: str
+    severity: str
+    count: int
+
+
+class RiskPatternDay(BaseModel):
+    date: str
+    fatal: int
+    warning: int
+    alert: int
+
+
+class RiskPatternReport(BaseModel):
+    period_days: int
+    top_rules: list[RiskPatternRule]
+    daily_trend: list[RiskPatternDay]
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -173,3 +200,85 @@ def get_score_history(
         "findings_error": current["findings_error"],
         "credit_at_risk": current["credit_at_risk"],
     }]
+
+
+@router.get(
+    "/risk-patterns",
+    response_model=RiskPatternReport,
+    summary="Padrão de risco agregado — findings recorrentes por regra/severidade no período",
+    dependencies=[Depends(require_plan("profissional", "empresarial", "contador"))],
+)
+def get_risk_patterns(
+    days: int = Query(30, ge=1, le=365, description="Janela de dias pra trás (default: 30)"),
+    top_n: int = Query(10, ge=1, le=50, description="Quantidade de regras no ranking"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Any:
+    """Gap 4 vs. TOTVS (#442) — equivalente ao add-on "Inteligência Fiscal by
+    IOB": cruza findings entre documentos/período pra achar padrão de risco
+    recorrente, em vez de validar documento a documento (1:1). Agrega sobre
+    `jobs.result->'findings'` já persistido — não requer mudança no motor.
+
+    Substitui a agregação client-side do dashboard (`topRules`/`trendLast7Days`
+    em page.tsx), que só olhava os últimos 50 jobs sem filtro de data —
+    sub-reportava para qualquer tenant com mais volume que isso no período.
+    """
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    tenant_id = str(current_user.tenant_id)
+    job_types = list(_RISK_PATTERN_JOB_TYPES)
+
+    top_rows = db.execute(
+        text("""
+            SELECT
+                f.value->>'rule_id' AS rule_id,
+                COALESCE(f.value->>'severity', 'UNKNOWN') AS severity,
+                COUNT(*) AS cnt
+            FROM jobs j
+            CROSS JOIN LATERAL jsonb_array_elements(j.result->'findings') AS f
+            WHERE j.tenant_id = CAST(:tid AS uuid)
+              AND j.job_type = ANY(:job_types)
+              AND j.created_at >= :since
+              AND jsonb_typeof(j.result->'findings') = 'array'
+            GROUP BY 1, 2
+            ORDER BY cnt DESC
+            LIMIT :top_n
+        """),
+        {"tid": tenant_id, "job_types": job_types, "since": since, "top_n": top_n},
+    ).mappings().all()
+
+    trend_rows = db.execute(
+        text("""
+            SELECT
+                (j.created_at AT TIME ZONE 'UTC')::date AS day,
+                COALESCE(f.value->>'severity', 'UNKNOWN') AS severity,
+                COUNT(*) AS cnt
+            FROM jobs j
+            CROSS JOIN LATERAL jsonb_array_elements(j.result->'findings') AS f
+            WHERE j.tenant_id = CAST(:tid AS uuid)
+              AND j.job_type = ANY(:job_types)
+              AND j.created_at >= :since
+              AND jsonb_typeof(j.result->'findings') = 'array'
+            GROUP BY 1, 2
+            ORDER BY 1
+        """),
+        {"tid": tenant_id, "job_types": job_types, "since": since},
+    ).mappings().all()
+
+    by_day: dict[str, dict[str, int]] = {}
+    for row in trend_rows:
+        day = row["day"].isoformat()
+        bucket = by_day.setdefault(day, {"fatal": 0, "warning": 0, "alert": 0})
+        sev = str(row["severity"]).lower()
+        if sev in bucket:
+            bucket[sev] += int(row["cnt"])
+
+    return {
+        "period_days": days,
+        "top_rules": [
+            {"rule_id": r["rule_id"], "severity": r["severity"], "count": int(r["cnt"])}
+            for r in top_rows
+        ],
+        "daily_trend": [
+            {"date": day, **counts} for day, counts in sorted(by_day.items())
+        ],
+    }

--- a/backend/tests/test_compliance.py
+++ b/backend/tests/test_compliance.py
@@ -1,0 +1,164 @@
+"""Compliance — risk-patterns (#442).
+
+Gap 4 vs. TOTVS (Inteligência Fiscal by IOB): agregação de findings por
+regra/severidade num período, cruzando documentos em vez de validar 1:1.
+Testa a query real (jsonb_array_elements) contra Postgres de verdade — mock
+de `db.execute()` não valida se o SQL está correto.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_password_hash
+from app.models.auth import Tenant, User
+from app.models.jobs import Job
+from app.routers.compliance import get_risk_patterns
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+
+def _pg_available() -> bool:
+    try:
+        with create_engine(DATABASE_URL).connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _tenant_and_user(session) -> tuple[Tenant, User]:
+    tenant = Tenant(name="Empresa Teste", slug=f"t-{uuid.uuid4().hex[:10]}")
+    session.add(tenant)
+    session.flush()
+    user = User(
+        tenant_id=tenant.id, email=f"{uuid.uuid4().hex[:8]}@example.com", full_name="Teste",
+        password_hash=get_password_hash("x"), email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+    return tenant, user
+
+
+def _job(tenant_id, job_type: str, findings: list[dict], days_ago: int) -> Job:
+    job = Job(
+        tenant_id=tenant_id,
+        job_type=job_type,
+        status="SUCCESS" if not findings else "FAIL",
+        result={"findings": findings, "fatals": sum(1 for f in findings if f["severity"] == "FATAL"), "alerts": 0},
+        created_at=datetime.now(timezone.utc) - timedelta(days=days_ago),
+    )
+    return job
+
+
+def _finding(rule_id: str, severity: str) -> dict:
+    return {
+        "id": f"F_{uuid.uuid4().hex[:6]}", "rule_id": rule_id, "severity": severity,
+        "title": "t", "where": {"field": "x"}, "recommendation": "r", "evidence_ids": [],
+    }
+
+
+def test_top_rules_agrega_por_regra_e_severidade(session):
+    tenant, user = _tenant_and_user(session)
+    session.add_all([
+        _job(tenant.id, "task_a_validate_cbs_ibs", [_finding("CLASSTRIB_CST_COMPAT", "FATAL")] * 3, days_ago=1),
+        _job(tenant.id, "task_a_validate_cbs_ibs", [_finding("CLASSTRIB_CST_COMPAT", "FATAL"), _finding("CST_VALID", "WARNING")], days_ago=2),
+    ])
+    session.flush()
+
+    result = get_risk_patterns(days=30, top_n=10, db=session, current_user=user)
+
+    top = {(r["rule_id"], r["severity"]): r["count"] for r in result["top_rules"]}
+    assert top[("CLASSTRIB_CST_COMPAT", "FATAL")] == 4
+    assert top[("CST_VALID", "WARNING")] == 1
+
+
+def test_janela_de_dias_exclui_jobs_fora_do_periodo(session):
+    tenant, user = _tenant_and_user(session)
+    session.add_all([
+        _job(tenant.id, "task_a_validate_cbs_ibs", [_finding("CLASSTRIB_CST_COMPAT", "FATAL")], days_ago=5),
+        _job(tenant.id, "task_a_validate_cbs_ibs", [_finding("CLASSTRIB_CST_COMPAT", "FATAL")], days_ago=45),
+    ])
+    session.flush()
+
+    result = get_risk_patterns(days=30, top_n=10, db=session, current_user=user)
+
+    top = {(r["rule_id"], r["severity"]): r["count"] for r in result["top_rules"]}
+    assert top[("CLASSTRIB_CST_COMPAT", "FATAL")] == 1
+
+
+def test_isolamento_entre_tenants(session):
+    tenant_a, user_a = _tenant_and_user(session)
+    tenant_b, _user_b = _tenant_and_user(session)
+    session.add_all([
+        _job(tenant_a.id, "task_a_validate_cbs_ibs", [_finding("RULE_A", "FATAL")], days_ago=1),
+        _job(tenant_b.id, "task_a_validate_cbs_ibs", [_finding("RULE_A", "FATAL")] * 10, days_ago=1),
+    ])
+    session.flush()
+
+    result = get_risk_patterns(days=30, top_n=10, db=session, current_user=user_a)
+
+    top = {(r["rule_id"], r["severity"]): r["count"] for r in result["top_rules"]}
+    assert top[("RULE_A", "FATAL")] == 1  # não vaza o volume do tenant B
+
+
+def test_daily_trend_conta_por_severidade(session):
+    tenant, user = _tenant_and_user(session)
+    session.add_all([
+        _job(tenant.id, "task_a_validate_cbs_ibs", [_finding("A", "FATAL"), _finding("B", "WARNING")], days_ago=0),
+        _job(tenant.id, "task_a_validate_cbs_ibs", [_finding("A", "ALERT")], days_ago=0),
+    ])
+    session.flush()
+
+    result = get_risk_patterns(days=30, top_n=10, db=session, current_user=user)
+
+    today = [d for d in result["daily_trend"] if d["date"] == datetime.now(timezone.utc).date().isoformat()]
+    assert len(today) == 1
+    assert today[0] == {"date": today[0]["date"], "fatal": 1, "warning": 1, "alert": 1}
+
+
+def test_sped_validation_fora_do_escopo_nao_quebra(session):
+    # SPED guarda achados em result.produtos (formato diferente) — o filtro
+    # job_type já exclui esse tipo, não deve aparecer nem quebrar a query.
+    tenant, user = _tenant_and_user(session)
+    job = Job(
+        tenant_id=tenant.id, job_type="sped_validation", status="SUCCESS",
+        result={"produtos": [{"ncm": "1234", "status": "ok"}]},
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(job)
+    session.flush()
+
+    result = get_risk_patterns(days=30, top_n=10, db=session, current_user=user)
+
+    assert result["top_rules"] == []
+
+
+def test_sem_dados_retorna_vazio(session):
+    _tenant, user = _tenant_and_user(session)
+
+    result = get_risk_patterns(days=30, top_n=10, db=session, current_user=user)
+
+    assert result == {"period_days": 30, "top_rules": [], "daily_trend": []}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,8 +5,9 @@ import { useEffect, useMemo, useState } from "react";
 import { Skeleton } from "@/components/common/Skeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { Toast } from "@/components/common/Toast";
-import { ComplianceScore, getAudits, getComplianceScore, getJobs, getSplitPaymentSummary, listExceptionRequests } from "@/lib/api";
-import type { SplitPaymentSummary } from "@/lib/api";
+import UpgradeGate from "@/components/common/UpgradeGate";
+import { ComplianceScore, getAudits, getComplianceScore, getJobs, getRiskPatterns, getSplitPaymentSummary, listExceptionRequests } from "@/lib/api";
+import type { RiskPatternReport, SplitPaymentSummary } from "@/lib/api";
 import { formatDateTimeBR } from "@/lib/formatDateTimeBR";
 import { AuditLog, ExceptionRequest, Finding, Job } from "@/lib/types";
 import { getAccountType, getTenantId, getTenants, type StoredTenant } from "@/lib/storage";
@@ -90,6 +91,79 @@ function TrendChart({ data }: { data: TrendDay[] }) {
         );
       })}
     </div>
+  );
+}
+
+const SEVERITY_CLASSES: Record<string, string> = {
+  FATAL: "bg-red-100 text-red-700",
+  WARNING: "bg-amber-100 text-amber-700",
+  ALERT: "bg-blue-100 text-blue-700",
+};
+
+/**
+ * Padrão de risco agregado (#442, Gap 4 vs. TOTVS/IOB) — cruza findings entre
+ * documentos/período (ex. "N notas com Rejeição 1024 nos últimos 30 dias"),
+ * diferente da validação 1:1 documento a documento. Fetch próprio (não entra
+ * no Promise.allSettled do painel) porque só carrega quando o UpgradeGate
+ * (Profissional+) já liberou o render.
+ */
+function RiskPatternCard() {
+  const [report, setReport] = useState<RiskPatternReport | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getRiskPatterns(30, 8)
+      .then(setReport)
+      .catch(() => setReport(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const totals = useMemo(() => {
+    if (!report) return { fatal: 0, warning: 0, alert: 0 };
+    return report.daily_trend.reduce(
+      (acc, d) => ({ fatal: acc.fatal + d.fatal, warning: acc.warning + d.warning, alert: acc.alert + d.alert }),
+      { fatal: 0, warning: 0, alert: 0 },
+    );
+  }, [report]);
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="mb-1 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-slate-700">Padrão de Risco (30 dias)</h2>
+      </div>
+      <p className="mb-3 text-xs text-slate-500">
+        Regras que mais geraram findings cruzando todos os documentos do período — não é validação 1:1.
+      </p>
+      {loading ? (
+        <Skeleton className="h-32 w-full" />
+      ) : !report || report.top_rules.length === 0 ? (
+        <p className="text-sm text-slate-500">Sem findings recorrentes no período.</p>
+      ) : (
+        <>
+          <ul className="space-y-2">
+            {report.top_rules.map((rule, idx) => (
+              <li key={`${rule.rule_id}-${rule.severity}`} className="flex items-center justify-between rounded border border-slate-100 p-2">
+                <div className="flex items-center gap-2">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-slate-100 text-xs font-bold text-slate-600">
+                    {idx + 1}
+                  </span>
+                  <span className="font-mono text-sm">{rule.rule_id}</span>
+                  <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${SEVERITY_CLASSES[rule.severity] ?? "bg-slate-100 text-slate-600"}`}>
+                    {rule.severity}
+                  </span>
+                </div>
+                <span className="text-sm font-semibold text-slate-700">{rule.count}x</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-3 flex gap-4 border-t border-slate-100 pt-3 text-xs text-slate-500">
+            <span>Total no período: <strong className="text-red-600">{totals.fatal} FATAL</strong></span>
+            <span><strong className="text-amber-600">{totals.warning} WARNING</strong></span>
+            <span><strong className="text-blue-600">{totals.alert} ALERT</strong></span>
+          </div>
+        </>
+      )}
+    </section>
   );
 }
 
@@ -340,6 +414,13 @@ export default function DashboardPage() {
           )}
         </section>
       </div>
+
+      <UpgradeGate
+        requiredPlan="profissional"
+        message="Padrão de risco agregado (últimos 30 dias, cruzando todos os documentos do tenant) disponível a partir do plano Profissional."
+      >
+        <RiskPatternCard />
+      </UpgradeGate>
 
       <div className="grid gap-4 lg:grid-cols-2">
         <section className="rounded-xl border border-slate-200 bg-white p-4">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -598,6 +598,18 @@ export async function getComplianceHistory(): Promise<ComplianceHistory[]> {
   return apiFetch("/api/v1/compliance/score/history");
 }
 
+export type RiskPatternRule = { rule_id: string; severity: string; count: number };
+export type RiskPatternDay = { date: string; fatal: number; warning: number; alert: number };
+export type RiskPatternReport = {
+  period_days: number;
+  top_rules: RiskPatternRule[];
+  daily_trend: RiskPatternDay[];
+};
+
+export async function getRiskPatterns(days = 30, topN = 10): Promise<RiskPatternReport> {
+  return apiFetch(`/api/v1/compliance/risk-patterns?days=${days}&top_n=${topN}`);
+}
+
 // ── Split Payment ────────────────────────────────────────────────────────────
 
 export type SplitPaymentDoc = {

--- a/frontend/src/lib/plan.ts
+++ b/frontend/src/lib/plan.ts
@@ -31,6 +31,7 @@ export type PlanFeatures = {
   hasApiAccess: boolean;
   hasMultiCnpj: boolean;
   hasJustificativaFiscal: boolean; // Justificativa técnica + base legal por finding
+  hasRiskPatternReport: boolean; // Padrão de risco agregado por período (#442)
   trialDays: number | null;
 };
 
@@ -45,6 +46,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasApiAccess: false,
     hasMultiCnpj: false,
     hasJustificativaFiscal: false,
+    hasRiskPatternReport: false,
     trialDays: 3,
   },
   starter: {
@@ -57,6 +59,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasApiAccess: false,
     hasMultiCnpj: false,
     hasJustificativaFiscal: false,
+    hasRiskPatternReport: false,
     trialDays: null,
   },
   profissional: {
@@ -69,6 +72,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasApiAccess: true,
     hasMultiCnpj: false,
     hasJustificativaFiscal: true,
+    hasRiskPatternReport: true,
     trialDays: null,
   },
   empresarial: {
@@ -81,6 +85,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasApiAccess: true,
     hasMultiCnpj: true, // filiais — até 10 CNPJs
     hasJustificativaFiscal: true,
+    hasRiskPatternReport: true,
     trialDays: null,
   },
   contador: {
@@ -93,6 +98,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasApiAccess: true,
     hasMultiCnpj: true,
     hasJustificativaFiscal: true,
+    hasRiskPatternReport: true,
     trialDays: null,
   },
   admin: {
@@ -105,6 +111,7 @@ export const PLAN_FEATURES: Record<PlanSlug, PlanFeatures> = {
     hasApiAccess: true,
     hasMultiCnpj: true,
     hasJustificativaFiscal: true,
+    hasRiskPatternReport: true,
     trialDays: null,
   },
 };


### PR DESCRIPTION
## Summary
Fecha #442.

Gap 4 vs. TOTVS (competitive/totvs.md): "Inteligência Fiscal by IOB" cruza múltiplos documentos/períodos pra achar padrão de risco histórico; a Tribultz validava 1:1 (mesmo em lote). Este PR adiciona a camada de agregação — não requer mudança no motor de validação, é só query sobre `jobs.result->'findings'` já persistido.

**Governança (#444)**: mesmo caso do #440/#441 desta semana — mérito próprio (aproveitar dado já coletado), não "construir porque a TOTVS tem". Zero Customer Evidence formal, mas escopo baixo-risco e explicitamente delimitado pela própria issue (sem alteração de motor).

## Achado durante a investigação
O dashboard já tinha widgets "Top 3 Regras Violadas" e "Trend (7 dias)" — mas **100% client-side sobre os últimos 50 jobs, sem filtro de data** (`getJobs()` sem params). Isso sub-reporta silenciosamente qualquer tenant com mais de 50 validações na janela. Não toquei nesses widgets (ficam como estão, grátis pra todo tier) — a nova seção resolve o problema real com agregação de verdade no backend.

## O que foi entregue
- **`GET /api/v1/compliance/risk-patterns?days=30&top_n=10`**: `top_rules` (rule_id/severidade/contagem, ordenado) + `daily_trend` (FATAL/WARNING/ALERT por dia). Gate: profissional/empresarial/contador (mesmo padrão de `split_payment.py`).
- Nova seção "Padrão de Risco (30 dias)" no dashboard, via `UpgradeGate` (componente já existente, reaproveitado).
- Migration: índice `(tenant_id, created_at)` em `jobs` — sem ele o filtro de período seria sequential scan.
- `hasRiskPatternReport` nova flag em `frontend/src/lib/plan.ts`.

## Test plan
- [x] 6 testes novos contra Postgres real (`test_compliance.py`) — agregação por regra/severidade, janela de dias, isolamento entre tenants, trend diário, SPED fora do escopo não quebra, sem dados retorna vazio
- [x] `pytest tests/` — 760 passed · `ruff` limpo · `pyright` 0 erros
- [x] `npm test` — 188 passed · `npm run build` limpo
- [x] `python tools/architecture_audit.py` — sem regressão (1 achado pré-existente não relacionado, #490)
- [x] **Validação end-to-end real**: rebuild do container local, dados inseridos direto no Postgres, endpoint chamado com token real — contagem bate exato (5 FATAL `CLASSTRIB_CST_COMPAT`, 3 WARNING `CST_VALID`). Confirmado 403 real pra tier Starter (resolvido via assinatura no banco, não confia no claim do JWT).