### PR TITLE
feat(billing): enforcement numérico de limite de CNPJs por plano (Escopo 3.5)

### DIFF
--- a/backend/app/alembic/versions/2026_07_28_0030_add_plan_max_cnpj.py
+++ b/backend/app/alembic/versions/2026_07_28_0030_add_plan_max_cnpj.py
@@ -1,0 +1,36 @@
+"""add_plan_max_cnpj — limite numérico de CNPJs por plano (go-live billing, Escopo 3.5)
+
+`has_multi_cnpj` (booleano) nunca foi de fato enforced em código — a página
+/pricing já promete números específicos por plano ("1 CNPJ", "Até 10 CNPJs",
+"Até 50 CNPJs") que não tinham nenhum campo numérico correspondente. Mapeamento
+confirmado com o Techlead (28/07/2026): Trial/Starter/Profissional=1,
+Empresarial=10, Contador=50 — bate com o texto já publicado em cada plano.
+
+Revision ID: 2026_07_28_0030
+Revises: 2026_07_21_0029
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_07_28_0030"
+down_revision = "2026_07_21_0029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "plans",
+        sa.Column("max_cnpj", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.execute("""
+        UPDATE plans SET max_cnpj = 1 WHERE slug IN ('trial', 'starter', 'profissional');
+        UPDATE plans SET max_cnpj = 10 WHERE slug = 'empresarial';
+        UPDATE plans SET max_cnpj = 50 WHERE slug = 'contador';
+    """)
+
+
+def downgrade() -> None:
+    op.drop_column("plans", "max_cnpj")

--- a/backend/app/api/plan_gate.py
+++ b/backend/app/api/plan_gate.py
@@ -146,6 +146,11 @@ def get_plan_slug(db: Session, user: User) -> str | None:
     return str(plan.slug)
 
 
+def get_effective_plan(db: Session, user: User) -> Any:
+    """Public wrapper — resolve o Plan completo (não só o slug) do usuário."""
+    return _get_effective_plan(db, user)
+
+
 def _get_effective_plan(db: Session, user: User) -> Any:
     """Resolve o Plan efetivo do usuário — Grant ativo (ADR-0008, Grant Adapter)
     tem precedência sobre a assinatura, mesmo ponto único de resolução já usado

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -35,6 +35,7 @@ class Plan(Base):
     has_dashboard = Column(Boolean, nullable=False, default=False)
     has_api_access = Column(Boolean, nullable=False, default=False)
     has_multi_cnpj = Column(Boolean, nullable=False, default=False)
+    max_cnpj = Column(Integer, nullable=False, default=1)  # 1|1|1|10|50 (trial..contador)
     trial_days = Column(Integer, nullable=True)  # 3 for trial, NULL otherwise
     is_active = Column(Boolean, nullable=False, default=True)
     created_at = Column(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -580,6 +580,24 @@ async def add_cnpj(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Apenas contas de contador podem adicionar CNPJs.",
+        )
+
+    # Limite numérico de CNPJs por plano (Escopo 3.5 do go-live de billing,
+    # 28/07/2026) — Trial/Starter/Profissional=1, Empresarial=10, Contador=50.
+    from app.api.plan_gate import get_effective_plan
+    plan = get_effective_plan(db, user)
+    max_cnpj = int(plan.max_cnpj) if plan is not None else 1
+    current_cnpj_count = db.execute(
+        select(func.count(UserTenant.id)).where(UserTenant.user_id == user_id)
+    ).scalar() or 0
+    if current_cnpj_count >= max_cnpj:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Limite de {max_cnpj} CNPJ(s) do seu plano atingido. "
+                "Faça upgrade para adicionar mais empresas."
+            ),
+            headers={"X-Upgrade-Required": "true"},
         )
 
     cnpj_normalized = normalize_cnpj(data.cnpj)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from app.database import get_db
@@ -217,3 +217,87 @@ def test_login_nonexistent_email(client, test_user):
     )
     assert response.status_code == 401
     assert response.json()["detail"] == "Email ou senha incorretos"
