### PR TITLE
feat(prospecting): rubrica + pré-score + classificador de e-mail (Fase 1, fatia 2/5)

### DIFF
--- a/backend/app/data/prospecting/rubrics/rubric_v1.yaml
+++ b/backend/app/data/prospecting/rubrics/rubric_v1.yaml
@@ -1,0 +1,81 @@
+# Rubrica de pré-score — Fase 1 (PO-2026-07-SALES-001)
+#
+# Versão imutável: uma vez publicada, nunca é editada in-place. Uma recalibração
+# gera um arquivo novo (rubric_v2.yaml, ...) para que reprocessar uma lista antiga
+# com outra rubrica e comparar estatisticamente os resultados (Fase 4, futura)
+# permaneça possível. Cada execução real de score_and_select.py grava a versão +
+# o checksum sha256 deste arquivo em prospect_scoring_runs.
+#
+# Fórmula de agregação (não especificada pela PO — decisão documentada aqui):
+#   score = clamp(base_score + soma dos pesos de cada dimensão, 0, 100)
+# MEI e e-mail ausente usam peso -100 propositalmente: devem dominar qualquer
+# outra pontuação positiva e levar o score para perto de 0, independentemente
+# da calibração das demais dimensões. Além disso, um guard de código (não só de
+# rubrica) força tier <= B quando opcao_mei é verdadeiro — o critério de aceite
+# "nenhum Tier A pode ser MEI" nunca depende só do peso -100 aqui.
+
+version: v1
+description: "Rubrica de pré-score Fase 1 — Plano Contador (PO-2026-07-SALES-001)"
+
+base_score: 50
+
+tiers:
+  A: {min: 80}
+  B: {min: 60}
+  C: {min: 40}
+  D: {min: 0}
+
+scoring:
+  # Quantidade de sócios (Sócios.csv, contagem por cnpj_basico)
+  socios:
+    "1": 2
+    "2": 6
+    "3_or_more": 10
+
+  # Porte (Empresas.csv) mesclado com o indicador MEI (Simples.csv) — quando
+  # opcao_mei é verdadeiro, a chave "mei" é usada em vez do código de porte
+  # (ver scoring.py: MEI não é um dos 4 códigos de porte, é um flag separado).
+  porte:
+    mei: -100
+    "00": 0
+    "01": 3
+    "03": 8
+    "05": 12
+
+  # Capital social (Empresas.csv), em reais
+  capital_social:
+    faixas:
+      - {ate: 5000, peso: 0}
+      - {ate: 50000, peso: 4}
+      - {ate: 200000, peso: 8}
+      - {acima: 200000, peso: 12}
+
+  # Idade da empresa em anos, a partir de data_inicio_atividade (Estabelecimentos.csv)
+  idade_anos:
+    faixas:
+      - {ate: 1, peso: -3}
+      - {ate: 3, peso: 2}
+      - {ate: 10, peso: 6}
+      - {acima: 10, peso: 10}
+
+  # Categoria do domínio de e-mail (ver email_classifier.py)
+  email_domain_category:
+    ausente: -100
+    gratuito: 2
+    dominio_generico: 7
+    dominio_nominal: 12
+
+  # Quantidade de estabelecimentos (matriz + filiais) do CNPJ básico
+  estabelecimentos:
+    "1": 0
+    "2_3": 5
+    "4_plus": 10
+
+  # UF do estabelecimento matriz. "default" cobre qualquer UF não listada
+  # explicitamente — nunca falha por rubrica incompleta.
+  geografia:
+    default: 0
+    RS: 10
+    SC: 7
+    PR: 6
+    SP: 5

