### PR TITLE
feat(prospecting): dedup por domínio + filtro de supressão (Fase 1, fatia 4/5)

### DIFF
--- a/backend/app/services/prospecting/dedup.py
+++ b/backend/app/services/prospecting/dedup.py
@@ -1,0 +1,107 @@
+"""Deduplicação por domínio de e-mail entre CNPJ básicos distintos
+(PO-2026-07-SALES-001, Fase 1).
+
+A consolidação por CNPJ básico (matriz+filiais) já garante que nunca existam
+dois registros para o mesmo CNPJ básico — isso é trivial e acontece em
+consolidation.py. O caso difícil, tratado aqui, é: dois CNPJ básicos
+DIFERENTES que na prática são o mesmo escritório (várias inscrições para
+linhas de serviço/filiais separadas, todas sob o mesmo domínio de e-mail).
+
+Regra (decisão de design documentada — a PO não especifica o critério exato):
+- Só domínio "dominio_nominal" (derivado do nome da própria empresa) participa
+  do agrupamento. Domínio gratuito (gmail etc.) nunca deduplica por coincidência
+  — dois escritórios não relacionados compartilhando @gmail.com é coincidência,
+  não evidência de serem a mesma empresa.
+- Grupo de 2 até --max-group-size (padrão 5): mescla, mantendo o "primário"
+  (mais estabelecimentos -> maior capital social -> menor cnpj_basico,
+  determinístico e reproduzível) e marcando os demais como 'merged' (nunca
+  apagados — a origem RF é preservada para auditoria).
+- Grupo maior que --max-group-size: mais provável ser plataforma/hospedagem
+  white-label do que uma única firma — não mescla, mantém todos 'unique'.
+
+Idempotente: cada execução reseta dedup_status/merged_into_id de TODOS os
+registros e recalcula os grupos do zero a partir do estado atual da tabela —
+por isso é seguro rodar de novo a qualquer momento (ex.: após um novo ingest).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import cast
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from app.models.prospect_org import ProspectOrg
+
+DEFAULT_MAX_GROUP_SIZE = 5
+
+
+@dataclass(frozen=True)
+class DedupSummary:
+    groups_merged: int
+    orgs_merged: int
+    domains_skipped_too_large: int
+
+
+def _pick_primary(members: list[ProspectOrg]) -> ProspectOrg:
+    """Desempate determinístico: mais estabelecimentos -> maior capital social
+    -> menor cnpj_basico."""
+    return sorted(
+        members,
+        key=lambda o: (
+            -cast(int, o.qtd_estabelecimentos),
+            -float(cast(Decimal, o.capital_social)),
+            cast(str, o.cnpj_basico),
+        ),
+    )[0]
+
+
+def apply_dedup(db: Session, max_group_size: int = DEFAULT_MAX_GROUP_SIZE) -> DedupSummary:
+    """Recalcula do zero o agrupamento por domínio nominal e aplica dedup_status/
+    merged_into_id. Faz commit ao final."""
+    # dedup_status é um cache mutável (não append-only) — reset garante que
+    # reprocessar reflita o estado atual da tabela, não decisões de execuções passadas.
+    db.execute(update(ProspectOrg).values(dedup_status="unique", merged_into_id=None))
+    db.flush()
+
+    candidates = db.execute(
+        select(ProspectOrg).where(ProspectOrg.email_domain_category == "dominio_nominal")
+    ).scalars().all()
+
+    groups: dict[str, list[ProspectOrg]] = defaultdict(list)
+    for org in candidates:
+        email_domain = cast("str | None", org.email_domain)
+        if email_domain:
+            groups[email_domain].append(org)
+
+    groups_merged = 0
+    orgs_merged = 0
+    domains_skipped_too_large = 0
+
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        if len(members) > max_group_size:
+            domains_skipped_too_large += 1
+            continue
+
+        primary = _pick_primary(members)
+        primary.dedup_status = "primary"  # type: ignore[assignment]
+        primary_id = cast("object", primary.id)
+        for member in members:
+            if cast("object", member.id) == primary_id:
+                continue
+            member.dedup_status = "merged"  # type: ignore[assignment]
+            member.merged_into_id = primary.id  # type: ignore[assignment]
+            orgs_merged += 1
+        groups_merged += 1
+
+    db.commit()
+    return DedupSummary(
+        groups_merged=groups_merged,
+        orgs_merged=orgs_merged,
+        domains_skipped_too_large=domains_skipped_too_large,
+    )

--- a/backend/app/services/prospecting/suppression.py
+++ b/backend/app/services/prospecting/suppression.py
@@ -1,0 +1,74 @@
+"""Filtro contra a lista de supressão (PO-2026-07-SALES-001, Fase 1).
+
+Semântica de exclusão (decisão de design documentada — a PO define os status
+mas não qual é obrigatório vs. configurável):
+- opt_out/cliente: exclusão dura, incondicional, sem flag de CLI para
+  desativar — "nunca poderão reaparecer", literal da PO.
+- lead_ativo/desqualificado: excluídos por padrão (uma lista de prospecção nova
+  não deveria trazer de volta um CNPJ que o comercial já tem em negociação
+  ativa, ou que já foi avaliado e rejeitado), mas configurável via
+  --suppress-statuses.
+- hard_bounce: NÃO excluído por padrão — um e-mail que bateu hoje não
+  desqualifica a FIRMA; um contato corrigido pode aparecer no enriquecimento
+  da Fase 2. Operador pode incluir explicitamente se quiser.
+
+Casamento por cnpj_basico OU email_domain (a tabela de supressão não exige as
+duas colunas — ver CheckConstraint no model).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.prospect_org import ProspectOrg
+from app.models.prospect_suppression import ProspectSuppression
+
+MANDATORY_EXCLUDE_STATUSES: frozenset[str] = frozenset({"opt_out", "cliente"})
+DEFAULT_EXCLUDE_STATUSES: frozenset[str] = frozenset(
+    {"opt_out", "cliente", "lead_ativo", "desqualificado"}
+)
+
+
+def get_suppressed_keys(
+    db: Session, exclude_statuses: frozenset[str] = DEFAULT_EXCLUDE_STATUSES
+) -> tuple[set[str], set[str]]:
+    """Retorna (cnpj_basicos, email_domains) suprimidos para os status pedidos.
+
+    MANDATORY_EXCLUDE_STATUSES é sempre incluído, mesmo que o chamador não o
+    peça explicitamente — não há como desativar opt_out/cliente.
+    """
+    statuses = MANDATORY_EXCLUDE_STATUSES | exclude_statuses
+    rows = db.execute(
+        select(ProspectSuppression).where(ProspectSuppression.status.in_(statuses))
+    ).scalars().all()
+    cnpjs = {cast(str, r.cnpj_basico) for r in rows if cast("str | None", r.cnpj_basico)}
+    domains = {cast(str, r.email_domain) for r in rows if cast("str | None", r.email_domain)}
+    return cnpjs, domains
+
+
+def is_suppressed(
+    org: ProspectOrg, suppressed_cnpjs: set[str], suppressed_domains: set[str]
+) -> bool:
+    if cast(str, org.cnpj_basico) in suppressed_cnpjs:
+        return True
+    email_domain = cast("str | None", org.email_domain)
+    if email_domain and email_domain in suppressed_domains:
+        return True
+    return False
+
+
+def filter_candidates(
+    db: Session,
+    candidates: list[ProspectOrg],
+    exclude_statuses: frozenset[str] = DEFAULT_EXCLUDE_STATUSES,
+) -> list[ProspectOrg]:
+    """Remove candidatos suprimidos. exclude_statuses controla só a parte
+    configurável — opt_out/cliente são sempre aplicados, ver MANDATORY_EXCLUDE_STATUSES."""
+    suppressed_cnpjs, suppressed_domains = get_suppressed_keys(db, exclude_statuses)
+    return [
+        org for org in candidates
+        if not is_suppressed(org, suppressed_cnpjs, suppressed_domains)
+    ]

