### PR TITLE
docs(rules): PF_CONTRIB_CNPJ — cita também a Resolução CGIBS nº 13/2026 (IBS)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -327,11 +327,13 @@ def _within_no_penalty_window(emission_date: dict | None) -> bool:
 
 
 # ── Comunicado Conjunto CGIBS/RFB nº 01/2025 — CNPJ p/ PF contribuinte ───────
-# Previa 01/07/2026; o Decreto 13.075/2026 (altera o Decreto 12.955/2026, art. 239)
-# adiou para 01/01/2027 a PF contribuinte de IBS/CBS ter que se inscrever no CNPJ e
-# não poder emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento como
-# contribuinte não é verificável do XML → ALERT informativo (verificar enquadramento).
-# Não editar sem checar se um decreto mais recente adiou de novo.
+# Previa 01/07/2026; o Decreto 13.075/2026 (CBS, altera o Decreto 12.955/2026
+# art. 239) e a Resolução CGIBS nº 13/2026 (IBS, altera o art. 617 do
+# Regulamento do IBS/Resolução CGIBS nº 6/2026) adiaram, em conjunto, para
+# 01/01/2027 a PF contribuinte de IBS/CBS ter que se inscrever no CNPJ e não
+# poder emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento
+# como contribuinte não é verificável do XML → ALERT informativo (verificar
+# enquadramento). Não editar sem checar se um ato mais recente adiou de novo.
 _PF_CNPJ_REQUIRED_DATE = "2027-01-01"
 
 # ── NF-e de devolução: referência à nota original por item via DFeReferenciado ──
