### PR TITLE
fix(ncm-suggest): max_tokens insuficiente para modelos de raciocínio

### DIFF
--- a/backend/app/routers/ncm_suggest.py
+++ b/backend/app/routers/ncm_suggest.py
@@ -33,7 +33,9 @@ _CACHE_TTL_SECONDS = 86_400 * 30  # 30 days
 _LLM_MODELS = [
     "openrouter/openai/gpt-oss-20b:free",
     "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
-    "openrouter/google/gemma-4-31b-it:free",
+    # gemma-4-31b-it:free ficou persistentemente rate-limited (429) em produção
+    # 2026-07-26 — troca por outra variante Gemma, endpoint upstream diferente.
+    "openrouter/google/gemma-4-26b-a4b-it:free",
 ]
 
 _SYSTEM_PROMPT = """\
@@ -171,7 +173,10 @@ def _llm_classify(descricao: str) -> dict:
                 ],
                 api_key=api_key,
                 base_url="https://openrouter.ai/api/v1",
-                max_tokens=150,
+                # 150 cortava modelos de raciocínio (gpt-oss, nemotron) no meio do
+                # "thinking", antes de emitirem o JSON final (confirmado em log de
+                # produção, 2026-07-26) — 500 dá espaço pro raciocínio + resposta.
+                max_tokens=500,
                 temperature=0.1,
                 timeout=20,
             )


### PR DESCRIPTION
## Continuação do incidente (#530 não resolveu completamente)

Depois do deploy de #530, testei o endpoint público em produção e ainda
falhava (503). Log de produção mostrou a causa real:

- `openai/gpt-oss-20b:free` e `nvidia/nemotron-3-super-120b-a12b:free` são
  modelos de **raciocínio** — gastam o budget de `max_tokens=150` no
  "thinking" e nunca chegam a emitir o JSON final. O log do nemotron mostra
  isso literalmente: a resposta é cortada no meio do raciocínio ("Let's
  recall: 8471 = Automatic data processing m...") sem nenhum `{` — não é
  falta de capacidade do modelo, é budget de token insuficiente.
- `google/gemma-4-31b-it:free` seguia rate-limited (429) em toda tentativa.

## Fix

- `max_tokens`: 150 → 500 (espaço pro raciocínio + resposta final).
- Troca `gemma-4-31b-it:free` (rate-limited) por `gemma-4-26b-a4b-it:free`.

## Test plan

- [x] `pytest tests/ -k ncm_suggest` — 4/4 passando
- [x] `ruff check` — limpo
- [ ] Validar end-to-end contra produção após deploy — vou confirmar com
  uma classificação real assim que completar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)