### PR TITLE
fix(rules): PF_CONTRIB_CNPJ — Decreto 13.075/2026 adia prazo p/ 01/01/2027

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -327,10 +327,12 @@ def _within_no_penalty_window(emission_date: dict | None) -> bool:
 
 
 # ── Comunicado Conjunto CGIBS/RFB nº 01/2025 — CNPJ p/ PF contribuinte ───────
-# A partir de 01/07/2026, a PF contribuinte de IBS/CBS deve se inscrever no CNPJ e não
-# pode emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento como
+# Previa 01/07/2026; o Decreto 13.075/2026 (altera o Decreto 12.955/2026, art. 239)
+# adiou para 01/01/2027 a PF contribuinte de IBS/CBS ter que se inscrever no CNPJ e
+# não poder emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento como
 # contribuinte não é verificável do XML → ALERT informativo (verificar enquadramento).
-_PF_CNPJ_REQUIRED_DATE = "2026-07-01"
+# Não editar sem checar se um decreto mais recente adiou de novo.
+_PF_CNPJ_REQUIRED_DATE = "2027-01-01"
 
 # ── NF-e de devolução: referência à nota original por item via DFeReferenciado ──
 # v1.40: a partir de 01/09/2026, a devolução (finNFe=4) referencia a nota original
@@ -1244,12 +1246,14 @@ def validate_xml(
                         title="Emitente pessoa física (CPF) — verificar obrigação de inscrição no CNPJ",
                         where=FindingWhere(field="emit/CPF", xpath=_xpath("CPF", doc_type), snippet=emit_cpf["snippet"]),
                         recommendation=(
-                            "Emitente identificado por CPF. A partir de 01/07/2026, a pessoa física "
-                            "contribuinte de IBS/CBS deve se inscrever no CNPJ e não pode emitir documento "
-                            "fiscal por CPF (Comunicado Conjunto CGIBS/RFB nº 01/2025; LC 214 art. 251). "
-                            "Verifique o enquadramento como contribuinte (atividade econômica habitual; "
-                            "locação com mais de 3 imóveis e renda anual acima de R$ 240 mil) e, se for o "
-                            "caso, providencie a inscrição no CNPJ. A inscrição não transforma a PF em PJ."
+                            "Emitente identificado por CPF. A partir de 01/01/2027 (Decreto 13.075/2026, "
+                            "que alterou o Decreto 12.955/2026 art. 239 e adiou o prazo original do "
+                            "Comunicado Conjunto CGIBS/RFB nº 01/2025), a pessoa física contribuinte de "
+                            "IBS/CBS deve se inscrever no CNPJ e não pode emitir documento fiscal por CPF "
+                            "(LC 214 art. 251). Verifique o enquadramento como contribuinte (atividade "
+                            "econômica habitual; locação com mais de 3 imóveis e renda anual acima de "
+                            "R$ 240 mil) e, se for o caso, providencie a inscrição no CNPJ. A inscrição "
+                            "não transforma a PF em PJ."
                         ),
                         evidence_ids=[ev_id],
                     ),

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -533,13 +533,14 @@ class TestImportIbscbsRequired:
         assert self._find(self._nfe(cfop="3102", no_ibscbs=True)) == []
 
 
-# ── Item 3: PF_CONTRIB_CNPJ — PF contribuinte deve ter CNPJ (Comunicado CGIBS/RFB 01/2025) ──
+# ── Item 3: PF_CONTRIB_CNPJ — PF contribuinte deve ter CNPJ (Decreto 13.075/2026) ──
 
 
 class TestPfContribCnpj:
-    """A partir de 01/07/2026 a PF contribuinte de IBS/CBS deve ter CNPJ (emissão por CPF
-    não permitida, LC 214 art. 251). Enquadramento não verificável do XML → ALERT:
-    emitente CPF + data ≥ 01/07/2026."""
+    """Comunicado Conjunto CGIBS/RFB 01/2025 previa 01/07/2026; o Decreto 13.075/2026
+    (altera o Decreto 12.955/2026 art. 239) adiou para 01/01/2027 a PF contribuinte de
+    IBS/CBS ter CNPJ (emissão por CPF não permitida a partir daí, LC 214 art. 251).
+    Enquadramento não verificável do XML → ALERT: emitente CPF + data ≥ 01/01/2027."""
 
     def _nfe(self, ident, dh=None):
         dh_xml = f"<dhEmi>{dh}</dhEmi>" if dh else ""
