### PR TITLE
feat(billing): Política de Reembolso + direito de arrependimento de 7 dias

### DIFF
--- a/backend/app/alembic/versions/2026_07_28_0032_add_refund_policy_consent.py
+++ b/backend/app/alembic/versions/2026_07_28_0032_add_refund_policy_consent.py
@@ -1,0 +1,25 @@
+"""add_refund_policy_consent — aceite da Política de Reembolso (go-live billing, Escopo 4.2/#4)
+
+Terceiro documento a exigir aceite explícito no /register, ao lado de
+lgpd_consent e terms_accepted (mesma migration series, 2026_07_28_0031).
+
+Revision ID: 2026_07_28_0032
+Revises: 2026_07_28_0031
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_07_28_0032"
+down_revision = "2026_07_28_0031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("refund_policy_accepted_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "refund_policy_accepted_at")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -82,8 +82,9 @@ class User(Base):
     is_active = Column(Boolean, nullable=False, default=True)
     lgpd_consent_at = Column(DateTime(timezone=True), nullable=True)
     terms_accepted_at = Column(DateTime(timezone=True), nullable=True)
-    # IP no momento do aceite (LGPD + Termos, capturados juntos no /register) —
-    # Escopo 4.2 do go-live de billing: data, hora e IP do aceite.
+    refund_policy_accepted_at = Column(DateTime(timezone=True), nullable=True)
+    # IP no momento do aceite (LGPD + Termos + Reembolso, capturados juntos no
+    # /register) — Escopo 4.2 do go-live de billing: data, hora e IP do aceite.
     consent_ip = Column(String(45), nullable=True)  # cabe IPv6
     email_verified = Column(Boolean, nullable=False, default=False)
     email_verification_token = Column(String(500), nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -334,6 +334,7 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
         role="admin" if data.account_type == "empresa" else "contador",
         lgpd_consent_at=consent_at,
         terms_accepted_at=consent_at,
+        refund_policy_accepted_at=consent_at,
         consent_ip=ip,
         email_verified=False,
     )

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -586,7 +586,14 @@ async def cancel_subscription_endpoint(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Cancel the current subscription."""
+    """Cancel the current subscription.
+
+    Direito de arrependimento (CDC art. 49, Política de Reembolso, #4): se o
+    cancelamento ocorre até 7 dias da primeira assinatura do usuário —
+    contratação "fora do estabelecimento comercial" — reembolsa integralmente
+    tudo que foi pago no período e revoga o acesso imediatamente. Depois dos
+    7 dias, comportamento padrão: sem reembolso, acesso até o fim do período.
+    """
     sub = db.execute(
         select(Subscription)
         .where(
@@ -608,8 +615,70 @@ async def cancel_subscription_endpoint(
         except Exception:
             logger.warning("Falha ao cancelar assinatura Asaas: %s", cancel_sub_id)
 
+    now = datetime.now(timezone.utc)
+
+    # Direito de arrependimento: ancorado na PRIMEIRA assinatura do usuário
+    # (não reseta a cada upgrade) — "durante o prazo de reflexão" (CDC art. 49).
+    earliest_sub = db.execute(
+        select(Subscription)
+        .where(Subscription.user_id == current_user.id)
+        .order_by(Subscription.created_at.asc())
+        .limit(1)
+    ).scalar_one_or_none()
+    contract_start = cast(datetime, earliest_sub.created_at) if earliest_sub is not None else now
+    within_withdrawal_window = (now - contract_start) <= timedelta(days=7)
+
+    refunded_cents = 0
+    if within_withdrawal_window:
+        confirmed_payments = db.execute(
+            select(Payment)
+            .join(Subscription, Payment.subscription_id == Subscription.id)
+            .where(
+                Subscription.user_id == current_user.id,
+                Payment.status == "confirmed",
+            )
+        ).scalars().all()
+
+        for payment in confirmed_payments:
+            try:
+                await asaas.refund_payment(
+                    cast(str, payment.asaas_payment_id),
+                    description="Direito de arrependimento (CDC art. 49) — cancelamento em até 7 dias.",
+                )
+                payment.status = "refunded"  # type: ignore[assignment]
+                refunded_cents += cast(int, payment.amount_cents)
+            except Exception:
+                logger.exception(
+                    "Falha ao estornar pagamento %s (direito de arrependimento)",
+                    payment.asaas_payment_id,
+                )
+
+        # Revoga acesso imediatamente — o contrato foi desfeito, não só cancelado
+        # para o futuro. Encerra TODAS as assinaturas não-canceladas do usuário.
+        db.execute(
+            update(Subscription)
+            .where(
+                Subscription.user_id == current_user.id,
+                Subscription.status != "cancelled",
+            )
+            .values(status="cancelled", cancelled_at=now, current_period_end=now)
+        )
+        _audit_billing_event(
+            db, event="WITHDRAWAL_REFUND_7_DAYS", target_type="subscription", target_id=str(sub.id),
+            detail={"user_id": str(current_user.id), "refunded_cents": refunded_cents},
+        )
+        db.commit()
+
+        return {
+            "status": "cancelled",
+            "message": "Cancelado dentro do prazo de arrependimento (7 dias). Reembolso integral processado.",
+            "access_until": now.isoformat(),
+            "refunded": True,
+            "refunded_cents": refunded_cents,
+        }
+
     sub.status = "cancelled"  # type: ignore[assignment]
-    sub.cancelled_at = datetime.now(timezone.utc)  # type: ignore[assignment]
+    sub.cancelled_at = now  # type: ignore[assignment]
     # User keeps access until current_period_end — do NOT deactivate
     db.commit()
 
@@ -619,4 +688,6 @@ async def cancel_subscription_endpoint(
         "status": "cancelled",
         "message": "Assinatura cancelada. Acesso mantido até o fim do período atual.",
         "access_until": period_end,
+        "refunded": False,
+        "refunded_cents": 0,
     }

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -63,6 +63,7 @@ class UserRegister(BaseModel):
     billing_type: str = "PIX"  # PIX | CREDIT_CARD (boleto not supported)
     lgpd_consent: bool = False
     terms_accepted: bool = False
+    refund_policy_accepted: bool = False
     tenant_slug: str = "default"
     captcha_token: str = ""
     # Proveniência comercial (RFC-0025): código do Partner que indicou a empresa,
@@ -134,6 +135,15 @@ class UserRegister(BaseModel):
         if not v:
             raise ValueError(
                 "Aceite dos Termos de Uso obrigatório para cadastro."
+            )
+        return v
+
+    @field_validator("refund_policy_accepted")
+    @classmethod
+    def validate_refund_policy_accepted(cls, v: bool) -> bool:
+        if not v:
+            raise ValueError(
+                "Aceite da Política de Reembolso obrigatório para cadastro."
             )
         return v
 

--- a/backend/app/services/asaas_service.py
+++ b/backend/app/services/asaas_service.py
@@ -219,6 +219,26 @@ class AsaasService:
     async def get_payment(self, payment_id: str) -> dict[str, Any]:
         return await self._request("GET", f"/v3/payments/{payment_id}")
 
+    async def refund_payment(
+        self,
+        payment_id: str,
+        value: float | None = None,
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Estorna um pagamento confirmado/recebido (cartão ou PIX).
+
+        value=None reembolsa o valor total da cobrança (padrão da API).
+        Usado pelo direito de arrependimento de 7 dias (CDC art. 49, #4).
+        """
+        payload: dict[str, Any] = {}
+        if value is not None:
+            payload["value"] = value
+        if description:
+            payload["description"] = description
+        result = await self._request("POST", f"/v3/payments/{payment_id}/refund", json=payload)
+        logger.info("Asaas payment refunded: %s", payment_id)
+        return result
+
     async def get_pix_qr_code(self, payment_id: str) -> dict[str, Any]:
         """Returns {encodedImage: base64_png, payload: copy_paste_code, expirationDate}."""
         result = await self._request("GET", f"/v3/payments/{payment_id}/pixQrCode")

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -209,6 +209,7 @@ class TestUserRegisterValidation:
             "billing_type": "PIX",
             "lgpd_consent": True,
             "terms_accepted": True,
+            "refund_policy_accepted": True,
             "tenant_slug": "default",
         }
         defaults.update(overrides)
@@ -261,6 +262,10 @@ class TestUserRegisterValidation:
     def test_terms_accepted_required(self):
         with pytest.raises(ValueError):
             UserRegister(**self._base_data(terms_accepted=False))
+
+    def test_refund_policy_accepted_required(self):
+        with pytest.raises(ValueError):
+            UserRegister(**self._base_data(refund_policy_accepted=False))
 
     def test_account_type_invalid(self):
         with pytest.raises(ValueError):

--- a/backend/tests/test_billing_cancel_withdrawal.py
+++ b/backend/tests/test_billing_cancel_withdrawal.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, update
 from sqlalchemy.orm import sessionmaker
 
 from app.database import get_db
@@ -84,7 +84,7 @@ def _user_with_confirmed_subscription(session, *, subscription_created_at, perio
     session.flush()
     # created_at tem server_default — força a data desejada explicitamente
     session.execute(
-        Subscription.__table__.update()
+        update(Subscription)
         .where(Subscription.id == sub.id)
         .values(created_at=subscription_created_at)
     )

--- a/backend/tests/test_billing_cancel_withdrawal.py
+++ b/backend/tests/test_billing_cancel_withdrawal.py
@@ -1,0 +1,181 @@
+"""Direito de arrependimento de 7 dias (CDC art. 49) no /cancel — Escopo 4
+do go-live de billing.
+
+Cancelamento dentro de 7 dias da primeira assinatura do usuário deve
+reembolsar integralmente e revogar acesso na hora; depois dos 7 dias,
+comportamento padrão (sem reembolso, acesso até o fim do período).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.billing import Payment, Plan, Subscription
+from app.core.security import get_password_hash
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://tribultz:tribultz@localhost:5432/tribultz",
+)
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    conn = engine.connect()
+    tx = conn.begin()
+    session = TestingSessionLocal(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _user_with_confirmed_subscription(session, *, subscription_created_at, period_end=None):
+    tenant = Tenant(name="Empresa Cancelamento Teste", slug=f"cancel-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+
+    user = User(
+        email=f"cancel-{uuid.uuid4()}@test.com",
+        full_name="Usuário Cancelamento",
+        password_hash=get_password_hash("password123"),
+        tenant_id=tenant.id,
+        role="admin",
+        account_type="empresa",
+        email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+
+    plan = session.execute(select(Plan).where(Plan.slug == "starter")).scalar_one()
+    sub = Subscription(
+        tenant_id=tenant.id,
+        user_id=user.id,
+        plan_id=plan.id,
+        status="active",
+        asaas_customer_id="cus_withdrawal_001",
+        current_period_start=subscription_created_at,
+        current_period_end=period_end or (subscription_created_at + timedelta(days=30)),
+    )
+    session.add(sub)
+    session.flush()
+    # created_at tem server_default — força a data desejada explicitamente
+    session.execute(
+        Subscription.__table__.update()
+        .where(Subscription.id == sub.id)
+        .values(created_at=subscription_created_at)
+    )
+
+    payment = Payment(
+        tenant_id=tenant.id,
+        subscription_id=sub.id,
+        asaas_payment_id=f"pay_withdrawal_{uuid.uuid4().hex[:8]}",
+        amount_cents=4990,
+        status="confirmed",
+        payment_method="pix",
+        paid_at=subscription_created_at,
+    )
+    session.add(payment)
+    session.commit()
+    session.refresh(user)
+    session.refresh(sub)
+    return user, tenant, sub, payment
+
+
+def _login(client, user, tenant):
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "password123", "tenant_slug": tenant.slug},
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+class TestCancelWithdrawalWindow:
+    def test_cancel_within_7_days_refunds_in_full(self, client, db_session):
+        """Assinatura criada há 2 dias — dentro do prazo de reflexão (CDC art. 49)."""
+        created_at = datetime.now(timezone.utc) - timedelta(days=2)
+        user, tenant, sub, payment = _user_with_confirmed_subscription(
+            db_session, subscription_created_at=created_at
+        )
+        token = _login(client, user, tenant)
+
+        with patch(
+            "app.routers.billing.asaas.refund_payment",
+            new=AsyncMock(return_value={"status": "REFUNDED"}),
+        ) as mock_refund:
+            resp = client.post(
+                "/api/v1/billing/cancel",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["refunded"] is True
+        assert body["refunded_cents"] == 4990
+
+        mock_refund.assert_called_once()
+        assert mock_refund.call_args.args[0] == payment.asaas_payment_id
+
+        db_session.expire_all()
+        assert db_session.get(Payment, payment.id).status == "refunded"
+        reloaded_sub = db_session.get(Subscription, sub.id)
+        assert reloaded_sub.status == "cancelled"
+        # Acesso revogado na hora — current_period_end não fica no futuro
+        assert reloaded_sub.current_period_end <= datetime.now(timezone.utc)
+
+    def test_cancel_after_7_days_no_refund(self, client, db_session):
+        """Assinatura antiga (criada há 30 dias, renovada, período atual ainda em
+        curso) — fora do prazo de reflexão, comportamento padrão."""
+        created_at = datetime.now(timezone.utc) - timedelta(days=30)
+        user, tenant, sub, payment = _user_with_confirmed_subscription(
+            db_session,
+            subscription_created_at=created_at,
+            period_end=datetime.now(timezone.utc) + timedelta(days=10),
+        )
+        token = _login(client, user, tenant)
+
+        with patch(
+            "app.routers.billing.asaas.refund_payment", new=AsyncMock()
+        ) as mock_refund:
+            resp = client.post(
+                "/api/v1/billing/cancel",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["refunded"] is False
+        assert body["refunded_cents"] == 0
+        mock_refund.assert_not_called()
+
+        db_session.expire_all()
+        # Pagamento permanece confirmado — não foi estornado
+        assert db_session.get(Payment, payment.id).status == "confirmed"
+        reloaded_sub = db_session.get(Subscription, sub.id)
+        assert reloaded_sub.status == "cancelled"
+        # Acesso mantido até o fim do período original (não revogado na hora)
+        assert reloaded_sub.current_period_end > datetime.now(timezone.utc)

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -494,7 +494,7 @@ export default function PricingPage() {
             {[
               {
                 q: "Posso cancelar a qualquer momento?",
-                a: "Sim. Sem fidelidade, sem multa. Cancele pelo painel e mantenha o acesso até o fim do período pago.",
+                a: "Sim. Sem fidelidade, sem multa. Nos primeiros 7 dias, reembolso integral (direito de arrependimento, CDC art. 49). Depois disso, cancele pelo painel e mantenha o acesso até o fim do período pago.",
               },
               {
                 q: "Quais formas de pagamento são aceitas?",

--- a/frontend/src/app/refund-policy/page.tsx
+++ b/frontend/src/app/refund-policy/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Política de Reembolso",
+  description: "Direito de arrependimento de 7 dias e regras de cancelamento das assinaturas Tribultz.",
+};
+
+export default function RefundPolicyPage() {
+  return (
+    <LegalPageLayout
+      title="Política de Reembolso"
+      updatedAt="28 de julho de 2026"
+      summary="Como funciona o reembolso nos primeiros 7 dias e o que acontece quando você cancela depois desse prazo."
+    >
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900">1. Direito de arrependimento (7 dias)</h2>
+        <p>
+          Como a contratação da Tribultz acontece à distância (fora do estabelecimento comercial),
+          você tem direito de desistir da assinatura em até <strong>7 dias corridos</strong> a partir
+          da data em que ela começou — sem precisar justificar o motivo. Esse direito é garantido pelo
+          artigo 49 do Código de Defesa do Consumidor (Lei 8.078/1990):
+        </p>
+        <blockquote className="mt-3 border-l-4 border-slate-200 pl-4 italic text-slate-600">
+          &quot;O consumidor pode desistir do contrato, no prazo de 7 dias a contar de sua assinatura
+          ou do ato de recebimento do produto ou serviço, sempre que a contratação de fornecimento de
+          produtos e serviços ocorrer fora do estabelecimento comercial [...]. Se o consumidor
+          exercitar o direito de arrependimento previsto neste artigo, os valores eventualmente pagos,
+          a qualquer título, durante o prazo de reflexão, serão devolvidos, de imediato, monetariamente
+          atualizados.&quot;
+        </blockquote>
+        <p className="mt-3">
+          Na prática: cancele pelo painel (Configurações → Assinatura → Cancelar) em até 7 dias da sua
+          primeira assinatura, e devolvemos <strong>o valor integral pago</strong>, sem retenção. O
+          prazo conta a partir da sua primeira assinatura — trocar de plano dentro desses 7 dias não
+          reinicia a contagem.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900">2. Prazo de processamento do reembolso</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-6">
+          <li>
+            <strong>PIX:</strong> reembolso processado diretamente pelo nosso provedor de pagamentos.
+          </li>
+          <li>
+            <strong>Cartão de crédito:</strong> o estorno é solicitado imediatamente à operadora do
+            cartão, mas pode levar até 10 dias úteis para aparecer na fatura — esse prazo é do banco
+            emissor do cartão, não da Tribultz.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900">3. Cancelamento após os 7 dias</h2>
+        <p>
+          Depois do prazo de arrependimento, a assinatura Tribultz é <strong>sem fidelidade</strong>:
+          cancele quando quiser, direto pelo painel, sem multa. Nesse caso não há reembolso do valor já
+          pago no período corrente — você mantém acesso completo ao plano até o fim da data em que a
+          próxima cobrança aconteceria, e a cobrança não se repete depois disso.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900">4. Como pedir o reembolso</h2>
+        <p>
+          O cancelamento é feito pelo próprio painel (Configurações → Assinatura → Cancelar) — o
+          sistema identifica automaticamente se você ainda está dentro do prazo de 7 dias e processa o
+          reembolso sem necessidade de abrir chamado. Em caso de dúvida, fale com{" "}
+          <strong>contato@tribultz.com.br</strong>.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900">5. O que não está incluído</h2>
+        <p>
+          Esta política cobre o valor da assinatura em si. Créditos de API já consumidos (chamadas
+          efetivamente processadas antes do cancelamento) não são estornados isoladamente — o
+          reembolso incide sobre o valor pago pela assinatura.
+        </p>
+      </section>
+    </LegalPageLayout>
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -78,6 +78,7 @@ export default function RegisterPage() {
   const [billingType, setBillingType] = useState<"PIX" | "CREDIT_CARD">("PIX");
   const [lgpdConsent, setLgpdConsent] = useState(false);
   const [termsAccepted, setTermsAccepted] = useState(false);
+  const [refundPolicyAccepted, setRefundPolicyAccepted] = useState(false);
   const [multiTenantConsent, setMultiTenantConsent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [registered, setRegistered] = useState(false);
@@ -125,6 +126,10 @@ export default function RegisterPage() {
       setToast({ tone: "error", msg: "Você deve aceitar os Termos de Uso para prosseguir." });
       return false;
     }
+    if (!refundPolicyAccepted) {
+      setToast({ tone: "error", msg: "Você deve aceitar a Política de Reembolso para prosseguir." });
+      return false;
+    }
     if ((planSlug === "empresarial" || planSlug === "contador") && !multiTenantConsent) {
       setToast({ tone: "error", msg: "Você deve aceitar o termo de Responsabilidade Multi-Tenant para prosseguir." });
       return false;
@@ -159,6 +164,7 @@ export default function RegisterPage() {
         billing_type: billingType,
         lgpd_consent: lgpdConsent,
         terms_accepted: termsAccepted,
+        refund_policy_accepted: refundPolicyAccepted,
         tenant_slug: "",
         captcha_token: captchaToken,
         partner_code: partnerCode || undefined,
@@ -449,6 +455,15 @@ export default function RegisterPage() {
               Li e concordo com os{" "}
               <Link href="/terms" target="_blank" className="font-medium text-tribultz-700 underline">Termos de Uso</Link>{" "}
               da Tribultz.
+            </span>
+          </label>
+
+          <label className="flex items-start gap-2 text-sm">
+            <input type="checkbox" checked={refundPolicyAccepted} onChange={(e) => setRefundPolicyAccepted(e.target.checked)} className="mt-1 h-4 w-4 rounded border-slate-300" />
+            <span className="text-slate-600">
+              Li e concordo com a{" "}
+              <Link href="/refund-policy" target="_blank" className="font-medium text-tribultz-700 underline">Política de Reembolso</Link>{" "}
+              (direito de arrependimento de 7 dias, CDC art. 49).
             </span>
           </label>
 

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -32,6 +32,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${SITE_URL}/privacy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
     { url: `${SITE_URL}/lgpd`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
     { url: `${SITE_URL}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${SITE_URL}/refund-policy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
     { url: `${SITE_URL}/cookies`, lastModified: now, changeFrequency: "yearly", priority: 0.2 },
   ];
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -84,6 +84,7 @@ type RegisterRequest = {
   billing_type: string;
   lgpd_consent: boolean;
   terms_accepted: boolean;
+  refund_policy_accepted: boolean;
   tenant_slug: string;
   captcha_token?: string;
   // Proveniência comercial (RFC-0025): código do Partner do link ?partner=/?ref=.

--- a/frontend/src/lib/legal.ts
+++ b/frontend/src/lib/legal.ts
@@ -8,4 +8,5 @@ export const LEGAL_LINKS: LegalLink[] = [
   { href: "/cookies", label: "Cookies" },
   { href: "/lgpd", label: "LGPD" },
   { href: "/terms", label: "Termos de Uso" },
+  { href: "/refund-policy", label: "Reembolso" },
 ];


### PR DESCRIPTION
Item 4 do go-live de billing (28/07/2026, 9h) — flagueado ontem de
madrugada como pendente de decisão, retomado agora com a confirmação do
Techlead.

## Base legal (verificada, não presumida)

CDC art. 49 (Lei 8.078/1990) — 7 dias de desistência para contratação
fora do estabelecimento comercial (SaaS online se qualifica), com
devolução **imediata e integral**. Não é política do negócio, é piso
legal obrigatório. O `/cancel` anterior sempre fazia "acesso até o fim
do período, sem reembolso" — incompatível com os primeiros 7 dias.

## O que mudou

**Backend**
- `asaas_service.py`: `refund_payment()` novo —
  `POST /v3/payments/{id}/refund` (confirmado em
  docs.asaas.com/reference/refund-payment, não presumido).
- `billing.py` `/cancel`: prazo de 7 dias ancorado na **primeira**
  assinatura do usuário (não reseta a cada upgrade). Dentro do prazo:
  estorna todos os pagamentos confirmados, cancela tudo, revoga acesso
  na hora. Fora do prazo: inalterado.
- Migration: `users.refund_policy_accepted_at` — terceiro documento
  exigindo aceite explícito no cadastro (mesmo padrão de
  `lgpd_consent`/`terms_accepted` desta semana).

**Frontend**
- `/refund-policy`: página nova, citando o art. 49 na íntegra.
- Terceiro checkbox obrigatório no cadastro.
- FAQ de `/pricing` atualizada.

## Test plan

- [x] Migration aplicada localmente, coluna confirmada
- [x] 2 testes novos de `/cancel` (dentro e fora dos 7 dias) + 1 de
  validação do schema
- [x] `pytest tests/` — 788/788
- [x] `npm test` — 193/193
- [x] `npm run build` — sitemap e nav das páginas legais confirmados
- [x] `ruff check` — limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)