### PR TITLE
feat(blog): estratégia de atualização de conteúdo + rodapé com data/referência

### DIFF
--- a/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
+++ b/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
@@ -8,7 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
-updatedAt: "2026-06-05"
+updatedAt: "2026-07-26"
+updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Referências à tabela cClassTrib SVRS deixaram de citar número de versão fixo, já que é re-sincronizada diariamente."
 tags:
   - cClassTrib
   - NCM
@@ -27,12 +28,12 @@ legalRefs:
     artigo: "Art. 348 §§ 3º e 4º"
     descricao: "Período educativo 2026 — alíquotas CBS 0,9% e IBS 0,1%."
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp227.htm"
-  - instrumento: "NT 2025.002 V1.36"
+  - instrumento: "NT 2025.002-RTC v1.40"
     artigo: "Seção 4.2"
     descricao: "Define a estrutura do campo cClassTrib, a tabela de CSTs válidos e as regras de rejeição 1024–1035."
-  - instrumento: "Tabela cClassTrib SVRS V1.36"
+  - instrumento: "Tabela cClassTrib SVRS"
     artigo: "—"
-    descricao: "Mapeamento oficial NCM → regime → cClassTrib. Atualizada em abril de 2026."
+    descricao: "Mapeamento oficial NCM → regime → cClassTrib, re-sincronizado diariamente da fonte oficial SVRS."
     link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria"
   - instrumento: "Convênio ICMS 142/2018"
     artigo: "Anexo I e II"
