### PR TITLE
fix(auth): aceita CNPJ alfanumérico (RFB, produção 27/07/2026)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from datetime import datetime, timedelta, timezone
 from typing import cast
 from uuid import UUID
@@ -26,7 +25,7 @@ from app.core.security import (
 )
 from app.api.deps import get_current_user
 from app.services.captcha_service import verify_captcha
-from app.services.cnpj_validator import validate_cnpj
+from app.services.cnpj_validator import is_valid_cnpj_format, normalize_cnpj, validate_cnpj
 from app.services.email_service import send_verification_email, send_password_reset_email
 from app.services.rate_limit import RateLimiter
 
@@ -57,9 +56,13 @@ def _client_ip(request: Request) -> str:
 
 
 def _cnpj_to_slug(cnpj: str) -> str:
-    """Convert CNPJ digits to a tenant slug: 12345678000199 → cnpj-12345678000199."""
-    digits = re.sub(r"\D", "", cnpj)
-    return f"cnpj-{digits}"
+    """Convert CNPJ to a tenant slug: 12345678000199 → cnpj-12345678000199.
+
+    Preserva letras (CNPJ alfanumérico, RFB — produção 27/07/2026): descartar
+    non-digits colidiria dois CNPJs alfanuméricos diferentes que compartilhem
+    os mesmos dígitos.
+    """
+    return f"cnpj-{normalize_cnpj(cnpj)}"
 
 
 def _get_or_create_tenant_for_cnpj(
@@ -557,13 +560,6 @@ async def resend_verification(
 class AddCnpjRequest(BaseModel):
     cnpj: str
 
-    @classmethod
-    def validate_cnpj_format(cls, v: str) -> str:
-        digits = re.sub(r"\D", "", v)
-        if len(digits) != 14:
-            raise ValueError("CNPJ deve ter 14 dígitos.")
-        return digits
-
 
 @router.post("/add-cnpj")
 async def add_cnpj(
@@ -586,18 +582,21 @@ async def add_cnpj(
             detail="Apenas contas de contador podem adicionar CNPJs.",
         )
 
-    cnpj_digits = re.sub(r"\D", "", data.cnpj)
-    if len(cnpj_digits) != 14:
-        raise HTTPException(status_code=400, detail="CNPJ deve ter 14 dígitos.")
+    cnpj_normalized = normalize_cnpj(data.cnpj)
+    if not is_valid_cnpj_format(cnpj_normalized):
+        raise HTTPException(
+            status_code=400,
+            detail="CNPJ deve ter 14 caracteres (12 alfanuméricos + 2 dígitos verificadores).",
+        )
 
     # Validate CNPJ
-    cnpj_result = await validate_cnpj(cnpj_digits)
+    cnpj_result = await validate_cnpj(cnpj_normalized)
     if not cnpj_result.valid:
         raise HTTPException(status_code=400, detail="CNPJ inválido ou não encontrado na Receita Federal.")
     company_name = cnpj_result.company_name
 
     # Get or create tenant
-    tenant = _get_or_create_tenant_for_cnpj(db, cnpj_digits, company_name)
+    tenant = _get_or_create_tenant_for_cnpj(db, cnpj_normalized, company_name)
 
     # Check if association already exists
     existing = db.execute(
@@ -624,7 +623,7 @@ async def add_cnpj(
 
     logger.info(
         "cnpj_added",
-        extra={"user_id": str(user_id), "cnpj": cnpj_digits, "tenant_slug": cast(str, tenant.slug)},
+        extra={"user_id": str(user_id), "cnpj": cnpj_normalized, "tenant_slug": cast(str, tenant.slug)},
     )
 
     tenants = _get_user_tenants(db, user_id)

--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -2069,6 +2069,7 @@ async def _enrich_classtrib(xml: str) -> dict[str, bool | None] | None:
 
 async def _enrich_cnpj(xml: str) -> tuple[bool, str] | None:
     """Pre-fetch emitter CNPJ status for enrichment."""
+    from app.services.cnpj_validator import is_valid_cnpj_format
     from app.services.cnpj_validator import validate_cnpj as _validate_cnpj
 
     # Extract emitter CNPJ (first CNPJ in emit block, or first CNPJ in document)
@@ -2076,7 +2077,7 @@ async def _enrich_cnpj(xml: str) -> tuple[bool, str] | None:
     if not emit_block:
         return None
     cnpj_tag = _first_tag(emit_block["snippet"], ["CNPJ"])
-    if not cnpj_tag or not re.match(r"^\d{14}$", cnpj_tag["value"]):
+    if not cnpj_tag or not is_valid_cnpj_format(cnpj_tag["value"]):
         return None
     try:
         result = await _validate_cnpj(cnpj_tag["value"])

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -4,6 +4,8 @@ from typing import Optional
 from uuid import UUID
 from pydantic import BaseModel, EmailStr, field_validator
 
+from app.services.cnpj_validator import is_valid_cnpj_format, normalize_cnpj
+
 
 class TenantInfo(BaseModel):
     id: UUID
@@ -104,10 +106,10 @@ class UserRegister(BaseModel):
     def validate_cnpj(cls, v: str) -> str:
         if not v:
             return v
-        digits = re.sub(r"\D", "", v)
-        if len(digits) != 14:
-            raise ValueError("CNPJ deve ter 14 dígitos.")
-        return digits
+        normalized = normalize_cnpj(v)
+        if not is_valid_cnpj_format(normalized):
+            raise ValueError("CNPJ deve ter 14 caracteres (12 alfanuméricos + 2 dígitos verificadores).")
+        return normalized
 
     @field_validator("account_type")
     @classmethod

--- a/backend/app/services/cnpj_validator.py
+++ b/backend/app/services/cnpj_validator.py
@@ -7,6 +7,12 @@ Graceful degradation: if both APIs are unavailable, allow registration
 with a warning log (never block user registration due to external API).
 
 LRU cache (TTL 24h, max 500 entries) prevents excessive API calls in batch scenarios.
+
+Formato aceito: 14 caracteres — 12 alfanuméricos (raiz + ordem do
+estabelecimento) + 2 dígitos verificadores numéricos. A partir de 31/07/2026
+a Receita Federal emite CNPJ alfanumérico (NT Conjunta 2025.001, produção dos
+sistemas RFB em 27/07/2026) — CNPJs já existentes continuam 100% numéricos,
+formato subset do alfanumérico. Ver docs/context/reference_cnpj_alfanumerico.md.
 """
 
 import logging
@@ -66,8 +72,20 @@ class _CnpjCache:
 _cnpj_cache = _CnpjCache()
 
 
-def _digits_only(cnpj: str) -> str:
-    return re.sub(r"\D", "", cnpj)
+CNPJ_FORMAT_RE = re.compile(r"^[A-Z0-9]{12}\d{2}$")
+
+
+def normalize_cnpj(cnpj: str) -> str:
+    """Remove pontuação (., /, -, espaço) e uppercase — preserva letras.
+
+    CNPJ alfanumérico (RFB, produção 27/07/2026) usa letras nas 12 primeiras
+    posições; só os 2 dígitos verificadores finais continuam numéricos.
+    """
+    return re.sub(r"[.\-/\s]", "", cnpj).upper()
+
+
+def is_valid_cnpj_format(cnpj: str) -> bool:
+    return bool(CNPJ_FORMAT_RE.match(normalize_cnpj(cnpj)))
 
 
 async def validate_cnpj(cnpj: str) -> CnpjResult:
@@ -75,34 +93,34 @@ async def validate_cnpj(cnpj: str) -> CnpjResult:
 
     Uses LRU cache (24h TTL) to avoid repeated API calls for the same CNPJ.
     """
-    digits = _digits_only(cnpj)
-    if len(digits) != 14:
+    normalized = normalize_cnpj(cnpj)
+    if not is_valid_cnpj_format(normalized):
         return CnpjResult(
-            valid=False, cnpj=digits, company_name="", status="",
-            error="CNPJ deve ter 14 dígitos.",
+            valid=False, cnpj=normalized, company_name="", status="",
+            error="CNPJ deve ter 14 caracteres (12 alfanuméricos + 2 dígitos verificadores).",
         )
 
     # Check cache first
-    cached = _cnpj_cache.get(digits)
+    cached = _cnpj_cache.get(normalized)
     if cached is not None:
         return cached
 
     # Try BrasilAPI first
-    result = await _try_brasilapi(digits)
+    result = await _try_brasilapi(normalized)
     if result is not None:
-        _cnpj_cache.put(digits, result)
+        _cnpj_cache.put(normalized, result)
         return result
 
     # Fallback to ReceitaWS
-    result = await _try_receitaws(digits)
+    result = await _try_receitaws(normalized)
     if result is not None:
-        _cnpj_cache.put(digits, result)
+        _cnpj_cache.put(normalized, result)
         return result
 
     # Both APIs failed — allow with warning (don't cache failures)
-    logger.warning("cnpj_validation_unavailable", extra={"cnpj": digits})
+    logger.warning("cnpj_validation_unavailable", extra={"cnpj": normalized})
     return CnpjResult(
-        valid=True, cnpj=digits, company_name="", status="API_UNAVAILABLE",
+        valid=True, cnpj=normalized, company_name="", status="API_UNAVAILABLE",
         error="",
     )
 

--- a/backend/tests/test_cnpj_validator.py
+++ b/backend/tests/test_cnpj_validator.py
@@ -1,0 +1,69 @@
+"""CNPJ alfanumérico (RFB, produção 27/07/2026) — #514.
+
+Formato oficial: 14 caracteres — 12 alfanuméricos (raiz + ordem do
+estabelecimento) + 2 dígitos verificadores, que permanecem numéricos.
+Regressão coberta aqui: o validador antigo assumia 14 dígitos puramente
+numéricos e rejeitava (ou descartava letras de) um CNPJ alfanumérico legítimo.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.cnpj_validator import is_valid_cnpj_format, normalize_cnpj, validate_cnpj
+
+
+def test_cnpj_numerico_tradicional_valido():
+    assert is_valid_cnpj_format("12345678000199")
+
+
+def test_cnpj_numerico_formatado_com_pontuacao_valido():
+    assert is_valid_cnpj_format("12.345.678/0001-99")
+
+
+def test_cnpj_alfanumerico_valido():
+    assert is_valid_cnpj_format("12ABC34501DE35")
+
+
+def test_cnpj_alfanumerico_formatado_com_pontuacao_valido():
+    assert is_valid_cnpj_format("12.ABC.345/01DE-35")
+
+
+def test_cnpj_alfanumerico_minusculo_normaliza_para_maiusculo():
+    assert is_valid_cnpj_format("12abc34501de35")
+
+
+def test_cnpj_digitos_verificadores_devem_ser_numericos():
+    assert not is_valid_cnpj_format("12ABC34501DEAB")  # últimos 2 não numéricos
+
+
+def test_cnpj_tamanho_errado_invalido():
+    assert not is_valid_cnpj_format("1234567800019")  # 13 chars
+    assert not is_valid_cnpj_format("123456780001999")  # 15 chars
+
+
+def test_normalize_cnpj_remove_pontuacao_e_uppercase():
+    assert normalize_cnpj("12.abc.345/01de-35") == "12ABC34501DE35"
+
+
+@pytest.mark.asyncio
+async def test_validate_cnpj_formato_invalido_nao_chama_api_externa():
+    with patch("app.services.cnpj_validator._try_brasilapi", new_callable=AsyncMock) as mock_api:
+        result = await validate_cnpj("123")
+    assert result.valid is False
+    assert "14 caracteres" in result.error
+    mock_api.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_validate_cnpj_alfanumerico_formato_valido_chama_api_externa():
+    from app.services.cnpj_validator import CnpjResult
+
+    fake_result = CnpjResult(valid=True, cnpj="12ABC34501DE35", company_name="Empresa Teste", status="ATIVA", error="")
+    with patch("app.services.cnpj_validator._try_brasilapi", new_callable=AsyncMock, return_value=fake_result) as mock_api:
+        result = await validate_cnpj("12.ABC.345/01DE-35")
+    mock_api.assert_called_once_with("12ABC34501DE35")
+    assert result.valid is True
+    assert result.cnpj == "12ABC34501DE35"


### PR DESCRIPTION
Closes #514.

## Contexto

Achado da varredura de notícias regulatórias de 21/07/2026, priorizado como P0 (matriz de priorização, tribultz-brain#16) por ter cronograma regulatório apertado: produção dos sistemas RFB em 27/07/2026, primeiro CNPJ alfanumérico emitido em 31/07/2026.

## Problema

3 pontos assumiam CNPJ como 14 dígitos puramente numéricos e bloqueariam o cadastro de uma empresa nova:

1. `schemas/auth.py` (`RegisterRequest.validate_cnpj`) — bloqueava o cadastro (422 na API).
2. `services/cnpj_validator.py` (`validate_cnpj`) — bloqueava antes de consultar BrasilAPI/ReceitaWS.
3. `routers/auth.py` (endpoint `/add-cnpj`, contador) — mesmo bug inline.

Mais 2 pontos relacionados:

4. `routers/auth.py` (`_cnpj_to_slug`) — descartava letras ao montar o slug do tenant (risco de colisão silenciosa entre CNPJs alfanuméricos diferentes).
5. `routers/validate_xml.py` (`_enrich_cnpj`) — degradava silenciosamente o enriquecimento de status (severidade menor, não bloqueava validação de XML).

**Achado extra durante a implementação**: `AddCnpjRequest.validate_cnpj_format` era um `@classmethod` sem `@field_validator` — nunca era chamado pelo Pydantic. Código morto, removido; o gate real estava inline no endpoint (mesmo bug do item 3, corrigido).

## Fix

Formato oficial (NT Conjunta 2025.001, RFB): 14 caracteres — 12 alfanuméricos (raiz + ordem do estabelecimento) + 2 dígitos verificadores numéricos. CNPJ 100% numérico continua válido (subset do novo formato).

Consolida a lógica de formato num único lugar (`services/cnpj_validator.py`): `normalize_cnpj()` (remove pontuação, uppercase, preserva letras) + `is_valid_cnpj_format()` (regex `^[A-Z0-9]{12}\d{2}$`), reaproveitado pelos 4 pontos que hoje duplicavam a mesma checagem com regex diferente.

## Testes

- `backend/tests/test_cnpj_validator.py` (novo, 10 casos): formato numérico tradicional, alfanumérico, com pontuação, minúsculo, dígito verificador não-numérico rejeitado, tamanho errado, e que o gate de formato inválido não chega a chamar a API externa.
- Suíte completa: 770 passed. `ruff check` e `pyright` limpos.

## Validação E2E (Docker real, API real)

- CNPJ alfanumérico bem formatado (`12.ABC.345/01DE-35`) passa o gate local em `/register` e `/add-cnpj`, chega à consulta externa (BrasilAPI 404 → fallback ReceitaWS, mensagem real da API) — antes seria bloqueado com "CNPJ deve ter 14 dígitos" antes de qualquer chamada externa.
- CNPJ malformado continua rejeitado localmente com a nova mensagem.
- CNPJ numérico real e ativo (Petrobras, `33.000.167/0001-01`, confirmado ATIVA via BrasilAPI) segue funcionando ponta-a-ponta em `/register` e `/add-cnpj` sem regressão — tenant criado corretamente, nome da empresa resolvido.
- Dados de teste limpos do Postgres após a validação.

## Risco residual (não coberto aqui)

Não é possível confirmar hoje se BrasilAPI/ReceitaWS têm cobertura completa de CNPJs alfanuméricos reais, porque nenhum foi emitido ainda (primeiro em 31/07/2026). O design existente já degrada com segurança nesse cenário (`API_UNAVAILABLE` → `valid=True` com warning, nunca bloqueia por indisponibilidade externa) — comportamento preexistente, não alterado por este PR.