### PR TITLE
feat(admin): diagnóstico gratuito para prospecção comercial direta (Escopo A)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -7,7 +7,7 @@ from alembic import context
 
 from app.database import Base
 from app.config import settings
-from app.models import api_key, auth, billing, documents, feedback, founding_partner, jobs, news, partner, reports  # noqa: F401
+from app.models import api_key, auth, billing, documents, feedback, founding_partner, jobs, news, partner, prospect_diagnostic, reports  # noqa: F401
 
 # Import models to register them with metadata
 

--- a/backend/app/alembic/versions/2026_07_28_0033_add_prospect_diagnostics.py
+++ b/backend/app/alembic/versions/2026_07_28_0033_add_prospect_diagnostics.py
@@ -1,0 +1,47 @@
+"""add_prospect_diagnostics — diagnóstico gratuito p/ prospecção direta (Escopo A)
+
+Ferramenta interna (superadmin): sobe 10-20 XMLs de um escritório contábil
+prospect e gera um PDF auditável, sem que o prospect precise ter conta.
+Tenant.prospect_diagnostic_id rastreia qual diagnóstico originou um cadastro
+via ?diag= no link do PDF (mesmo padrão não-bloqueante do Partner/RFC-0025).
+
+Revision ID: 2026_07_28_0033
+Revises: 2026_07_28_0032
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_28_0033"
+down_revision = "2026_07_28_0032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prospect_diagnostics",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("office_name", sa.String(length=200), nullable=False),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="RESTRICT"), nullable=False),
+        sa.Column("invoice_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("rejected_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("storage_key", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "prospect_diagnostic_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("prospect_diagnostics.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenants", "prospect_diagnostic_id")
+    op.drop_table("prospect_diagnostics")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -34,6 +34,15 @@ class Tenant(Base):
         ForeignKey("partners.id", ondelete="RESTRICT"),
         nullable=True,
     )
+    # Atribuição de qual diagnóstico gratuito (prospecção comercial direta)
+    # trouxe este cadastro — link ?diag= no PDF (ver auth.py). Opcional,
+    # permanente, ondelete=SET NULL: apagar o diagnóstico não deve apagar a
+    # Tenant. Não é o rastreio geral de canal/UTM (Escopo B, ainda não construído).
+    prospect_diagnostic_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("prospect_diagnostics.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     # Using server_default=func.now() for creation
     # Using onupdate=func.now() to ensure python-side updates trigger the timestamp update
     # Schema just says DEFAULT now(), so DB side auto-update depends on triggers (not present in standard schema dump).

--- a/backend/app/models/prospect_diagnostic.py
+++ b/backend/app/models/prospect_diagnostic.py
@@ -1,0 +1,43 @@
+"""ProspectDiagnostic — diagnóstico gratuito para prospecção comercial direta.
+
+Fluxo interno (superadmin): sobe 10-20 XMLs de um escritório contábil
+prospect, gera um PDF auditável com o que seria rejeitado hoje e a data em
+que a penalidade CBS/IBS passa a valer, sem que o prospect precise ter conta.
+O PDF termina com um link de trial atribuído a este diagnóstico
+(``?diag=<id>``) — a Tenant que se cadastrar por esse link é vinculada aqui
+via ``Tenant.prospect_diagnostic_id`` (ver auth.py, captura não-bloqueante,
+mesmo padrão do Partner/RFC-0025).
+
+Não é o mesmo que Partner (RFC-0025): Partner é proveniência de indicação
+permanente de um parceiro de referência; isto é a atribuição de UM envio de
+diagnóstico específico. Não substitui o rastreio geral de canal/UTM
+(Escopo B do plano de aquisição) — é o suporte mínimo para o link do PDF.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class ProspectDiagnostic(Base):
+    __tablename__ = "prospect_diagnostics"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    office_name = Column(String(200), nullable=False)
+    created_by_user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    invoice_count = Column(Integer, nullable=False, default=0)
+    rejected_count = Column(Integer, nullable=False, default=0)
+    storage_key = Column(String(500), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -5,12 +5,13 @@ from datetime import datetime, timezone
 from typing import Annotated, Any, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
+from app.config import settings
 from app.core.security import get_password_hash
 from app.database import get_db
 from app.models.admin_audit import AdminAuditLog
@@ -23,6 +24,10 @@ from app.models.partner import (
     Partner,
     normalize_partner_code,
 )
+from app.models.prospect_diagnostic import ProspectDiagnostic
+from app.routers.validate_xml import validate_xml
+from app.services.pdf_service import generate_prospect_diagnostic_pdf
+from app.tools import s3_tool
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
@@ -838,3 +843,168 @@ def admin_set_tenant_partner(
     )
     db.commit()
     return {"id": str(tenant.id), "partner_id": str(body.partner_id) if body.partner_id else None}
+
+
+# ── Prospect Diagnostics (Escopo A, plano de aquisição comercial) ──────
+# Ferramenta interna: sobe 10-20 XMLs de um escritório contábil prospect e
+# gera um PDF auditável sem que o prospect precise ter conta. O PDF termina
+# com um link de trial atribuído (?diag=<id>) — ver _attach_prospect_diagnostic
+# em auth.py para a captura no /register.
+
+_PROSPECT_PRESIGNED_TTL = 3600  # uso interno (superadmin) — não precisa ser tão curto quanto o do cliente final
+
+
+class ProspectDiagnosticInvoiceResult(BaseModel):
+    label: str
+    status: str  # PASS | FAIL
+    fatal_count: int
+
+
+class ProspectDiagnosticResponse(BaseModel):
+    id: UUID
+    office_name: str
+    invoice_count: int
+    rejected_count: int
+    download_url: str
+    trial_url: str
+    invoices: list[ProspectDiagnosticInvoiceResult]
+
+
+@router.post("/prospect-diagnostics", response_model=ProspectDiagnosticResponse)
+async def create_prospect_diagnostic(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    office_name: str = Form(...),
+    files: list[UploadFile] = File(...),
+) -> ProspectDiagnosticResponse:
+    """Valida os XMLs de um prospect com o motor determinístico e gera um PDF
+    auditável (findings FATAL, base legal, data da penalidade) com link de
+    trial atribuído no final."""
+    office_name = office_name.strip()
+    if not office_name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nome do escritório é obrigatório.")
+    if not files:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Envie ao menos um XML.")
+    if len(files) > 20:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Máximo de 20 XMLs por diagnóstico.")
+
+    invoices: list[dict[str, Any]] = []
+    for upload in files:
+        raw = await upload.read()
+        try:
+            xml_content = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            xml_content = raw.decode("latin-1", errors="replace")
+        try:
+            result = validate_xml(xml_content)
+        except Exception:
+            logger.exception("Falha ao validar XML de prospect: %s", upload.filename)
+            continue
+        fatal_findings = [
+            {"rule_id": f.rule_id, "title": f.title, "recommendation": f.recommendation}
+            for f in result.findings
+            if f.severity == "FATAL"
+        ]
+        invoices.append({
+            "label": upload.filename or "nota.xml",
+            "status": "FAIL" if fatal_findings else "PASS",
+            "fatal_findings": fatal_findings,
+        })
+
+    if not invoices:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nenhum XML pôde ser processado.")
+
+    rejected_count = sum(1 for inv in invoices if inv["status"] == "FAIL")
+
+    diagnostic = ProspectDiagnostic(
+        office_name=office_name,
+        created_by_user_id=_admin.id,
+        invoice_count=len(invoices),
+        rejected_count=rejected_count,
+    )
+    db.add(diagnostic)
+    db.flush()
+
+    storage_key = f"prospect-diagnostics/{diagnostic.id}.pdf"
+    trial_url = f"{settings.FRONTEND_URL}/register?diag={diagnostic.id}"
+
+    try:
+        generate_prospect_diagnostic_pdf(
+            office_name=office_name,
+            invoices=invoices,
+            trial_url=trial_url,
+            storage_key=storage_key,
+        )
+    except Exception:
+        logger.exception("Falha ao gerar PDF de diagnóstico de prospect")
+        raise HTTPException(status_code=500, detail="Erro ao gerar PDF do diagnóstico.")
+
+    diagnostic.storage_key = storage_key  # type: ignore[assignment]
+    _audit(
+        db, _admin, "prospect_diagnostic.create", "prospect_diagnostic", diagnostic.id,
+        {"office_name": office_name, "invoice_count": len(invoices), "rejected_count": rejected_count},
+    )
+    db.commit()
+    db.refresh(diagnostic)
+
+    try:
+        download_url = s3_tool.get_object_url(key=storage_key, expires_in=_PROSPECT_PRESIGNED_TTL)
+    except Exception:
+        logger.exception("Erro ao gerar URL presigned para storage_key=%s", storage_key)
+        raise HTTPException(status_code=503, detail="PDF gerado, mas falhou ao criar o link de download.")
+
+    return ProspectDiagnosticResponse(
+        id=diagnostic.id,  # type: ignore[arg-type]
+        office_name=office_name,
+        invoice_count=len(invoices),
+        rejected_count=rejected_count,
+        download_url=download_url,
+        trial_url=trial_url,
+        invoices=[
+            ProspectDiagnosticInvoiceResult(
+                label=inv["label"], status=inv["status"], fatal_count=len(inv["fatal_findings"])
+            )
+            for inv in invoices
+        ],
+    )
+
+
+@router.get("/prospect-diagnostics")
+def list_prospect_diagnostics(
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+    limit: int = 50,
+) -> dict[str, Any]:
+    rows = db.execute(
+        select(ProspectDiagnostic).order_by(ProspectDiagnostic.created_at.desc()).limit(limit)
+    ).scalars().all()
+    return {
+        "total": len(rows),
+        "items": [
+            {
+                "id": str(r.id),
+                "office_name": r.office_name,
+                "invoice_count": r.invoice_count,
+                "rejected_count": r.rejected_count,
+                "created_at": r.created_at.isoformat(),
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.get("/prospect-diagnostics/{diagnostic_id}/download")
+def download_prospect_diagnostic(
+    diagnostic_id: UUID,
+    db: Annotated[Session, Depends(get_db)],
+    _admin: Annotated[User, Depends(_require_superadmin)],
+) -> dict[str, str]:
+    diagnostic = db.get(ProspectDiagnostic, diagnostic_id)
+    if diagnostic is None or not cast(str, diagnostic.storage_key):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Diagnóstico não encontrado.")
+    try:
+        download_url = s3_tool.get_object_url(key=cast(str, diagnostic.storage_key), expires_in=_PROSPECT_PRESIGNED_TTL)
+    except Exception:
+        logger.exception("Erro ao gerar URL presigned para diagnóstico %s", diagnostic_id)
+        raise HTTPException(status_code=503, detail="Erro ao gerar URL de download.")
+    return {"download_url": download_url}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -109,6 +109,32 @@ def _attach_partner_from_code(db: Session, tenant: Tenant, raw_code: str) -> Non
     logger.info("partner attribution: tenant %s → partner %s", tenant.slug, code)
 
 
+def _attach_prospect_diagnostic(db: Session, tenant: Tenant, raw_diag_id: str) -> None:
+    """Captura a atribuição de diagnóstico gratuito (Escopo A, plano de
+    aquisição comercial) sem nunca bloquear o cadastro.
+
+    Vincula ``tenant.prospect_diagnostic_id`` ao ProspectDiagnostic cujo id
+    bate com o link ``?diag=`` no PDF. Id inválido/inexistente → apenas loga.
+    A origem é permanente, mesmo padrão do Partner (RFC-0025).
+    """
+    if not raw_diag_id:
+        return
+    if tenant.prospect_diagnostic_id is not None:
+        return  # origem já registrada — permanente, não sobrescreve
+    try:
+        diag_id = UUID(raw_diag_id)
+    except ValueError:
+        logger.info("prospect diagnostic attribution ignorada: id inválido %r", raw_diag_id)
+        return
+    from app.models.prospect_diagnostic import ProspectDiagnostic
+    diagnostic = db.get(ProspectDiagnostic, diag_id)
+    if diagnostic is None:
+        logger.info("prospect diagnostic attribution ignorada: id %s inexistente", diag_id)
+        return
+    tenant.prospect_diagnostic_id = diagnostic.id  # type: ignore[assignment]
+    logger.info("prospect diagnostic attribution: tenant %s → diagnostic %s", tenant.slug, diag_id)
+
+
 def _get_user_tenants(db: Session, user_id: UUID) -> list[TenantInfo]:
     """Get all tenants a user has access to."""
     rows = db.execute(
@@ -301,6 +327,8 @@ async def register(data: UserRegister, request: Request, db: Session = Depends(g
         tenant = _get_or_create_tenant_for_cnpj(db, data.cnpj, company_name)
         # Proveniência comercial (RFC-0025): captura não-bloqueante do Partner.
         _attach_partner_from_code(db, tenant, data.partner_code)
+        # Atribuição de diagnóstico gratuito (Escopo A): captura não-bloqueante.
+        _attach_prospect_diagnostic(db, tenant, data.diag_id)
     else:
         # Fallback to default tenant
         tenant = db.execute(

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -69,6 +69,10 @@ class UserRegister(BaseModel):
     # Proveniência comercial (RFC-0025): código do Partner que indicou a empresa,
     # capturado do link ?partner=/?ref=. Inválido/inativo NÃO bloqueia o cadastro.
     partner_code: str = ""
+    # Atribuição de diagnóstico gratuito (Escopo A, plano de aquisição comercial):
+    # id do ProspectDiagnostic capturado do link ?diag= no PDF. Inválido NÃO
+    # bloqueia o cadastro. Independente de partner_code (não é o mesmo conceito).
+    diag_id: str = ""
 
     @field_validator("phone")
     @classmethod

--- a/backend/app/services/pdf_service.py
+++ b/backend/app/services/pdf_service.py
@@ -186,6 +186,55 @@ def generate_credit_report_pdf(
     }
 
 
+def generate_prospect_diagnostic_pdf(
+    *,
+    office_name: str,
+    invoices: list[dict],
+    trial_url: str,
+    storage_key: str = "",
+) -> dict:
+    """Diagnóstico gratuito p/ prospecção comercial direta (Escopo A, plano de
+    aquisição). Cada item de ``invoices`` é {label, status (PASS|FAIL),
+    fatal_findings: [{rule_id, title, recommendation}]} — reaproveita o
+    Finding já produzido por validate_xml(), sem lógica específica por regra.
+
+    Returns a dict with keys: bytes, storage_key, file_size.
+    """
+    template = _jinja_env.get_template("report_prospect_diagnostic.html")
+    now = _generated_at_brasilia()
+
+    total = len(invoices)
+    rejected = sum(1 for inv in invoices if inv.get("status") == "FAIL")
+
+    html = template.render(
+        office_name=office_name,
+        generated_at=now,
+        invoices=invoices,
+        total=total,
+        rejected=rejected,
+        trial_url=trial_url,
+    )
+
+    try:
+        from weasyprint import HTML
+        pdf_bytes: bytes = HTML(string=html).write_pdf()  # type: ignore[assignment]
+        logger.info("Prospect diagnostic PDF generated for %r (%d bytes)", office_name, len(pdf_bytes))
+        if storage_key:
+            _persist_to_s3(storage_key, pdf_bytes, "application/pdf")
+    except (ImportError, OSError):
+        logger.warning("WeasyPrint unavailable (missing GTK/system libs), returning HTML fallback")
+        pdf_bytes = html.encode("utf-8")
+        if storage_key:
+            html_key = storage_key.replace(".pdf", ".html") if storage_key.endswith(".pdf") else storage_key + ".html"
+            _persist_to_s3(html_key, pdf_bytes, "text/html")
+
+    return {
+        "bytes": pdf_bytes,
+        "storage_key": storage_key,
+        "file_size": len(pdf_bytes),
+    }
+
+
 def generate_batch_report_pdf(
     *,
     company_name: str,

--- a/backend/app/templates/report_prospect_diagnostic.html
+++ b/backend/app/templates/report_prospect_diagnostic.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Diagnóstico Gratuito — Tribultz</title>
+  <style>
+    @page {
+      size: A4;
+      margin: 2cm;
+      @bottom-center { content: "Tribultz — Diagnóstico Gratuito — Página " counter(page) " de " counter(pages); font-size: 8pt; color: #666; }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 10pt; color: #1e293b; line-height: 1.5; }
+    .header { border-bottom: 3px solid #2563eb; padding-bottom: 12pt; margin-bottom: 16pt; }
+    .header h1 { font-size: 18pt; color: #2563eb; margin-bottom: 4pt; }
+    .header .subtitle { font-size: 10pt; color: #64748b; }
+    .meta-grid { display: flex; flex-wrap: wrap; gap: 8pt; margin-bottom: 16pt; }
+    .meta-item { flex: 1 1 45%; }
+    .meta-item .label { font-size: 8pt; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5pt; }
+    .meta-item .value { font-size: 11pt; font-weight: 600; }
+    .alert-box { background: #fef2f2; border: 1px solid #fecaca; border-radius: 6pt; padding: 10pt 14pt; margin-bottom: 16pt; }
+    .alert-box .alert-title { color: #991b1b; font-weight: 700; font-size: 11pt; margin-bottom: 3pt; }
+    .alert-box .alert-body { color: #7f1d1d; font-size: 9pt; }
+    .summary-cards { display: flex; gap: 8pt; margin-bottom: 16pt; }
+    .card { flex: 1; border: 1px solid #e2e8f0; border-radius: 4pt; padding: 8pt; text-align: center; }
+    .card .card-label { font-size: 8pt; color: #94a3b8; text-transform: uppercase; }
+    .card .card-value { font-size: 14pt; font-weight: 700; color: #1e293b; }
+    .card.card-danger .card-value { color: #dc2626; }
+    .section { margin-bottom: 16pt; }
+    .section h2 { font-size: 13pt; color: #1e293b; border-bottom: 1px solid #e2e8f0; padding-bottom: 4pt; margin-bottom: 8pt; }
+    .invoice-block { border: 1px solid #e2e8f0; border-radius: 6pt; margin-bottom: 10pt; overflow: hidden; }
+    .invoice-head { display: flex; justify-content: space-between; align-items: center; padding: 7pt 10pt; background: #f8fafc; }
+    .invoice-head .name { font-weight: 600; font-size: 9.5pt; }
+    .status-badge { display: inline-block; padding: 2pt 9pt; border-radius: 3pt; font-weight: 700; font-size: 8.5pt; }
+    .status-pass { background: #dcfce7; color: #166534; }
+    .status-fail { background: #fef2f2; color: #991b1b; }
+    .finding { padding: 6pt 10pt; border-top: 1px solid #f1f5f9; }
+    .finding .rule { font-size: 8pt; font-weight: 700; color: #dc2626; text-transform: uppercase; letter-spacing: 0.3pt; }
+    .finding .title { font-size: 9pt; font-weight: 600; margin: 2pt 0; }
+    .finding .basis { font-size: 8pt; color: #64748b; }
+    .cta-box { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8pt; padding: 16pt; margin-top: 20pt; text-align: center; }
+    .cta-box .cta-title { font-size: 12pt; font-weight: 700; color: #1e3a8a; margin-bottom: 6pt; }
+    .cta-box .cta-body { font-size: 9pt; color: #1e40af; margin-bottom: 10pt; }
+    .cta-box .cta-link { display: inline-block; background: #2563eb; color: #fff; padding: 8pt 20pt; border-radius: 5pt; font-weight: 700; font-size: 10pt; text-decoration: none; }
+    .footer { margin-top: 24pt; padding-top: 8pt; border-top: 1px solid #e2e8f0; font-size: 8pt; color: #94a3b8; text-align: center; }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <div style="display:flex; align-items:center; gap:10pt; margin-bottom:4pt;">
+    <span style="font-size:20pt; font-weight:900; color:#2563eb; letter-spacing:-1pt;">Tribultz</span>
+    <span style="font-size:9pt; color:#94a3b8; border-left:1px solid #cbd5e1; padding-left:10pt;">Plataforma de Conformidade Fiscal</span>
+  </div>
+  <h1>Diagnóstico Gratuito CBS/IBS</h1>
+  <div class="subtitle">Reforma Tributária Brasileira · LC 214/2025 + LC 227/2026</div>
+</div>
+
+<div class="meta-grid">
+  <div class="meta-item">
+    <div class="label">Escritório / Empresa</div>
+    <div class="value">{{ office_name }}</div>
+  </div>
+  <div class="meta-item">
+    <div class="label">Gerado em</div>
+    <div class="value">{{ generated_at }}</div>
+  </div>
+</div>
+
+<div class="alert-box">
+  <div class="alert-title">As penalidades CBS/IBS entram em vigor em agosto de 2026</div>
+  <div class="alert-body">
+    As notas com pendência abaixo, se emitidas hoje, seriam rejeitadas pela SEFAZ. Depois de
+    agosto/2026, o mesmo erro pode gerar penalidade — corrigir agora evita retrabalho e risco fiscal.
+  </div>
+</div>
+
+<div class="summary-cards">
+  <div class="card">
+    <div class="card-label">Notas analisadas</div>
+    <div class="card-value">{{ total }}</div>
+  </div>
+  <div class="card card-danger">
+    <div class="card-label">Seriam rejeitadas</div>
+    <div class="card-value">{{ rejected }}</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Em conformidade</div>
+    <div class="card-value">{{ total - rejected }}</div>
+  </div>
+</div>
+
+<div class="section">
+  <h2>Detalhamento por nota</h2>
+  {% for inv in invoices %}
+  <div class="invoice-block">
+    <div class="invoice-head">
+      <span class="name">{{ inv.label }}</span>
+      <span class="status-badge {% if inv.status == 'PASS' %}status-pass{% else %}status-fail{% endif %}">
+        {{ 'CONFORME' if inv.status == 'PASS' else 'SERIA REJEITADA' }}
+      </span>
+    </div>
+    {% for f in inv.fatal_findings %}
+    <div class="finding">
+      <div class="rule">{{ f.rule_id }}</div>
+      <div class="title">{{ f.title }}</div>
+      <div class="basis">{{ f.recommendation }}</div>
+    </div>
+    {% endfor %}
+    {% if not inv.fatal_findings %}
+    <div class="finding" style="color:#166534;">Nenhum erro crítico identificado.</div>
+    {% endif %}
+  </div>
+  {% endfor %}
+</div>
+
+<div class="cta-box">
+  <div class="cta-title">Quer corrigir isso antes de emitir a próxima nota?</div>
+  <div class="cta-body">
+    Comece um trial gratuito e valide automaticamente todas as notas do seu escritório
+    contra as 35+ regras determinísticas da reforma tributária.
+  </div>
+  <a class="cta-link" href="{{ trial_url }}">Começar trial gratuito →</a>
+</div>
+
+<div class="footer">
+  Diagnóstico gerado automaticamente pela plataforma Tribultz — tribultz.com.br<br>
+  LC 214/2025 + LC 227/2026 · NT 2025.002-RTC + NT 2026.002
+</div>
+
+</body>
+</html>

--- a/backend/tests/test_prospect_diagnostic.py
+++ b/backend/tests/test_prospect_diagnostic.py
@@ -1,0 +1,299 @@
+"""Prospect Diagnostic (Escopo A, plano de aquisição comercial, 2026-07-28).
+
+- Gate: endpoints são superadmin-only (sem token → 401/403, nunca 404/200).
+- Integração (Postgres, como o CI): upload de XMLs, geração de PDF, listagem.
+- Atribuição no /register: captura não-bloqueante de ?diag= (mesmo padrão do
+  Partner/RFC-0025, testado diretamente contra o helper — sem HTTP, mesmo
+  padrão usado para o resto da suíte de auth).
+"""
+
+import os
+import uuid
+from typing import cast
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_password_hash
+from app.database import get_db
+from app.main import app
+from app.models.auth import Tenant, User
+from app.models.prospect_diagnostic import ProspectDiagnostic
+
+anon_client = TestClient(app)
+
+# ── Gate (sem DB) ─────────────────────────────────────────────────────────────
+
+PROSPECT_READ = ["/api/v1/admin/prospect-diagnostics"]
+
+
+def test_prospect_diagnostic_endpoints_registrados():
+    for path in PROSPECT_READ:
+        assert anon_client.get(path).status_code != 404, f"{path} não registrado"
+
+
+def test_prospect_diagnostic_leitura_exige_superadmin():
+    for path in PROSPECT_READ:
+        assert anon_client.get(path).status_code in (401, 403)
+
+
+def test_prospect_diagnostic_criacao_exige_superadmin():
+    resp = anon_client.post(
+        "/api/v1/admin/prospect-diagnostics",
+        data={"office_name": "X"},
+        files=[("files", ("nota.xml", b"<a/>", "application/xml"))],
+    )
+    assert resp.status_code in (401, 403)
+
+
+# ── Integração DB (Postgres, igual ao CI) ─────────────────────────────────────
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+
+
+def _pg_available() -> bool:
+    try:
+        eng = create_engine(DATABASE_URL)
+        with eng.connect():
+            return True
+    except Exception:
+        return False
+
+
+pytestmark_db = pytest.mark.skipif(not _pg_available(), reason="Postgres indisponível (roda no CI)")
+
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(name="superadmin")
+def superadmin_fixture(session):
+    from app.api.deps import get_current_user
+
+    tenant = Tenant(name="Admin Tenant", slug=f"admin-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+    admin = User(
+        tenant_id=tenant.id,
+        email=f"admin-{uuid.uuid4().hex[:8]}@tribultz.com.br",
+        full_name="Super Admin",
+        password_hash=get_password_hash("x"),
+        role="superadmin",
+        email_verified=True,
+    )
+    session.add(admin)
+    session.flush()
+
+    def override():
+        return admin
+
+    app.dependency_overrides[get_current_user] = override
+    yield admin
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+VALID_NFE_XML = """<?xml version="1.0"?>
+<nfeProc>
+  <NFe>
+    <infNFe>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod>
+          <NCM>84713012</NCM>
+          <CEST>2106300</CEST>
+          <CFOP>5102</CFOP>
+        </prod>
+        <imposto>
+          <IBSCBS>
+            <CST>000</CST>
+            <cClassTrib>100001</cClassTrib>
+            <gIBSCBS>
+              <vBC>1000.00</vBC>
+              <pCBS>0.0010</pCBS>
+              <vCBS>1.00</vCBS>
+              <pIBSUF>0.0050</pIBSUF>
+              <vIBSUF>5.00</vIBSUF>
+              <pIBSMun>0.0040</pIBSMun>
+              <vIBSMun>4.00</vIBSMun>
+              <vIBS>9.00</vIBS>
+            </gIBSCBS>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total>
+        <IBSCBSTot>
+          <vCBS>1.00</vCBS>
+          <vIBS>9.00</vIBS>
+        </IBSCBSTot>
+      </total>
+    </infNFe>
+  </NFe>
+</nfeProc>
+"""
+
+INVALID_NFE_XML_MISSING_CST = """<?xml version="1.0"?>
+<nfeProc>
+  <NFe>
+    <infNFe>
+      <emit><CNPJ>12345678000195</CNPJ></emit>
+      <det nItem="1">
+        <prod><NCM>84713012</NCM><CEST>2106300</CEST></prod>
+        <imposto>
+          <IBSCBS>
+            <CST>999</CST>
+            <cClassTrib>100001</cClassTrib>
+          </IBSCBS>
+        </imposto>
+      </det>
+      <total></total>
+    </infNFe>
+  </NFe>
+</nfeProc>
+"""
+
+
+@pytestmark_db
+def test_gera_diagnostico_com_xmls_mistos(client, superadmin):
+    resp = client.post(
+        "/api/v1/admin/prospect-diagnostics",
+        data={"office_name": "Contabilidade Teste Ltda"},
+        files=[
+            ("files", ("nota_ok.xml", VALID_NFE_XML.encode("utf-8"), "application/xml")),
+            ("files", ("nota_erro.xml", INVALID_NFE_XML_MISSING_CST.encode("utf-8"), "application/xml")),
+        ],
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["office_name"] == "Contabilidade Teste Ltda"
+    assert body["invoice_count"] == 2
+    assert body["rejected_count"] == 1
+    assert body["download_url"]
+    assert body["id"] in body["trial_url"]
+    statuses = {inv["label"]: inv["status"] for inv in body["invoices"]}
+    assert statuses["nota_ok.xml"] == "PASS"
+    assert statuses["nota_erro.xml"] == "FAIL"
+
+
+@pytestmark_db
+def test_diagnostico_persistido_e_listado(client, superadmin, session):
+    resp = client.post(
+        "/api/v1/admin/prospect-diagnostics",
+        data={"office_name": "Escritório Listagem"},
+        files=[("files", ("nota.xml", VALID_NFE_XML.encode("utf-8"), "application/xml"))],
+    )
+    assert resp.status_code == 200
+    diag_id = resp.json()["id"]
+
+    row = session.get(ProspectDiagnostic, uuid.UUID(diag_id))
+    assert row is not None
+    assert row.storage_key is not None
+    assert row.created_by_user_id == superadmin.id
+
+    listed = client.get("/api/v1/admin/prospect-diagnostics")
+    assert listed.status_code == 200
+    ids = [item["id"] for item in listed.json()["items"]]
+    assert diag_id in ids
+
+
+@pytestmark_db
+def test_rejeita_sem_arquivos_ou_sem_nome(client, superadmin):
+    r1 = client.post("/api/v1/admin/prospect-diagnostics", data={"office_name": "   "}, files=[("files", ("a.xml", b"<a/>", "application/xml"))])
+    assert r1.status_code == 400, r1.text
+    r2 = client.post("/api/v1/admin/prospect-diagnostics", data={"office_name": "X"}, files=[])
+    assert r2.status_code in (400, 422)
+
+
+# ── Atribuição no /register (?diag=) ─────────────────────────────────────────
+
+@pytestmark_db
+def test_attach_prospect_diagnostic_vincula_tenant(session):
+    from app.routers.auth import _attach_prospect_diagnostic
+
+    tenant_admin = Tenant(name="Admin", slug=f"admin-{uuid.uuid4().hex[:8]}")
+    session.add(tenant_admin)
+    session.flush()
+    admin_user = User(
+        tenant_id=tenant_admin.id, email=f"a-{uuid.uuid4().hex[:8]}@x.com",
+        full_name="A", password_hash=get_password_hash("x"), role="superadmin", email_verified=True,
+    )
+    session.add(admin_user)
+    session.flush()
+
+    diagnostic = ProspectDiagnostic(office_name="Prospect X", created_by_user_id=admin_user.id)
+    session.add(diagnostic)
+    session.flush()
+
+    tenant = Tenant(name="Empresa Nova", slug=f"nova-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+
+    _attach_prospect_diagnostic(session, tenant, str(diagnostic.id))
+    assert cast(uuid.UUID, tenant.prospect_diagnostic_id) == diagnostic.id
+
+
+@pytestmark_db
+def test_attach_prospect_diagnostic_ignora_id_invalido_sem_bloquear(session):
+    from app.routers.auth import _attach_prospect_diagnostic
+
+    tenant = Tenant(name="Empresa Sem Diag", slug=f"semdiag-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+
+    _attach_prospect_diagnostic(session, tenant, "não-é-um-uuid")
+    assert tenant.prospect_diagnostic_id is None
+
+    _attach_prospect_diagnostic(session, tenant, str(uuid.uuid4()))  # inexistente
+    assert tenant.prospect_diagnostic_id is None
+
+
+@pytestmark_db
+def test_attach_prospect_diagnostic_e_permanente(session):
+    from app.routers.auth import _attach_prospect_diagnostic
+
+    tenant_admin = Tenant(name="Admin2", slug=f"admin2-{uuid.uuid4().hex[:8]}")
+    session.add(tenant_admin)
+    session.flush()
+    admin_user = User(
+        tenant_id=tenant_admin.id, email=f"b-{uuid.uuid4().hex[:8]}@x.com",
+        full_name="B", password_hash=get_password_hash("x"), role="superadmin", email_verified=True,
+    )
+    session.add(admin_user)
+    session.flush()
+
+    diag1 = ProspectDiagnostic(office_name="Primeiro", created_by_user_id=admin_user.id)
+    diag2 = ProspectDiagnostic(office_name="Segundo", created_by_user_id=admin_user.id)
+    session.add_all([diag1, diag2])
+    session.flush()
+
+    tenant = Tenant(name="Empresa Fixa", slug=f"fixa-{uuid.uuid4().hex[:8]}")
+    session.add(tenant)
+    session.flush()
+
+    _attach_prospect_diagnostic(session, tenant, str(diag1.id))
+    assert cast(uuid.UUID, tenant.prospect_diagnostic_id) == diag1.id
+
+    _attach_prospect_diagnostic(session, tenant, str(diag2.id))
+    assert cast(uuid.UUID, tenant.prospect_diagnostic_id) == diag1.id  # não sobrescreve

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -11,6 +11,7 @@ const NAV = [
   { href: "/admin/tenants", label: "Tenants" },
   { href: "/admin/partners", label: "Parceiros" },
   { href: "/admin/founding-partners", label: "Founding Partners" },
+  { href: "/admin/prospeccao", label: "Prospecção" },
   { href: "/admin/users", label: "Usuários" },
   { href: "/admin/usage", label: "Uso & Operações" },
   { href: "/admin/system", label: "Saúde do sistema" },

--- a/frontend/src/app/admin/prospeccao/page.tsx
+++ b/frontend/src/app/admin/prospeccao/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useAdminData, adminUpload } from "@/lib/useAdminData";
+
+type InvoiceResult = {
+  label: string;
+  status: "PASS" | "FAIL";
+  fatal_count: number;
+};
+
+type DiagnosticResponse = {
+  id: string;
+  office_name: string;
+  invoice_count: number;
+  rejected_count: number;
+  download_url: string;
+  trial_url: string;
+  invoices: InvoiceResult[];
+};
+
+type DiagnosticListItem = {
+  id: string;
+  office_name: string;
+  invoice_count: number;
+  rejected_count: number;
+  created_at: string;
+};
+type ListResp = { total: number; items: DiagnosticListItem[] };
+
+export default function AdminProspeccaoPage() {
+  const { data, reload } = useAdminData<ListResp>("/api/v1/admin/prospect-diagnostics?limit=50");
+  const [officeName, setOfficeName] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DiagnosticResponse | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!officeName.trim() || files.length === 0) {
+      setError("Informe o nome do escritório e ao menos um XML.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const form = new FormData();
+      form.append("office_name", officeName.trim());
+      files.forEach((f) => form.append("files", f));
+      const resp = await adminUpload<DiagnosticResponse>("/api/v1/admin/prospect-diagnostics", form);
+      setResult(resp);
+      setOfficeName("");
+      setFiles([]);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Falha ao gerar diagnóstico.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function copyTrialUrl(url: string) {
+    navigator.clipboard.writeText(url).catch(() => {});
+  }
+
+  const inputCls = "w-full rounded-lg border border-slate-200 px-3 py-2 text-sm";
+
+  return (
+    <div>
+      <h1 className="mb-1 text-2xl font-bold text-slate-900">Prospecção — Diagnóstico Gratuito</h1>
+      <p className="mb-5 text-sm text-slate-500">
+        Sobe de 10 a 20 XMLs de um escritório contábil prospect e gera um PDF auditável com o
+        que seria rejeitado hoje, a base legal e um link de trial atribuído — sem que o prospect
+        precise ter conta.
+      </p>
+
+      <form onSubmit={submit} className="mb-8 grid grid-cols-1 gap-3 rounded-xl border border-slate-200 p-4">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">Nome do escritório *</label>
+          <input
+            className={inputCls}
+            value={officeName}
+            required
+            placeholder="Contabilidade Exemplo Ltda."
+            onChange={(e) => setOfficeName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-500">
+            XMLs (10 a 20 notas) *
+          </label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".xml"
+            multiple
+            className={inputCls}
+            onChange={(e) => setFiles(Array.from(e.target.files ?? []))}
+          />
+          {files.length > 0 && (
+            <p className="mt-1 text-xs text-slate-500">{files.length} arquivo(s) selecionado(s).</p>
+          )}
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <div>
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-lg bg-[#2956E3] px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {busy ? "Gerando diagnóstico…" : "Gerar diagnóstico"}
+          </button>
+        </div>
+      </form>
+
+      {result && (
+        <div className="mb-8 rounded-xl border border-green-200 bg-green-50 p-4">
+          <h2 className="mb-2 text-sm font-semibold text-green-800">
+            Diagnóstico gerado para {result.office_name}
+          </h2>
+          <p className="mb-3 text-sm text-green-700">
+            {result.rejected_count} de {result.invoice_count} nota(s) seriam rejeitadas hoje.
+          </p>
+          <div className="mb-3 flex flex-wrap gap-2">
+            <a
+              href={result.download_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg bg-[#2956E3] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
+            >
+              Baixar PDF
+            </a>
+            <button
+              type="button"
+              onClick={() => copyTrialUrl(result.trial_url)}
+              className="rounded-lg border border-green-300 bg-white px-3 py-1.5 text-xs font-medium text-green-700 hover:bg-green-100"
+            >
+              Copiar link de trial atribuído
+            </button>
+          </div>
+          <div className="overflow-x-auto rounded-lg border border-green-200 bg-white">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="bg-slate-50 text-left uppercase tracking-wide text-slate-400">
+                  <th className="px-3 py-2">Arquivo</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Erros críticos</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.invoices.map((inv, i) => (
+                  <tr key={i} className="border-t border-slate-100">
+                    <td className="px-3 py-2 font-mono">{inv.label}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                          inv.status === "PASS" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
+                        }`}
+                      >
+                        {inv.status === "PASS" ? "Conforme" : "Seria rejeitada"}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">{inv.fatal_count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <h2 className="mb-3 text-sm font-semibold text-slate-700">Diagnósticos anteriores</h2>
+      {data && (
+        <div className="overflow-x-auto rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Escritório</th>
+                <th className="px-4 py-3">Notas</th>
+                <th className="px-4 py-3">Rejeitadas</th>
+                <th className="px-4 py-3">Gerado em</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {data.items.map((d) => (
+                <tr key={d.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 font-medium text-slate-900">{d.office_name}</td>
+                  <td className="px-4 py-3">{d.invoice_count}</td>
+                  <td className="px-4 py-3">{d.rejected_count}</td>
+                  <td className="px-4 py-3 text-slate-500">
+                    {new Date(d.created_at).toLocaleDateString("pt-BR")}
+                  </td>
+                </tr>
+              ))}
+              {data.items.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-8 text-center text-slate-400">
+                    Nenhum diagnóstico gerado ainda.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -87,17 +87,22 @@ export default function RegisterPage() {
   const [captchaToken, setCaptchaToken] = useState("");
   // Proveniência comercial (RFC-0025): captura o código do link ?partner=/?ref=.
   const [partnerCode, setPartnerCode] = useState("");
+  // Atribuição de diagnóstico gratuito (Escopo A): captura o id do link ?diag=
+  // no PDF. Independente do Partner acima — não é o mesmo conceito.
+  const [diagId, setDiagId] = useState("");
   const turnstileRef = useRef<TurnstileInstance>(null);
   const captchaConfigured = Boolean(TURNSTILE_SITE_KEY?.trim());
 
   const isPaidPlan = planSlug !== "trial";
 
   useEffect(() => {
-    // Lê ?partner=/?ref= no carregamento (client-only, seguro no build).
+    // Lê ?partner=/?ref= e ?diag= no carregamento (client-only, seguro no build).
     if (typeof window === "undefined") return;
     const params = new URLSearchParams(window.location.search);
     const code = params.get("partner") ?? params.get("ref");
     if (code) setPartnerCode(code.trim().toUpperCase());
+    const diag = params.get("diag");
+    if (diag) setDiagId(diag.trim());
   }, []);
 
   function validateStep1(): boolean {
@@ -168,6 +173,7 @@ export default function RegisterPage() {
         tenant_slug: "",
         captcha_token: captchaToken,
         partner_code: partnerCode || undefined,
+        diag_id: diagId || undefined,
       });
 
       track("sign_up", { method: accountType, plan: planSlug });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -89,6 +89,8 @@ type RegisterRequest = {
   captcha_token?: string;
   // Proveniência comercial (RFC-0025): código do Partner do link ?partner=/?ref=.
   partner_code?: string;
+  // Atribuição de diagnóstico gratuito (Escopo A): id do link ?diag= no PDF.
+  diag_id?: string;
 };
 
 type RegisterResponse = {


### PR DESCRIPTION
## Summary
Escopo A do plano de aquisição comercial (2026-07-28): o go-live de billing está tecnicamente concluído, mas o gargalo agora é comercial (zero trials). A estratégia é abordagem direta a escritórios contábeis com diagnóstico gratuito de um lote real de notas do prospect.

- **A.1**: fluxo interno (`/admin/prospeccao`, superadmin-only) — sobe 10-20 XMLs de um prospect sem precisar criar conta para ele, valida com o motor determinístico já existente (`validate_xml()`, mesmo usado em `/validate/cbs-ibs`), gera PDF auditável.
- **A.2**: o PDF traz nome do escritório no cabeçalho, notas que seriam rejeitadas, o CST × cClassTrib incorreto de cada uma (reaproveita o `Finding.recommendation` já produzido pelo engine — sem lógica nova por regra), a base legal do erro (já embutida no `recommendation`, ex.: "SEFAZ: Rejeição 1024 (regra UB14-20)") e a data da penalidade (agosto/2026).
- **A.3**: botão no fim do PDF leva a `/register?diag=<id>` — link de trial atribuído.
- Atribuição: `Tenant.prospect_diagnostic_id`, captura não-bloqueante e permanente no `/register`, mesmo padrão do Partner (RFC-0025) mas um conceito independente — não é o rastreio geral de canal/UTM do Escopo B (ainda não construído, conforme investigado).

## Test plan
- [x] `pytest tests/ -q` — 803 passed
- [x] `ruff check app/ tests/` — clean
- [x] `npx pyright@1.1.411` — 0 errors
- [x] `npm test --silent` (frontend) — 193 passed
- [x] `npm run build` (frontend) — clean, `/admin/prospeccao` gerada
- [x] Migration aplicada localmente sem conflito (chain linear até `2026_07_28_0033`)