### PR TITLE
docs(rules): IMPORT_IBSCBS_REQUIRED — cita também Resolução CGIBS nº 6/2026 (IBS)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -1194,8 +1194,10 @@ def validate_xml(
             )
 
     # ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────
-    # Decreto 12.955/2026 art. 65 (LC 214 art. 63): IBS/CBS incidem sobre a importação
-    # de bens e serviços independentemente de o importador ser habitual. Detecção:
+    # Decreto 12.955/2026 art. 65 (CBS) + Resolução CGIBS nº 6/2026 art. 65 (IBS)
+    # — mesmo número de artigo nos dois regulamentos, publicados juntos em
+    # 30/04/2026 (LC 214 art. 63): IBS/CBS incidem sobre a importação de bens e
+    # serviços independentemente de o importador ser habitual. Detecção:
     # CFOP iniciando em "3" (entrada do exterior) OU grupo de importação (<DI>/<DUIMP>).
     # Export (CFOP 7xxx, imune) e internas ficam de fora. Escopo: grupo IBSCBS presente
     # porém zerado com CST tributável — grupo ausente já é coberto por IBSCBS_MISSING.
@@ -1219,7 +1221,8 @@ def validate_xml(
                         f'Operação de importação (CFOP 3xxx ou grupo DI/DUIMP) com IBS/CBS zerado e '
                         f'CST {cst_value or "(ausente)"} tributável. O IBS e a CBS incidem sobre a importação '
                         f'de bens e serviços independentemente de o importador ser habitual '
-                        f'(Decreto 12.955/2026 art. 65 / LC 214 art. 63). A alíquota deve corresponder à da '
+                        f'(Decreto 12.955/2026 art. 65 para CBS + Resolução CGIBS nº 6/2026 art. 65 '
+                        f'para IBS — mesmo artigo nos dois regulamentos; LC 214 art. 63). A alíquota deve corresponder à da '
                         f'operação interna com o mesmo bem/serviço (art. 469-470). Informe vCBS/vIBS ou ajuste o CST.'
                     ),
                     evidence_ids=[ev_id],

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -921,8 +921,10 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   }
 
   // ── Rule: IMPORT_IBSCBS_REQUIRED — incidência na importação (#item2) ──────
-  // Decreto 12.955/2026 art. 65 (LC 214 art. 63): IBS/CBS incidem sobre a
-  // importação de bens e serviços independentemente de o importador ser habitual.
+  // Decreto 12.955/2026 art. 65 (CBS) + Resolução CGIBS nº 6/2026 art. 65 (IBS)
+  // — mesmo número de artigo nos dois regulamentos, publicados juntos em
+  // 30/04/2026 (LC 214 art. 63): IBS/CBS incidem sobre a importação de bens e
+  // serviços independentemente de o importador ser habitual.
   // Detecção: CFOP iniciando em "3" (entrada do exterior) OU grupo de importação
   // (<DI>/<DUIMP>). Export (CFOP 7xxx, imune) e internas ficam de fora.
   // Escopo: grupo IBSCBS presente porém zerado com CST tributável — o grupo ausente
@@ -951,7 +953,8 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
             `Operação de importação (CFOP 3xxx ou grupo DI/DUIMP) com IBS/CBS zerado e ` +
             `CST ${cstValue || "(ausente)"} tributável. O IBS e a CBS incidem sobre a importação ` +
             `de bens e serviços independentemente de o importador ser habitual ` +
-            `(Decreto 12.955/2026 art. 65 / LC 214 art. 63). A alíquota deve corresponder à da ` +
+            `(Decreto 12.955/2026 art. 65 para CBS + Resolução CGIBS nº 6/2026 art. 65 ` +
+            `para IBS — mesmo artigo nos dois regulamentos; LC 214 art. 63). A alíquota deve corresponder à da ` +
             `operação interna com o mesmo bem/serviço (art. 469-470). Informe vCBS/vIBS ou ajuste o CST.`,
         }),
         makeEvidence({ id: evId, type: "xml", label: "Importação — IBS/CBS ausente", xpath: inferXpath("IBSCBS", docType), snippet: ibscbsBlock.snippet }),


### PR DESCRIPTION
## Contexto

Follow-up direto do padrão registrado em `docs/context/reference_cbs_ibs_par_normativo.md` (PR #525): mudanças/regras que afetam CBS e IBS conjuntamente tendem a ter base legal em dois atos — um por tributo.

## O que foi confirmado

A regra `IMPORT_IBSCBS_REQUIRED` citava só "Decreto 12.955/2026 art. 65" (CBS). Pesquisei e confirmei (duas fontes independentes — Conjur e um resumo de escritório de advocacia) que o **art. 65 da Resolução CGIBS nº 6/2026** estabelece a mesma incidência de IBS sobre importação — mesmo número de artigo nos dois regulamentos, publicados juntos em 30/04/2026 (mesma data já documentada no código pra outra regra, `NO_PENALTY_WINDOW`).

## Mudança

Não altera lógica (a regra não tem gate de data — a incidência vale desde a publicação dos regulamentos) — só completa a citação legal no comentário e no texto de recomendação do finding, que antes citava só metade da base legal real.

## Testes

Frontend 189 passed, backend `test_validate_xml.py` 140 passed (nenhum teste faz assert de texto exato da recomendação desta regra). `ruff` e `pyright` limpos.