+
+
+# ── /add-cnpj — limite numérico por plano (Escopo 3.5 do go-live de billing) ──
+
+
+def _contador_with_plan(session, plan_slug: str):
+    """Cria um usuário account_type=contador com assinatura no plano informado
+    e 1 UserTenant já existente (o próprio tenant, is_default=True) — estado
+    real de qualquer conta contador recém-criada."""
+    import uuid
+    from app.models.billing import Plan, Subscription
+
+    tenant = Tenant(name="Escritório Contábil Teste", slug=f"contador-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+
+    user = User(
+        email=f"contador-{uuid.uuid4()}@test.com",
+        full_name="Contador Teste",
+        password_hash=get_password_hash("password123"),
+        tenant_id=tenant.id,
+        role="contador",
+        account_type="contador",
+        email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+
+    session.add(UserTenant(user_id=user.id, tenant_id=tenant.id, role="contador", is_default=True))
+
+    plan = session.execute(select(Plan).where(Plan.slug == plan_slug)).scalar_one()
+    session.add(Subscription(
+        tenant_id=tenant.id, user_id=user.id, plan_id=plan.id, status="active",
+    ))
+    session.commit()
+    session.refresh(user)
+    return user, tenant
+
+
+def test_add_cnpj_blocks_when_plan_limit_reached(client, session):
+    """Plano Profissional (max_cnpj=1): usuário já tem 1 CNPJ (o próprio) —
+    /add-cnpj deve bloquear com 403 antes de chamar a Receita Federal."""
+    user, tenant = _contador_with_plan(session, "profissional")
+
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "password123", "tenant_slug": tenant.slug},
+    )
+    assert login.status_code == 200
+
+    response = client.post(
+        "/api/v1/auth/add-cnpj",
+        json={"cnpj": "11222333000181"},
+        headers={"Authorization": f"Bearer {login.json()['access_token']}"},
+    )
+    assert response.status_code == 403
+    assert "Limite" in response.json()["detail"]
+
+
+def test_add_cnpj_allows_when_under_plan_limit(client, session):
+    """Plano Empresarial (max_cnpj=10): usuário com 1 CNPJ ainda tem margem —
+    /add-cnpj deve passar da checagem de limite (chega a validar o CNPJ)."""
+    from unittest.mock import AsyncMock, patch
+    from app.services.cnpj_validator import CnpjResult
+
+    user, tenant = _contador_with_plan(session, "empresarial")
+
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "password123", "tenant_slug": tenant.slug},
+    )
+    assert login.status_code == 200
+
+    mock_result = CnpjResult(
+        valid=True, cnpj="11222333000181", company_name="Cliente Teste Ltda",
+        status="ATIVA", error="",
+    )
+    with patch("app.routers.auth.validate_cnpj", new=AsyncMock(return_value=mock_result)):
+        response = client.post(
+            "/api/v1/auth/add-cnpj",
+            json={"cnpj": "11222333000181"},
+            headers={"Authorization": f"Bearer {login.json()['access_token']}"},
+        )
+    assert response.status_code == 200


### PR DESCRIPTION
Escopo 3.5 da ordem de go-live de billing (28/07/2026) — parte de "Nenhum
limite pode ser contornável pelo cliente".

## Achado

`has_multi_cnpj` (booleano) nunca foi de fato enforced em código, embora
`/pricing` já prometesse números específicos por plano: Starter/
Profissional "1 CNPJ", Empresarial "Até 10 CNPJs", Contador "Até 50
CNPJs". Mapeamento confirmado com o Techlead — bate exatamente com o
texto já publicado.

## Onde enforçar (investigação, não presumido)

`documents.fiscal_metadata->>'cnpj_emitente'` só é escrito pelo router de
upload de documentos, não pelo fluxo principal de validação — não seria
um sinal confiável de "quantos CNPJs o tenant usa". O sinal real é
`POST /api/v1/auth/add-cnpj`: o fluxo de contador adicionando um CNPJ de
cliente (valida na Receita Federal → cria/reusa `Tenant` → associa via
`UserTenant`). Esse é o ponto de enforcement correto.

## Mudanças

- Migration `2026_07_28_0030`: `plans.max_cnpj` (Integer), populado com
  1/1/1/10/50 (trial/starter/profissional/empresarial/contador).
- `plan_gate.py`: `get_effective_plan()` — wrapper público do
  `_get_effective_plan()` já existente (Grant Adapter aware), reusado em
  vez de duplicar a resolução de plano.
- `auth.py` `/add-cnpj`: conta `UserTenant` existentes do usuário, 403
  antes de chamar a Receita Federal se o plano já está no limite.
  Camada independente do gate `account_type=="contador"` que já existia
  — não substitui, complementa.

## Test plan

- [x] Migration aplicada localmente (`docker compose up -d --build` +
  container `migrate`) — `plans.max_cnpj` confirmado com os 5 valores
  corretos via `psql`
- [x] 2 testes novos: bloqueio no limite (Profissional, max=1, já tem 1)
  e passagem sob o limite (Empresarial, max=10, tem 1) — `pytest
  tests/test_auth.py` 8/8 passando
- [x] `pytest tests/` completo — 782/782 passando
- [x] `ruff check` — limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)