### PR TITLE
feat(prospecting): schema da Fase 1 — pipeline de prospecção CNPJ (PO-2026-07-SALES-001)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -7,7 +7,11 @@ from alembic import context
 
 from app.database import Base
 from app.config import settings
-from app.models import api_key, auth, billing, documents, feedback, founding_partner, jobs, news, partner, prospect_diagnostic, reports  # noqa: F401
+from app.models import (  # noqa: F401
+    api_key, auth, billing, documents, feedback, founding_partner, jobs, news,
+    partner, prospect_diagnostic, prospect_org, prospect_scoring_run,
+    prospect_suppression, reports,
+)
 
 # Import models to register them with metadata
 

--- a/backend/app/alembic/versions/2026_07_28_0034_add_prospecting_pipeline.py
+++ b/backend/app/alembic/versions/2026_07_28_0034_add_prospecting_pipeline.py
@@ -1,0 +1,119 @@
+"""add_prospecting_pipeline — schema da Fase 1 do pipeline de prospecção comercial
+direta (PO-2026-07-SALES-001)
+
+Três tabelas: prospect_orgs (registro consolidado por CNPJ básico), prospect_suppressions
+(lista de supressão permanente) e prospect_scoring_runs (histórico append-only de
+execuções, com versão/checksum de rubrica — suporta reprocessamento futuro sem migration
+nova). Ferramenta interna (tools/prospecting/), sem superfície de API nesta fase.
+
+Revision ID: 2026_07_28_0034
+Revises: 2026_07_28_0033
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_28_0034"
+down_revision = "2026_07_28_0033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prospect_orgs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("cnpj_basico", sa.String(length=8), nullable=False),
+        sa.Column("porte", sa.String(length=2), nullable=False),
+        sa.Column("opcao_mei", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("opcao_simples", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("capital_social", sa.Numeric(18, 2), nullable=False, server_default="0"),
+        sa.Column("situacao_cadastral", sa.String(length=2), nullable=False),
+        sa.Column("data_inicio_atividade", sa.Date(), nullable=True),
+        sa.Column("qtd_socios", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("qtd_estabelecimentos", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("uf", sa.String(length=2), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("email_domain", sa.String(length=255), nullable=True),
+        sa.Column("email_domain_category", sa.String(length=20), nullable=True),
+        sa.Column("cnpj_matriz", sa.String(length=14), nullable=False),
+        sa.Column("razao_social", sa.String(length=200), nullable=False),
+        sa.Column("nome_fantasia", sa.String(length=200), nullable=True),
+        sa.Column("municipio_codigo", sa.String(length=7), nullable=True),
+        sa.Column("municipio_nome", sa.String(length=120), nullable=True),
+        sa.Column("logradouro", sa.String(length=200), nullable=True),
+        sa.Column("numero", sa.String(length=20), nullable=True),
+        sa.Column("complemento", sa.String(length=200), nullable=True),
+        sa.Column("bairro", sa.String(length=100), nullable=True),
+        sa.Column("cep", sa.String(length=8), nullable=True),
+        sa.Column("ddd_telefone1", sa.String(length=4), nullable=True),
+        sa.Column("telefone1", sa.String(length=20), nullable=True),
+        sa.Column("cnae_principal", sa.String(length=7), nullable=False),
+        sa.Column("cnaes_secundarios", postgresql.JSONB(), nullable=False, server_default="[]"),
+        sa.Column("data_situacao_cadastral", sa.Date(), nullable=True),
+        sa.Column("dedup_status", sa.String(length=16), nullable=False, server_default="unique"),
+        sa.Column("merged_into_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("pre_score", sa.Integer(), nullable=True),
+        sa.Column("pre_score_tier", sa.String(length=1), nullable=True),
+        sa.Column("pre_score_rubric_version", sa.String(length=32), nullable=True),
+        sa.Column("pre_scored_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_dump_reference", sa.String(length=32), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_unique_constraint("uq_prospect_orgs_cnpj_basico", "prospect_orgs", ["cnpj_basico"])
+    op.create_foreign_key(
+        "fk_prospect_orgs_merged_into_id", "prospect_orgs", "prospect_orgs",
+        ["merged_into_id"], ["id"], ondelete="SET NULL",
+    )
+    op.create_index("ix_prospect_orgs_email_domain", "prospect_orgs", ["email_domain"])
+    op.create_index("ix_prospect_orgs_uf", "prospect_orgs", ["uf"])
+    op.create_index("ix_prospect_orgs_pre_score", "prospect_orgs", ["pre_score"])
+    op.create_index("ix_prospect_orgs_dedup_status", "prospect_orgs", ["dedup_status"])
+
+    op.create_table(
+        "prospect_suppressions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("cnpj_basico", sa.String(length=8), nullable=True),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("email_domain", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "cnpj_basico IS NOT NULL OR email IS NOT NULL OR email_domain IS NOT NULL",
+            name="ck_prospect_suppressions_has_key",
+        ),
+    )
+    op.create_index("ix_prospect_suppressions_cnpj_basico", "prospect_suppressions", ["cnpj_basico"])
+    op.create_index("ix_prospect_suppressions_email_domain", "prospect_suppressions", ["email_domain"])
+    op.create_index("ix_prospect_suppressions_email", "prospect_suppressions", ["email"])
+
+    op.create_table(
+        "prospect_scoring_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("rubric_version", sa.String(length=32), nullable=False),
+        sa.Column("rubric_checksum", sa.String(length=64), nullable=False),
+        sa.Column("source_dump_reference", sa.String(length=32), nullable=False),
+        sa.Column("params", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("candidate_count", sa.Integer(), nullable=False),
+        sa.Column("selected_count", sa.Integer(), nullable=False),
+        sa.Column("output_uri", sa.String(length=500), nullable=False),
+        sa.Column("output_checksum", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="completed"),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("run_started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("run_finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_prospect_scoring_runs_rubric_version", "prospect_scoring_runs", ["rubric_version"])
+    op.create_index("ix_prospect_scoring_runs_created_at", "prospect_scoring_runs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("prospect_scoring_runs")
+    op.drop_table("prospect_suppressions")
+    op.drop_constraint("fk_prospect_orgs_merged_into_id", "prospect_orgs", type_="foreignkey")
+    op.drop_table("prospect_orgs")

--- a/backend/app/models/prospect_org.py
+++ b/backend/app/models/prospect_org.py
@@ -1,0 +1,89 @@
+"""ProspectOrg — registro consolidado de escritório contábil para prospecção comercial
+direta (PO-2026-07-SALES-001, Fase 1).
+
+Um registro por CNPJ básico (matriz + filiais consolidadas). Origem: Dados Abertos do
+CNPJ (Receita Federal). Não é tenant da Tribultz — é um alvo de prospecção, ainda sem
+conta. Campos de endereço/contato/CNAE são carregados aqui mesmo sem uso pelo pré-score
+da Fase 1, deliberadamente, para que a Fase 2 (agente de enriquecimento externo) não
+precise de migration nova.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class ProspectOrg(Base):
+    __tablename__ = "prospect_orgs"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+
+    # ── Identidade / fatos da RF usados diretamente pelo pré-score ──
+    cnpj_basico = Column(String(8), nullable=False, unique=True)
+    porte = Column(String(2), nullable=False)
+    # RF usa S/N/branco ("outros"); "branco" é colapsado em False — só o eixo
+    # MEI/não-MEI importa para o pré-score da Fase 1 (ver scoring.py).
+    opcao_mei = Column(Boolean, nullable=False, default=False)
+    opcao_simples = Column(Boolean, nullable=False, default=False)
+    capital_social = Column(Numeric(18, 2), nullable=False, default=0)
+    situacao_cadastral = Column(String(2), nullable=False)
+    data_inicio_atividade = Column(Date, nullable=True)
+    qtd_socios = Column(Integer, nullable=False, default=0)
+    qtd_estabelecimentos = Column(Integer, nullable=False, default=1)
+    uf = Column(String(2), nullable=False)
+    email = Column(String(255), nullable=True)
+    email_domain = Column(String(255), nullable=True)
+    email_domain_category = Column(String(20), nullable=True)  # ausente|gratuito|dominio_generico|dominio_nominal
+
+    # ── Fatos da RF carregados só para não bloquear a Fase 2 (enriquecimento) ──
+    cnpj_matriz = Column(String(14), nullable=False)
+    razao_social = Column(String(200), nullable=False)
+    nome_fantasia = Column(String(200), nullable=True)
+    municipio_codigo = Column(String(7), nullable=True)
+    municipio_nome = Column(String(120), nullable=True)
+    logradouro = Column(String(200), nullable=True)
+    numero = Column(String(20), nullable=True)
+    complemento = Column(String(200), nullable=True)
+    bairro = Column(String(100), nullable=True)
+    cep = Column(String(8), nullable=True)
+    ddd_telefone1 = Column(String(4), nullable=True)
+    telefone1 = Column(String(20), nullable=True)
+    cnae_principal = Column(String(7), nullable=False)
+    cnaes_secundarios = Column(JSONB, nullable=False, server_default="[]")
+    data_situacao_cadastral = Column(Date, nullable=True)
+
+    # ── Controle do pipeline ──
+    dedup_status = Column(String(16), nullable=False, default="unique")  # unique|primary|merged
+    merged_into_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("prospect_orgs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    pre_score = Column(Integer, nullable=True)
+    pre_score_tier = Column(String(1), nullable=True)
+    pre_score_rubric_version = Column(String(32), nullable=True)
+    pre_scored_at = Column(DateTime(timezone=True), nullable=True)
+    source_dump_reference = Column(String(32), nullable=False)  # ex.: "2026-07"
+
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/models/prospect_scoring_run.py
+++ b/backend/app/models/prospect_scoring_run.py
@@ -1,0 +1,38 @@
+"""ProspectScoringRun — histórico append-only de execuções do pipeline de prospecção
+comercial direta (PO-2026-07-SALES-001, Fase 1).
+
+Cada execução real de score_and_select.py insere uma linha aqui (nunca sobrescreve) —
+é o que permite, em fase futura, reprocessar uma lista antiga com outra versão de
+rubrica e comparar estatisticamente os resultados sem qualquer migration nova.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class ProspectScoringRun(Base):
+    __tablename__ = "prospect_scoring_runs"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    rubric_version = Column(String(32), nullable=False)
+    rubric_checksum = Column(String(64), nullable=False)  # sha256 do YAML, detecta edição
+    source_dump_reference = Column(String(32), nullable=False)
+    params = Column(JSONB, nullable=False, server_default="{}")  # snapshot dos args da CLI
+    candidate_count = Column(Integer, nullable=False)  # pós consolidação+dedup+supressão
+    selected_count = Column(Integer, nullable=False)  # tamanho do Top-N realmente escrito
+    output_uri = Column(String(500), nullable=False)
+    output_checksum = Column(String(64), nullable=True)
+    status = Column(String(16), nullable=False, server_default="completed")  # running|completed|failed
+    error_message = Column(Text, nullable=True)
+    run_started_at = Column(DateTime(timezone=True), nullable=False)
+    run_finished_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/prospect_suppression.py
+++ b/backend/app/models/prospect_suppression.py
@@ -1,0 +1,48 @@
+"""ProspectSuppression — lista de supressão da prospecção comercial direta
+(PO-2026-07-SALES-001, Fase 1).
+
+Registros com status opt_out ou cliente jamais podem reaparecer em uma lista gerada —
+regra dura, aplicada incondicionalmente em suppression.py, sem flag de CLI para
+desativar. Casamento por cnpj_basico OU email_domain (não exige as duas colunas).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import CheckConstraint, Column, DateTime, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+# Status suportados (PO-2026-07-SALES-001). opt_out/cliente = exclusão dura e
+# incondicional; lead_ativo/desqualificado = exclusão por padrão mas configurável
+# via --suppress-statuses; hard_bounce = não exclui por padrão (ver suppression.py).
+SUPPRESSION_STATUSES: tuple[str, ...] = (
+    "opt_out",
+    "cliente",
+    "lead_ativo",
+    "desqualificado",
+    "hard_bounce",
+)
+
+
+class ProspectSuppression(Base):
+    __tablename__ = "prospect_suppressions"
+    __table_args__ = (
+        CheckConstraint(
+            "cnpj_basico IS NOT NULL OR email IS NOT NULL OR email_domain IS NOT NULL",
+            name="ck_prospect_suppressions_has_key",
+        ),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    cnpj_basico = Column(String(8), nullable=True)
+    email = Column(String(255), nullable=True)
+    email_domain = Column(String(255), nullable=True)
+    status = Column(String(20), nullable=False)
+    reason = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ gunicorn==23.0.0
 sentry-sdk[fastapi]==2.66.0
 weasyprint==63.1
 jinja2==3.1.6
+PyYAML==6.0.3
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
 testcontainers[postgres]>=4.8.2


### PR DESCRIPTION
## Summary
Fatia 1 de 5 do plano aprovado para a Fase 1 da PO-2026-07-SALES-001 (classificação e priorização de escritórios contábeis para prospecção comercial). Só schema — sem lógica de negócio ainda (parser, dedup, scoring vêm nas próximas fatias).

- `prospect_orgs` — um registro por CNPJ básico (matriz+filiais consolidadas). Campos de endereço/CNAE carregados mesmo sem uso pelo pré-score, para não bloquear a Fase 2 (enriquecimento externo).
- `prospect_suppressions` — lista de supressão permanente (`opt_out`/`cliente` nunca reaparecem).
- `prospect_scoring_runs` — histórico append-only de execuções, com `rubric_version`/`rubric_checksum`, suportando reprocessamento futuro sem migration nova.

## Test plan
- [x] `pytest tests/ -q` — 803 passed (nenhum teste novo nesta fatia, só confirma que a migration não quebra nada)
- [x] `ruff check app/ tests/` — clean
- [x] `npx pyright@1.1.411` — 0 errors
- [x] Migration aplica limpo (roda automaticamente via `backend/conftest.py` em todo run de teste)