### PR TITLE
feat(documents): retenção de 12 meses + criptografia em repouso (Escopo 4.3)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -47,6 +47,10 @@ celery.conf.update(
             "task": "crm.audit",
             "schedule": crontab(minute="0", hour="9"),  # daily at 09:00 BRT
         },
+        "purge-expired-documents-monthly": {
+            "task": "documents.purge_expired",
+            "schedule": crontab(minute="30", hour="2", day_of_month="1"),  # 1st of month at 02:30
+        },
     },
 )
 
@@ -60,5 +64,6 @@ celery.autodiscover_tasks([
     "app.tasks.task_g_billing",
     "app.tasks.task_h_sped",
     "app.tasks.task_i_compliance",
+    "app.tasks.task_j_retention",
     "app.tasks.task_crm",
 ])

--- a/backend/app/tasks/task_j_retention.py
+++ b/backend/app/tasks/task_j_retention.py
@@ -1,0 +1,70 @@
+"""Celery task — descarte de documentos após 12 meses (Escopo 4.3, go-live de billing).
+
+Retenção definida: 12 meses a partir do upload (Document.created_at).
+Depois disso, o objeto no S3/MinIO e a linha em `documents` são apagados —
+minimização de dado (LGPD art. 6º, III) sobre XMLs de terceiros que a
+Tribultz processa mas não tem motivo de negócio para reter indefinidamente.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+
+from app.celery_app import celery
+from app.database import SessionLocal
+from app.models.documents import Document
+from app.tools.s3_tool import delete_object
+
+logger = logging.getLogger(__name__)
+
+RETENTION_DAYS = 365
+
+
+@celery.task(name="documents.purge_expired")
+def purge_expired_documents():
+    """Apaga documentos (S3 + linha no banco) com mais de 12 meses.
+
+    Roda mensalmente via beat schedule. Falha ao apagar do S3 não impede
+    seguir para o próximo documento — cada um é tratado independentemente
+    e reportado no log, para não deixar um erro isolado travar a rotina
+    inteira do mês.
+    """
+    db = SessionLocal()
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+        expired = db.execute(
+            select(Document).where(Document.created_at < cutoff)
+        ).scalars().all()
+
+        deleted_count = 0
+        error_count = 0
+        for doc in expired:
+            try:
+                delete_object(str(doc.storage_key))
+            except Exception:
+                logger.exception(
+                    "purge_expired_documents: falha ao apagar do S3, mantendo linha no banco | document_id=%s",
+                    doc.id,
+                )
+                error_count += 1
+                continue
+
+            db.delete(doc)
+            deleted_count += 1
+
+        if deleted_count or error_count:
+            db.commit()
+            logger.info(
+                "purge_expired_documents: %d apagados, %d com erro (mantidos p/ retry no próximo ciclo)",
+                deleted_count, error_count,
+            )
+        else:
+            logger.debug("purge_expired_documents: nenhum documento expirado")
+
+    except Exception:
+        db.rollback()
+        logger.exception("purge_expired_documents failed")
+        raise
+    finally:
+        db.close()

--- a/backend/app/tools/s3_tool.py
+++ b/backend/app/tools/s3_tool.py
@@ -46,7 +46,12 @@ def put_object(
     def _write() -> dict:
         client = _client()
         sha = hashlib.sha256(data).hexdigest()
-        extra: dict = {"ContentType": content_type}
+        # Criptografia em repouso explícita (Escopo 4.3, go-live de billing) —
+        # a doc oficial da Magalu Object Storage não confirma SSE por padrão
+        # especificamente para Object Storage, então não dependemos do default
+        # da infra. AES256 (SSE-S3) é suportado tanto por MinIO (dev) quanto
+        # por provedores S3-compatíveis em produção.
+        extra: dict = {"ContentType": content_type, "ServerSideEncryption": "AES256"}
         if metadata:
             extra["Metadata"] = metadata
         client.put_object(
@@ -94,7 +99,18 @@ def get_object_url(
     )
 
 
-# ── 3. Checksum ──────────────────────────────────────────────
+# ── 3. Delete Object ─────────────────────────────────────────
+def delete_object(
+    key: str,
+    bucket: Optional[str] = None,
+) -> None:
+    """Delete an object from S3/MinIO — usado pelo job de retenção (Escopo 4.3)."""
+    bucket = bucket or settings.S3_BUCKET
+    client = _client()
+    client.delete_object(Bucket=bucket, Key=key)
+
+
+# ── 4. Checksum ──────────────────────────────────────────────
 def checksum(
     key: str,
     bucket: Optional[str] = None,

--- a/backend/tests/test_document_retention.py
+++ b/backend/tests/test_document_retention.py
@@ -1,0 +1,130 @@
+"""Job de retenção de documentos — 12 meses (Escopo 4.3, go-live de billing).
+
+Documento com mais de 12 meses deve ser apagado do S3 e do banco; documento
+mais recente não é tocado. Falha ao apagar do S3 mantém a linha no banco
+(retry no próximo ciclo, não perde o registro silenciosamente).
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, update
+from sqlalchemy.orm import sessionmaker
+
+from app.models.auth import Tenant, User
+from app.models.documents import Document
+from app.core.security import get_password_hash
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://tribultz:tribultz@localhost:5432/tribultz",
+)
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    conn = engine.connect()
+    tx = conn.begin()
+    session = TestingSessionLocal(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+def _make_document(session, *, created_at, storage_key=None):
+    tenant = Tenant(name="Empresa Retenção Teste", slug=f"retention-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+
+    user = User(
+        email=f"retention-{uuid.uuid4()}@test.com",
+        full_name="Usuário Retenção",
+        password_hash=get_password_hash("password123"),
+        tenant_id=tenant.id,
+        role="admin",
+        account_type="empresa",
+        email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+
+    doc = Document(
+        tenant_id=tenant.id,
+        user_id=user.id,
+        doc_type="nfe",
+        storage_key=storage_key or f"docs/{uuid.uuid4()}.xml",
+        status="confirmed",
+    )
+    session.add(doc)
+    session.flush()
+    session.execute(
+        update(Document).where(Document.id == doc.id).values(created_at=created_at)
+    )
+    session.commit()
+    session.refresh(doc)
+    return doc
+
+
+class TestPurgeExpiredDocuments:
+    def test_document_older_than_12_months_is_deleted(self, db_session, monkeypatch):
+        from app.tasks import task_j_retention
+
+        monkeypatch.setattr(task_j_retention, "SessionLocal", lambda: db_session)
+        # rollback/close do fixture cuidam da limpeza — task não deve fechar a sessão de teste
+        db_session.close = lambda: None
+
+        old_doc = _make_document(
+            db_session, created_at=datetime.now(timezone.utc) - timedelta(days=400)
+        )
+
+        with patch(
+            "app.tasks.task_j_retention.delete_object"
+        ) as mock_delete:
+            task_j_retention.purge_expired_documents()
+
+        mock_delete.assert_called_once_with(old_doc.storage_key)
+        db_session.expire_all()
+        assert db_session.get(Document, old_doc.id) is None
+
+    def test_document_within_12_months_is_kept(self, db_session, monkeypatch):
+        from app.tasks import task_j_retention
+
+        monkeypatch.setattr(task_j_retention, "SessionLocal", lambda: db_session)
+        db_session.close = lambda: None
+
+        recent_doc = _make_document(
+            db_session, created_at=datetime.now(timezone.utc) - timedelta(days=30)
+        )
+
+        with patch("app.tasks.task_j_retention.delete_object") as mock_delete:
+            task_j_retention.purge_expired_documents()
+
+        mock_delete.assert_not_called()
+        db_session.expire_all()
+        assert db_session.get(Document, recent_doc.id) is not None
+
+    def test_s3_delete_failure_keeps_document_for_retry(self, db_session, monkeypatch):
+        from app.tasks import task_j_retention
+
+        monkeypatch.setattr(task_j_retention, "SessionLocal", lambda: db_session)
+        db_session.close = lambda: None
+
+        old_doc = _make_document(
+            db_session, created_at=datetime.now(timezone.utc) - timedelta(days=400)
+        )
+
+        with patch(
+            "app.tasks.task_j_retention.delete_object",
+            side_effect=Exception("S3 indisponível"),
+        ):
+            task_j_retention.purge_expired_documents()
+
+        db_session.expire_all()
+        # Não apagou do banco — mantém para nova tentativa no próximo ciclo
+        assert db_session.get(Document, old_doc.id) is not None

--- a/docs/context/xml_document_retention_policy.md
+++ b/docs/context/xml_document_retention_policy.md
@@ -1,0 +1,40 @@
+# Política de retenção de documentos (XMLs) — Escopo 4.3, go-live de billing
+
+Referência técnica interna. Versão pública (customer-facing): `/privacy` seção 5 e `/refund-policy`.
+
+## Retenção
+
+- **Prazo**: 12 meses a partir do upload (`Document.created_at`).
+- **Mecanismo**: task Celery `documents.purge_expired`
+  (`backend/app/tasks/task_j_retention.py`), rodando mensalmente (dia 1,
+  02:30 BRT, via `beat_schedule` em `celery_app.py`).
+- **O que é apagado**: o objeto no S3/MinIO (`storage_key`) + a linha em
+  `documents`. Falha ao apagar do S3 mantém a linha no banco para nova
+  tentativa no próximo ciclo — não perde o registro silenciosamente, mas
+  também não deixa "órfão" (linha sem o objeto correspondente) fora de um
+  cenário de erro temporário.
+- **Por quê 12 meses**: cobre um ciclo fiscal completo (a maioria das
+  obrigações acessórias e prazos de fiscalização operam em base anual),
+  sem reter indefinidamente XML de terceiros que a Tribultz processa mas
+  não é parte do negócio manter — minimização de dado (LGPD art. 6º, III).
+
+## Criptografia em repouso
+
+- `backend/app/tools/s3_tool.py` `put_object()` passa
+  `ServerSideEncryption: "AES256"` explicitamente em toda gravação.
+- Motivo de ser explícito no código, não implícito na infra: a
+  documentação oficial da Magalu Object Storage (verificada em
+  docs.magalu.cloud, 28/07/2026) menciona "criptografia avançada" de
+  forma genérica, sem confirmar SSE em repouso especificamente para
+  Object Storage — não dá pra tratar como garantido por padrão.
+- MinIO (dev local) e provedores S3-compatíveis en geral suportam
+  SSE-S3/AES256 nativamente — sem dependência de KMS externo.
+
+## O que NÃO está coberto por este documento
+
+- Retenção de `AdminAuditLog` (log de billing, Escopo 5.3) — regra
+  oposta: retenção MÍNIMA de 12 meses (não há job de descarte associado
+  a esse prazo; é um piso de auditoria, não um teto de privacidade).
+- Dados de billing (`payments`, `subscriptions`) — não têm job de
+  descarte; ficam sujeitos à retenção fiscal/contábil padrão da empresa,
+  fora do escopo desta política específica de XML.

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -89,9 +89,13 @@ export default function PrivacyPage() {
       <section>
         <h2 className="text-lg font-semibold text-slate-900">5. Segurança e retenção</h2>
         <ul className="mt-3 list-disc space-y-2 pl-6">
-          <li>Criptografia em trânsito, isolamento por tenant e controles de acesso.</li>
+          <li>Criptografia em trânsito e em repouso, isolamento por tenant e controles de acesso.</li>
           <li>Logs de auditoria e rastreabilidade para operações críticas.</li>
-          <li>Retenção de dados fiscais e operacionais conforme exigência legal e contratual.</li>
+          <li>
+            Os XMLs e demais documentos fiscais enviados são retidos por <strong>12 meses</strong> a
+            partir do envio; depois disso, são apagados automaticamente do armazenamento e do banco
+            de dados.
+          </li>
           <li>
             Anonimização ou exclusão de dados pessoais quando a retenção não for mais necessária
             ou quando houver obrigação legal compatível com o pedido do titular.


### PR DESCRIPTION
Escopo 4.3 do go-live de billing (28/07/2026).

## Retenção (12 meses, confirmado com o Techlead ontem à noite)

Job Celery mensal (`documents.purge_expired`) apaga documentos com mais
de 12 meses — objeto no S3/MinIO + linha em `documents`. Falha ao apagar
do S3 mantém a linha no banco pra nova tentativa no ciclo seguinte, em
vez de perder o registro silenciosamente ou deixar um objeto órfão.

## Criptografia em repouso

`s3_tool.py` `put_object()` passa `ServerSideEncryption=AES256`
explicitamente. Verifiquei direto na doc oficial da Magalu Object
Storage antes de presumir — ela menciona "criptografia avançada" de
forma genérica, **sem confirmar SSE em repouso especificamente para
Object Storage**. Dado isso, não dá pra depender do default da infra —
força explicitamente no código, que funciona tanto no MinIO (dev) quanto
em qualquer provedor S3-compatível.

## Documentação

- `/privacy` (customer-facing): seção 5 atualizada com o prazo de 12
  meses e a criptografia em repouso.
- `docs/context/xml_document_retention_policy.md` (interna): mecanismo,
  motivo dos 12 meses, e o que este documento explicitamente NÃO cobre
  (AdminAuditLog tem retenção MÍNIMA de 12 meses, não descarte; billing
  não tem job de descarte, fica na retenção fiscal/contábil padrão).

## Test plan

- [x] 3 testes novos: documento >12 meses apagado (S3 + banco);
  documento recente mantido; falha no S3 mantém a linha
- [x] `pytest tests/` — 788/788
- [x] `npm test` — 193/193
- [x] `npm run build` — OK
- [x] `pyright` — 0 erros
- [x] `ruff check` — limpo
