### PR TITLE
chore(pricing): remove FAQ de sandbox — Escopo 1 do go-live de billing

### DIFF
--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -497,10 +497,6 @@ export default function PricingPage() {
                 a: "Sim. Sem fidelidade, sem multa. Cancele pelo painel e mantenha o acesso até o fim do período pago.",
               },
               {
-                q: "O ambiente é sandbox agora. Quando vai para produção?",
-                a: "O billing está em sandbox enquanto validamos os fluxos. Pagamentos de teste não geram cobranças reais.",
-              },
-              {
                 q: "Quais formas de pagamento são aceitas?",
                 a: "PIX e cartão de crédito, ambos com aprovação instantânea.",
               },


### PR DESCRIPTION
Escopo 1 da ordem de go-live de billing (28/07/2026, prioridade máxima).

## Varredura completa (Escopo 1.1)

\`grep -rniE "sandbox|test.?mode|ambiente de teste|homologação|staging"\`
em todo o frontend/backend. 15 ocorrências, classificadas:

| Ocorrência | Classificação | Ação |
|---|---|---|
| \`pricing/page.tsx\` FAQ "O ambiente é sandbox agora..." | **copy visível** | Removida (este PR) |
| \`auth.py\` \`VALID_TEST_MODES\`/\`select-mode\` | ferramenta interna (superadmin simula planos p/ QA) | mantida — não é sobre billing sandbox |
| \`health.py\` comentário "ambientes de staging sem CRM" | comentário de código | mantido |
| \`config.py\` \`ENVIRONMENT\`/\`ASAAS_ENVIRONMENT\` | variável de ambiente | mantida — é o mecanismo correto |
| \`asaas_service.py\` URLs sandbox/production | implementação (lê de env) | mantida |
| \`settings/api/page.tsx\` placeholder "Ex: TOTVS Homologação" | texto de exemplo de formulário (nome que o próprio usuário dá à integração dele) | mantido — não é sobre a Tribultz |

E-mails transacionais (Escopo 1.4) auditados (\`email_service.py\` +
\`templates/emails/\`): nenhuma menção a sandbox/teste — já limpos.

## Nenhuma FAQPage JSON-LD associada

Verificado que \`/pricing\` não tem schema \`FAQPage\` duplicando essa
pergunta — remoção é completa com essa única edição.

## Test plan

- [x] \`npm test --silent\` — 193/193 passando
- [x] \`npm run build\` — build de produção OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)