### PR TITLE
fix(infra): worker em produção usa o mesmo healthcheck nativo do dev

### DIFF
--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -109,9 +109,15 @@ services:
       context: ../backend
       dockerfile: Dockerfile
     <<: *common
-    # Celery worker não expõe HTTP — desabilita HEALTHCHECK do Dockerfile
+    # Celery worker não expõe HTTP — o HEALTHCHECK do Dockerfile (curl :8000/health)
+    # sempre reportaria "unhealthy" por design, não por defeito real (#522). Mesma
+    # checagem nativa já validada no docker-compose.yml de dev: inspect ping.
     healthcheck:
-      disable: true
+      test: ["CMD", "celery", "-A", "app.celery_app", "inspect", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     command:
       - celery
       - -A


### PR DESCRIPTION
## Contexto

Ao verificar o estado da infra em produção (hoje), percebi que
`docker-compose.prod.yml` desabilita completamente o healthcheck do
`worker` (igual ao `beat`) — resolvia o bug original de #522 (falso
"unhealthy" herdado do HEALTHCHECK do Dockerfile, que faz `curl
:8000/health`, e nenhum dos dois processos Celery serve HTTP), mas como
efeito colateral produção fica sem qualquer monitoramento ativo de saúde
do worker via Docker.

`docker-compose.yml` (dev) já resolveu isso de forma mais completa desde
#523: em vez de desabilitar, dá ao worker uma checagem nativa via `celery
inspect ping` — validada localmente na época ("worker mostra 'healthy' de
verdade após rebuild").

## Fix

Replica a mesma configuração de #523 para `docker-compose.prod.yml`:

\`\`\`yaml
healthcheck:
  test: ["CMD", "celery", "-A", "app.celery_app", "inspect", "ping"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 15s
\`\`\`

`beat` continua com `healthcheck: disable: true` — não há RPC de
inspeção equivalente pro processo de scheduler, mesma decisão de #523.

## Test plan

- [x] `docker compose -f docker-compose.prod.yml config` — YAML válido,
  healthcheck do worker resolve corretamente
- [ ] Pós-deploy: confirmar via SSH que `docker inspect infra-worker-1`
  mostra `Health.Status: healthy` (vou validar assim que o deploy
  completar — infra/** dispara `deploy-prod.yml` automaticamente)
