### PR TITLE
feat(admin): assinantes ativos por plano + taxa de churn mensal (Escopo 5.2)

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -78,6 +78,38 @@ def _plan_distribution(db: Session) -> list[dict[str, Any]]:
         return []
 
 
+def _active_plan_distribution(db: Session) -> list[dict[str, Any]]:
+    """Assinantes ATIVOS por plano (Escopo 5.2, go-live billing) — distinto de
+    _plan_distribution, que conta todo status (trial/cancelled inclusive)."""
+    try:
+        rows = db.execute(
+            select(Plan.slug, func.count(Subscription.id).label("cnt"))
+            .select_from(Subscription)
+            .join(Plan, Subscription.plan_id == Plan.id)
+            .where(Subscription.status == "active")
+            .group_by(Plan.slug)
+        ).fetchall()
+        return [{"plan": r.slug, "count": r.cnt} for r in rows]
+    except Exception:
+        return []
+
+
+def _churn_rate_month(db: Session, month_start: datetime, active_count: int) -> tuple[int, float]:
+    """Churn do mês (Escopo 5.2): cancelamentos no mês / (ativos + cancelados
+    no mês) — aproxima a taxa mensal sem precisar de snapshot histórico do
+    tamanho da base no início do mês. Retorna (cancelled_month, rate_pct)."""
+    cancelled_month = _safe_count(
+        db,
+        select(func.count(Subscription.id)).where(
+            Subscription.cancelled_at.isnot(None),
+            Subscription.cancelled_at >= month_start,
+        ),
+    )
+    denominator = active_count + cancelled_month
+    rate = round(cancelled_month / denominator * 100, 2) if denominator > 0 else 0.0
+    return cancelled_month, rate
+
+
 def _revenue_by_plan(db: Session, month_start: datetime) -> list[dict[str, Any]]:
     """Revenue per plan this month (from confirmed payments)."""
     try:
@@ -210,6 +242,8 @@ async def admin_dashboard(
     )
     total_tenants = _safe_count(db, select(func.count(Tenant.id)))
 
+    cancelled_month, churn_rate_month = _churn_rate_month(db, month_start, paid_count)
+
     registrations_today = _safe_count(
         db, select(func.count(User.id)).where(User.created_at >= today_start)
     )