@@ -554,13 +555,17 @@ class TestPfContribCnpj:
     def _find(self, xml, doc="NFE"):
         return [f for f in validate_xml(xml, doc).findings if f.rule_id == "PF_CONTRIB_CNPJ"]
 
-    def test_emit_cpf_apos_01_07_2026_alert(self):
-        f = self._find(self._nfe("<CPF>12345678909</CPF>", "2026-07-01T10:00:00-03:00"))
+    def test_emit_cpf_apos_01_01_2027_alert(self):
+        f = self._find(self._nfe("<CPF>12345678909</CPF>", "2027-01-01T10:00:00-03:00"))
         assert f and f[0].severity == "ALERT"
-        assert "Comunicado Conjunto CGIBS/RFB" in f[0].recommendation
+        assert "Decreto 13.075/2026" in f[0].recommendation
 
-    def test_emit_cpf_antes_de_01_07_2026_sem_finding(self):
-        assert self._find(self._nfe("<CPF>12345678909</CPF>", "2026-06-30T10:00:00-03:00")) == []
+    def test_emit_cpf_antes_de_01_01_2027_sem_finding(self):
+        assert self._find(self._nfe("<CPF>12345678909</CPF>", "2026-12-31T10:00:00-03:00")) == []
+
+    def test_emit_cpf_em_01_07_2026_prazo_antigo_adiado_sem_finding(self):
+        # Prazo original (Comunicado Conjunto 01/2025) — adiado pelo Decreto 13.075/2026.
+        assert self._find(self._nfe("<CPF>12345678909</CPF>", "2026-07-01T10:00:00-03:00")) == []
 
     def test_emit_cnpj_sem_finding(self):
         assert self._find(self._nfe("<CNPJ>12345678000195</CNPJ>", "2026-08-10T10:00:00-03:00")) == []
@@ -574,7 +579,7 @@ class TestPfContribCnpj:
 
     def test_nfse_prestador_cpf_alert(self):
         xml = (
-            '<NFS-e><infNfse><DataEmissao>2026-07-15T10:00:00</DataEmissao>'
+            '<NFS-e><infNfse><DataEmissao>2027-02-01T10:00:00</DataEmissao>'
             '<PrestadorServico><RazaoSocial>X</RazaoSocial><CPF>98765432100</CPF></PrestadorServico>'
             '<TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>'
             '<PrestacaoServico><Servico><CodigoServico>123456</CodigoServico><cClassTrib>654321</cClassTrib>'

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -826,10 +826,12 @@ test("IMPORT: sem grupo IBSCBS → IMPORT não dispara (coberto por IBSCBS_MISSI
   assert.equal(importFinding(nfeImport({ cfop: "3102", noIbscbs: true })), undefined);
 });
 
-// ── Item 3: PF_CONTRIB_CNPJ — PF contribuinte deve ter CNPJ (Comunicado CGIBS/RFB 01/2025) ──
-// A partir de 01/07/2026 a PF contribuinte de IBS/CBS deve se inscrever no CNPJ e
-// não pode emitir por CPF (LC 214 art. 251). Como o enquadramento não é verificável
-// do XML, a regra é ALERT informativo: emitente CPF + data ≥ 01/07/2026.
+// ── Item 3: PF_CONTRIB_CNPJ — PF contribuinte deve ter CNPJ (Decreto 13.075/2026) ──
+// Comunicado Conjunto CGIBS/RFB 01/2025 previa 01/07/2026; o Decreto 13.075/2026
+// (altera o Decreto 12.955/2026 art. 239) adiou para 01/01/2027 a PF contribuinte
+// de IBS/CBS se inscrever no CNPJ e não poder emitir por CPF (LC 214 art. 251).
+// Como o enquadramento não é verificável do XML, a regra é ALERT informativo:
+// emitente CPF + data ≥ 01/01/2027.
 
 const nfeEmit = (ident: string, dhEmi?: string) => `<?xml version="1.0" encoding="UTF-8"?>
 <nfeProc><NFe><infNFe>
@@ -845,15 +847,19 @@ const pfFinding = (xml: string, doc: "NFE" | "NFSE" = "NFE") =>
   validateXmlWithRules({ tenantId: "t", documentType: doc, xml }).findings
     .find((f) => f.rule_id === "PF_CONTRIB_CNPJ");
 
-test("PF_CNPJ: emitente CPF + data ≥ 01/07/2026 → ALERT", () => {
-  const f = pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2026-07-01T10:00:00-03:00"));
+test("PF_CNPJ: emitente CPF + data ≥ 01/01/2027 → ALERT", () => {
+  const f = pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2027-01-01T10:00:00-03:00"));
   assert.ok(f, "PF_CONTRIB_CNPJ esperado");
   assert.equal(f!.severity, "ALERT");
-  assert.match(f!.recommendation ?? "", /Comunicado Conjunto CGIBS\/RFB/);
+  assert.match(f!.recommendation ?? "", /Decreto 13\.075\/2026/);
 });
 
-test("PF_CNPJ: emitente CPF antes de 01/07/2026 → sem finding", () => {
-  assert.equal(pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2026-06-30T10:00:00-03:00")), undefined);
+test("PF_CNPJ: emitente CPF antes de 01/01/2027 → sem finding", () => {
+  assert.equal(pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2026-12-31T10:00:00-03:00")), undefined);
+});
+
+test("PF_CNPJ: emitente CPF em 01/07/2026 (prazo antigo, adiado pelo Decreto 13.075/2026) → sem finding", () => {
+  assert.equal(pfFinding(nfeEmit("<CPF>12345678909</CPF>", "2026-07-01T10:00:00-03:00")), undefined);
 });
 
 test("PF_CNPJ: emitente CNPJ (PJ) → sem finding", () => {
@@ -868,9 +874,9 @@ test("PF_CNPJ: destinatário CPF mas emitente CNPJ → sem finding (só emitente
   assert.equal(pfFinding(nfeEmit("<CNPJ>12345678000195</CNPJ>", "2026-09-01T10:00:00-03:00")), undefined);
 });
 
-test("PF_CNPJ: NFS-e prestador CPF + DataEmissao ≥ 01/07/2026 → ALERT", () => {
+test("PF_CNPJ: NFS-e prestador CPF + DataEmissao ≥ 01/01/2027 → ALERT", () => {
   const xml = `<NFS-e><infNfse>
