### PR TITLE
fix(ncm-suggest): substitui modelo LLM descontinuado pela OpenRouter

### DIFF
--- a/backend/app/routers/ncm_suggest.py
+++ b/backend/app/routers/ncm_suggest.py
@@ -32,7 +32,7 @@ _CACHE_TTL_SECONDS = 86_400 * 30  # 30 days
 
 _LLM_MODELS = [
     "openrouter/openai/gpt-oss-20b:free",
-    "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+    "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
     "openrouter/google/gemma-4-31b-it:free",
 ]
 
@@ -184,6 +184,7 @@ def _llm_classify(descricao: str) -> dict:
                 if "ncm" in data and "confidence" in data:
                     logger.info("ncm_suggest: model=%s ncm=%s confidence=%s", model, data.get("ncm"), data.get("confidence"))
                     return data
+            logger.warning("ncm_suggest: model=%s returned no usable JSON: %s", model, content[:200])
         except Exception as exc:
             logger.warning("ncm_suggest: model=%s failed: %s", model, str(exc)[:200])
             continue


### PR DESCRIPTION
## Incidente

`/classificacao` (página pública, freemium) retornando "Classificação
indisponível no momento" para 100% das requisições desde o último restart
do container `infra-api-1` (2026-07-25 21:38 UTC).

## Causa raiz (confirmada via logs de produção)

Os 3 modelos do fallback (`_LLM_MODELS`) estavam todos falhando:

1. `meta-llama/llama-3.3-70b-instruct:free` — **descontinuado pela
   OpenRouter** (`NotFoundError`: "This model is unavailable for free...
   use this slug instead: meta-llama/llama-3.3-70b" — versão paga). Não é
   transitório, nunca mais vai funcionar como estava configurado.
2. `google/gemma-4-31b-it:free` — rate-limited upstream (429), possivelmente
   transitório.
3. `openai/gpt-oss-20b:free` — falhava **silenciosamente** (nenhum log de
   erro; o código só cai pro próximo modelo do loop quando a resposta não
   bate o regex/chaves esperadas).

Com os 3 falhando, toda requisição batia no 503 final.

## Fix

- Troca `meta-llama/llama-3.3-70b-instruct:free` por
  `nvidia/nemotron-3-super-120b-a12b:free` — confirmado como disponível
  via consulta direta a `openrouter.ai/api/v1/models` (não por suposição).
- Adiciona `logger.warning` quando um modelo responde mas não produz JSON
  utilizável, pra próxima falha silenciosa desse tipo aparecer no log.

## Test plan

- [x] `pytest tests/ -k ncm_suggest` — 4/4 passando
- [x] `ruff check app/routers/ncm_suggest.py` — limpo
- [ ] Validar end-to-end contra produção após deploy (endpoint público,
  sem necessidade de credencial — vou confirmar com uma classificação real
  assim que o deploy completar)