### PR TITLE
feat(billing): cobrança proporcional no upgrade de plano (Escopo 3.2)

### DIFF
--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -437,6 +437,26 @@ async def upgrade_plan(
     if not current_sub:
         raise HTTPException(status_code=400, detail="Nenhuma assinatura encontrada.")
 
+    # ── Proporcionalidade (Escopo 3.2) ──────────────────────────
+    # Crédito pelos dias não usados do plano atual, abatido do primeiro
+    # pagamento do novo plano. Sem crédito (ex.: upgrade a partir do trial,
+    # sem período pago corrente) → comportamento cheio, sem proporção.
+    old_plan = db.execute(
+        select(Plan).where(Plan.id == current_sub.plan_id)
+    ).scalar_one_or_none()
+    now = datetime.now(timezone.utc)
+    days_remaining = 0
+    if current_sub.current_period_end is not None:
+        period_end = cast(datetime, current_sub.current_period_end)
+        if period_end > now:
+            days_remaining = min(30, (period_end - now).days)
+
+    old_price_cents = cast(int, old_plan.price_cents) if old_plan is not None else 0
+    target_price_cents = cast(int, target_plan.price_cents)
+    credit_cents = (old_price_cents * days_remaining) // 30 if days_remaining > 0 else 0
+    prorated_charge_cents = max(0, target_price_cents - credit_cents)
+    has_proration = credit_cents > 0 and prorated_charge_cents < target_price_cents
+
     # Cancel old Asaas subscription if exists
     asaas_sub_id = cast(str, current_sub.asaas_subscription_id) if current_sub.asaas_subscription_id is not None else None
     if asaas_sub_id:
@@ -450,7 +470,7 @@ async def upgrade_plan(
     current_sub.cancelled_at = datetime.now(timezone.utc)  # type: ignore[assignment]
 
     # Create new Asaas payment
-    value = cast(int, target_plan.price_cents) / 100.0
+    value = target_price_cents / 100.0
     checkout_url = None
     pix_qr_code = None
     pix_copy_paste = None
@@ -474,21 +494,43 @@ async def upgrade_plan(
             )
             customer_id = cust["id"]
 
-        # Create recurring Asaas subscription (monthly)
-        sub_resp = await asaas.create_subscription(
-            customer_id=customer_id,
-            value=value,
-            billing_type=billing_type.upper(),
-            description=f"Upgrade Tribultz — {cast(str, target_plan.name)}",
-        )
-        new_asaas_sub_id = sub_resp["id"]
+        if has_proration:
+            # Cobrança avulsa proporcional agora; a assinatura recorrente (valor
+            # cheio) só gera o próximo pagamento quando o período antigo acabaria
+            # — evita cobrar o valor cheio duas vezes no mesmo ciclo.
+            prorated_payment = await asaas.create_payment(
+                customer_id=customer_id,
+                value=prorated_charge_cents / 100.0,
+                billing_type=billing_type.upper(),
+                description=f"Upgrade Tribultz — {cast(str, target_plan.name)} (proporcional)",
+            )
+            asaas_payment_id = prorated_payment["id"]
 
-        # Retrieve first payment created automatically by Asaas
-        sub_payments = await asaas.get_subscription_payments(new_asaas_sub_id)
-        if not sub_payments:
-            raise ValueError("Asaas subscription created but no payment found")
-        first_payment = sub_payments[0]
-        asaas_payment_id = first_payment["id"]
+            next_due = cast(datetime, current_sub.current_period_end).strftime("%Y-%m-%d")
+            sub_resp = await asaas.create_subscription(
+                customer_id=customer_id,
+                value=value,
+                billing_type=billing_type.upper(),
+                description=f"Assinatura Tribultz — {cast(str, target_plan.name)}",
+                next_due_date=next_due,
+            )
+            new_asaas_sub_id = sub_resp["id"]
+        else:
+            # Create recurring Asaas subscription (monthly)
+            sub_resp = await asaas.create_subscription(
+                customer_id=customer_id,
+                value=value,
+                billing_type=billing_type.upper(),
+                description=f"Upgrade Tribultz — {cast(str, target_plan.name)}",
+            )
+            new_asaas_sub_id = sub_resp["id"]
+
+            # Retrieve first payment created automatically by Asaas
+            sub_payments = await asaas.get_subscription_payments(new_asaas_sub_id)
+            if not sub_payments:
+                raise ValueError("Asaas subscription created but no payment found")
+            first_payment = sub_payments[0]
+            asaas_payment_id = first_payment["id"]
 
         if billing_type.upper() == "PIX":
             pix_data = await asaas.get_pix_qr_code(asaas_payment_id)
@@ -512,12 +554,13 @@ async def upgrade_plan(
     db.add(new_sub)
     db.flush()
 
-    # Create payment record
+    # Create payment record — valor proporcional quando há crédito do plano anterior
+    charged_cents = prorated_charge_cents if has_proration else target_price_cents
     new_payment = Payment(
         tenant_id=current_sub.tenant_id,
         subscription_id=new_sub.id,
         asaas_payment_id=asaas_payment_id,
-        amount_cents=cast(int, target_plan.price_cents),
+        amount_cents=charged_cents,
         status="pending",
         payment_method=billing_type.lower(),
         pix_qr_code=pix_qr_code,
@@ -533,6 +576,8 @@ async def upgrade_plan(
         "checkout_url": checkout_url,
         "pix_qr_code": pix_qr_code,
         "pix_copy_paste": pix_copy_paste,
+        "amount_charged_cents": charged_cents,
+        "prorated": has_proration,
     }
 
 

--- a/backend/tests/test_billing_upgrade_proration.py
+++ b/backend/tests/test_billing_upgrade_proration.py
@@ -1,0 +1,189 @@
+"""Proporcionalidade no upgrade de plano (Escopo 3.2 do go-live de billing).
+
+Cobrança do primeiro pagamento após upgrade deve descontar o crédito pelos
+dias não usados do plano anterior — sem isso, o cliente paga o valor cheio
+do novo plano em cima do que já pagou pelo período corrente do antigo.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.billing import Plan, Subscription
+from app.core.security import get_password_hash
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://tribultz:tribultz@localhost:5432/tribultz",
+)
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    conn = engine.connect()
+    tx = conn.begin()
+    session = TestingSessionLocal(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _user_with_subscription(session, *, plan_slug: str, period_end):
+    """Cria tenant + user (com CNPJ) + subscription ativa no plano informado.
+
+    period_end=None simula assinatura sem período corrente (ex.: trial) —
+    caso em que não há crédito a proporcionalizar.
+    """
+    tenant = Tenant(name="Empresa Upgrade Teste", slug=f"upg-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+
+    user = User(
+        email=f"upgrade-{uuid.uuid4()}@test.com",
+        full_name="Usuário Upgrade",
+        password_hash=get_password_hash("password123"),
+        tenant_id=tenant.id,
+        role="admin",
+        account_type="empresa",
+        cnpj="11.222.333/0001-81",
+        email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+
+    plan = session.execute(select(Plan).where(Plan.slug == plan_slug)).scalar_one()
+    sub = Subscription(
+        tenant_id=tenant.id,
+        user_id=user.id,
+        plan_id=plan.id,
+        status="active",
+        asaas_customer_id="cus_existing_001",
+        current_period_start=datetime.now(timezone.utc) - timedelta(days=15),
+        current_period_end=period_end,
+    )
+    session.add(sub)
+    session.commit()
+    session.refresh(user)
+    return user, tenant, plan
+
+
+def _login(client, user, tenant):
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "password123", "tenant_slug": tenant.slug},
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+class TestUpgradeProration:
+    def test_upgrade_with_remaining_period_charges_prorated_amount(self, client, db_session):
+        """Starter (R$49,90) → Profissional (R$149,00), 15 dias restantes de 30:
+        crédito = 4990 * 15 // 30 = 2495; cobrança = 14900 - 2495 = 12405.
+        +1h de margem: `.days` trunca, e o tempo real decorrido entre criar a
+        fixture e o endpoint calcular `now` não pode derrubar 15 para 14."""
+        period_end = datetime.now(timezone.utc) + timedelta(days=15, hours=1)
+        user, tenant, _old_plan = _user_with_subscription(
+            db_session, plan_slug="starter", period_end=period_end
+        )
+        token = _login(client, user, tenant)
+
+        with (
+            patch("app.routers.billing.asaas.cancel_subscription", new=AsyncMock(return_value={})),
+            patch(
+                "app.routers.billing.asaas.create_payment",
+                new=AsyncMock(return_value={"id": "pay_prorated_001"}),
+            ) as mock_create_payment,
+            patch(
+                "app.routers.billing.asaas.create_subscription",
+                new=AsyncMock(return_value={"id": "sub_new_001"}),
+            ) as mock_create_subscription,
+            patch(
+                "app.routers.billing.asaas.get_pix_qr_code",
+                new=AsyncMock(return_value={"encodedImage": "b64img", "payload": "pix-copy-paste"}),
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/billing/upgrade",
+                json={"plan_slug": "profissional", "billing_type": "PIX"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["prorated"] is True
+        assert body["amount_charged_cents"] == 12405
+
+        # Cobrança avulsa criada com o valor proporcional, não o valor cheio
+        mock_create_payment.assert_called_once()
+        assert mock_create_payment.call_args.kwargs["value"] == pytest.approx(124.05)
+
+        # Assinatura recorrente criada a valor cheio, com next_due_date no fim do período antigo
+        mock_create_subscription.assert_called_once()
+        sub_kwargs = mock_create_subscription.call_args.kwargs
+        assert sub_kwargs["value"] == pytest.approx(149.00)
+        assert sub_kwargs["next_due_date"] == period_end.strftime("%Y-%m-%d")
+
+    def test_upgrade_without_remaining_period_charges_full_price(self, client, db_session):
+        """Sem current_period_end (ex.: trial) — sem crédito, cobra o valor cheio
+        e usa o primeiro pagamento auto-gerado pela assinatura (comportamento
+        anterior à proporcionalidade)."""
+        user, tenant, _old_plan = _user_with_subscription(
+            db_session, plan_slug="trial", period_end=None
+        )
+        token = _login(client, user, tenant)
+
+        with (
+            patch("app.routers.billing.asaas.cancel_subscription", new=AsyncMock(return_value={})),
+            patch(
+                "app.routers.billing.asaas.create_subscription",
+                new=AsyncMock(return_value={"id": "sub_new_002"}),
+            ) as mock_create_subscription,
+            patch(
+                "app.routers.billing.asaas.get_subscription_payments",
+                new=AsyncMock(return_value=[{"id": "pay_full_001"}]),
+            ),
+            patch(
+                "app.routers.billing.asaas.get_pix_qr_code",
+                new=AsyncMock(return_value={"encodedImage": "b64img", "payload": "pix-copy-paste"}),
+            ),
+            patch("app.routers.billing.asaas.create_payment", new=AsyncMock()) as mock_create_payment,
+        ):
+            resp = client.post(
+                "/api/v1/billing/upgrade",
+                json={"plan_slug": "starter", "billing_type": "PIX"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["prorated"] is False
+        assert body["amount_charged_cents"] == 4990
+
+        mock_create_payment.assert_not_called()
+        sub_kwargs = mock_create_subscription.call_args.kwargs
+        assert "next_due_date" not in sub_kwargs or sub_kwargs.get("next_due_date") is None


### PR DESCRIPTION
Escopo 3.2 da ordem de go-live de billing (28/07/2026).

## Problema

`/api/v1/billing/upgrade` cancelava a assinatura antiga e cobrava o valor
**cheio** do novo plano imediatamente — sem desconto pelos dias já pagos
e não usados do plano anterior. Cliente pagava duas vezes o mesmo
período.

## Fórmula

```
dias_restantes = min(30, dias até current_period_end)
crédito = preço_plano_antigo × dias_restantes ÷ 30
cobrança = max(0, preço_plano_novo − crédito)
```

Sem `current_period_end` (ex.: upgrade a partir do Trial, que não tem
período pago corrente) → sem crédito, cobra o valor cheio — comportamento
idêntico ao que já existia.

## Como evita cobrar duas vezes

Quando há crédito: a primeira cobrança vira um pagamento avulso
(`asaas.create_payment`) no valor proporcional; a assinatura recorrente
(valor cheio, para os próximos ciclos) é criada com `next_due_date` no
fim do período antigo. Sem isso, a assinatura geraria automaticamente um
segundo pagamento a valor cheio no mesmo ciclo.

Response ganha `amount_charged_cents` e `prorated` para o frontend
mostrar o valor real cobrado.

## Test plan

- [x] 2 testes novos: upgrade com 15 dias restantes de um plano de
  R$49,90 → crédito de R$24,95, cobrança de R$124,05 no lugar dos
  R$149,00 cheios (mocks de `create_payment`/`create_subscription`
  verificando os valores exatos passados); upgrade sem período corrente
  → cobra valor cheio, usa o fluxo antigo (payment auto-gerado)
- [x] `pytest tests/` completo — 782/782 passando
- [x] `ruff check` — limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)