-    <DataEmissao>2026-07-15T10:00:00</DataEmissao>
+    <DataEmissao>2027-02-01T10:00:00</DataEmissao>
     <PrestadorServico><RazaoSocial>X</RazaoSocial><CPF>98765432100</CPF></PrestadorServico>
     <TomadorServico><RazaoSocial>Y</RazaoSocial></TomadorServico>
     <PrestacaoServico><Servico><CodigoServico>123456</CodigoServico><cClassTrib>654321</cClassTrib>

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -96,7 +96,10 @@ function isWithinNoPenaltyWindow(emissionDate: string | undefined): boolean {
 // no CNPJ e não pode emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento
 // como contribuinte (atividade habitual; locação com >3 imóveis e renda > R$ 240 mil/ano)
 // não é verificável do XML — por isso a regra é ALERT informativo (verificar enquadramento).
-const PF_CNPJ_REQUIRED_DATE = "2026-07-01";
+// Decreto 13.075/2026 (altera o Decreto 12.955/2026, art. 239) adiou de
+// 01/07/2026 para 01/01/2027 — não editar sem checar se um decreto mais
+// recente adiou de novo.
+const PF_CNPJ_REQUIRED_DATE = "2027-01-01";
 
 // NF-e de devolução (finNFe=4): a partir de 01/09/2026 referencia a nota original por item,
 // exclusivamente via grupo DFeReferenciado (v1.40, Rejeição 321 — VC02-14/VC03-20).
@@ -957,10 +960,12 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   }
 
   // ── Rule: PF_CONTRIB_CNPJ — PF contribuinte deve se inscrever no CNPJ (#item3) ──
