### PR TITLE
chore(ci): permissions explícito nos 4 workflows sem bloco próprio (#448)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: deploy-prod
   cancel-in-progress: false

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -5,6 +5,9 @@ on:
     - cron: "*/5 * * * *"   # a cada 5 minutos
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: monitor
   cancel-in-progress: true

--- a/.github/workflows/ops-set-sentry.yml
+++ b/.github/workflows/ops-set-sentry.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: "0.0"
 
+permissions:
+  contents: read
+
 jobs:
   set-sentry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #448.

## Contexto

`gh api repos/mickbap/tribultz/actions/permissions/workflow` confirma `default_workflow_permissions: write` — qualquer workflow sem bloco `permissions:` próprio herda `GITHUB_TOKEN` com escrita ampla. Isso se aplicava a `ci.yml`, `deploy-prod.yml`, `monitor.yml` e `ops-set-sentry.yml`.

## Verificação (não confiei cegamente na análise da própria issue)

Li os 4 workflows antes de aplicar a correção proposta:
- `ci.yml`: checkout, setup-python/node, upload-artifact — nada exige escrita.
- `deploy-prod.yml`: checkout + SSH deploy — nada exige escrita no repo (a escrita real acontece na VM via SSH, não via `GITHUB_TOKEN`).
- `monitor.yml` e `ops-set-sentry.yml`: nem fazem `checkout` — não tocam o repo de jeito nenhum.

`contents: read` é seguro pros 4, seguindo o mesmo padrão já usado em `classtrib-sync.yml`/`soro-blog-sync.yml`/`publish-news.yml` (que precisam de mais escopo — `write`/`pull-requests` — porque abrem PR, e por isso já declaravam explícito).

## Risco mitigado

Reduz o raio de explosão de um `GITHUB_TOKEN` comprometido (ex.: Action de terceiro vulnerável no pipeline) — mais relevante em `deploy-prod.yml`, que já usa secrets de SSH direto pra produção.

## Validação

O próprio CI desta PR exercita `ci.yml` com a permissão restrita de verdade (não é só leitura estática do YAML).