### PR TITLE
chore(infra): healthcheck próprio pra worker/beat (#522)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -116,6 +116,14 @@ services:
     networks: [tribultz]
     <<: *backend-env
     command: ["celery", "-A", "app.celery_app", "worker", "--loglevel=info", "--concurrency=2"]
+    # Sobrescreve o HEALTHCHECK do Dockerfile (curl :8000/health) — worker não
+    # serve HTTP, sempre reportaria "unhealthy" por design, não por defeito (#522).
+    healthcheck:
+      test: ["CMD", "celery", "-A", "app.celery_app", "inspect", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     depends_on:
       db:
         condition: service_healthy
@@ -135,6 +143,11 @@ services:
     networks: [tribultz]
     <<: *backend-env
     command: ["celery", "-A", "app.celery_app", "beat", "--loglevel=info"]
+    # Sobrescreve o HEALTHCHECK do Dockerfile — beat não serve HTTP nem responde
+    # a inspect (é só o scheduler, sem RPC de worker) (#522). Sem checagem nativa
+    # equivalente; "container rodando" já é o sinal disponível.
+    healthcheck:
+      disable: true
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Closes #522.

## Contexto

Achado na análise de infra de 25/07/2026: `worker` e `beat` apareciam como "unhealthy" persistentemente no `docker compose ps`, apesar de funcionando corretamente (log confirma tasks de billing/CRM executando com sucesso).

## Causa

`backend/Dockerfile` define um `HEALTHCHECK` fixo (`curl http://localhost:8000/health`), herdado por qualquer container construído da mesma imagem — incluindo `worker`/`beat`, que rodam Celery e nunca escutam na porta 8000. Sempre falhava, por design.

## Fix

- `worker`: healthcheck próprio via `celery -A app.celery_app inspect ping`.
- `beat`: healthcheck desabilitado (não há RPC de inspeção nativa pro scheduler).

## Validação

Rebuild local: `worker` mostra `healthy` de verdade; `beat` não reporta mais status falso.