-  // Comunicado Conjunto CGIBS/RFB nº 01/2025 + LC 214 art. 251: a partir de
-  // 01/07/2026 a PF contribuinte de IBS/CBS deve ter CNPJ (emissão por CPF não é
-  // permitida). Verificável do XML: emitente identificado por CPF + data ≥ 01/07/2026.
-  // O enquadramento como contribuinte não é verificável → ALERT informativo.
+  // Comunicado Conjunto CGIBS/RFB nº 01/2025 + LC 214 art. 251 previam 01/07/2026;
+  // o Decreto 13.075/2026 (altera o Decreto 12.955/2026, art. 239) adiou para
+  // 01/01/2027 a PF contribuinte de IBS/CBS ter CNPJ (emissão por CPF não é
+  // permitida a partir daí). Verificável do XML: emitente identificado por CPF +
+  // data ≥ 01/01/2027. O enquadramento como contribuinte não é verificável →
+  // ALERT informativo.
   {
     const emitBlock = firstTag(xml, ["emit", "PrestadorServico", "prest", "Prestador"]);
     const emDate = emissionDate?.value?.slice(0, 10) ?? "";
@@ -981,12 +986,14 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
             snippet: emitCpf.snippet,
             evidenceId: evId,
             recommendation:
-              `Emitente identificado por CPF. A partir de 01/07/2026, a pessoa física ` +
-              `contribuinte de IBS/CBS deve se inscrever no CNPJ e não pode emitir documento ` +
-              `fiscal por CPF (Comunicado Conjunto CGIBS/RFB nº 01/2025; LC 214 art. 251). ` +
-              `Verifique o enquadramento como contribuinte (atividade econômica habitual; ` +
-              `locação com mais de 3 imóveis e renda anual acima de R$ 240 mil) e, se for o ` +
-              `caso, providencie a inscrição no CNPJ. A inscrição não transforma a PF em PJ.`,
+              `Emitente identificado por CPF. A partir de 01/01/2027 (Decreto 13.075/2026, ` +
+              `que alterou o Decreto 12.955/2026 art. 239 e adiou o prazo original do ` +
+              `Comunicado Conjunto CGIBS/RFB nº 01/2025), a pessoa física contribuinte de ` +
+              `IBS/CBS deve se inscrever no CNPJ e não pode emitir documento fiscal por CPF ` +
+              `(LC 214 art. 251). Verifique o enquadramento como contribuinte (atividade ` +
+              `econômica habitual; locação com mais de 3 imóveis e renda anual acima de ` +
+              `R$ 240 mil) e, se for o caso, providencie a inscrição no CNPJ. A inscrição ` +
+              `não transforma a PF em PJ.`,
           }),
           makeEvidence({ id: evId, type: "xml", label: "Emitente PF (CPF) — verificar CNPJ", xpath: inferXpath("CPF", docType), snippet: emitCpf.snippet }),
         );


### PR DESCRIPTION
Closes #520.

## Contexto

Achado ao analisar o Decreto nº 13.075/2026 (21/07/2026) a pedido do usuário. Confirmado em múltiplas fontes independentes, incluindo comunicado oficial da Receita Federal:

- [Receita Federal (gov.br)](https://www.gov.br/receitafederal/pt-br/assuntos/noticias/emissao-do-cnpj-e-de-documentos-fiscais-por-pessoas-fisicas-contribuintes-da-cbs-comecara-em-1o-de-janeiro-de-2027)
- [Agência Brasil](https://agenciabrasil.ebc.com.br/economia/noticia/2026-07/decreto-adia-exigencia-de-cnpj-para-autonomos-e-produtores-rurais)

O decreto altera o Decreto 12.955/2026 (art. 239) e adia de 01/07/2026 para **01/01/2027** a obrigatoriedade de inscrição no CNPJ e emissão de documento fiscal por CNPJ (em vez de CPF) para pessoa física contribuinte/responsável tributário da CBS e produtor rural pessoa física.

## Problema

A regra `PF_CONTRIB_CNPJ` (dual-stack) usava a data antiga (`2026-07-01`) hardcoded — o motor vinha gerando **ALERT indevido desde 01/07/2026 (21 dias em produção)** para todo emitente PF que usa CPF corretamente, exatamente a conduta que o decreto confirma como legal até 31/12/2026.

## Fix

- `frontend/src/lib/validation/xmlRules.ts` e `backend/app/routers/validate_xml.py`: constante de data `2026-07-01` → `2027-01-01`, comentários e texto de recomendação atualizados citando o Decreto 13.075/2026 (mantendo a referência ao Comunicado Conjunto original como contexto histórico).
- Testes atualizados (`xmlRules.test.ts`, `test_validate_xml.py`): datas de gatilho movidas para ≥ 2027-01-01 + **teste de regressão novo** confirmando que a data antiga (01/07/2026) não dispara mais o finding.

## Testes

- Frontend: 189 passed (era 188, +1 teste de regressão).
- Backend: `test_validate_xml.py` 140 passed; suíte completa 775 passed. `ruff` e `pyright` limpos.

## Validação E2E (Docker real)

Rebuild do container `api`. Chamada real da função de validação dentro do container:
- CPF emitido em 15/07/2026 (prazo antigo, adiado) → sem finding (correto, antes gerava ALERT indevido).
- CPF emitido em 01/02/2027 (novo prazo vigente) → ALERT (correto, regra continua funcionando pro caso real).

## Governança

Pula Discovery/RFC — conformidade regulatória obrigatória, não preferência de produto (mesma exceção do #514).