### PR TITLE
feat(admin): tráfego do site (Cloudflare Analytics) no painel superadmin

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,6 +53,13 @@ class Settings(BaseSettings):
     GA4_MEASUREMENT_ID: str = "G-KJ986WZ5ZJ"
     GA4_MP_API_SECRET: str = ""
 
+    # ── Cloudflare Analytics (tráfego do site, painel admin) ────────────────
+    # Sem token → seção do dashboard degrada graciosamente (sem quebrar o resto).
+    # Token: Cloudflare → Meu Perfil → API Tokens → Custom Token
+    #   (Zone:Analytics:Read + Zone:Zone:Read, escopo só para o zone abaixo).
+    CLOUDFLARE_ANALYTICS_TOKEN: str = ""
+    CLOUDFLARE_ZONE_ID: str = "0dca11f87046e628725aba0347548ccf"
+
     # ── Turnstile (CAPTCHA) ─────────────────────────────────
     TURNSTILE_SECRET_KEY: str = ""
     CAPTCHA_ENABLED: bool = False

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -184,7 +184,7 @@ def _redis_info(redis_url: str) -> dict[str, Any]:
 
 
 @router.get("/dashboard")
-def admin_dashboard(
+async def admin_dashboard(
     db: Annotated[Session, Depends(get_db)],
     _admin: Annotated[User, Depends(_require_superadmin)],
 ):
@@ -252,7 +252,9 @@ def admin_dashboard(
 
     # ── Infra ────────────────────────────────────────────────
     from app.config import settings
+    from app.services.cloudflare_analytics import get_today_traffic
     redis_data = _redis_info(settings.REDIS_URL)
+    site_traffic = await get_today_traffic()
 
     db_status = "healthy"
     try:
@@ -310,6 +312,7 @@ def admin_dashboard(
             "db_status": db_status,
             "redis": redis_data,
         },
+        "site_traffic": site_traffic,
         "validations": {
             "today": validations_today,
             "month": validations_month,

--- a/backend/app/services/cloudflare_analytics.py
+++ b/backend/app/services/cloudflare_analytics.py
@@ -1,0 +1,78 @@
+"""Tráfego do site via Cloudflare GraphQL Analytics API (zona já proxied, plano Free).
+
+`uniques` é uma aproximação de borda sobre todo o tráfego HTTP da zona —
+inclui bots/crawlers, não só visitantes humanos. O plano Free não expõe
+filtro por bot-score no GraphQL (recurso pago de Bot Management).
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+GRAPHQL_URL = "https://api.cloudflare.com/client/v4/graphql"
+TIMEOUT_SECONDS = 5.0
+
+_QUERY = """
+query ($zoneTag: string!, $date: string!) {
+  viewer {
+    zones(filter: {zoneTag: $zoneTag}) {
+      httpRequests1dGroups(filter: {date: $date}, limit: 1) {
+        uniq { uniques }
+        sum { requests pageViews }
+      }
+    }
+  }
+}
+"""
+
+
+async def get_today_traffic() -> dict[str, Any] | None:
+    """Retorna tráfego do dia (UTC) ou None se não configurado/indisponível.
+
+    Nunca levanta exceção — degrada graciosamente pra não quebrar o dashboard.
+    """
+    if not settings.CLOUDFLARE_ANALYTICS_TOKEN:
+        return None
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            resp = await client.post(
+                GRAPHQL_URL,
+                headers={"Authorization": f"Bearer {settings.CLOUDFLARE_ANALYTICS_TOKEN}"},
+                json={
+                    "query": _QUERY,
+                    "variables": {"zoneTag": settings.CLOUDFLARE_ZONE_ID, "date": today},
+                },
+            )
+            if resp.status_code != 200:
+                logger.warning("cloudflare_analytics_http_error", extra={"status": resp.status_code})
+                return None
+            data = resp.json()
+            if data.get("errors"):
+                logger.warning("cloudflare_analytics_graphql_error", extra={"errors": data["errors"]})
+                return None
+            groups = (
+                data.get("data", {})
+                .get("viewer", {})
+                .get("zones", [{}])[0]
+                .get("httpRequests1dGroups", [])
+            )
+            if not groups:
+                return {"date": today, "uniques": 0, "page_views": 0, "requests": 0}
+            group = groups[0]
+            return {
+                "date": today,
+                "uniques": group.get("uniq", {}).get("uniques", 0),
+                "page_views": group.get("sum", {}).get("pageViews", 0),
+                "requests": group.get("sum", {}).get("requests", 0),
+            }
+    except Exception as exc:
+        logger.warning("cloudflare_analytics_unavailable", extra={"error": str(exc)})
+        return None

--- a/backend/tests/test_cloudflare_analytics.py
+++ b/backend/tests/test_cloudflare_analytics.py
@@ -1,0 +1,81 @@
+"""Tráfego do site (Cloudflare Analytics) — #518."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.cloudflare_analytics import get_today_traffic
+
+
+@pytest.mark.asyncio
+async def test_sem_token_retorna_none_sem_chamar_api():
+    with patch("app.services.cloudflare_analytics.settings") as mock_settings:
+        mock_settings.CLOUDFLARE_ANALYTICS_TOKEN = ""
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            result = await get_today_traffic()
+    assert result is None
+    mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resposta_valida_extrai_uniques_pageviews_requests():
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {
+        "data": {
+            "viewer": {
+                "zones": [
+                    {
+                        "httpRequests1dGroups": [
+                            {"uniq": {"uniques": 168}, "sum": {"requests": 1687, "pageViews": 117}}
+                        ]
+                    }
+                ]
+            }
+        },
+        "errors": None,
+    }
+    mock_client = AsyncMock()
+    mock_client.post.return_value = fake_response
+    mock_client.__aenter__.return_value = mock_client
+
+    with patch("app.services.cloudflare_analytics.settings") as mock_settings:
+        mock_settings.CLOUDFLARE_ANALYTICS_TOKEN = "fake-token"
+        mock_settings.CLOUDFLARE_ZONE_ID = "fake-zone"
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await get_today_traffic()
+
+    assert result is not None
+    assert result["uniques"] == 168
+    assert result["page_views"] == 117
+    assert result["requests"] == 1687
+
+
+@pytest.mark.asyncio
+async def test_erro_http_degrada_graciosamente():
+    fake_response = MagicMock()
+    fake_response.status_code = 403
+    mock_client = AsyncMock()
+    mock_client.post.return_value = fake_response
+    mock_client.__aenter__.return_value = mock_client
+
+    with patch("app.services.cloudflare_analytics.settings") as mock_settings:
+        mock_settings.CLOUDFLARE_ANALYTICS_TOKEN = "fake-token"
+        mock_settings.CLOUDFLARE_ZONE_ID = "fake-zone"
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await get_today_traffic()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_excecao_de_rede_degrada_graciosamente():
+    with patch("app.services.cloudflare_analytics.settings") as mock_settings:
+        mock_settings.CLOUDFLARE_ANALYTICS_TOKEN = "fake-token"
+        mock_settings.CLOUDFLARE_ZONE_ID = "fake-zone"
+        with patch("httpx.AsyncClient", side_effect=Exception("timeout")):
+            result = await get_today_traffic()
+
+    assert result is None

--- a/docs/infra/secrets_inventory.md
+++ b/docs/infra/secrets_inventory.md
@@ -48,6 +48,13 @@ curl -s -o /dev/null -w '%{http_code}\n' --aws-sigv4 "aws:amz:$(g S3_REGION):s3"
 # Cloudflare — espera-se "success":true e "status":"active"
 curl -s -H "Authorization: Bearer <token>" https://api.cloudflare.com/client/v4/user/tokens/verify
 
+# Cloudflare Analytics (tráfego do site, painel admin, #518) — token dedicado,
+# escopo Zone:Analytics:Read + Zone:Zone:Read só na zona tribultz.com.br —
+# espera-se "success":true e um objeto "data" com viewer.zones
+curl -s -X POST https://api.cloudflare.com/client/v4/graphql \
+  -H "Authorization: Bearer $(g CLOUDFLARE_ANALYTICS_TOKEN)" -H "Content-Type: application/json" \
+  -d '{"query":"query($z:string!){viewer{zones(filter:{zoneTag:$z}){httpRequests1dGroups(limit:1){uniq{uniques}}}}}","variables":{"z":"0dca11f87046e628725aba0347548ccf"}}'
+
 # Magalu CLI e SSH
 mgc virtual-machine instances list --api-key <key>
 ssh -i ~/.ssh/id_ed25519 ubuntu@201.54.20.18 'echo ok'
@@ -58,6 +65,16 @@ Para comparar cópia local com a VM sem expor valores, compare o md5 de cada val
 ## Estado em 2026-07-15
 
 Válidos: Magalu (API key, SSH, Object Storage), Cloudflare, Turnstile, Asaas produção, OpenRouter, HubSpot, GitHub.
+
+## Pendência (2026-07-22): `CLOUDFLARE_ANALYTICS_TOKEN`
+
+Gerado e testado (E2E, local) para a seção de tráfego do site no painel admin
+(#518) — token dedicado, escopo mínimo (`Zone:Analytics:Read` + `Zone:Zone:Read`
+só na zona `tribultz.com.br`), sem custo. **Ainda não adicionado a
+`/opt/tribultz/.env` na VM** — até isso acontecer, o painel admin em produção
+mostra a seção como "não configurado" (degradação graciosa, não quebra o
+resto do dashboard). `CLOUDFLARE_ZONE_ID` (`0dca11f87046e628725aba0347548ccf`)
+não é segredo — já tem default no `app/config.py`.
 
 > 🔒 **Ordem vigente (2026-07-15): NÃO rotacionar, revogar nem encerrar sessão de credencial alguma enquanto o produto não escala.** Vale inclusive para as pendências listadas abaixo — inclusive as comprovadamente vazadas ou já revogadas. Documentar e seguir; não propor rotação de novo. O objetivo da fase é acesso livre e sem atrito a partir de Windows e Mac. Reavaliar quando o produto escalar.
 >

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -44,6 +44,12 @@ type AdminStats = {
       uptime_days: number;
     };
   };
+  site_traffic: {
+    date: string;
+    uniques: number;
+    page_views: number;
+    requests: number;
+  } | null;
   validations: {
     today: number;
     month: number;
@@ -290,6 +296,32 @@ export default function AdminPage() {
           <MiniBar data={s.users.registrations_30d} label="Cadastros (ultimos 30 dias)" />
           <PlanDistributionTable data={s.users.plan_distribution} />
         </div>
+      </section>
+
+      {/* ── Trafego do Site ──────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">
+          Trafego do Site (hoje)
+        </h2>
+        {s.site_traffic ? (
+          <>
+            <div className="grid gap-4 sm:grid-cols-3">
+              <StatCard label="Visitantes unicos (aprox.)" value={s.site_traffic.uniques} accent="blue" />
+              <StatCard label="Page views" value={s.site_traffic.page_views} />
+              <StatCard label="Requisicoes totais" value={s.site_traffic.requests} />
+            </div>
+            <p className="mt-2 text-xs text-slate-400">
+              Fonte: Cloudflare Zone Analytics. &quot;Visitantes unicos&quot; e uma aproximacao
+              de borda sobre todo o trafego HTTP da zona — inclui bots/crawlers, nao so
+              humanos (o plano Free nao filtra por bot-score).
+            </p>
+          </>
+        ) : (
+          <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-5 text-sm text-slate-500">
+            Cloudflare Analytics nao configurado (
+            <code className="text-xs">CLOUDFLARE_ANALYTICS_TOKEN</code>).
+          </div>
+        )}
       </section>
 
       {/* ── Financeiro ────────────────────────── */}


### PR DESCRIPTION
Closes #518.

## Contexto

Pedido direto do owner em 22/07/2026: ver visitantes do site direto no painel superadmin, sem precisar perguntar manualmente a cada "análise do dia". A fonte (Cloudflare Zone Analytics) já foi validada em conversa — `tribultz.com.br` já está atrás da Cloudflare (plano Free, sem custo), então não precisou de nenhuma conta/serviço novo.

## O que muda

- `backend/app/services/cloudflare_analytics.py` (novo) — consulta a GraphQL Analytics API da Cloudflare (`httpRequests1dGroups`) para uniques/pageViews/requests do dia. Degrada graciosamente (retorna `None`) sem token configurado ou em qualquer erro — nunca quebra o dashboard.
- `backend/app/config.py` — `CLOUDFLARE_ANALYTICS_TOKEN` (secreto, default vazio) e `CLOUDFLARE_ZONE_ID` (não secreto, default já preenchido).
- `backend/app/routers/admin.py` — `GET /api/v1/admin/dashboard` agora inclui `site_traffic`; endpoint virou `async def` pra poder chamar o serviço.
- `frontend/src/app/admin/page.tsx` — nova seção "Tráfego do Site (hoje)", com o caveat de bot/crawler visível na própria UI, não só em doc.
- `docs/infra/secrets_inventory.md` — novo comando de validação + nota de pendência (token ainda não está na VM).

## Testes

- `backend/tests/test_cloudflare_analytics.py` (novo, 4 casos): sem token não chama a API; resposta válida extrai os 3 campos; erro HTTP degrada; exceção de rede degrada.
- Suíte completa: 767 passed (as 7 falhas de `test_billing_webhook.py` são o quirk já documentado em #484 — `REDIS_URL` do `.env` aponta pro hostname do compose quando roda do host; confirmei que são as mesmas falhas antes e depois desta mudança, zero regressão). `ruff` limpo. `pyright` limpo nos arquivos tocados.
- Frontend: 188 passed, build ok.

## Validação E2E (Docker real)

- Rebuild do container `api` com o código novo.
- Função `get_today_traffic()` chamada dentro do container real, contra a API real da Cloudflare (token de teste), retornou os dados reais corretos.
- Endpoint `/api/v1/admin/dashboard` chamado via HTTP real (JWT de superadmin real) **sem** o token configurado — `site_traffic: null`, resto do dashboard intacto (confirma a degradação graciosa no caminho que hoje está em produção).

## Pendência (fora deste PR)

`CLOUDFLARE_ANALYTICS_TOKEN` ainda não foi adicionado a `/opt/tribultz/.env` na VM — até isso acontecer, a seção aparece como "não configurado" em produção. Documentado em `secrets_inventory.md`.