### PR TITLE
feat(prospecting): scripts CLI + testes fim-a-fim (Fase 1, fatia 5/5 — completa)

### DIFF
--- a/backend/tests/test_prospecting_pipeline_cli.py
+++ b/backend/tests/test_prospecting_pipeline_cli.py
@@ -1,0 +1,202 @@
+"""Teste fim-a-fim dos 3 scripts CLI da Fase 1 (PO-2026-07-SALES-001) — Postgres real.
+
+Chama main() de cada script diretamente (não via subprocess, para velocidade e
+cobertura), contra as mesmas fixtures usadas pelos testes de parser/consolidação.
+
+Cada execução usa um --dump-reference único (uuid) para poder limpar depois só
+os registros deste teste — score_and_select.py e dedup_prospects.py operam
+sobre TODA a tabela prospect_orgs por design (é o "estado atual do mundo" a
+pontuar/deduplicar, não um recorte por dump), então a limpeza no teardown é o
+que evita que uma execução deste teste contamine as demais.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine, delete
+from sqlalchemy.orm import sessionmaker
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOLS_PROSPECTING = _REPO_ROOT / "tools" / "prospecting"
+if str(_TOOLS_PROSPECTING) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_PROSPECTING))
+
+ingest_cnpj_dump = importlib.import_module("ingest_cnpj_dump")
+dedup_prospects = importlib.import_module("dedup_prospects")
+score_and_select = importlib.import_module("score_and_select")
+
+from app.models.prospect_org import ProspectOrg  # noqa: E402
+from app.models.prospect_scoring_run import ProspectScoringRun  # noqa: E402
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "prospecting"
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+EXPECTED_CNPJS = {"10000000", "20000000", "40000000"}  # ALPHA, BETA, DELTA — GAMA excluída, LOJA fora do alvo
+
+
+@pytest.fixture()
+def dump_reference():
+    """CLI scripts usam SessionLocal() próprio e commitam de verdade — não há
+    rollback de transação de teste aqui (ao contrário dos outros testes
+    DB-backed de prospecting). Por isso a limpeza no teardown é obrigatória."""
+    ref = f"e2e-{uuid.uuid4().hex[:8]}"
+    yield ref
+    session = TestingSessionLocal()
+    try:
+        session.execute(
+            delete(ProspectScoringRun).where(ProspectScoringRun.source_dump_reference == ref)
+        )
+        session.execute(delete(ProspectOrg).where(ProspectOrg.source_dump_reference == ref))
+        session.commit()
+    finally:
+        session.close()
+
+
+class TestFullPipeline:
+    def test_ingest_is_idempotent(self, dump_reference):
+        rc1 = ingest_cnpj_dump.main(
+            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference]
+        )
+        assert rc1 == 0
+
+        session = TestingSessionLocal()
+        try:
+            orgs = (
+                session.query(ProspectOrg)
+                .filter(ProspectOrg.source_dump_reference == dump_reference)
+                .all()
+            )
+            assert {o.cnpj_basico for o in orgs} == EXPECTED_CNPJS
+        finally:
+            session.close()
+
+        # reexecutar não duplica (ON CONFLICT DO UPDATE)
+        rc2 = ingest_cnpj_dump.main(
+            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference]
+        )
+        assert rc2 == 0
+        session = TestingSessionLocal()
+        try:
+            count = (
+                session.query(ProspectOrg)
+                .filter(ProspectOrg.source_dump_reference == dump_reference)
+                .count()
+            )
+            assert count == 3
+        finally:
+            session.close()
+
+    def test_ingest_dry_run_writes_nothing(self, dump_reference):
+        rc = ingest_cnpj_dump.main(
+            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference, "--dry-run"]
+        )
+        assert rc == 0
+        session = TestingSessionLocal()
+        try:
+            count = (
+                session.query(ProspectOrg)
+                .filter(ProspectOrg.source_dump_reference == dump_reference)
+                .count()
+            )
+            assert count == 0
+        finally:
+            session.close()
+
+    def test_full_pipeline_ingest_dedup_score(self, dump_reference, tmp_path):
+        rc_ingest = ingest_cnpj_dump.main(
+            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference]
+        )
+        assert rc_ingest == 0
+
+        rc_dedup = dedup_prospects.main([])
+        assert rc_dedup == 0
+
+        output_path = tmp_path / "top.csv"
+        rc_score = score_and_select.main(
+            [
+                "--rubric-version", "v1",
+                "--dump-reference", dump_reference,
+                "--output", str(output_path),
+                "--format", "csv",
+                "--top-n", "2000",
+            ]
+        )
+        assert rc_score == 0
+        assert output_path.exists()
+
+        with output_path.open(newline="", encoding="utf-8") as fh:
+            rows = list(csv.DictReader(fh))
+        my_rows = {r["cnpj_basico"]: r for r in rows if r["cnpj_basico"] in EXPECTED_CNPJS}
+        assert set(my_rows) == EXPECTED_CNPJS
+        for row in my_rows.values():
+            assert row["rubric_version"] == "v1"
+            assert row["tier"] in ("A", "B", "C", "D")
+            assert row["justificativa"]
+
+        session = TestingSessionLocal()
+        try:
+            run = (
+                session.query(ProspectScoringRun)
+                .filter(ProspectScoringRun.source_dump_reference == dump_reference)
+                .one()
+            )
+            assert cast(str, run.rubric_version) == "v1"
+            assert cast(int, run.candidate_count) >= 3
+            assert cast(int, run.selected_count) >= 3
+            assert cast(str, run.output_uri) == str(output_path)
+        finally:
+            session.close()
+
+    def test_score_and_select_dry_run_writes_no_run_row(self, dump_reference, tmp_path):
+        ingest_cnpj_dump.main(["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference])
+
+        output_path = tmp_path / "would_not_be_written.csv"
+        rc = score_and_select.main(
+            [
+                "--rubric-version", "v1",
+                "--dump-reference", dump_reference,
+                "--output", str(output_path),
+                "--dry-run",
+            ]
+        )
+        assert rc == 0
+        assert not output_path.exists()
+
+        session = TestingSessionLocal()
+        try:
+            count = (
+                session.query(ProspectScoringRun)
+                .filter(ProspectScoringRun.source_dump_reference == dump_reference)
+                .count()
+            )
+            assert count == 0
+        finally:
+            session.close()
+
+    def test_json_output_format(self, dump_reference, tmp_path):
+        ingest_cnpj_dump.main(["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference])
+        output_path = tmp_path / "top.json"
+        rc = score_and_select.main(
+            [
+                "--rubric-version", "v1",
+                "--dump-reference", dump_reference,
+                "--output", str(output_path),
+                "--format", "json",
+            ]
+        )
+        assert rc == 0
+        import json
+        data = json.loads(output_path.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert any(row["cnpj_basico"] in EXPECTED_CNPJS for row in data)

--- a/tools/prospecting/README.md
+++ b/tools/prospecting/README.md
@@ -1,0 +1,73 @@
+# Pipeline de Prospecção CNPJ — Fase 1
+
+Ferramenta interna (PO-2026-07-SALES-001): transforma o dump bruto de Dados
+Abertos do CNPJ (Receita Federal) em uma lista comercial priorizada de
+escritórios contábeis para prospecção ativa. Sem CRM, sem disparo de e-mail —
+esta entrega termina na geração da lista classificada (Top 2.000).
+
+Não é um serviço de produto: são scripts standalone, executados manualmente
+pelo operador, reaproveitando o `backend/.venv` (mesmo padrão de
+`tools/architecture_audit.py` e `tools/qa_gates/run_gates.py`).
+
+## Pré-requisito: baixar os arquivos oficiais
+
+1. Baixe os arquivos em `https://arquivos.receitafederal.gov.br/` (Dados
+   Abertos do CNPJ) — as tabelas **Empresas**, **Estabelecimentos**,
+   **Simples** e **Sócios** vêm divididas em várias partes numeradas (ex.:
+   `Estabelecimentos0.zip`..`Estabelecimentos9.zip`); baixe também
+   **Municípios** (tabela de domínio, um único arquivo pequeno).
+2. Extraia tudo em um único diretório, ex.: `~/dados-rf/2026-07/`. Os nomes
+   dos arquivos extraídos devem começar com o nome da tabela (o parser
+   localiza por `glob("Estabelecimentos*")` etc. — não precisa remover o
+   sufixo numérico nem a extensão).
+3. Layout oficial vigente:
+   `gov.br/receitafederal/dados/cnpj-metadados.pdf` — os scripts abaixo já
+   implementam esse layout; revalide-o se a Receita publicar um novo formato.
+
+## Sequência de execução
+
+```bash
+cd backend && source .venv/bin/activate
+
+# 1) Parser -> Normalização -> Consolidação -> upsert em prospect_orgs
+python ../tools/prospecting/ingest_cnpj_dump.py \
+    --dump-dir ~/dados-rf/2026-07 --dump-reference 2026-07
+
+# 2) Dedup por domínio de e-mail nominal entre CNPJ básicos distintos
+python ../tools/prospecting/dedup_prospects.py
+
+# 3) Supressão -> Pré-score -> Top-N -> arquivo de saída
+python ../tools/prospecting/score_and_select.py \
+    --rubric-version v1 --dump-reference 2026-07 --top-n 2000 \
+    --output ../reports/prospecting/top_2000_v1_2026-07.csv
+```
+
+Cada script tem `--help` com todas as opções. `--dry-run` está disponível em
+`ingest_cnpj_dump.py` e `score_and_select.py` (roda tudo, mas não escreve no
+banco/arquivo) — útil para conferir contagens antes de uma execução real.
+
+## Idempotência
+
+- `ingest_cnpj_dump.py`: `ON CONFLICT (cnpj_basico) DO UPDATE` — seguro
+  reexecutar após uma falha ou com um dump mensal atualizado.
+- `dedup_prospects.py`: reseta e recalcula os grupos do zero a cada execução.
+- `score_and_select.py`: **não** é idempotente por design — cada execução real
+  insere uma linha nova em `prospect_scoring_runs` (histórico append-only, é
+  o que permite comparar rubricas diferentes no futuro). `pre_score`/
+  `pre_score_tier` em `prospect_orgs` são um cache mutável (a "leitura atual"),
+  sobrescritos a cada execução.
+
+## Runtime esperado
+
+Os arquivos da RF somam múltiplos GB (dezenas de milhões de linhas em
+Estabelecimentos/Empresas/Sócios). `ingest_cnpj_dump.py` faz no máximo 4-5
+passadas completas em streaming (nunca carrega um arquivo inteiro em
+memória) — espere minutos, não segundos, na primeira execução contra o dump
+completo. `dedup_prospects.py` e `score_and_select.py` operam só sobre os
+~80 mil registros já consolidados em `prospect_orgs`, muito mais rápidos.
+
+## Fora desta entrega (Fase 1 termina no Top 2.000)
+
+Agente de enriquecimento externo, reclassificação, exportação para a API
+comercial (HubSpot), telemetria e scripts de feedback loop são fases
+seguintes — ver o plano da Fase 1 para o desenho completo.

--- a/tools/prospecting/dedup_prospects.py
+++ b/tools/prospecting/dedup_prospects.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Passada de dedup por domínio de e-mail nominal (PO-2026-07-SALES-001, Fase 1).
+
+Só banco de dados — não toca nos arquivos da RF. Idempotente: reseta e
+recalcula os grupos do zero a cada execução, então é seguro rodar de novo a
+qualquer momento (ex.: depois de um novo ingest).
+
+Uso:
+  cd backend && source .venv/bin/activate
+  python ../tools/prospecting/dedup_prospects.py [--max-group-size 5]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND_ROOT = _REPO_ROOT / "backend"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from app.database import SessionLocal  # noqa: E402
+from app.services.prospecting.dedup import DEFAULT_MAX_GROUP_SIZE, apply_dedup  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("prospecting.dedup_prospects")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--max-group-size", type=int, default=DEFAULT_MAX_GROUP_SIZE,
+        help="Domínio compartilhado por mais organizações que isso não é mesclado "
+             "(mais provável ser plataforma white-label do que uma única firma).",
+    )
+    args = parser.parse_args(argv)
+
+    db = SessionLocal()
+    try:
+        summary = apply_dedup(db, max_group_size=args.max_group_size)
+    finally:
+        db.close()
+
+    logger.info(
+        "Dedup concluído: %d grupos mesclados, %d organizações marcadas 'merged', "
+        "%d domínios pulados (grupo maior que --max-group-size=%d)",
+        summary.groups_merged, summary.orgs_merged,
+        summary.domains_skipped_too_large, args.max_group_size,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/prospecting/ingest_cnpj_dump.py
+++ b/tools/prospecting/ingest_cnpj_dump.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Parser -> Normalização -> Consolidação -> upsert idempotente em prospect_orgs
+(PO-2026-07-SALES-001, Fase 1).
+
+Uso:
+  cd backend && source .venv/bin/activate
+  python ../tools/prospecting/ingest_cnpj_dump.py \\
+      --dump-dir /caminho/para/dump/2026-07 --dump-reference 2026-07
+
+--dump-dir deve conter os arquivos oficiais extraídos (Empresas*, Estabelecimentos*,
+Simples*, Socios*, Municipios*), baixados de arquivos.receitafederal.gov.br — ver
+README.md deste diretório para o passo a passo completo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND_ROOT = _REPO_ROOT / "backend"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models.prospect_org import ProspectOrg  # noqa: E402
+from app.services.prospecting.consolidation import (  # noqa: E402
+    TARGET_CNAES,
+    ConsolidatedOrg,
+    build_consolidated_orgs,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("prospecting.ingest_cnpj_dump")
+
+_UPSERT_COLUMNS = (
+    "cnpj_matriz", "razao_social", "nome_fantasia", "porte", "opcao_mei",
+    "opcao_simples", "capital_social", "situacao_cadastral", "data_situacao_cadastral",
+    "data_inicio_atividade", "qtd_socios", "qtd_estabelecimentos", "uf",
+    "municipio_codigo", "municipio_nome", "logradouro", "numero", "complemento",
+    "bairro", "cep", "ddd_telefone1", "telefone1", "email", "email_domain",
+    "email_domain_category", "cnae_principal", "cnaes_secundarios", "source_dump_reference",
+)
+
+
+def _row_from_org(org: ConsolidatedOrg) -> dict:
+    row = {"cnpj_basico": org.cnpj_basico}
+    for col in _UPSERT_COLUMNS:
+        row[col] = getattr(org, col)
+    row["situacao_cadastral"] = str(org.situacao_cadastral)
+    return row
+
+
+def upsert_orgs(db, orgs: list[ConsolidatedOrg]) -> int:
+    """Upsert idempotente via ON CONFLICT (cnpj_basico) DO UPDATE — seguro
+    reexecutar após uma falha ou com um dump mensal atualizado."""
+    if not orgs:
+        return 0
+    rows = [_row_from_org(o) for o in orgs]
+    stmt = pg_insert(ProspectOrg).values(rows)
+    update_cols = {col: getattr(stmt.excluded, col) for col in _UPSERT_COLUMNS}
+    stmt = stmt.on_conflict_do_update(index_elements=["cnpj_basico"], set_=update_cols)
+    db.execute(stmt)
+    db.commit()
+    return len(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dump-dir", required=True, type=Path, help="Diretório com os arquivos oficiais extraídos.")
+    parser.add_argument("--dump-reference", required=True, help='Ex.: "2026-07" — vintage do dump.')
+    parser.add_argument("--target-cnaes", default=",".join(sorted(TARGET_CNAES)))
+    parser.add_argument("--dry-run", action="store_true", help="Só parseia e reporta contagens, não escreve no banco.")
+    args = parser.parse_args(argv)
+
+    if not args.dump_dir.is_dir():
+        parser.error(f"--dump-dir não é um diretório: {args.dump_dir}")
+
+    target_cnaes = frozenset(c.strip() for c in args.target_cnaes.split(",") if c.strip())
+
+    logger.info("Iniciando ingestão: dump_dir=%s dump_reference=%s target_cnaes=%s", args.dump_dir, args.dump_reference, sorted(target_cnaes))
+    orgs = build_consolidated_orgs(args.dump_dir, dump_reference=args.dump_reference, target_cnaes=target_cnaes)
+    logger.info("%d organizações consolidadas (situação cadastral ativa, dedup por CNPJ básico)", len(orgs))
+
+    if args.dry_run:
+        logger.info("--dry-run: nenhuma escrita no banco.")
+        return 0
+
+    db = SessionLocal()
+    try:
+        written = upsert_orgs(db, orgs)
+        logger.info("%d registros upsertados em prospect_orgs", written)
+    finally:
+        db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/prospecting/score_and_select.py
+++ b/tools/prospecting/score_and_select.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Supressão -> Pré-score -> Top-N -> arquivo de saída + registro em
+prospect_scoring_runs (PO-2026-07-SALES-001, Fase 1).
+
+Uso:
+  cd backend && source .venv/bin/activate
+  python ../tools/prospecting/score_and_select.py \\
+      --rubric-version v1 --dump-reference 2026-07 --top-n 2000
+
+Cada execução real (sem --dry-run) grava uma linha nova em prospect_scoring_runs
+(append-only) com a versão/checksum da rubrica usada — isso é o que permite, em
+fase futura, reprocessar uma lista antiga com outra rubrica e comparar
+estatisticamente os resultados sem qualquer migration nova.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv as csv_module
+import hashlib
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND_ROOT = _REPO_ROOT / "backend"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from sqlalchemy import select  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models.prospect_org import ProspectOrg  # noqa: E402
+from app.models.prospect_scoring_run import ProspectScoringRun  # noqa: E402
+from app.services.prospecting.rubric_loader import load_rubric  # noqa: E402
+from app.services.prospecting.scoring import ScoreInput, compute_score  # noqa: E402
+from app.services.prospecting.suppression import (  # noqa: E402
+    DEFAULT_EXCLUDE_STATUSES,
+    filter_candidates,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("prospecting.score_and_select")
+
+CSV_FIELDS = [
+    "cnpj_basico", "razao_social", "nome_fantasia", "municipio_nome", "uf",
+    "email", "telefone1", "score", "tier", "rubric_version", "justificativa",
+]
+
+
+def _score_input_from_org(org: ProspectOrg) -> ScoreInput:
+    return ScoreInput(
+        qtd_socios=org.qtd_socios,
+        porte=org.porte,
+        opcao_mei=org.opcao_mei,
+        capital_social=org.capital_social,
+        data_inicio_atividade=org.data_inicio_atividade,
+        email_domain_category=org.email_domain_category or "ausente",
+        qtd_estabelecimentos=org.qtd_estabelecimentos,
+        uf=org.uf,
+        razao_social=org.razao_social,
+    )
+
+
+def _rows_for_output(scored: list[tuple[ProspectOrg, "object"]]) -> list[dict]:
+    return [
+        {
+            "cnpj_basico": org.cnpj_basico,
+            "razao_social": org.razao_social,
+            "nome_fantasia": org.nome_fantasia,
+            "municipio_nome": org.municipio_nome,
+            "uf": org.uf,
+            "email": org.email,
+            "telefone1": org.telefone1,
+            "score": result.score,
+            "tier": result.tier,
+            "rubric_version": result.rubric_version,
+            "justificativa": result.justification,
+        }
+        for org, result in scored
+    ]
+
+
+def _write_output(rows: list[dict], output_path: Path, fmt: str) -> str:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if fmt == "json":
+        output_path.write_text(json.dumps(rows, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+    else:
+        with output_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv_module.DictWriter(fh, fieldnames=CSV_FIELDS)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow({k: row.get(k, "") for k in CSV_FIELDS})
+    return hashlib.sha256(output_path.read_bytes()).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--rubric-version", help='Ex.: "v1" -> rubric_v1.yaml.')
+    parser.add_argument("--rubric-path", help="Override explícito (usado pelos testes).")
+    parser.add_argument("--dump-reference", required=True)
+    parser.add_argument("--top-n", type=int, default=2000)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--format", choices=["csv", "json"], default="csv")
+    parser.add_argument(
+        "--suppress-statuses",
+        default=",".join(sorted(DEFAULT_EXCLUDE_STATUSES)),
+        help="opt_out/cliente são sempre aplicados independente desta lista.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Não escreve arquivo nem grava prospect_scoring_runs.")
+    args = parser.parse_args(argv)
+
+    if not args.rubric_version and not args.rubric_path:
+        parser.error("Informe --rubric-version ou --rubric-path.")
+
+    rubric = load_rubric(version=args.rubric_version, path=args.rubric_path)
+    exclude_statuses = frozenset(s.strip() for s in args.suppress_statuses.split(",") if s.strip())
+
+    started_at = datetime.now(timezone.utc)
+    db = SessionLocal()
+    try:
+        all_orgs = list(
+            db.execute(select(ProspectOrg).where(ProspectOrg.dedup_status != "merged")).scalars().all()
+        )
+        logger.info("%d organizações elegíveis (dedup_status != 'merged')", len(all_orgs))
+
+        candidates = filter_candidates(db, all_orgs, exclude_statuses=exclude_statuses)
+        logger.info("%d após filtro de supressão (excluídos: %s)", len(candidates), sorted(exclude_statuses))
+
+        scored = []
+        for org in candidates:
+            result = compute_score(_score_input_from_org(org), rubric)
+            org.pre_score = result.score
+            org.pre_score_tier = result.tier
+            org.pre_score_rubric_version = result.rubric_version
+            org.pre_scored_at = started_at
+            scored.append((org, result))
+
+        scored.sort(key=lambda pair: pair[1].score, reverse=True)
+        top = scored[: args.top_n]
+        rows = _rows_for_output(top)
+
+        if args.dry_run:
+            logger.info(
+                "--dry-run: %d candidatos pontuados, %d selecionados para o Top-N — nenhuma escrita.",
+                len(candidates), len(top),
+            )
+            db.rollback()
+            return 0
+
+        output_path = args.output or (
+            _REPO_ROOT / "reports" / "prospecting" / f"top_candidates_{rubric.version}_{args.dump_reference}.{args.format}"
+        )
+        output_checksum = _write_output(rows, output_path, args.format)
+
+        run = ProspectScoringRun(
+            rubric_version=rubric.version,
+            rubric_checksum=rubric.checksum,
+            source_dump_reference=args.dump_reference,
+            params={
+                "top_n": args.top_n,
+                "suppress_statuses": sorted(exclude_statuses),
+                "output": str(output_path),
+                "format": args.format,
+            },
+            candidate_count=len(candidates),
+            selected_count=len(top),
+            output_uri=str(output_path),
+            output_checksum=output_checksum,
+            status="completed",
+            run_started_at=started_at,
+            run_finished_at=datetime.now(timezone.utc),
+        )
+        db.add(run)
+        db.commit()
+        logger.info("Top %d escrito em %s (run_id=%s, rubrica=%s)", len(top), output_path, run.id, rubric.version)
+    finally:
+        db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Fatia 5 de 5 — fecha a Fase 1 da PO-2026-07-SALES-001 (classificação e priorização de escritórios contábeis para prospecção comercial).

Três scripts standalone em `tools/prospecting/` (reaproveitam `backend/.venv`, mesmo padrão de `tools/architecture_audit.py`/`tools/qa_gates/run_gates.py`):

1. **`ingest_cnpj_dump.py`** — Parser → Normalização → Consolidação → upsert idempotente em `prospect_orgs`.
2. **`dedup_prospects.py`** — passada de dedup por domínio nominal, só banco (não toca nos arquivos da RF).
3. **`score_and_select.py`** — Supressão → Pré-score → Top-N → arquivo CSV/JSON + registro em `prospect_scoring_runs`.

`README.md` documenta o passo a passo completo pro operador (onde baixar os arquivos oficiais, sequência exata dos comandos, runtime esperado, semântica de idempotência de cada script).

Com isso a Fase 1 do plano aprovado está completa: do dump bruto de Dados Abertos do CNPJ até uma lista Top-N pré-pontuada, determinística, sem chamada externa nem IA. Fases seguintes (agente de enriquecimento externo, telemetria comercial, feedback loop) ficam para depois, conforme o desenho do plano.

## Test plan
- [x] `pytest tests/ -q` — 878 passed (5 novos, fim-a-fim contra Postgres real, chamando `main()` de cada script diretamente)
- [x] `ruff check app/ tests/ ../tools/prospecting/` — clean
- [x] `npx pyright@1.1.411` — 0 errors
- [x] Verificação manual: `ingest_cnpj_dump.py --dry-run` contra as fixtures reporta as contagens esperadas (3 organizações consolidadas de 4 CNAE-alvo, 1 excluída por situação cadastral inativa)