### PR TITLE
feat(auth): aceite de Termos de Uso + IP do consentimento (Escopo 4.2)

### DIFF
--- a/backend/app/alembic/versions/2026_07_28_0031_add_terms_consent_ip.py
+++ b/backend/app/alembic/versions/2026_07_28_0031_add_terms_consent_ip.py
@@ -1,0 +1,30 @@
+"""add_terms_consent_ip — aceite de Termos + IP do consentimento (go-live billing, Escopo 4.2)
+
+`lgpd_consent_at` já existia mas o backend nunca de fato checava o valor
+enviado pelo cliente (`data.lgpd_consent`) — o timestamp era gravado
+incondicionalmente. Correção: schema Pydantic ganha validator (já existia
+para lgpd_consent, adicionado agora para terms_accepted também), e o
+momento do aceite passa a registrar o IP de origem.
+
+Revision ID: 2026_07_28_0031
+Revises: 2026_07_28_0030
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_07_28_0031"
+down_revision = "2026_07_28_0030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("terms_accepted_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("consent_ip", sa.String(length=45), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "consent_ip")
+    op.drop_column("users", "terms_accepted_at")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -81,6 +81,10 @@ class User(Base):
     account_type = Column(String(20), nullable=False, default="empresa")  # empresa | contador
     is_active = Column(Boolean, nullable=False, default=True)
     lgpd_consent_at = Column(DateTime(timezone=True), nullable=True)
+    terms_accepted_at = Column(DateTime(timezone=True), nullable=True)
+    # IP no momento do aceite (LGPD + Termos, capturados juntos no /register) —
+    # Escopo 4.2 do go-live de billing: data, hora e IP do aceite.
+    consent_ip = Column(String(45), nullable=True)  # cabe IPv6
     email_verified = Column(Boolean, nullable=False, default=False)
     email_verification_token = Column(String(500), nullable=True)
     deleted_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -322,6 +322,7 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
         )
 
     # Create user
+    consent_at = datetime.now(timezone.utc)
     user = User(
         tenant_id=tenant.id,
         email=data.email,
@@ -331,7 +332,9 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
         phone=data.phone or None,
         account_type=data.account_type,
         role="admin" if data.account_type == "empresa" else "contador",
-        lgpd_consent_at=datetime.now(timezone.utc),
+        lgpd_consent_at=consent_at,
+        terms_accepted_at=consent_at,
+        consent_ip=ip,
         email_verified=False,
     )
     db.add(user)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -62,6 +62,7 @@ class UserRegister(BaseModel):
     plan_slug: str = "trial"  # trial | starter | profissional | contador
     billing_type: str = "PIX"  # PIX | CREDIT_CARD (boleto not supported)
     lgpd_consent: bool = False
+    terms_accepted: bool = False
     tenant_slug: str = "default"
     captcha_token: str = ""
     # Proveniência comercial (RFC-0025): código do Partner que indicou a empresa,
@@ -124,6 +125,15 @@ class UserRegister(BaseModel):
         if not v:
             raise ValueError(
                 "Consentimento LGPD obrigatório para cadastro."
+            )
+        return v
+
+    @field_validator("terms_accepted")
+    @classmethod
+    def validate_terms_accepted(cls, v: bool) -> bool:
+        if not v:
+            raise ValueError(
+                "Aceite dos Termos de Uso obrigatório para cadastro."
             )
         return v
 

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -208,6 +208,7 @@ class TestUserRegisterValidation:
             "plan_slug": "trial",
             "billing_type": "PIX",
             "lgpd_consent": True,
+            "terms_accepted": True,
             "tenant_slug": "default",
         }
         defaults.update(overrides)
@@ -256,6 +257,10 @@ class TestUserRegisterValidation:
     def test_lgpd_consent_required(self):
         with pytest.raises(ValueError):
             UserRegister(**self._base_data(lgpd_consent=False))
+
+    def test_terms_accepted_required(self):
+        with pytest.raises(ValueError):
+            UserRegister(**self._base_data(terms_accepted=False))
 
     def test_account_type_invalid(self):
         with pytest.raises(ValueError):

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -77,6 +77,7 @@ export default function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [billingType, setBillingType] = useState<"PIX" | "CREDIT_CARD">("PIX");
   const [lgpdConsent, setLgpdConsent] = useState(false);
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [multiTenantConsent, setMultiTenantConsent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [registered, setRegistered] = useState(false);
@@ -120,6 +121,10 @@ export default function RegisterPage() {
       setToast({ tone: "error", msg: "Você deve aceitar a Política de Privacidade para prosseguir." });
       return false;
     }
+    if (!termsAccepted) {
+      setToast({ tone: "error", msg: "Você deve aceitar os Termos de Uso para prosseguir." });
+      return false;
+    }
     if ((planSlug === "empresarial" || planSlug === "contador") && !multiTenantConsent) {
       setToast({ tone: "error", msg: "Você deve aceitar o termo de Responsabilidade Multi-Tenant para prosseguir." });
       return false;
@@ -152,7 +157,8 @@ export default function RegisterPage() {
         account_type: accountType,
         plan_slug: planSlug,
         billing_type: billingType,
-        lgpd_consent: true,
+        lgpd_consent: lgpdConsent,
+        terms_accepted: termsAccepted,
         tenant_slug: "",
         captcha_token: captchaToken,
         partner_code: partnerCode || undefined,
@@ -434,6 +440,15 @@ export default function RegisterPage() {
               Li e concordo com a{" "}
               <Link href="/privacy" target="_blank" className="font-medium text-tribultz-700 underline">Política de Privacidade</Link>{" "}
               e autorizo o tratamento dos meus dados pessoais e financeiros conforme a LGPD (Lei 13.709/2018).
+            </span>
+          </label>
+
+          <label className="flex items-start gap-2 text-sm">
+            <input type="checkbox" checked={termsAccepted} onChange={(e) => setTermsAccepted(e.target.checked)} className="mt-1 h-4 w-4 rounded border-slate-300" />
+            <span className="text-slate-600">
+              Li e concordo com os{" "}
+              <Link href="/terms" target="_blank" className="font-medium text-tribultz-700 underline">Termos de Uso</Link>{" "}
+              da Tribultz.
             </span>
           </label>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -83,6 +83,7 @@ type RegisterRequest = {
   plan_slug: string;
   billing_type: string;
   lgpd_consent: boolean;
+  terms_accepted: boolean;
   tenant_slug: string;
   captcha_token?: string;
   // Proveniência comercial (RFC-0025): código do Partner do link ?partner=/?ref=.


### PR DESCRIPTION
Escopo 4.2 da ordem de go-live de billing (28/07/2026) — parcial.

## Correção ao relatório desta sessão

Eu tinha afirmado que o backend nunca checava `lgpd_consent` — errado.
Existe `@field_validator("lgpd_consent")` em `schemas/auth.py` desde
antes, rejeitando `False`. O gap real era outro: **`terms_accepted` não
existia como campo nenhum**, e o frontend só tinha checkbox de Política
de Privacidade — nunca de Termos de Uso, apesar de `/terms` já existir
como página. Nenhum dos dois registrava IP.

## Mudanças

- `schemas/auth.py`: `terms_accepted: bool`, com `@field_validator`
  espelhando o padrão já usado em `lgpd_consent` (rejeita `False` com
  422) — mesma camada, mesmo estilo, não um check redundante no router.
- Migration `2026_07_28_0031`: `users.terms_accepted_at` +
  `users.consent_ip` (IPv4/IPv6, reaproveita o `_client_ip()` já usado
  no rate limiter do `/register`).
- Frontend (`register/page.tsx`): novo checkbox "Li e concordo com os
  Termos de Uso" ao lado do de Privacidade. Payload de `/register` passa
  a enviar os valores reais dos checkboxes (`lgpd_consent` estava
  hardcoded como `true` no payload, independente do estado real — corrigido
  também).

## Fora desta PR — precisa de decisão, não é código

**Política de Reembolso não existe** — nem página própria, nem seção em
`/terms`. Não é gap de tracking (não tem o que aceitar). Além disso, há
uma pergunta de conformidade real: CDC art. 49 garante 7 dias de direito
de arrependimento com reembolso integral para compra fora do
estabelecimento (o que inclui SaaS online), independente do que a
política do próprio negócio diz. O `/cancel` atual sempre faz "mantém
acesso até fim do período, sem devolução em dinheiro" — não abre exceção
pros primeiros 7 dias. Não vou escrever a política nem mexer no
`/cancel` sem confirmação de que isso está correto.

## Test plan

- [x] Migration aplicada localmente (`docker compose up -d --build` +
  `migrate`) — colunas confirmadas via `psql`
- [x] 1 teste novo (`test_terms_accepted_required`, espelha o existente
  `test_lgpd_consent_required`) + `_base_data()` do
  `TestUserRegisterValidation` atualizado com `terms_accepted: True`
  (senão os outros testes da classe quebrariam com o validator novo)
- [x] `pytest tests/` completo — 783/783 passando
- [x] `npm test` — 193/193 passando
- [x] `npm run build` — build de produção OK
- [x] `ruff check` — limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)