### PR TITLE
feat(frontend): retry automático em falha de rede na calculadora e classificador

### DIFF
--- a/frontend/src/app/calculadora/Calculator.tsx
+++ b/frontend/src/app/calculadora/Calculator.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { API_BASE, createTransactionId } from "@/lib/api";
+import { API_BASE, createTransactionId, fetchWithRetry } from "@/lib/api";
 import { UF_LIST } from "@/lib/data/ufList";
 import { CST_LIST } from "@/lib/data/cstList";
 
@@ -80,9 +80,8 @@ function CalculadoraInner() {
       if (ncm.trim()) body.ncm_code = ncm.trim();
 
       const endpoint = `${API_BASE}/api/v1/public/calculadora/regime-geral`;
-      console.log("Endpoint da calculadora:", endpoint);
 
-      const res = await fetch(endpoint, {
+      const res = await fetchWithRetry(endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -140,7 +139,7 @@ function CalculadoraInner() {
     setSuggestLoading(true);
     setSuggestResult(null);
     try {
-      const res = await fetch(`${API_BASE}/api/v1/public/ncm/suggest`, {
+      const res = await fetchWithRetry(`${API_BASE}/api/v1/public/ncm/suggest`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ descricao: suggestDesc.trim() }),

--- a/frontend/src/app/classificacao/Classifier.tsx
+++ b/frontend/src/app/classificacao/Classifier.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import Link from "next/link";
-import { API_BASE } from "@/lib/api";
+import { API_BASE, fetchWithRetry } from "@/lib/api";
 
 const WA_NUMBER = "5551991881026";
 const WA_REJEICAO = `https://wa.me/${WA_NUMBER}?text=${encodeURIComponent(
@@ -44,7 +44,7 @@ export function Classifier() {
     setResult(null);
     setError(null);
     try {
-      const res = await fetch(`${API_BASE}/api/v1/public/ncm/suggest`, {
+      const res = await fetchWithRetry(`${API_BASE}/api/v1/public/ncm/suggest`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ descricao: desc }),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,28 @@ import { getTenantId, getToken } from "./storage";
 // which hits the Next.js server itself and returns 404.
 export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 
+/**
+ * Retries only on network-level failures (fetch throwing — DNS, connection
+ * refused/reset, CORS). Never retries HTTP error responses (429/422/503 are
+ * real business responses, not transient blips) — those still reach the
+ * caller via a normal (non-ok) Response. Guards public tools (calculadora,
+ * classificacao) against brief gaps during a backend deploy/restart.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  retries = 2,
+  delayMs = 600,
+): Promise<Response> {
+  try {
+    return await fetch(url, options);
+  } catch (err) {
+    if (retries <= 0) throw err;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return fetchWithRetry(url, options, retries - 1, delayMs * 2);
+  }
+}
+
 export function createTransactionId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();


### PR DESCRIPTION
## Contexto

Depois do incidente de hoje no `/classificacao` (#530, #531), ao validar o
`/calculadora` o usuário bateu num "Erro de conexão" transitório — causado
pelo restart do container `api` durante meu próprio deploy do fix anterior
(confirmado: container reiniciou em 18:40:36 UTC, bem na janela do teste).

Como `/calculadora` e `/classificacao` são as duas ferramentas públicas que
a semana de posts de LinkedIn vai apontar tráfego, uma falha transitória
de alguns segundos (deploy, blip de rede) hoje mostra erro na cara do
visitante e perde a oportunidade — sem chance de recuperação automática.

## Fix

`fetchWithRetry()` em `lib/api.ts`: até 2 tentativas extras (600ms, depois
1200ms) **somente quando o `fetch()` lança exceção** (falha de rede real —
DNS, conexão recusada/resetada, CORS). Respostas HTTP normais (429 rate
limit, 422 validação, 503 serviço indisponível) **não são reprocessadas** —
são respostas de negócio legítimas, repetir não ajudaria e no caso do 429
pioraria.

Aplicado nas duas chamadas que já tinham o catch-all "Erro de conexão":
calculadora (`regime-geral` + sugestão NCM) e classificador
(`ncm/suggest`).

Bônus: removido um `console.log` de debug esquecido no endpoint da
calculadora.

## Test plan

- [x] `npm test --silent` — 193/193 passando
- [x] `npm run build` — build de produção OK, 67 rotas geradas