@@ -220,7 +221,7 @@ Acesse a tabela oficial em [dfe-portal.svrs.rs.gov.br](https://dfe-portal.svrs.r
 Confirme que os três primeiros dígitos do cClassTrib coincidem com o CST que será emitido no XML. Esse é o ponto exato que a SEFAZ valida para a [Rejeição 1024](/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir).
 
 **6. Atualize o cadastro e valide o XML**
-Insira o cClassTrib correto no cadastro do produto do ERP. Antes de emitir, valide o XML pelo [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico). A validação prévia aplica as 18 regras da NT 2025.002 e devolve um relatório de inconsistências com severidade e sugestão de correção — evitando que a Rejeição 1024 apareça só na SEFAZ, em produção, com operação já comprometida.
+Insira o cClassTrib correto no cadastro do produto do ERP. Antes de emitir, valide o XML pelo [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico). A validação prévia aplica as regras da NT 2025.002-RTC v1.40 e devolve um relatório de inconsistências com severidade e sugestão de correção — evitando que a Rejeição 1024 apareça só na SEFAZ, em produção, com operação já comprometida.
 
 ---
 
@@ -262,7 +263,7 @@ O [Classificador NCM → cClassTrib](https://tribultz.com.br/classificacao) da T
 
 1. Informe o NCM
 2. Selecione o tipo de operação (saída nacional, exportação, entidade beneficente...)
-3. O classificador consulta a tabela SVRS V1.36 e retorna o cClassTrib correto + CST compatível + base legal
+3. O classificador consulta a tabela SVRS (re-sincronizada diariamente) e retorna o cClassTrib correto + CST compatível + base legal
 
 Para volume, a API pública `POST /api/v1/public/classtrib/{ncm}` aceita requisições sem autenticação até 100/dia — suficiente para validar o cadastro de produtos de uma empresa de médio porte em uma tarde.
 

--- a/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
+++ b/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
@@ -8,7 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
-updatedAt: "2026-06-05"
+updatedAt: "2026-07-26"
+updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Seção sobre versões da tabela cClassTrib reescrita: removidas afirmações específicas não verificáveis sobre a V1.36, substituídas por explicação de que a tabela é re-sincronizada diariamente da fonte oficial SVRS."
 tags:
   - cClassTrib
   - NCM
@@ -27,15 +28,15 @@ legalRefs:
     artigo: "Art. 348 §§ 3º e 4º"
     descricao: "Período educativo 2026 — alíquotas reduzidas de CBS (0,9%) e IBS (0,1%) durante a fase de transição."
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp227.htm"
-  - instrumento: "NT 2025.002 V1.36"
-    artigo: "Regras 01–18"
+  - instrumento: "NT 2025.002-RTC v1.40"
+    artigo: "—"
     descricao: "Nota Técnica que define as regras de validação cClassTrib × CST, incluindo a Rejeição 1024 e estrutura do gIBSCBS."
   - instrumento: "Convênio ICMS 142/2018"
     artigo: "Anexo I e II"
     descricao: "Lista de NCMs sujeitos à substituição tributária — CEST obrigatório, relevante para cClassTrib em operações com ST."
-  - instrumento: "Tabela cClassTrib SVRS V1.36"
+  - instrumento: "Tabela cClassTrib SVRS"
     artigo: "—"
-    descricao: "Tabela oficial de classificação tributária CBS/IBS, atualizada em abril de 2026."
+    descricao: "Tabela oficial de classificação tributária CBS/IBS, re-sincronizada diariamente da fonte oficial."
     link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria"
 ---
 
@@ -117,7 +118,7 @@ Após identificar o cClassTrib, valide que os três primeiros dígitos coincidem
 
 ## Tabela de regimes e seus cClassTrib
 
-A tabela a seguir resume os principais regimes tributários CBS/IBS e os prefixos cClassTrib correspondentes na NT 2025.002 (versão V1.36, atualização de abril de 2026):
+A tabela a seguir resume os principais regimes tributários CBS/IBS e os prefixos cClassTrib correspondentes na NT 2025.002-RTC (versão vigente v1.40):
 
 | Regime (situação tributária oficial) | CST | Prefixo cClassTrib | Exemplos de produtos |
 |--------|-----|--------------------|---------------------|
@@ -174,19 +175,15 @@ Use a API pública da Tribultz (`POST /api/v1/public/classtrib/{ncm}`) ou a inte
 Importe o de-para (NCM → cClassTrib) pelo módulo de importação do seu ERP. ERPs como TOTVS, SAP e Omie já possuem campos específicos para cClassTrib na tabela de produtos.
 
 **5. Execute uma validação pré-emissão**
-Antes de voltar para produção, valide uma amostra de XMLs pelo [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico). O diagnóstico aplica as 18 regras da NT 2025.002 e destaca incompatibilidades cClassTrib × CST.
+Antes de voltar para produção, valide uma amostra de XMLs pelo [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico). O diagnóstico aplica as regras da NT 2025.002-RTC v1.40 e destaca incompatibilidades cClassTrib × CST.
 
 ---
 
-## Atenção: versões da tabela cClassTrib
+## Atenção: a tabela cClassTrib muda com frequência
 
-A tabela cClassTrib é atualizada periodicamente pela SVRS. A versão vigente em junho de 2026 é a **V1.36**, publicada em abril de 2026. Mudanças relevantes nessa versão:
+A SVRS atualiza a tabela cClassTrib com frequência — a tabela oficial usada pela Tribultz é re-sincronizada diariamente, não presa a uma versão fixa. Códigos novos são incluídos e códigos antigos podem ser descontinuados a qualquer momento, sem calendário fixo de publicação.
 
-- Inclusão de novos cClassTrib para dispositivos médicos com benefício fiscal (LC 214, art. 53)
-- Revisão dos cClassTrib para veículos elétricos (CST 200, alíquota reduzida)
-- Novos cClassTrib para ajustes de IBS em operações na Zona Franca de Manaus (CST 810)
-
-Se seu sistema foi configurado com uma versão anterior da tabela, alguns cClassTrib podem ter sido descontinuados, causando rejeição mesmo que a combinação CST × prefixo seja válida formalmente.
+Se seu sistema consulta uma cópia local da tabela (em vez de integrar com a fonte oficial ou com um serviço que sincroniza continuamente), alguns cClassTrib podem estar desatualizados — causando rejeição mesmo que a combinação CST × prefixo tenha sido válida no passado.
 
 ---
 
@@ -194,7 +191,7 @@ Se seu sistema foi configurado com uma versão anterior da tabela, alguns cClass
 
 | Ferramenta | O que valida | Limite gratuito |
 |------------|-------------|-----------------|
-| [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) | 18 regras NT 2025.002 + cClassTrib | 20/dia |
+| [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) | Regras da NT 2025.002-RTC v1.40 + cClassTrib | 20/dia |
 | [Classificador NCM](https://tribultz.com.br/classificacao) | NCM → cClassTrib + CST | 100/dia |
 | [Calculadora CBS/IBS](https://tribultz.com.br/calculadora) | Cálculo vCBS/vIBS por NCM + UF | 100/dia |
 | API pública `/classtrib/{ncm}` | Consulta programática | 100 req/dia |

--- a/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
+++ b/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
@@ -8,7 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
-updatedAt: "2026-06-05"
+updatedAt: "2026-07-26"
+updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Referências à tabela cClassTrib SVRS deixaram de citar número de versão fixo, já que é re-sincronizada diariamente."
 tags:
   - NCM
   - TIPI
@@ -33,7 +34,7 @@ legalRefs:
     artigo: "Anexos I–VI"
     descricao: "Os produtos listados nos Anexos têm regime tributário CBS/IBS diferenciado — o NCM é o critério de enquadramento."
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
-  - instrumento: "NT 2025.002 V1.36"
+  - instrumento: "NT 2025.002-RTC v1.40"
     artigo: "Seção 4.2"
     descricao: "Define a obrigatoriedade do NCM correto como base para o cClassTrib na NF-e."
 ---
@@ -281,14 +282,14 @@ A multa por classificação incorreta de NCM varia de **75% a 150% do IPI** não
 
 O [Classificador NCM → cClassTrib](https://tribultz.com.br/classificacao) da Tribultz parte do NCM já classificado e automatiza os passos seguintes:
 
-1. Consulta a tabela cClassTrib SVRS V1.36
+1. Consulta a tabela cClassTrib SVRS (re-sincronizada diariamente)
 2. Retorna o cClassTrib correto para o NCM informado, considerando regime e tipo de operação
 3. Exibe o CST compatível e a base legal (qual Anexo da LC 214 se aplica)
 4. Disponibiliza o snippet XML pronto para inserção no ERP
 
 O classificador **não substitui a classificação do NCM em si** — essa ainda é responsabilidade do contador ou especialista fiscal. Mas ele elimina o passo manual e propenso a erro de mapear NCM → cClassTrib a partir da tabela SVRS.
 
-Para validação pré-emissão, o [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) aplica as 18 regras da NT 2025.002 sobre o XML completo — incluindo a compatibilidade NCM × cClassTrib, cálculos de CBS/IBS e completude do grupo gIBSCBS.
+Para validação pré-emissão, o [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) aplica as regras da NT 2025.002-RTC v1.40 sobre o XML completo — incluindo a compatibilidade NCM × cClassTrib, cálculos de CBS/IBS e completude do grupo gIBSCBS.
 
 Planos pagos (a partir de R$ 49,90/mês) oferecem acesso à API autenticada com até 50.000 consultas/mês, ideal para equipes de compliance que precisam revisar catálogos grandes de produtos antes de auditorias ou mudanças de leiaute da NF-e.
 

--- a/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
+++ b/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
@@ -8,7 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-05"
-updatedAt: "2026-06-05"
+updatedAt: "2026-07-26"
+updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Referências à tabela cClassTrib SVRS deixaram de citar número de versão fixo, já que é re-sincronizada diariamente."
 tags:
   - "Rejeição 1024"
   - NF-e
@@ -19,7 +20,7 @@ tags:
   - "Reforma Tributária"
 coverImage: "https://tribultz.com.br/blog/og-rejeicao-1024.png"
 legalRefs:
-  - instrumento: "NT 2025.002 V1.36"
+  - instrumento: "NT 2025.002-RTC v1.40"
     artigo: "Regra 05"
     descricao: "Define a Rejeição 1024 — incompatibilidade entre CST declarado e os três primeiros dígitos do cClassTrib."
   - instrumento: "LC 214/2025"
@@ -31,9 +32,9 @@ legalRefs:
   - instrumento: "Ajuste SINIEF 31/2024"
     artigo: "Cláusula 3ª"
     descricao: "Altera o leiaute da NF-e para incluir o grupo gIBSCBS, campos cClassTrib, pCBS, vCBS, pIBS e vIBS por item."
-  - instrumento: "Tabela cClassTrib SVRS V1.36"
+  - instrumento: "Tabela cClassTrib SVRS"
     artigo: "—"
-    descricao: "Tabela oficial de mapeamento NCM × CST × cClassTrib, atualizada em abril de 2026."
+    descricao: "Tabela oficial de mapeamento NCM × CST × cClassTrib, re-sincronizada diariamente da fonte oficial."
     link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria"
 ---
 
@@ -155,11 +156,11 @@ Localize o campo `cClassTrib` no mesmo grupo `gIBSCBS`. Os três primeiros dígi
 
 **Passo 4 — Consulte o cClassTrib correto**
 
-Acesse [tribultz.com.br/classificacao](https://tribultz.com.br/classificacao), informe o NCM do produto e o regime tributário aplicável. O classificador retorna o cClassTrib correto e o CST compatível com base na tabela SVRS V1.36.
+Acesse [tribultz.com.br/classificacao](https://tribultz.com.br/classificacao), informe o NCM do produto e o regime tributário aplicável. O classificador retorna o cClassTrib correto e o CST compatível com base na tabela SVRS (re-sincronizada diariamente).
 
 **Passo 5 — Atualize o cadastro e reemita**
 
-Corrija o cClassTrib no cadastro do produto no ERP. Antes de reemitir, use o [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico) para validar o XML completo contra as 18 regras da NT 2025.002 — incluindo as camadas 2 e 3 da tabela acima.
+Corrija o cClassTrib no cadastro do produto no ERP. Antes de reemitir, use o [Diagnóstico NF-e da Tribultz](https://tribultz.com.br/diagnostico) para validar o XML completo contra as regras da NT 2025.002-RTC v1.40 — incluindo as camadas 2 e 3 da tabela acima.
 
 ---
 
@@ -208,7 +209,7 @@ ERPs cloud geralmente publicam a tabela cClassTrib via atualização automática
 
 ## Como o Tribultz previne a Rejeição 1024
 
-O [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) da Tribultz aplica as 18 regras da NT 2025.002 antes da emissão, diretamente sobre o XML gerado pelo seu ERP:
+O [Diagnóstico NF-e](https://tribultz.com.br/diagnostico) da Tribultz aplica as regras da NT 2025.002-RTC v1.40 antes da emissão, diretamente sobre o XML gerado pelo seu ERP:
 
 | Regra validada | O que detecta |
 |---------------|---------------|

--- a/frontend/src/app/blog/[slug]/page.tsx
+++ b/frontend/src/app/blog/[slug]/page.tsx
@@ -144,6 +144,19 @@ export default async function BlogPostPage({
         </article>
 
         <footer className="mt-16 border-t border-slate-100 pt-8">
+          {post.updatedAt && post.updatedAt !== post.publishedAt && (
+            <p className="mb-4 text-xs text-slate-500">
+              Atualizado em{" "}
+              <time dateTime={post.updatedAt}>
+                {new Date(post.updatedAt + "T00:00:00").toLocaleDateString("pt-BR", {
+                  day: "2-digit",
+                  month: "long",
+                  year: "numeric",
+                })}
+              </time>
+              {post.updateNote && <> — {post.updateNote}</>}
+            </p>
+          )}
           <Link
             href="/blog"
             className="text-sm font-semibold text-blue-700 hover:underline"

--- a/frontend/src/lib/blog.ts
+++ b/frontend/src/lib/blog.ts
@@ -20,6 +20,8 @@ export type PostFrontmatter = {
   author: PostAuthor;
   publishedAt: string;
   updatedAt?: string;
+  /** Referência curta do que mudou na atualização (ex.: "NT 2025.002-RTC v1.36 → v1.40"). Exibida no rodapé junto com updatedAt. */
+  updateNote?: string;
   tags: string[];
   coverImage?: string;
   legalRefs?: LegalRef[];

--- a/frontend/src/lib/blogFiscalLint.test.ts
+++ b/frontend/src/lib/blogFiscalLint.test.ts
@@ -74,3 +74,23 @@ test("guard: conteúdo correto → sem findings", () => {
   );
   assert.equal(f.length, 0);
 });
+
+test("guard: NT 2025.002 V1.36 citada (vigente é v1.40) → erro NT_VERSAO_DESATUALIZADA", () => {
+  const f = lintBlogFiscal('instrumento: "NT 2025.002 V1.36"', valid);
+  assert.ok(f.some((x) => x.rule === "NT_VERSAO_DESATUALIZADA"));
+});
+
+test("guard: NT 2025.002-RTC v1.40 citada (vigente) → sem finding", () => {
+  const f = lintBlogFiscal('instrumento: "NT 2025.002-RTC v1.40"', valid);
+  assert.equal(f.filter((x) => x.rule === "NT_VERSAO_DESATUALIZADA").length, 0);
+});
+
+test("guard: NT 2026.002 v1.00 citada (vigente) → sem finding", () => {
+  const f = lintBlogFiscal("conforme a NT 2026.002 v1.00", valid);
+  assert.equal(f.filter((x) => x.rule === "NT_VERSAO_DESATUALIZADA").length, 0);
+});
+
+test("guard: NT sem versão vigente registrada (ex. NT 007/2026) → sem finding (não derruba por falta de dado)", () => {
+  const f = lintBlogFiscal("conforme a NT 999.999 v1.00", valid);
+  assert.equal(f.filter((x) => x.rule === "NT_VERSAO_DESATUALIZADA").length, 0);
+});

--- a/frontend/src/lib/blogFiscalLint.ts
+++ b/frontend/src/lib/blogFiscalLint.ts
@@ -10,8 +10,15 @@
  * OFICIAL SVRS (`backend/app/data/classtrib.json`). Roda no CI via `blogFiscalLint.test.ts`
  * sobre todos os posts — determinístico, sem LLM, custo zero de token.
  *
+ * Também valida (regra F) que nenhum post cita uma versão de Nota Técnica mais
+ * antiga que a vigente (`NT_CURRENT_VERSION`, rulesMeta.ts) — achado real: 4 posts
+ * citando "NT 2025.002 V1.36" quando a vigente já é v1.40 (2026-07-26). Esse é o
+ * mecanismo de detecção da estratégia de atualização de posts do blog.
+ *
  * Filosofia: somos uma empresa de validação determinística — dogfood no nosso conteúdo.
  */
+
+import { NT_CURRENT_VERSION } from "./validation/rulesMeta";
 
 export type FiscalFinding = { rule: string; severity: "error"; message: string };
 
@@ -65,6 +72,26 @@ export function lintBlogFiscal(mdx: string, valid: ClassTribValid): FiscalFindin
         rule: "CST_INEXISTENTE",
         severity: "error",
         message: `CST \`${m[1]}\` não consta na tabela oficial IBS/CBS (ex.: 000, 200, 400, 410, 510, 550, 620, 800).`,
+      });
+    }
+  }
+
+  // F) Versão de NT citada (legalRefs.instrumento ou prosa) desatualizada em relação
+  //    à vigente (NT_CURRENT_VERSION). Cobre "NT 2025.002 V1.36" e "NT 2025.002-RTC v1.40".
+  const ntVersionRx = /NT\s+(\d{4}\.\d{3})(?:-RTC)?\s+[vV](\d+)\.(\d+)/g;
+  for (const m of mdx.matchAll(ntVersionRx)) {
+    const ntId = m[1];
+    const citedMajor = parseInt(m[2], 10);
+    const citedMinor = parseInt(m[3], 10);
+    const current = NT_CURRENT_VERSION[`NT ${ntId}`];
+    if (!current) continue;
+    const [curMajor, curMinor] = current.split(".").map((n) => parseInt(n, 10));
+    const isOlder = citedMajor !== curMajor ? citedMajor < curMajor : citedMinor < curMinor;
+    if (isOlder) {
+      out.push({
+        rule: "NT_VERSAO_DESATUALIZADA",
+        severity: "error",
+        message: `Cita NT ${ntId} v${m[2]}.${m[3]} — a versão vigente é v${current}. Revisar conteúdo e atualizar legalRefs + updatedAt.`,
       });
     }
   }

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -33,3 +33,15 @@ export const RULES_LABEL = `${RULES_COUNT} regras determinísticas alinhadas às
  * automaticamente porque o arquivo-fonte vive no backend (fora do build do frontend).
  */
 export const CLASSTRIB_COUNT = 164;
+
+/**
+ * Versão vigente de cada Nota Técnica coberta pelo motor — fonte única pro
+ * `blogFiscalLint` detectar posts do blog que citam uma versão desatualizada
+ * (achado real: 4 posts citando "NT 2025.002 V1.36" quando a vigente já é
+ * v1.40, 2026-07-26). Atualizar aqui sempre que o motor migrar pra versão
+ * nova de uma NT — o lint aponta sozinho todo post que ficou pra trás.
+ */
+export const NT_CURRENT_VERSION: Record<string, string> = {
+  "NT 2025.002": "1.40",
+  "NT 2026.002": "1.00",
+};


### PR DESCRIPTION
## Contexto

O motor de validação evolui com frequência (novas versões de NT, tabela cClassTrib re-sincronizada diariamente), mas o blog era estático — sem mecanismo pra sinalizar quando um post ficou desatualizado em relação ao motor.

Achado real ao investigar: 4 posts citavam **"NT 2025.002 V1.36"** em `legalRefs`/prosa quando a versão vigente já é **v1.40**.

## Estratégia de atualização (determinística, sem LLM)

1. **Fonte única de verdade**: `NT_CURRENT_VERSION` em [rulesMeta.ts](frontend/src/lib/validation/rulesMeta.ts) — já é o registro canônico reusado em copy/blog/metadados (`RULES_COUNT`, `CLASSTRIB_COUNT`). Atualizar aqui sempre que o motor migrar de versão de NT.
2. **Detecção automática**: nova regra `NT_VERSAO_DESATUALIZADA` em [blogFiscalLint.ts](frontend/src/lib/blogFiscalLint.ts), rodando em CI via `blogFiscalLint.test.ts`. Compara a versão de NT citada no MDX (frontmatter ou prosa) contra `NT_CURRENT_VERSION` e falha o teste se o post ficou pra trás — mesmo dogfooding do lint fiscal já existente (checagem de cClassTrib/CST fabricado).
3. **Correção humana com evidência**: quando o lint aponta um post desatualizado, alguém revisa e atualiza o conteúdo (sem fabricar fatos não verificáveis — nesta rodada, uma seção com afirmações específicas não verificáveis sobre a V1.36 foi generalizada em vez de inventar um novo número).
4. **Rodapé de transparência**: pedido explícito do usuário — o post agora exibe "Atualizado em [data]" + a referência do que mudou, sempre que `updatedAt` difere de `publishedAt`.

## Mudanças

- `rulesMeta.ts`: registro `NT_CURRENT_VERSION`.
- `blogFiscalLint.ts` + testes: regra F, detecta citação de NT desatualizada (frontmatter ou prosa).
- `blog.ts`: campo `updateNote?: string` no frontmatter.
- `blog/[slug]/page.tsx`: rodapé com data de atualização (pt-BR) + `updateNote`.
- 4 posts corrigidos: NT v1.36 → v1.40, `updatedAt` + `updateNote` preenchidos; uma seção com claims não verificáveis sobre a V1.36 foi generalizada.

## Test plan

- [x] `npm test --silent` — 193/193 passando (4 novos testes cobrindo: versão desatualizada → erro; versão vigente → sem erro; NT não registrada → sem erro/sem crash)
- [x] `npm run build` — build de produção OK, todas as 67 rotas geradas
- [x] Lint fiscal confirmou detecção real ANTES da correção (4 falhas exatas nos 4 posts), depois 0 falhas após corrigir