### PR TITLE
feat(billing): eventos de webhook faltando + log auditável (Escopo 2.4/5.3)

### DIFF
--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.database import get_db
+from app.models.admin_audit import AdminAuditLog
 from app.models.auth import User
 from app.models.billing import Payment, Plan, Subscription, UsageTracking
 from app.services.asaas_service import asaas
@@ -18,6 +19,31 @@ from app.services.email_service import send_payment_confirmation_email
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/billing", tags=["billing"])
+
+
+def _audit_billing_event(
+    db: Session,
+    *,
+    event: str,
+    target_type: str,
+    target_id: str,
+    detail: dict,
+) -> None:
+    """Log a billing webhook event to AdminAuditLog (12 meses de retenção, Escopo 5.3).
+
+    Eventos de webhook não têm um admin como ator — actor_email marca a
+    origem como o próprio gateway, para diferenciar de ações manuais.
+    """
+    db.add(
+        AdminAuditLog(
+            actor_user_id=None,
+            actor_email="system:asaas-webhook",
+            action=event,
+            target_type=target_type,
+            target_id=target_id,
+            detail=detail,
+        )
+    )
 
 
 # ── Webhook (public, no auth) ──────────────────────────────────
@@ -56,6 +82,10 @@ async def asaas_webhook(
                 .where(Subscription.asaas_subscription_id == sub_id)
                 .values(status="cancelled", cancelled_at=datetime.now(timezone.utc))
             )
+            _audit_billing_event(
+                db, event=event, target_type="subscription", target_id=sub_id,
+                detail={"user_id": str(cancelled_sub.user_id)} if cancelled_sub else {},
+            )
             db.commit()
             logger.info("Subscription %s cancelled via webhook", sub_id)
             if cancelled_sub:
