### PR TITLE
feat(billing): alertas por e-mail em eventos críticos (Escopo 5.1)

### DIFF
--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -14,7 +14,7 @@ from app.models.admin_audit import AdminAuditLog
 from app.models.auth import User
 from app.models.billing import Payment, Plan, Subscription, UsageTracking
 from app.services.asaas_service import asaas
-from app.services.email_service import send_payment_confirmation_email
+from app.services.email_service import send_ops_alert, send_payment_confirmation_email
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +92,10 @@ async def asaas_webhook(
                 from app.tasks.task_crm import crm_sync, crm_engagement
                 crm_sync.delay(user_id=str(cancelled_sub.user_id), event_type="subscription_cancelled")
                 crm_engagement.delay(user_id=str(cancelled_sub.user_id), event_type="subscription_cancelled")
+                send_ops_alert(
+                    "Assinatura cancelada",
+                    f"Subscription {sub_id} (user {cancelled_sub.user_id}) foi cancelada via webhook Asaas.",
+                )
         return {"status": "ok", "action": "subscription_cancelled"}
 
     # ── SUBSCRIPTION_CREATED / SUBSCRIPTION_UPDATED (no payment id either) ──
@@ -224,6 +228,12 @@ async def asaas_webhook(
                     amount_cents=int(confirmed_plan.price_cents),  # type: ignore[arg-type]
                     payment_method=str(payment.payment_method),
                 )
+                send_ops_alert(
+                    "Pagamento confirmado",
+                    f"Usuário: {confirmed_user.email}\nPlano: {confirmed_plan.name}\n"
+                    f"Valor: R$ {int(confirmed_plan.price_cents) / 100:.2f}\n"
+                    f"Método: {payment.payment_method}\nAsaas payment id: {asaas_payment_id}",
+                )
             # CRM sync: move deal to closedwon
             from app.tasks.task_crm import crm_sync
             crm_sync.delay(user_id=str(sub.user_id), event_type="payment_confirmed")
@@ -266,6 +276,11 @@ async def asaas_webhook(
                 from app.tasks.task_crm import crm_sync, crm_engagement
                 crm_sync.delay(user_id=str(sub_overdue.user_id), event_type="payment_overdue")
                 crm_engagement.delay(user_id=str(sub_overdue.user_id), event_type="payment_overdue")
+                send_ops_alert(
+                    "Pagamento em atraso",
+                    f"Payment {asaas_payment_id} (user {sub_overdue.user_id}) marcado como overdue. "
+                    "Assinatura movida para past_due.",
+                )
 
         return {"status": "ok", "action": "payment_overdue"}
 
@@ -291,6 +306,11 @@ async def asaas_webhook(
             if sub_declined:
                 from app.tasks.task_crm import crm_engagement
                 crm_engagement.delay(user_id=str(sub_declined.user_id), event_type="payment_overdue")
+                send_ops_alert(
+                    "Cartão recusado",
+                    f"Payment {asaas_payment_id} (user {sub_declined.user_id}) teve captura recusada. "
+                    "Asaas reprocessará automaticamente (até 5 tentativas em ~2 dias).",
+                )
         return {"status": "ok", "action": "payment_declined"}
 
     # ── PAYMENT_REFUNDED / PAYMENT_PARTIALLY_REFUNDED ──
@@ -315,6 +335,12 @@ async def asaas_webhook(
             )
             db.commit()
             logger.warning("Payment %s refunded, access revoked — verificar manualmente", asaas_payment_id)
+            if sub_refunded:
+                send_ops_alert(
+                    "Reembolso processado — verificar",
+                    f"Payment {asaas_payment_id} (user {sub_refunded.user_id}) foi reembolsado pela Asaas. "
+                    "Assinatura cancelada e acesso revogado automaticamente.",
+                )
         return {"status": "ok", "action": "payment_refunded"}
 
     logger.info("Webhook event %s not handled, ignoring", event)
@@ -668,6 +694,12 @@ async def cancel_subscription_endpoint(
             detail={"user_id": str(current_user.id), "refunded_cents": refunded_cents},
         )
         db.commit()
+
+        send_ops_alert(
+            "Direito de arrependimento exercido (CDC art. 49)",
+            f"Usuário: {current_user.email}\nSubscription: {sub.id}\n"
+            f"Reembolsado: R$ {refunded_cents / 100:.2f}\nAcesso revogado imediatamente.",
+        )
 
         return {
             "status": "cancelled",

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -231,7 +231,7 @@ async def asaas_webhook(
                 send_ops_alert(
                     "Pagamento confirmado",
                     f"Usuário: {confirmed_user.email}\nPlano: {confirmed_plan.name}\n"
-                    f"Valor: R$ {int(confirmed_plan.price_cents) / 100:.2f}\n"
+                    f"Valor: R$ {cast(int, confirmed_plan.price_cents) / 100:.2f}\n"
                     f"Método: {payment.payment_method}\nAsaas payment id: {asaas_payment_id}",
                 )
             # CRM sync: move deal to closedwon

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -343,6 +343,22 @@ def send_payment_overdue_email(to_email: str, user_name: str) -> bool:
     )
 
 
+def send_ops_alert(subject: str, body: str) -> bool:
+    """Alerta interno para contato@tribultz.com.br em eventos críticos de billing
+    (pagamento confirmado, recusado, atrasado, reembolsado, cancelamento).
+
+    Substitui o WhatsApp Business API (Escopo 5.1, go-live de billing) — nunca
+    chegou a ser integrado, então este é o canal real de alerta ao time.
+    """
+    return _send_email(
+        to_email="contato@tribultz.com.br",
+        subject=f"[Tribultz] {subject}",
+        html_body=f"<pre>{body}</pre>",
+        text_body=body,
+        log_url=f"{settings.FRONTEND_URL}/admin",
+    )
+
+
 def send_staff_ticket_notification(ticket_title: str, user_email: str, priority: str) -> bool:
     """Notify contato@tribultz.com.br when a new ticket is opened."""
     priority_labels = {"low": "Baixa", "medium": "Média", "high": "Alta", "critical": "Crítica"}


### PR DESCRIPTION
## Summary
- Substitui o WhatsApp Business API (nunca chegou a ser integrado) por e-mail como canal de alerta interno, conforme decisão do Techlead (Prioridade Zero do plano de aquisição comercial, 2026-07-28).
- Novo `send_ops_alert()` em `email_service.py`, envia para `contato@tribultz.com.br`.
- Hooks em `billing.py`: pagamento confirmado (evento de receita), pagamento em atraso, cartão recusado, reembolso processado, assinatura cancelada, e exercício do direito de arrependimento (CDC art. 49).

## Test plan
- [x] `pytest tests/test_billing_webhook.py tests/test_billing_cancel_withdrawal.py tests/test_billing_upgrade_proration.py tests/test_billing.py -q` — 90 passed