@@ -1246,10 +1248,10 @@ def validate_xml(
                         title="Emitente pessoa física (CPF) — verificar obrigação de inscrição no CNPJ",
                         where=FindingWhere(field="emit/CPF", xpath=_xpath("CPF", doc_type), snippet=emit_cpf["snippet"]),
                         recommendation=(
-                            "Emitente identificado por CPF. A partir de 01/01/2027 (Decreto 13.075/2026, "
-                            "que alterou o Decreto 12.955/2026 art. 239 e adiou o prazo original do "
-                            "Comunicado Conjunto CGIBS/RFB nº 01/2025), a pessoa física contribuinte de "
-                            "IBS/CBS deve se inscrever no CNPJ e não pode emitir documento fiscal por CPF "
+                            "Emitente identificado por CPF. A partir de 01/01/2027 (Decreto 13.075/2026 "
+                            "para CBS + Resolução CGIBS nº 13/2026 para IBS, que adiaram em conjunto o "
+                            "prazo original do Comunicado Conjunto CGIBS/RFB nº 01/2025), a pessoa física "
+                            "contribuinte de IBS/CBS deve se inscrever no CNPJ e não pode emitir documento fiscal por CPF "
                             "(LC 214 art. 251). Verifique o enquadramento como contribuinte (atividade "
                             "econômica habitual; locação com mais de 3 imóveis e renda anual acima de "
                             "R$ 240 mil) e, se for o caso, providencie a inscrição no CNPJ. A inscrição "

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -96,9 +96,10 @@ function isWithinNoPenaltyWindow(emissionDate: string | undefined): boolean {
 // no CNPJ e não pode emitir documento fiscal por CPF (LC 214 art. 251). O enquadramento
 // como contribuinte (atividade habitual; locação com >3 imóveis e renda > R$ 240 mil/ano)
 // não é verificável do XML — por isso a regra é ALERT informativo (verificar enquadramento).
-// Decreto 13.075/2026 (altera o Decreto 12.955/2026, art. 239) adiou de
-// 01/07/2026 para 01/01/2027 — não editar sem checar se um decreto mais
-// recente adiou de novo.
+// Decreto 13.075/2026 (CBS, altera o Decreto 12.955/2026 art. 239) + Resolução
+// CGIBS nº 13/2026 (IBS, altera o art. 617 do Regulamento do IBS/Resolução
+// CGIBS nº 6/2026) adiaram, em conjunto, de 01/07/2026 para 01/01/2027 — não
+// editar sem checar se um ato mais recente adiou de novo.
 const PF_CNPJ_REQUIRED_DATE = "2027-01-01";
 
 // NF-e de devolução (finNFe=4): a partir de 01/09/2026 referencia a nota original por item,
@@ -961,11 +962,12 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
 
   // ── Rule: PF_CONTRIB_CNPJ — PF contribuinte deve se inscrever no CNPJ (#item3) ──
   // Comunicado Conjunto CGIBS/RFB nº 01/2025 + LC 214 art. 251 previam 01/07/2026;
-  // o Decreto 13.075/2026 (altera o Decreto 12.955/2026, art. 239) adiou para
-  // 01/01/2027 a PF contribuinte de IBS/CBS ter CNPJ (emissão por CPF não é
-  // permitida a partir daí). Verificável do XML: emitente identificado por CPF +
-  // data ≥ 01/01/2027. O enquadramento como contribuinte não é verificável →
-  // ALERT informativo.
+  // o Decreto 13.075/2026 (CBS, altera o Decreto 12.955/2026 art. 239) e a
+  // Resolução CGIBS nº 13/2026 (IBS, altera o art. 617 do Regulamento do IBS/
+  // Resolução CGIBS nº 6/2026) adiaram, em conjunto, para 01/01/2027 a PF
+  // contribuinte de IBS/CBS ter CNPJ (emissão por CPF não é permitida a partir
+  // daí). Verificável do XML: emitente identificado por CPF + data ≥ 01/01/2027.
+  // O enquadramento como contribuinte não é verificável → ALERT informativo.
   {
     const emitBlock = firstTag(xml, ["emit", "PrestadorServico", "prest", "Prestador"]);
     const emDate = emissionDate?.value?.slice(0, 10) ?? "";
@@ -986,10 +988,10 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
             snippet: emitCpf.snippet,
             evidenceId: evId,
             recommendation:
-              `Emitente identificado por CPF. A partir de 01/01/2027 (Decreto 13.075/2026, ` +
-              `que alterou o Decreto 12.955/2026 art. 239 e adiou o prazo original do ` +
-              `Comunicado Conjunto CGIBS/RFB nº 01/2025), a pessoa física contribuinte de ` +
-              `IBS/CBS deve se inscrever no CNPJ e não pode emitir documento fiscal por CPF ` +
+              `Emitente identificado por CPF. A partir de 01/01/2027 (Decreto 13.075/2026 ` +
+              `para CBS + Resolução CGIBS nº 13/2026 para IBS, que adiaram em conjunto o ` +
+              `prazo original do Comunicado Conjunto CGIBS/RFB nº 01/2025), a pessoa física ` +
+              `contribuinte de IBS/CBS deve se inscrever no CNPJ e não pode emitir documento fiscal por CPF ` +
               `(LC 214 art. 251). Verifique o enquadramento como contribuinte (atividade ` +
               `econômica habitual; locação com mais de 3 imóveis e renda anual acima de ` +
               `R$ 240 mil) e, se for o caso, providencie a inscrição no CNPJ. A inscrição ` +


### PR DESCRIPTION
## Contexto

Achado ao checar os portais federais da reforma (Receita Federal, CGIBS) por pedido do usuário. O fix do #520 (PR #521) já corrigiu a data (01/01/2027) citando o Decreto 13.075/2026 — mas esse decreto é só o lado **CBS** do adiamento.

## O que foi confirmado

**Resolução CGIBS nº 13/2026** (22/07/2026) — lido o PDF oficial diretamente via OCR — altera o art. 617 do Regulamento do IBS (Resolução CGIBS nº 6/2026), adiando para **01/01/2027** a mesma obrigação (CNPJ + emissão de documento fiscal) para pessoa física contribuinte/responsável tributário, referenciando os arts. 105 e 115 do Regulamento do IBS. É o lado **IBS** da mesma mudança — mesma data, mesmo grupo afetado.

## Mudança

Não altera lógica nenhuma (a constante `2027-01-01` já estava correta desde o #521) — só completa a citação legal nos comentários e no texto de recomendação do finding `PF_CONTRIB_CNPJ`, que antes citava só o Decreto (metade da base legal real da obrigação, já que PF deve IBS **e** CBS).

## Testes

Frontend 189 passed, backend `test_validate_xml.py` 140 passed (asserções de texto que checam a substring "Decreto 13.075/2026" continuam batendo — só acrescentei texto, não removi). `ruff` e `pyright` limpos.