@@ -63,6 +93,20 @@ async def asaas_webhook(
                 crm_sync.delay(user_id=str(cancelled_sub.user_id), event_type="subscription_cancelled")
                 crm_engagement.delay(user_id=str(cancelled_sub.user_id), event_type="subscription_cancelled")
         return {"status": "ok", "action": "subscription_cancelled"}
+
+    # ── SUBSCRIPTION_CREATED / SUBSCRIPTION_UPDATED (no payment id either) ──
+    # A assinatura já é criada pelo próprio app (endpoint /upgrade) — estes eventos
+    # são só confirmação/sincronização do lado da Asaas, registrados para auditoria.
+    if event in ("SUBSCRIPTION_CREATED", "SUBSCRIPTION_UPDATED"):
+        sub_data = body.get("subscription", {})
+        sub_id = sub_data.get("id", "") if isinstance(sub_data, dict) else ""
+        if sub_id:
+            _audit_billing_event(
+                db, event=event, target_type="subscription", target_id=sub_id,
+                detail={"raw": sub_data} if isinstance(sub_data, dict) else {},
+            )
+            db.commit()
+        return {"status": "ok", "action": event.lower()}
 
     if not asaas_payment_id:
         logger.info("Webhook %s without payment id, skipping", event)
@@ -151,6 +195,10 @@ async def asaas_webhook(
                     sub.user_id, asaas_payment_id,
                 )
 
+        _audit_billing_event(
+            db, event=event, target_type="payment", target_id=asaas_payment_id,
+            detail={"user_id": str(sub.user_id)} if sub else {},
+        )
         db.commit()
         logger.info("Payment %s confirmed, subscription activated", asaas_payment_id)
 
@@ -208,6 +256,10 @@ async def asaas_webhook(
                 .where(Subscription.id == payment.subscription_id)
                 .values(status="past_due")
             )
+            _audit_billing_event(
+                db, event=event, target_type="payment", target_id=asaas_payment_id,
+                detail={"user_id": str(sub_overdue.user_id)} if sub_overdue else {},
+            )
             db.commit()
             logger.info("Payment %s overdue, subscription past_due", asaas_payment_id)
             if sub_overdue:
@@ -216,6 +268,54 @@ async def asaas_webhook(
                 crm_engagement.delay(user_id=str(sub_overdue.user_id), event_type="payment_overdue")
 
         return {"status": "ok", "action": "payment_overdue"}
+
+    # ── PAYMENT_CREDIT_CARD_CAPTURE_REFUSED (cartão recusado) ──
+    # Asaas já reprocessa a cobrança automaticamente (5 tentativas em ~2 dias:
+    # 8h/14h/20h no vencimento + 2 tentativas no dia seguinte) antes de emitir
+    # PAYMENT_OVERDUE — não suspendemos aqui, só registramos e avisamos.
+    if event == "PAYMENT_CREDIT_CARD_CAPTURE_REFUSED":
+        payment = db.execute(
+            select(Payment).where(Payment.asaas_payment_id == asaas_payment_id)
+        ).scalar_one_or_none()
+        if payment and cast(str, payment.status) not in ("confirmed", "failed"):
+            payment.status = "failed"  # type: ignore[assignment]
+            sub_declined = db.execute(
+                select(Subscription).where(Subscription.id == payment.subscription_id)
+            ).scalar_one_or_none()
+            _audit_billing_event(
+                db, event=event, target_type="payment", target_id=asaas_payment_id,
+                detail={"user_id": str(sub_declined.user_id)} if sub_declined else {},
+            )
+            db.commit()
+            logger.info("Payment %s card declined, Asaas will retry automatically", asaas_payment_id)
+            if sub_declined:
+                from app.tasks.task_crm import crm_engagement
+                crm_engagement.delay(user_id=str(sub_declined.user_id), event_type="payment_overdue")
+        return {"status": "ok", "action": "payment_declined"}
+
+    # ── PAYMENT_REFUNDED / PAYMENT_PARTIALLY_REFUNDED ──
+    if event in ("PAYMENT_REFUNDED", "PAYMENT_PARTIALLY_REFUNDED"):
+        payment = db.execute(
+            select(Payment).where(Payment.asaas_payment_id == asaas_payment_id)
+        ).scalar_one_or_none()
+        if payment and cast(str, payment.status) != "refunded":
+            payment.status = "refunded"  # type: ignore[assignment]
+            sub_refunded = db.execute(
+                select(Subscription).where(Subscription.id == payment.subscription_id)
+            ).scalar_one_or_none()
+            if sub_refunded and cast(str, sub_refunded.status) not in ("cancelled",):
+                db.execute(
+                    update(Subscription)
+                    .where(Subscription.id == payment.subscription_id)
+                    .values(status="cancelled", cancelled_at=datetime.now(timezone.utc))
+                )
+            _audit_billing_event(
+                db, event=event, target_type="payment", target_id=asaas_payment_id,
+                detail={"user_id": str(sub_refunded.user_id)} if sub_refunded else {},
+            )
+            db.commit()
+            logger.warning("Payment %s refunded, access revoked — verificar manualmente", asaas_payment_id)
+        return {"status": "ok", "action": "payment_refunded"}
 
     logger.info("Webhook event %s not handled, ignoring", event)
     return {"status": "ignored", "reason": "unhandled event"}

--- a/backend/tests/test_billing_webhook.py
+++ b/backend/tests/test_billing_webhook.py
@@ -292,6 +292,95 @@ class TestWebhookPaymentOverdue:
         assert r2.status_code == 200
 
 
+class TestWebhookPaymentCardDeclined:
+    def test_card_declined_marks_payment_failed_no_suspension(
+        self, client, db_session, billing_fixtures
+    ):
+        """PAYMENT_CREDIT_CARD_CAPTURE_REFUSED → payment.status=failed, subscription
+        untouched (Asaas retries automatically before PAYMENT_OVERDUE)."""
+        fx = billing_fixtures
+        payload = {
+            "event": "PAYMENT_CREDIT_CARD_CAPTURE_REFUSED",
+            "payment": {"id": fx["asaas_payment_id"]},
+        }
+        resp = client.post(
+            "/api/v1/billing/webhooks/asaas", json=payload, headers=WEBHOOK_HEADERS
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "payment_declined"
+
+        db_session.expire_all()
+        assert db_session.get(Payment, fx["payment"].id).status == "failed"
+        assert db_session.get(Subscription, fx["subscription"].id).status == "pending"
+
+
+class TestWebhookPaymentRefunded:
+    def test_refund_marks_payment_and_cancels_subscription(
+        self, client, db_session, billing_fixtures
+    ):
+        """PAYMENT_REFUNDED → payment.status=refunded, subscription cancelled (access revoked)."""
+        fx = billing_fixtures
+        payload = {
+            "event": "PAYMENT_REFUNDED",
+            "payment": {"id": fx["asaas_payment_id"]},
+        }
+        resp = client.post(
+            "/api/v1/billing/webhooks/asaas", json=payload, headers=WEBHOOK_HEADERS
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "payment_refunded"
+
+        db_session.expire_all()
+        assert db_session.get(Payment, fx["payment"].id).status == "refunded"
+        sub = db_session.get(Subscription, fx["subscription"].id)
+        assert sub.status == "cancelled"
+        assert sub.cancelled_at is not None
+
+    def test_partial_refund_treated_same_as_full(
+        self, client, db_session, billing_fixtures
+    ):
+        """PAYMENT_PARTIALLY_REFUNDED uses the same handling as PAYMENT_REFUNDED."""
+        fx = billing_fixtures
+        payload = {
+            "event": "PAYMENT_PARTIALLY_REFUNDED",
+            "payment": {"id": fx["asaas_payment_id"]},
+        }
+        resp = client.post(
+            "/api/v1/billing/webhooks/asaas", json=payload, headers=WEBHOOK_HEADERS
+        )
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "payment_refunded"
+
+
+class TestWebhookSubscriptionCreatedUpdated:
+    def test_subscription_created_is_audited_not_ignored(
+        self, client, db_session, billing_fixtures
+    ):
+        """SUBSCRIPTION_CREATED is a sync/confirmation signal — audited, not 'ignored'."""
+        resp = client.post(
+            "/api/v1/billing/webhooks/asaas",
+            json={"event": "SUBSCRIPTION_CREATED", "subscription": {"id": "sub_new_001"}},
+            headers=WEBHOOK_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        assert resp.json()["action"] == "subscription_created"
+
+    def test_subscription_updated_is_audited_not_ignored(
+        self, client, db_session, billing_fixtures
+    ):
+        resp = client.post(
+            "/api/v1/billing/webhooks/asaas",
+            json={"event": "SUBSCRIPTION_UPDATED", "subscription": {"id": "sub_upd_001"}},
+            headers=WEBHOOK_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        assert resp.json()["action"] == "subscription_updated"
+
+
 class TestWebhookSubscriptionDeleted:
     def test_subscription_deleted_cancels(
         self, client, db_session, billing_fixtures
@@ -359,7 +448,7 @@ class TestWebhookRejectionAndEdgeCases:
         """Unknown event types must return 200+ignored gracefully."""
         resp = client.post(
             "/api/v1/billing/webhooks/asaas",
-            json={"event": "PAYMENT_REFUNDED", "payment": {"id": "pay_any"}},
+            json={"event": "PAYMENT_ANTICIPATED", "payment": {"id": "pay_any"}},
             headers=WEBHOOK_HEADERS,
         )
         assert resp.status_code == 200


### PR DESCRIPTION
Escopo 2.4 e 5.3 da ordem de go-live de billing (28/07/2026).

## Escopo 2.4 — eventos de webhook faltando

Nomes de evento confirmados direto em docs.asaas.com/docs/payment-events
e /subscription-events (não presumidos):

- `PAYMENT_CREDIT_CARD_CAPTURE_REFUSED` — marca payment=failed, notifica
  por e-mail (reusa `crm_engagement` já existente), **não suspende**. A
  Asaas já reprocessa automaticamente: 5 tentativas em ~2 dias (8h/14h/20h
  no vencimento + 2 no dia seguinte, confirmado na doc oficial) antes de
  emitir `PAYMENT_OVERDUE` — que já suspendia corretamente antes desta PR.
- `PAYMENT_REFUNDED` / `PAYMENT_PARTIALLY_REFUNDED` — marca
  payment=refunded e cancela a assinatura (revoga acesso). Não existia
  handler nenhum antes.
- `SUBSCRIPTION_CREATED` / `SUBSCRIPTION_UPDATED` — a assinatura já nasce
  no próprio app (`/upgrade`); esses eventos só confirmam/sincronizam do
  lado da Asaas — agora registrados para auditoria em vez de ignorados.

## Escopo 5.3 — log auditável

Todo evento de webhook tratado agora grava em `AdminAuditLog` (tabela já
existente, usada só por ações manuais de admin até então) — origem
marcada `system:asaas-webhook` para diferenciar de ação humana. Retenção
de 12 meses (job de limpeza) fica para uma PR seguinte.

## Correção de teste pré-existente

`test_unhandled_event_returns_ignored` usava `PAYMENT_REFUNDED` como
exemplo de "evento desconhecido" — trocado por `PAYMENT_ANTICIPATED`
(evento real da Asaas, ainda não tratado), já que `PAYMENT_REFUNDED`
agora tem handler próprio.

## Test plan

- [x] `pytest tests/test_billing_webhook.py` — 27/27 passando (6 testes
  novos: cartão recusado, reembolso total, reembolso parcial, assinatura
  criada, assinatura atualizada, + o teste corrigido)
- [x] `pytest tests/` completo — 780/780 passando
- [x] `ruff check` — limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)