### PR TITLE
feat(frontend): agrupa ferramentas gratuitas em dropdown no menu público

### DIFF
--- a/frontend/src/components/public/PublicNavbar.tsx
+++ b/frontend/src/components/public/PublicNavbar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { PublicNavbarMobileMenu } from "./PublicNavbarMobileMenu";
-import { PUBLIC_NAV_LINKS } from "./publicNavLinks";
+import { PUBLIC_NAV_LINKS, isNavGroup } from "./publicNavLinks";
 
 function TribultzLogo({ dark = false }: { dark?: boolean }) {
   const textColor = dark ? "#FFFFFF" : "#24292E";
@@ -25,11 +25,39 @@ export function PublicNavbar() {
         </Link>
 
         <nav className="hidden items-center gap-7 text-sm md:flex" aria-label="Navegação pública">
-          {PUBLIC_NAV_LINKS.map((link) => (
-            <Link key={link.href} href={link.href} className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
-              {link.label}
-            </Link>
-          ))}
+          {PUBLIC_NAV_LINKS.map((entry) =>
+            isNavGroup(entry) ? (
+              <div key={entry.label} className="group relative">
+                <button
+                  type="button"
+                  className="flex items-center gap-1 font-medium text-slate-600 transition-colors hover:text-[#2956E3]"
+                  aria-haspopup="true"
+                >
+                  {entry.label}
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" />
+                  </svg>
+                </button>
+                <div
+                  className="invisible absolute left-0 top-full z-10 w-52 rounded-xl border border-slate-200 bg-white py-2 opacity-0 shadow-lg transition-all group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+                >
+                  {entry.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className="block px-4 py-2 font-medium text-slate-600 transition-colors hover:bg-slate-50 hover:text-[#2956E3]"
+                    >
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <Link key={entry.href} href={entry.href} className="font-medium text-slate-600 transition-colors hover:text-[#2956E3]">
+                {entry.label}
+              </Link>
+            ),
+          )}
           <Link href="/login" className="font-medium text-slate-500 transition-colors hover:text-slate-800">
             Entrar
           </Link>

--- a/frontend/src/components/public/PublicNavbarMobileMenu.tsx
+++ b/frontend/src/components/public/PublicNavbarMobileMenu.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { PUBLIC_NAV_LINKS } from "./publicNavLinks";
+import { PUBLIC_NAV_LINKS, isNavGroup } from "./publicNavLinks";
 
 /** Menu hambúrguer do header público — visível só abaixo de md (#502). */
 export function PublicNavbarMobileMenu() {
@@ -36,16 +36,34 @@ export function PublicNavbarMobileMenu() {
           className="absolute inset-x-0 top-full border-b border-slate-200 bg-white shadow-lg"
         >
           <div className="mx-auto flex max-w-6xl flex-col px-4 py-2">
-            {PUBLIC_NAV_LINKS.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                onClick={() => setOpen(false)}
-                className="border-b border-slate-100 py-3 text-sm font-medium text-slate-700 hover:text-[#2956E3]"
-              >
-                {link.label}
-              </Link>
-            ))}
+            {PUBLIC_NAV_LINKS.map((entry) =>
+              isNavGroup(entry) ? (
+                <div key={entry.label} className="border-b border-slate-100 py-2">
+                  <span className="block px-0 pb-1 pt-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    {entry.label}
+                  </span>
+                  {entry.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setOpen(false)}
+                      className="block py-2 text-sm font-medium text-slate-700 hover:text-[#2956E3]"
+                    >
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <Link
+                  key={entry.href}
+                  href={entry.href}
+                  onClick={() => setOpen(false)}
+                  className="border-b border-slate-100 py-3 text-sm font-medium text-slate-700 hover:text-[#2956E3]"
+                >
+                  {entry.label}
+                </Link>
+              ),
+            )}
             <Link
               href="/login"
               onClick={() => setOpen(false)}

--- a/frontend/src/components/public/publicNavLinks.ts
+++ b/frontend/src/components/public/publicNavLinks.ts
@@ -1,10 +1,29 @@
 /** Links do header público — fonte única para o desktop (PublicNavbar) e o menu mobile. */
-export const PUBLIC_NAV_LINKS = [
-  { href: "/diagnostico", label: "Diagnóstico Gratuito" },
-  { href: "/calculadora", label: "Calculadora CBS/IBS" },
-  { href: "/simulador", label: "Simulador de Impacto" },
-  { href: "/classificacao", label: "Classificar NCM" },
+
+export type NavLink = { href: string; label: string };
+export type NavGroup = { label: string; items: NavLink[] };
+export type NavEntry = NavLink | NavGroup;
+
+export function isNavGroup(entry: NavEntry): entry is NavGroup {
+  return "items" in entry;
+}
+
+/**
+ * Agrupado sob "Funcionalidades Gratuitas" para não lotar a barra desktop
+ * (7 links soltos deixavam o header apertado) — mesmo conjunto de páginas,
+ * navegação em dropdown no lugar de link direto.
+ */
+export const PUBLIC_NAV_LINKS: NavEntry[] = [
+  {
+    label: "Funcionalidades Gratuitas",
+    items: [
+      { href: "/diagnostico", label: "Diagnóstico" },
+      { href: "/calculadora", label: "Calculadora CBS/IBS" },
+      { href: "/simulador", label: "Simulador de Impacto" },
+      { href: "/classificacao", label: "NCM" },
+    ],
+  },
   { href: "/pricing", label: "Planos" },
   { href: "/founding-partners", label: "Founding Partners" },
   { href: "/blog", label: "Blog" },
-] as const;
+];


### PR DESCRIPTION
Pedido do usuário: o header desktop ficou apertado depois que
`/classificacao` entrou no menu (#534) — 7 links diretos na barra.

## Mudança

Agrupa as 4 ferramentas gratuitas sob um dropdown **"Funcionalidades
Gratuitas"**:
- Diagnóstico
- Calculadora CBS/IBS
- Simulador de Impacto
- NCM

Barra desktop passa a ter: Funcionalidades Gratuitas (dropdown) · Planos ·
Founding Partners · Blog · Entrar.

## Implementação

- `publicNavLinks.ts`: tipo discriminado `NavLink | NavGroup` (com type
  guard `isNavGroup`) — continua sendo a fonte única para desktop e
  mobile, só muda a forma dos dados.
- Desktop (`PublicNavbar.tsx`): dropdown CSS-only (`group-hover` +
  `group-focus-within` do Tailwind) — sem novo client component, o
  componente continua Server Component.
- Mobile (`PublicNavbarMobileMenu.tsx`): grupo aparece como sub-header
  não colapsável (label cinza acima dos 4 itens) — espaço vertical no
  mobile é barato, não precisa esconder atrás de outro toggle.

## Test plan

- [x] `npm test --silent` — 193/193 passando
- [x] `npm run build` — build de produção OK
- [x] HTML gerado confirma a estrutura: label "Funcionalidades Gratuitas"
  + os 4 links (Diagnóstico, Calculadora CBS/IBS, Simulador de Impacto,
  NCM) dentro do dropdown