--- a/backend/tests/test_prospecting_dedup.py
+++ b/backend/tests/test_prospecting_dedup.py
@@ -1,0 +1,165 @@
+"""Deduplicação por domínio de e-mail nominal (PO-2026-07-SALES-001, Fase 1) — DB-backed."""
+
+import os
+import uuid
+from decimal import Decimal
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.prospect_org import ProspectOrg
+from app.services.prospecting.dedup import apply_dedup
+
+
+def _status(org: ProspectOrg) -> str:
+    return cast(str, org.dedup_status)
+
+
+def _merged_into(org: ProspectOrg):
+    return cast("uuid.UUID | None", org.merged_into_id)
+
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    db = TestingSessionLocal(bind=connection)
+    yield db
+    db.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _make_org(
+    session,
+    *,
+    email_domain: str | None,
+    email_domain_category: str = "dominio_nominal",
+    qtd_estabelecimentos: int = 1,
+    capital_social: Decimal = Decimal("0"),
+    cnpj_basico: str | None = None,
+) -> ProspectOrg:
+    cnpj_basico = cnpj_basico or uuid.uuid4().hex[:8]
+    org = ProspectOrg(
+        cnpj_basico=cnpj_basico,
+        cnpj_matriz=f"{cnpj_basico}000191",
+        razao_social=f"Empresa {cnpj_basico}",
+        porte="05",
+        capital_social=capital_social,
+        situacao_cadastral="02",
+        qtd_estabelecimentos=qtd_estabelecimentos,
+        uf="RS",
+        email_domain=email_domain,
+        email_domain_category=email_domain_category,
+        cnae_principal="6920601",
+        source_dump_reference="test",
+    )
+    session.add(org)
+    session.flush()
+    return org
+
+
+class TestMergesNominalDomainGroups:
+    def test_merges_two_orgs_sharing_nominal_domain(self, session):
+        primary = _make_org(session, email_domain="silva.com.br", qtd_estabelecimentos=3)
+        other = _make_org(session, email_domain="silva.com.br", qtd_estabelecimentos=1)
+
+        apply_dedup(session)
+        session.refresh(primary)
+        session.refresh(other)
+
+        assert _status(primary) == "primary"
+        assert _status(other) == "merged"
+        assert _merged_into(other) == primary.id
+
+    def test_does_not_merge_free_email_domain(self, session):
+        a = _make_org(session, email_domain="gmail.com", email_domain_category="gratuito")
+        b = _make_org(session, email_domain="gmail.com", email_domain_category="gratuito")
+
+        apply_dedup(session)
+        session.refresh(a)
+        session.refresh(b)
+
+        assert _status(a) == "unique"
+        assert _status(b) == "unique"
+
+    def test_group_larger_than_max_size_is_not_merged(self, session):
+        orgs = [_make_org(session, email_domain="plataforma.com.br") for _ in range(6)]
+
+        apply_dedup(session, max_group_size=5)
+
+        for org in orgs:
+            session.refresh(org)
+            assert _status(org) == "unique"
+
+    def test_unrelated_org_with_unique_domain_stays_unique(self, session):
+        solo = _make_org(session, email_domain="unico.com.br")
+
+        apply_dedup(session)
+        session.refresh(solo)
+
+        assert _status(solo) == "unique"
+
+
+class TestTieBreak:
+    def test_prefers_more_estabelecimentos(self, session):
+        weaker = _make_org(session, email_domain="empate.com.br", qtd_estabelecimentos=1, capital_social=Decimal("100"))
+        stronger = _make_org(session, email_domain="empate.com.br", qtd_estabelecimentos=5, capital_social=Decimal("1"))
+
+        apply_dedup(session)
+        session.refresh(weaker)
+        session.refresh(stronger)
+
+        assert _status(stronger) == "primary"
+        assert _merged_into(weaker) == stronger.id
+
+    def test_falls_back_to_capital_social_when_same_estabelecimentos(self, session):
+        poorer = _make_org(session, email_domain="empate2.com.br", qtd_estabelecimentos=2, capital_social=Decimal("100"))
+        richer = _make_org(session, email_domain="empate2.com.br", qtd_estabelecimentos=2, capital_social=Decimal("999999"))
+
+        apply_dedup(session)
+        session.refresh(poorer)
+        session.refresh(richer)
+
+        assert _status(richer) == "primary"
+        assert _merged_into(poorer) == richer.id
+
+    def test_falls_back_to_lowest_cnpj_basico_as_final_tiebreak(self, session):
+        second = _make_org(
+            session, email_domain="empate3.com.br", qtd_estabelecimentos=1,
+            capital_social=Decimal("0"), cnpj_basico="90000002",
+        )
+        first = _make_org(
+            session, email_domain="empate3.com.br", qtd_estabelecimentos=1,
+            capital_social=Decimal("0"), cnpj_basico="90000001",
+        )
+
+        apply_dedup(session)
+        session.refresh(first)
+        session.refresh(second)
+
+        assert _status(first) == "primary"
+        assert _merged_into(second) == first.id
+
+
+class TestIdempotency:
+    def test_rerunning_produces_the_same_result(self, session):
+        primary = _make_org(session, email_domain="reprocessa.com.br", qtd_estabelecimentos=3)
+        other = _make_org(session, email_domain="reprocessa.com.br", qtd_estabelecimentos=1)
+
+        first_run = apply_dedup(session)
+        second_run = apply_dedup(session)
+
+        session.refresh(primary)
+        session.refresh(other)
+        assert first_run == second_run
+        assert _status(primary) == "primary"
+        assert _status(other) == "merged"
+        assert _merged_into(other) == primary.id