@@ -297,6 +331,9 @@ async def admin_dashboard(
             "registrations_today": registrations_today,
             "registrations_30d": _registrations_last_30_days(db),
             "plan_distribution": _plan_distribution(db),
+            "active_plan_distribution": _active_plan_distribution(db),
+            "churn_rate_month_pct": churn_rate_month,
+            "cancelled_month": cancelled_month,
         },
         "revenue": {
             "mrr_cents": mrr_cents,

--- a/backend/tests/test_admin_dashboard_metrics.py
+++ b/backend/tests/test_admin_dashboard_metrics.py
@@ -1,0 +1,104 @@
+"""Métricas novas do admin dashboard — assinantes ativos por plano + churn
+(Escopo 5.2, go-live de billing)."""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models.auth import Tenant, User
+from app.models.billing import Plan, Subscription
+from app.core.security import get_password_hash
+from app.routers.admin import _active_plan_distribution, _churn_rate_month
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://tribultz:tribultz@localhost:5432/tribultz",
+)
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    conn = engine.connect()
+    tx = conn.begin()
+    session = TestingSessionLocal(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+def _make_subscription(session, *, plan_slug, status, cancelled_at=None):
+    tenant = Tenant(name="Empresa Métricas Teste", slug=f"metrics-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+
+    user = User(
+        email=f"metrics-{uuid.uuid4()}@test.com",
+        full_name="Usuário Métricas",
+        password_hash=get_password_hash("password123"),
+        tenant_id=tenant.id,
+        role="admin",
+        account_type="empresa",
+        email_verified=True,
+    )
+    session.add(user)
+    session.flush()
+
+    plan = session.execute(select(Plan).where(Plan.slug == plan_slug)).scalar_one()
+    sub = Subscription(
+        tenant_id=tenant.id,
+        user_id=user.id,
+        plan_id=plan.id,
+        status=status,
+        cancelled_at=cancelled_at,
+    )
+    session.add(sub)
+    session.commit()
+    return sub
+
+
+class TestActivePlanDistribution:
+    def test_counts_only_active_subscriptions(self, db_session):
+        _make_subscription(db_session, plan_slug="starter", status="active")
+        _make_subscription(db_session, plan_slug="starter", status="cancelled")
+        _make_subscription(db_session, plan_slug="starter", status="trial")
+        _make_subscription(db_session, plan_slug="profissional", status="active")
+
+        result = {row["plan"]: row["count"] for row in _active_plan_distribution(db_session)}
+
+        assert result.get("starter") == 1
+        assert result.get("profissional") == 1
+
+
+class TestChurnRateMonth:
+    def test_churn_rate_counts_cancellations_this_month(self, db_session):
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        # 1 cancelado este mês, 1 cancelado no mês passado (não deve contar)
+        _make_subscription(
+            db_session, plan_slug="starter", status="cancelled",
+            cancelled_at=now - timedelta(days=1),
+        )
+        _make_subscription(
+            db_session, plan_slug="starter", status="cancelled",
+            cancelled_at=month_start - timedelta(days=5),
+        )
+
+        cancelled_month, rate = _churn_rate_month(db_session, month_start, active_count=9)
+
+        assert cancelled_month == 1
+        assert rate == pytest.approx(10.0)  # 1 / (9 + 1) * 100
+
+    def test_churn_rate_zero_when_no_subscribers(self, db_session):
+        cancelled_month, rate = _churn_rate_month(
+            db_session, datetime.now(timezone.utc), active_count=0
+        )
+        assert cancelled_month == 0
+        assert rate == 0.0

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -24,6 +24,9 @@ type AdminStats = {
     registrations_today: number;
     registrations_30d: DayStat[];
     plan_distribution: PlanDist[];
+    active_plan_distribution: PlanDist[];
+    churn_rate_month_pct: number;
+    cancelled_month: number;
   };
   revenue: {
     mrr_cents: number;
@@ -131,7 +134,7 @@ function MiniBar({ data, label }: { data: DayStat[]; label: string }) {
   );
 }
 
-function PlanDistributionTable({ data }: { data: PlanDist[] }) {
+function PlanDistributionTable({ data, title = "Distribuicao por plano" }: { data: PlanDist[]; title?: string }) {
   const total = data.reduce((s, d) => s + d.count, 0) || 1;
   const colors: Record<string, string> = {
     trial: "bg-slate-400",
@@ -143,7 +146,7 @@ function PlanDistributionTable({ data }: { data: PlanDist[] }) {
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
       <p className="mb-3 text-xs font-medium uppercase tracking-wide text-slate-500">
-        Distribuicao por plano
+        {title}
       </p>
       {/* Bar */}
       <div className="mb-3 flex h-4 overflow-hidden rounded-full bg-slate-100">
@@ -296,6 +299,12 @@ export default function AdminPage() {
           <MiniBar data={s.users.registrations_30d} label="Cadastros (ultimos 30 dias)" />
           <PlanDistributionTable data={s.users.plan_distribution} />
         </div>
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          <PlanDistributionTable
+            data={s.users.active_plan_distribution}
+            title="Assinantes ativos por plano"
+          />
+        </div>
       </section>
 
       {/* ── Trafego do Site ──────────────────── */}
@@ -351,6 +360,12 @@ export default function AdminPage() {
             label="Pendentes / Atrasados"
             value={`${s.revenue.pending_count} / ${s.revenue.overdue_count}`}
             accent={s.revenue.overdue_count > 0 ? "red" : undefined}
+          />
+          <StatCard
+            label="Churn (mes)"
+            value={`${s.users.churn_rate_month_pct.toFixed(1)}%`}
+            sub={`${s.users.cancelled_month} cancelamento(s) no mes`}
+            accent={s.users.churn_rate_month_pct > 5 ? "red" : undefined}
           />
         </div>
         {s.revenue.by_plan.length > 0 && (


### PR DESCRIPTION
Escopo 5.2 do go-live de billing (28/07/2026) — último item pendente.

## Achado

`_plan_distribution()` já existia, mas conta subscriptions de **todo
status** (trial, cancelled, etc. inclusive) — não serve como "assinantes
ativos por plano". `mrr_cents` e `_revenue_by_plan()` (receita por plano
no mês) já existiam e já estavam corretos, sem necessidade de mudança.

## Mudanças

- `_active_plan_distribution()`: mesma query de `_plan_distribution`,
  filtrada por `status="active"`.
- `_churn_rate_month()`: cancelamentos do mês corrente ÷ (ativos +
  cancelados do mês) — aproxima a taxa mensal sem precisar de snapshot
  histórico do tamanho da base no início do mês.
- Admin dashboard: card de churn (destaque vermelho se >5%) + segunda
  tabela "Assinantes ativos por plano" ao lado da distribuição geral já
  existente (componente reaproveitado com prop `title` opcional).

## Test plan

- [x] 3 testes novos: filtro por status correto; cálculo de churn conta
  só o mês corrente; taxa zero sem assinantes
- [x] `pytest tests/` — 791/791
- [x] `npm test` — 193/193
- [x] `npm run build` — OK
- [x] `pyright` — 0 erros
- [x] `ruff check` — limpo