--- a/backend/app/services/prospecting/__init__.py
+++ b/backend/app/services/prospecting/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline de prospecção comercial direta — Fase 1 (PO-2026-07-SALES-001).
+
+Lógica pura, sem router/schema: esta fase não tem superfície de API, é
+consumida só pelos scripts standalone em tools/prospecting/.
+"""

--- a/backend/app/services/prospecting/email_classifier.py
+++ b/backend/app/services/prospecting/email_classifier.py
@@ -1,0 +1,81 @@
+"""Classifica o domínio de e-mail de um escritório contábil (PO-2026-07-SALES-001,
+Fase 1). Determinístico, sem chamada externa nem IA — exigência explícita da PO
+para o pré-score.
+
+Categorias: ausente | gratuito | dominio_generico | dominio_nominal.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+FREE_EMAIL_DOMAINS: frozenset[str] = frozenset({
+    "gmail.com", "hotmail.com", "outlook.com", "live.com", "yahoo.com",
+    "yahoo.com.br", "bol.com.br", "uol.com.br", "terra.com.br", "icloud.com",
+    "msn.com", "ig.com.br", "globo.com", "oi.com.br", "r7.com",
+})
+
+# Sufixos legais/genéricos descartados ao tokenizar a razão social/nome fantasia —
+# não ajudam a decidir se um domínio "deriva" do nome da empresa.
+_GENERIC_SUFFIXES: frozenset[str] = frozenset({
+    "ltda", "me", "epp", "eireli", "ss", "sa", "individual", "contabil",
+    "contabilidade", "assessoria", "servicos", "consultoria", "contadores",
+    "escritorio", "associados", "e", "de", "da", "do", "dos", "das",
+})
+
+_KNOWN_TLDS = (
+    ".com.br", ".net.br", ".org.br", ".adv.br", ".eng.br", ".com", ".net", ".org",
+)
+
+_MIN_TOKEN_LEN = 4
+
+
+def _strip_accents(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(c for c in normalized if not unicodedata.combining(c))
+
+
+def _normalize_tokens(text: str | None) -> set[str]:
+    if not text:
+        return set()
+    cleaned = _strip_accents(text).lower()
+    raw_tokens = re.split(r"[^a-z0-9]+", cleaned)
+    return {
+        t for t in raw_tokens
+        if len(t) >= _MIN_TOKEN_LEN and t not in _GENERIC_SUFFIXES
+    }
+
+
+def _strip_known_tld(domain: str) -> str:
+    for tld in _KNOWN_TLDS:
+        if domain.endswith(tld):
+            return domain[: -len(tld)]
+    # TLD desconhecido: cai no primeiro rótulo antes do primeiro ponto.
+    return domain.split(".", 1)[0]
+
+
+def extract_domain(email: str | None) -> str | None:
+    if not email or "@" not in email:
+        return None
+    domain = email.rsplit("@", 1)[-1].strip().lower()
+    return domain or None
+
+
+def classify_domain(
+    email: str | None,
+    razao_social: str | None = None,
+    nome_fantasia: str | None = None,
+) -> str:
+    """Retorna: ausente | gratuito | dominio_generico | dominio_nominal."""
+    domain = extract_domain(email)
+    if domain is None:
+        return "ausente"
+    if domain in FREE_EMAIL_DOMAINS:
+        return "gratuito"
+
+    root = _strip_known_tld(domain)
+    tokens = _normalize_tokens(razao_social) | _normalize_tokens(nome_fantasia)
+    if any(t in root or root in t for t in tokens):
+        return "dominio_nominal"
+    return "dominio_generico"

--- a/backend/app/services/prospecting/rubric_loader.py
+++ b/backend/app/services/prospecting/rubric_loader.py
@@ -1,0 +1,115 @@
+"""Carrega e valida a rubrica YAML de pré-score (PO-2026-07-SALES-001, Fase 1).
+
+Cada versão é um arquivo imutável em backend/app/data/prospecting/rubrics/. Uma
+recalibração cria um arquivo novo — nunca edita um existente — para que uma lista
+antiga possa ser reprocessada com outra rubrica e comparada estatisticamente
+(Fase 4, futura) sem ambiguidade sobre qual versão gerou qual resultado.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+RUBRICS_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "prospecting" / "rubrics"
+
+_REQUIRED_TOP_KEYS = ("version", "base_score", "tiers", "scoring")
+_REQUIRED_SCORING_DIMENSIONS = (
+    "socios",
+    "porte",
+    "capital_social",
+    "idade_anos",
+    "email_domain_category",
+    "estabelecimentos",
+    "geografia",
+)
+
+
+class RubricValidationError(ValueError):
+    """Rubrica malformada — faltando chave obrigatória ou tier."""
+
+
+@dataclass(frozen=True)
+class Rubric:
+    version: str
+    checksum: str
+    path: Path
+    base_score: int
+    tiers: dict[str, dict[str, int]]  # {"A": {"min": 80}, ...}
+    scoring: dict[str, Any]
+
+    def get_weight(self, dimension: str, key: str) -> int:
+        """Peso de uma dimensão discreta (ex.: socios, porte, estabelecimentos).
+
+        Cai em "default" quando a chave não existe explicitamente na rubrica —
+        nunca levanta exceção por cobertura incompleta (ex.: UF não listada).
+        """
+        weights = self.scoring.get(dimension, {})
+        if key in weights:
+            return int(weights[key])
+        if "default" in weights:
+            return int(weights["default"])
+        return 0
+
+    def tier_for_score(self, score: int) -> str:
+        """Maior tier cujo "min" o score atinge. Tiers ordenados do mais alto ao mais baixo."""
+        ordered = sorted(self.tiers.items(), key=lambda kv: kv[1]["min"], reverse=True)
+        for tier_name, cfg in ordered:
+            if score >= cfg["min"]:
+                return tier_name
+        return ordered[-1][0] if ordered else "D"
+
+
+def _resolve_path(version: str | None, path: str | Path | None) -> Path:
+    if path is not None:
+        return Path(path)
+    if not version:
+        raise RubricValidationError("Informe --rubric-version ou --rubric-path.")
+    return RUBRICS_DIR / f"rubric_{version}.yaml"
+
+
+def _validate(data: dict[str, Any], source: Path) -> None:
+    missing_top = [k for k in _REQUIRED_TOP_KEYS if k not in data]
+    if missing_top:
+        raise RubricValidationError(f"{source}: faltando chave(s) obrigatória(s): {missing_top}")
+
+    tiers = data["tiers"]
+    if not tiers or any("min" not in cfg for cfg in tiers.values()):
+        raise RubricValidationError(f"{source}: cada tier precisa de um valor 'min'.")
+
+    scoring = data["scoring"]
+    missing_dims = [d for d in _REQUIRED_SCORING_DIMENSIONS if d not in scoring]
+    if missing_dims:
+        raise RubricValidationError(f"{source}: faltando dimensão(ões) de score: {missing_dims}")
+
+
+def load_rubric(version: str | None = None, path: str | Path | None = None) -> Rubric:
+    """Carrega uma rubrica por versão (resolve o path padrão) ou por path explícito.
+
+    path explícito existe para os testes apontarem para fixtures fora do diretório
+    oficial de rubricas versionadas.
+    """
+    resolved = _resolve_path(version, path)
+    if not resolved.exists():
+        raise RubricValidationError(f"Rubrica não encontrada: {resolved}")
+
+    raw_bytes = resolved.read_bytes()
+    checksum = hashlib.sha256(raw_bytes).hexdigest()
+    data = yaml.safe_load(raw_bytes)
+    if not isinstance(data, dict):
+        raise RubricValidationError(f"{resolved}: YAML inválido (esperado um mapeamento no topo).")
+
+    _validate(data, resolved)
+
+    return Rubric(
+        version=str(data["version"]),
+        checksum=checksum,
+        path=resolved,
+        base_score=int(data["base_score"]),
+        tiers=data["tiers"],
+        scoring=data["scoring"],
+    )

--- a/backend/app/services/prospecting/scoring.py
+++ b/backend/app/services/prospecting/scoring.py
@@ -1,0 +1,155 @@
+"""Pré-score determinístico (PO-2026-07-SALES-001, Fase 1).
+
+Função pura, sem DB e sem chamada externa: compute_score() recebe os fatos já
+consolidados de um escritório e a rubrica carregada, devolve score 0-100, tier e
+uma justificativa legível por humano. A checagem de situação cadastral ativa
+acontece na consolidação (Fase 3 do trabalho) — um registro inativo nunca chega
+a ser pontuado aqui.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from app.services.prospecting.rubric_loader import Rubric
+
+# Ordem de força dos tiers, do mais alto ao mais baixo — usada pelo cap de MEI.
+_TIER_ORDER = ("A", "B", "C", "D")
+
+
+@dataclass(frozen=True)
+class ScoreInput:
+    qtd_socios: int
+    porte: str  # código RF: "00"|"01"|"03"|"05"
+    opcao_mei: bool
+    capital_social: Decimal
+    data_inicio_atividade: date | None
+    email_domain_category: str  # ausente|gratuito|dominio_generico|dominio_nominal
+    qtd_estabelecimentos: int
+    uf: str
+    razao_social: str = ""
+    as_of: date = field(default_factory=date.today)
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    score: int
+    tier: str
+    rubric_version: str
+    breakdown: dict[str, int]
+    justification: str
+
+
+def _socios_key(qtd: int) -> str:
+    if qtd >= 3:
+        return "3_or_more"
+    return str(max(qtd, 1))
+
+
+def _porte_key(porte: str, opcao_mei: bool) -> str:
+    # MEI não é um dos 4 códigos de porte da RF (00/01/03/05) — é um flag
+    # separado (Simples.csv) que a rubrica trata como uma 5ª chave, com
+    # precedência sobre o código de porte declarado.
+    if opcao_mei:
+        return "mei"
+    return porte
+
+
+def _estabelecimentos_key(qtd: int) -> str:
+    if qtd <= 1:
+        return "1"
+    if qtd <= 3:
+        return "2_3"
+    return "4_plus"
+
+
+def _faixa_peso(faixas: list[dict[str, Any]], value: float) -> int:
+    for faixa in faixas:
+        if "ate" in faixa and value <= faixa["ate"]:
+            return int(faixa["peso"])
+        if "acima" in faixa and value > faixa["acima"]:
+            return int(faixa["peso"])
+    return 0
+
+
+def _idade_anos(data_inicio: date | None, as_of: date) -> float:
+    if data_inicio is None:
+        return 0.0
+    dias = (as_of - data_inicio).days
+    return max(dias, 0) / 365.25
+
+
+def compute_score(inp: ScoreInput, rubric: Rubric) -> ScoreResult:
+    breakdown: dict[str, int] = {}
+
+    breakdown["socios"] = rubric.get_weight("socios", _socios_key(inp.qtd_socios))
+    breakdown["porte"] = rubric.get_weight("porte", _porte_key(inp.porte, inp.opcao_mei))
+    breakdown["capital_social"] = _faixa_peso(
+        rubric.scoring["capital_social"]["faixas"], float(inp.capital_social)
+    )
+    breakdown["idade_anos"] = _faixa_peso(
+        rubric.scoring["idade_anos"]["faixas"], _idade_anos(inp.data_inicio_atividade, inp.as_of)
+    )
+    breakdown["email_domain_category"] = rubric.get_weight(
+        "email_domain_category", inp.email_domain_category
+    )
+    breakdown["estabelecimentos"] = rubric.get_weight(
+        "estabelecimentos", _estabelecimentos_key(inp.qtd_estabelecimentos)
+    )
+    breakdown["geografia"] = rubric.get_weight("geografia", inp.uf)
+
+    raw = rubric.base_score + sum(breakdown.values())
+    score = max(0, min(100, raw))
+    tier = rubric.tier_for_score(score)
+
+    # Guard de código, não só de rubrica: "nenhum Tier A pode ser MEI" precisa
+    # valer mesmo que uma versão futura da rubrica enfraqueça o peso -100 de MEI.
+    if inp.opcao_mei and _TIER_ORDER.index(tier) < _TIER_ORDER.index("B"):
+        tier = "B"
+
+    justification = _build_justification(inp, breakdown)
+
+    return ScoreResult(
+        score=score,
+        tier=tier,
+        rubric_version=rubric.version,
+        breakdown=breakdown,
+        justification=justification,
+    )
+
+
+def _build_justification(inp: ScoreInput, breakdown: dict[str, int]) -> str:
+    parts: list[str] = []
+
+    if inp.opcao_mei:
+        parts.append("MEI")
+    elif inp.porte in ("03", "05"):
+        parts.append("porte consolidado")
+
+    socios_label = {
+        "1": "sócio único", "2": "dois sócios",
+    }.get(_socios_key(inp.qtd_socios), "três ou mais sócios")
+    parts.append(socios_label)
+
+    if inp.qtd_estabelecimentos > 1:
+        parts.append(f"{inp.qtd_estabelecimentos} estabelecimentos (matriz + filiais)")
+
+    domain_label = {
+        "dominio_nominal": "domínio de e-mail próprio",
+        "dominio_generico": "domínio de e-mail próprio (genérico)",
+        "gratuito": "e-mail gratuito",
+        "ausente": "sem e-mail cadastrado",
+    }[inp.email_domain_category]
+    parts.append(domain_label)
+
+    idade = _idade_anos(inp.data_inicio_atividade, inp.as_of)
+    if idade >= 10:
+        parts.append("empresa consolidada (10+ anos)")
+    elif idade < 1:
+        parts.append("empresa recém-aberta")
+
+    sentence = ", ".join(parts)
+    return sentence[0].upper() + sentence[1:] + "."

--- a/backend/tests/test_prospecting_email_classifier.py
+++ b/backend/tests/test_prospecting_email_classifier.py
@@ -1,0 +1,54 @@
+"""Classificador de domínio de e-mail (PO-2026-07-SALES-001, Fase 1) — puro, sem DB."""
+
+import pytest
+
+from app.services.prospecting.email_classifier import classify_domain, extract_domain
+
+
+class TestExtractDomain:
+    def test_extracts_domain_from_email(self):
+        assert extract_domain("contato@escritoriosilva.com.br") == "escritoriosilva.com.br"
+
+    def test_none_when_missing_at(self):
+        assert extract_domain("nao-e-email") is None
+
+    def test_none_when_empty(self):
+        assert extract_domain("") is None
+        assert extract_domain(None) is None
+
+
+class TestClassifyDomain:
+    def test_ausente_when_no_email(self):
+        assert classify_domain(None) == "ausente"
+        assert classify_domain("") == "ausente"
+
+    @pytest.mark.parametrize("domain", ["gmail.com", "hotmail.com", "yahoo.com.br", "uol.com.br"])
+    def test_gratuito_for_known_free_providers(self, domain):
+        assert classify_domain(f"contato@{domain}") == "gratuito"
+
+    def test_dominio_nominal_when_domain_derives_from_razao_social(self):
+        assert classify_domain(
+            "contato@silvacontabilidade.com.br",
+            razao_social="Silva Contabilidade Ltda",
+        ) == "dominio_nominal"
+
+    def test_dominio_nominal_when_domain_derives_from_nome_fantasia(self):
+        assert classify_domain(
+            "contato@contafacil.com.br",
+            razao_social="J. Pereira Serviços Contábeis Ltda",
+            nome_fantasia="ContaFacil",
+        ) == "dominio_nominal"
+
+    def test_dominio_generico_when_no_relation_to_company_name(self):
+        assert classify_domain(
+            "contato@escritoriodigital.com.br",
+            razao_social="Almeida & Souza Contabilidade Ltda",
+        ) == "dominio_generico"
+
+    def test_generic_legal_suffixes_are_not_enough_to_match(self):
+        # "contabilidade"/"ltda" sozinhos não deveriam bastar para casar com
+        # qualquer domínio genérico do ramo — são descartados na tokenização.
+        assert classify_domain(
+            "contato@contabilidadeonline.com.br",
+            razao_social="Ferreira Contabilidade Ltda",
+        ) == "dominio_generico"

--- a/backend/tests/test_prospecting_rubric_loader.py
+++ b/backend/tests/test_prospecting_rubric_loader.py
@@ -1,0 +1,69 @@
+"""Carregamento/validação da rubrica YAML (PO-2026-07-SALES-001, Fase 1) — puro, sem DB."""
+
+import pytest
+import yaml
+
+from app.services.prospecting.rubric_loader import (
+    RubricValidationError,
+    load_rubric,
+)
+
+
+class TestLoadRealRubricV1:
+    def test_loads_and_exposes_required_fields(self):
+        rubric = load_rubric(version="v1")
+        assert rubric.version == "v1"
+        assert rubric.base_score == 50
+        assert set(rubric.tiers) == {"A", "B", "C", "D"}
+        assert len(rubric.checksum) == 64  # sha256 hex
+
+    def test_checksum_is_stable_across_loads(self):
+        r1 = load_rubric(version="v1")
+        r2 = load_rubric(version="v1")
+        assert r1.checksum == r2.checksum
+
+    def test_get_weight_falls_back_to_default(self):
+        rubric = load_rubric(version="v1")
+        # UF não listada explicitamente na rubrica v1 -> cai no "default": 0
+        assert rubric.get_weight("geografia", "AM") == 0
+        assert rubric.get_weight("geografia", "RS") == 10
+
+    def test_get_weight_returns_zero_when_no_default_and_key_missing(self):
+        rubric = load_rubric(version="v1")
+        assert rubric.get_weight("socios", "999_nao_existe") == 0
+
+    def test_tier_for_score_picks_highest_matching_tier(self):
+        rubric = load_rubric(version="v1")
+        assert rubric.tier_for_score(85) == "A"
+        assert rubric.tier_for_score(80) == "A"
+        assert rubric.tier_for_score(79) == "B"
+        assert rubric.tier_for_score(60) == "B"
+        assert rubric.tier_for_score(40) == "C"
+        assert rubric.tier_for_score(0) == "D"
+
+
+class TestLoadRubricValidation:
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(RubricValidationError):
+            load_rubric(path=tmp_path / "does_not_exist.yaml")
+
+    def test_missing_top_level_key_raises(self, tmp_path):
+        bad = tmp_path / "bad_rubric.yaml"
+        bad.write_text(yaml.safe_dump({"version": "vX", "base_score": 50}))
+        with pytest.raises(RubricValidationError, match="tiers"):
+            load_rubric(path=bad)
+
+    def test_missing_scoring_dimension_raises(self, tmp_path):
+        bad = tmp_path / "bad_rubric.yaml"
+        bad.write_text(yaml.safe_dump({
+            "version": "vX",
+            "base_score": 50,
+            "tiers": {"A": {"min": 80}, "D": {"min": 0}},
+            "scoring": {"socios": {"1": 1}},
+        }))
+        with pytest.raises(RubricValidationError, match="porte"):
+            load_rubric(path=bad)
+
+    def test_no_version_and_no_path_raises(self):
+        with pytest.raises(RubricValidationError):
+            load_rubric()

--- a/backend/tests/test_prospecting_scoring.py
+++ b/backend/tests/test_prospecting_scoring.py
@@ -1,0 +1,140 @@
+"""Pré-score determinístico compute_score() (PO-2026-07-SALES-001, Fase 1) — puro, sem DB."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+import yaml
+
+from app.services.prospecting.rubric_loader import load_rubric
+from app.services.prospecting.scoring import ScoreInput, compute_score
+
+RUBRIC = load_rubric(version="v1")
+TODAY = date(2026, 7, 28)
+
+# Rubrica sintética com penalidade de MEI fraca (-5 em vez de -100 da v1 real) —
+# usada só para provar que o cap de tier é aplicado pelo CÓDIGO (scoring.py),
+# não apenas pela aritmética dos pesos. Com a v1 real o MEI já cai pra D pela
+# soma dos pesos, o que não exercitaria de fato o guard.
+_WEAK_MEI_PENALTY_RUBRIC_YAML = {
+    "version": "vTest-weak-mei",
+    "base_score": 50,
+    "tiers": {"A": {"min": 80}, "B": {"min": 60}, "C": {"min": 40}, "D": {"min": 0}},
+    "scoring": {
+        "socios": {"1": 10, "2": 10, "3_or_more": 10},
+        "porte": {"mei": -5, "00": 10, "01": 10, "03": 10, "05": 10},
+        "capital_social": {"faixas": [{"acima": 0, "peso": 10}]},
+        "idade_anos": {"faixas": [{"acima": 0, "peso": 10}]},
+        "email_domain_category": {"default": 10},
+        "estabelecimentos": {"default": 10},
+        "geografia": {"default": 10},
+    },
+}
+
+
+def _base_input(
+    *,
+    qtd_socios: int = 2,
+    porte: str = "05",
+    opcao_mei: bool = False,
+    capital_social: Decimal = Decimal("100000"),
+    data_inicio_atividade: date | None = date(2015, 1, 1),  # ~11 anos
+    email_domain_category: str = "dominio_nominal",
+    qtd_estabelecimentos: int = 3,
+    uf: str = "RS",
+    razao_social: str = "Escritório Modelo Contabilidade Ltda",
+    as_of: date = TODAY,
+) -> ScoreInput:
+    return ScoreInput(
+        qtd_socios=qtd_socios,
+        porte=porte,
+        opcao_mei=opcao_mei,
+        capital_social=capital_social,
+        data_inicio_atividade=data_inicio_atividade,
+        email_domain_category=email_domain_category,
+        qtd_estabelecimentos=qtd_estabelecimentos,
+        uf=uf,
+        razao_social=razao_social,
+        as_of=as_of,
+    )
+
+
+class TestComputeScoreBasics:
+    def test_strong_profile_lands_in_tier_a(self):
+        result = compute_score(_base_input(), RUBRIC)
+        assert result.tier == "A"
+        assert 0 <= result.score <= 100
+        assert result.rubric_version == "v1"
+        assert result.justification  # não vazio
+
+    def test_score_is_clamped_to_0_100(self):
+        # Perfil pior possível: sem e-mail, MEI, sócio único, recém-aberta.
+        weak = _base_input(
+            qtd_socios=1, opcao_mei=True, capital_social=Decimal("0"),
+            data_inicio_atividade=TODAY, email_domain_category="ausente",
+            qtd_estabelecimentos=1, uf="AM",
+        )
+        result = compute_score(weak, RUBRIC)
+        assert result.score == 0
+
+
+class TestMeiCapInvariant:
+    """Critério de aceite: nenhum Tier A pode ser MEI — mesmo se um perfil MEI
+    tivesse todos os outros sinais positivos ao extremo."""
+
+    def test_mei_never_reaches_tier_a_even_with_otherwise_ideal_profile(self):
+        mei_but_ideal = _base_input(
+            opcao_mei=True, qtd_socios=5, capital_social=Decimal("500000"),
+            data_inicio_atividade=date(2000, 1, 1), qtd_estabelecimentos=10,
+            email_domain_category="dominio_nominal", uf="RS",
+        )
+        result = compute_score(mei_but_ideal, RUBRIC)
+        assert result.tier in ("B", "C", "D")
+        assert result.tier != "A"
+
+    def test_code_level_guard_caps_tier_even_when_rubric_weights_would_reach_a(self, tmp_path):
+        """Prova que o cap é aplicado pelo código, não pela aritmética: com uma
+        rubrica cujo peso de MEI é fraco (-5), a soma bruta chegaria à Tier A
+        (raw=105 -> clamp 100) — o guard em scoring.py precisa rebaixar para B
+        mesmo assim."""
+        weak_rubric_path = tmp_path / "rubric_weak_mei.yaml"
+        weak_rubric_path.write_text(yaml.safe_dump(_WEAK_MEI_PENALTY_RUBRIC_YAML))
+        weak_rubric = load_rubric(path=weak_rubric_path)
+
+        result = compute_score(_base_input(opcao_mei=True), weak_rubric)
+        assert result.tier == "B"
+
+    def test_non_mei_ideal_profile_can_reach_tier_a(self):
+        ideal = _base_input(
+            opcao_mei=False, porte="05", qtd_socios=5, capital_social=Decimal("500000"),
+            data_inicio_atividade=date(2000, 1, 1), qtd_estabelecimentos=10,
+            email_domain_category="dominio_nominal", uf="RS",
+        )
+        result = compute_score(ideal, RUBRIC)
+        assert result.tier == "A"
+
+
+class TestBreakdownAndJustification:
+    def test_breakdown_has_all_six_dimensions(self):
+        result = compute_score(_base_input(), RUBRIC)
+        assert set(result.breakdown) == {
+            "socios", "porte", "capital_social", "idade_anos",
+            "email_domain_category", "estabelecimentos", "geografia",
+        }
+
+    def test_justification_mentions_mei_when_applicable(self):
+        result = compute_score(_base_input(opcao_mei=True), RUBRIC)
+        assert "MEI" in result.justification
+
+    def test_justification_mentions_own_domain_when_nominal(self):
+        result = compute_score(_base_input(email_domain_category="dominio_nominal"), RUBRIC)
+        assert "domínio de e-mail próprio" in result.justification.lower() or "domínio" in result.justification.lower()
+
+
+@pytest.mark.parametrize(
+    "qtd_socios,expected_key_weight",
+    [(1, "1"), (2, "2"), (3, "3_or_more"), (10, "3_or_more")],
+)
+def test_socios_bucketing_matches_rubric_keys(qtd_socios, expected_key_weight):
+    result = compute_score(_base_input(qtd_socios=qtd_socios), RUBRIC)
+    assert result.breakdown["socios"] == RUBRIC.get_weight("socios", expected_key_weight)


### PR DESCRIPTION
## Summary
Fatia 2 de 5 da Fase 1 da PO-2026-07-SALES-001. Lógica pura de scoring, sem DB e sem arquivo da RF ainda (parser/consolidação vêm na fatia 3).

- `rubric_v1.yaml` — pesos versionados e imutáveis (recalibração = arquivo novo, nunca edição in-place).
- `rubric_loader.py` — carrega/valida a rubrica, fallback "default" por dimensão (nunca falha por cobertura incompleta, ex. UF não listada).
- `scoring.py` — `compute_score()` puro: score 0-100, tier, breakdown por dimensão, justificativa legível. Guard de código força MEI a nunca alcançar Tier A, independente da calibração dos pesos.
- `email_classifier.py` — classificação determinística de domínio (ausente/gratuito/genérico/nominal), sem chamada externa nem IA (exigência da PO para o pré-score).

## Test plan
- [x] `pytest tests/ -q` — 836 passed (33 novos)
- [x] `ruff check app/ tests/` — clean
- [x] `npx pyright@1.1.411` — 0 errors