--- a/backend/tests/test_prospecting_suppression.py
+++ b/backend/tests/test_prospecting_suppression.py
@@ -1,0 +1,133 @@
+"""Filtro de supressão (PO-2026-07-SALES-001, Fase 1) — DB-backed."""
+
+import os
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.prospect_org import ProspectOrg
+from app.models.prospect_suppression import ProspectSuppression
+from app.services.prospecting.suppression import (
+    DEFAULT_EXCLUDE_STATUSES,
+    filter_candidates,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def session():
+    connection = engine.connect()
+    transaction = connection.begin()
+    db = TestingSessionLocal(bind=connection)
+    yield db
+    db.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _make_org(session, *, cnpj_basico=None, email_domain=None) -> ProspectOrg:
+    cnpj_basico = cnpj_basico or uuid.uuid4().hex[:8]
+    org = ProspectOrg(
+        cnpj_basico=cnpj_basico,
+        cnpj_matriz=f"{cnpj_basico}000191",
+        razao_social=f"Empresa {cnpj_basico}",
+        porte="05",
+        capital_social=Decimal("0"),
+        situacao_cadastral="02",
+        qtd_estabelecimentos=1,
+        uf="RS",
+        email_domain=email_domain,
+        email_domain_category="dominio_nominal" if email_domain else "ausente",
+        cnae_principal="6920601",
+        source_dump_reference="test",
+    )
+    session.add(org)
+    session.flush()
+    return org
+
+
+def _suppress(session, *, cnpj_basico=None, email_domain=None, status="opt_out"):
+    row = ProspectSuppression(cnpj_basico=cnpj_basico, email_domain=email_domain, status=status)
+    session.add(row)
+    session.flush()
+    return row
+
+
+class TestMandatoryExclusion:
+    def test_opt_out_by_cnpj_basico_is_always_excluded(self, session):
+        org = _make_org(session, cnpj_basico="10000001")
+        _suppress(session, cnpj_basico="10000001", status="opt_out")
+
+        result = filter_candidates(session, [org], exclude_statuses=frozenset())
+        assert org not in result
+
+    def test_cliente_by_email_domain_is_always_excluded(self, session):
+        org = _make_org(session, email_domain="jacliente.com.br")
+        _suppress(session, email_domain="jacliente.com.br", status="cliente")
+
+        result = filter_candidates(session, [org], exclude_statuses=frozenset())
+        assert org not in result
+
+    def test_mandatory_exclusion_cannot_be_disabled_via_flag(self, session):
+        """opt_out/cliente são aplicados mesmo se exclude_statuses vier vazio —
+        não existe flag de CLI que os desative."""
+        org = _make_org(session, cnpj_basico="10000002")
+        _suppress(session, cnpj_basico="10000002", status="opt_out")
+
+        result = filter_candidates(session, [org], exclude_statuses=frozenset())
+        assert result == []
+
+
+class TestConfigurableExclusion:
+    def test_lead_ativo_excluded_by_default(self, session):
+        org = _make_org(session, cnpj_basico="20000001")
+        _suppress(session, cnpj_basico="20000001", status="lead_ativo")
+
+        result = filter_candidates(session, [org], exclude_statuses=DEFAULT_EXCLUDE_STATUSES)
+        assert org not in result
+
+    def test_desqualificado_excluded_by_default(self, session):
+        org = _make_org(session, cnpj_basico="20000002")
+        _suppress(session, cnpj_basico="20000002", status="desqualificado")
+
+        result = filter_candidates(session, [org], exclude_statuses=DEFAULT_EXCLUDE_STATUSES)
+        assert org not in result
+
+    def test_lead_ativo_included_when_status_not_in_exclude_set(self, session):
+        org = _make_org(session, cnpj_basico="20000003")
+        _suppress(session, cnpj_basico="20000003", status="lead_ativo")
+
+        # Operador explicitamente NÃO pede exclusão de lead_ativo desta vez.
+        result = filter_candidates(session, [org], exclude_statuses=frozenset())
+        assert org in result
+
+
+class TestHardBounceNeverExcludedByDefault:
+    def test_hard_bounce_not_excluded_by_default(self, session):
+        org = _make_org(session, cnpj_basico="30000001")
+        _suppress(session, cnpj_basico="30000001", status="hard_bounce")
+
+        result = filter_candidates(session, [org], exclude_statuses=DEFAULT_EXCLUDE_STATUSES)
+        assert org in result
+
+    def test_hard_bounce_excluded_when_explicitly_requested(self, session):
+        org = _make_org(session, cnpj_basico="30000002")
+        _suppress(session, cnpj_basico="30000002", status="hard_bounce")
+
+        result = filter_candidates(
+            session, [org], exclude_statuses=DEFAULT_EXCLUDE_STATUSES | frozenset({"hard_bounce"})
+        )
+        assert org not in result
+
+
+class TestNoSuppressionMatch:
+    def test_org_without_any_suppression_row_passes_through(self, session):
+        org = _make_org(session, cnpj_basico="40000001", email_domain="livre.com.br")
+        result = filter_candidates(session, [org])
+        assert org in result


### PR DESCRIPTION
## Summary
Fatia 4 de 5 da Fase 1 da PO-2026-07-SALES-001.

- `dedup.py` — agrupa por domínio de e-mail **nominal** (derivado do nome da própria empresa) entre CNPJ básicos distintos que na prática são o mesmo escritório. Domínio gratuito nunca deduplica por coincidência. Desempate determinístico: mais estabelecimentos → maior capital social → menor cnpj_basico. Grupo maior que `--max-group-size` (padrão 5) não é mesclado — mais provável ser plataforma white-label do que uma única firma. Idempotente (reseta e recalcula do zero a cada execução, refletindo sempre o estado atual da tabela).
- `suppression.py` — `opt_out`/`cliente` são exclusão dura e incondicional (sem flag de CLI para desativar, literal da PO: "nunca poderão reaparecer"). `lead_ativo`/`desqualificado` excluídos por padrão mas configuráveis via `--suppress-statuses`. `hard_bounce` nunca exclui por padrão — um e-mail que bateu hoje não desqualifica a firma inteira.

## Test plan
- [x] `pytest tests/ -q` — 853 passed (17 novos)
- [x] `ruff check app/ tests/` — clean
- [x] `npx pyright@1.1.411` — 0 errors