### PR TITLE
feat(prospecting): schema de auditoria/rastreabilidade (Ordem Complementar, fatia 1/6)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -9,8 +9,8 @@ from app.database import Base
 from app.config import settings
 from app.models import (  # noqa: F401
     api_key, auth, billing, documents, feedback, founding_partner, jobs, news,
-    partner, prospect_diagnostic, prospect_org, prospect_scoring_run,
-    prospect_suppression, reports,
+    partner, prospect_dedup_run, prospect_diagnostic, prospect_ingestion_run,
+    prospect_org, prospect_scoring_run, prospect_suppression, reports,
 )
 
 # Import models to register them with metadata

--- a/backend/app/alembic/versions/2026_07_28_0035_add_prospecting_safeguards.py
+++ b/backend/app/alembic/versions/2026_07_28_0035_add_prospecting_safeguards.py
@@ -1,0 +1,76 @@
+"""add_prospecting_safeguards — auditoria/rastreabilidade da Fase 1 (Ordem
+Complementar à PO-2026-07-SALES-001)
+
+prospect_ingestion_runs e prospect_dedup_runs (guarda de sanidade, validação de
+layout, trava de sequenciamento); prospect_scoring_runs ganha rubric_snapshot
+(pesos completos, não só checksum); prospect_orgs ganha email_type (item 6 —
+critério "tipo do e-mail", independente de "domínio do e-mail").
+
+Revision ID: 2026_07_28_0035
+Revises: 2026_07_28_0034
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_07_28_0035"
+down_revision = "2026_07_28_0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prospect_ingestion_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("dump_reference", sa.String(length=32), nullable=False),
+        sa.Column("target_cnaes", postgresql.JSONB(), nullable=False),
+        sa.Column("download_date", sa.Date(), nullable=False),
+        sa.Column("total_estabelecimentos_scanned", sa.Integer(), nullable=True),
+        sa.Column("total_target_cnae_found", sa.Integer(), nullable=True),
+        sa.Column("total_ativas", sa.Integer(), nullable=True),
+        sa.Column("total_consolidated", sa.Integer(), nullable=True),
+        sa.Column("tolerance_params", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("file_count", sa.Integer(), nullable=True),
+        sa.Column("files_sha256", postgresql.JSONB(), nullable=True),
+        sa.Column("layout_signature", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=24), nullable=False, server_default="running"),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_prospect_ingestion_runs_dump_reference", "prospect_ingestion_runs", ["dump_reference"])
+    op.create_index("ix_prospect_ingestion_runs_status", "prospect_ingestion_runs", ["status"])
+    op.create_index("ix_prospect_ingestion_runs_finished_at", "prospect_ingestion_runs", ["finished_at"])
+
+    op.create_table(
+        "prospect_dedup_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("groups_merged", sa.Integer(), nullable=True),
+        sa.Column("orgs_merged", sa.Integer(), nullable=True),
+        sa.Column("domains_skipped_too_large", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="completed"),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_prospect_dedup_runs_finished_at", "prospect_dedup_runs", ["finished_at"])
+
+    op.add_column(
+        "prospect_scoring_runs",
+        sa.Column("rubric_snapshot", postgresql.JSONB(), nullable=False, server_default="{}"),
+    )
+    op.add_column(
+        "prospect_orgs",
+        sa.Column("email_type", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("prospect_orgs", "email_type")
+    op.drop_column("prospect_scoring_runs", "rubric_snapshot")
+    op.drop_table("prospect_dedup_runs")
+    op.drop_table("prospect_ingestion_runs")

--- a/backend/app/models/prospect_dedup_run.py
+++ b/backend/app/models/prospect_dedup_run.py
@@ -1,0 +1,33 @@
+"""ProspectDedupRun — auditoria de cada execução de dedup_prospects.py
+(Ordem Complementar à PO-2026-07-SALES-001, salvaguardas operacionais).
+
+Existe para a trava de sequenciamento: score_and_select.py só roda se o
+ProspectDedupRun concluído mais recente for posterior ao ProspectIngestionRun
+concluído mais recente — nunca pontua dados parcialmente processados.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+
+class ProspectDedupRun(Base):
+    __tablename__ = "prospect_dedup_runs"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    groups_merged = Column(Integer, nullable=True)
+    orgs_merged = Column(Integer, nullable=True)
+    domains_skipped_too_large = Column(Integer, nullable=True)
+    status = Column(String(16), nullable=False, server_default="completed")  # running|completed|failed
+
+    started_at = Column(DateTime(timezone=True), nullable=False)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/prospect_ingestion_run.py
+++ b/backend/app/models/prospect_ingestion_run.py
@@ -1,0 +1,60 @@
+"""ProspectIngestionRun — auditoria de cada execução de ingest_cnpj_dump.py
+(Ordem Complementar à PO-2026-07-SALES-001, salvaguardas operacionais).
+
+Cada execução real (sucesso, falha ou abortada por guarda de sanidade/layout)
+grava uma linha aqui, append-only. É a base para: guarda de sanidade (compara
+contra a última execução bem-sucedida com o mesmo target_cnaes), validação de
+layout (hash + assinatura dos arquivos usados) e trava de sequenciamento
+(score_and_select.py verifica se existe dedup posterior à ingestão mais recente).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, Date, DateTime, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import text
+
+from app.database import Base
+
+# running: em andamento; completed: sucesso; failed: erro inesperado;
+# aborted_sanity_check: guarda de volume/variação disparou; aborted_layout_mismatch:
+# layout dos arquivos não bate com o esperado.
+INGESTION_RUN_STATUSES: tuple[str, ...] = (
+    "running",
+    "completed",
+    "failed",
+    "aborted_sanity_check",
+    "aborted_layout_mismatch",
+)
+
+
+class ProspectIngestionRun(Base):
+    __tablename__ = "prospect_ingestion_runs"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    dump_reference = Column(String(32), nullable=False)
+    target_cnaes = Column(JSONB, nullable=False)  # lista ordenada, usada para comparar execuções compatíveis
+    download_date = Column(Date, nullable=False)  # informado pelo operador — não é inferível de forma confiável
+
+    # Métricas de volume (guarda de sanidade)
+    total_estabelecimentos_scanned = Column(Integer, nullable=True)
+    total_target_cnae_found = Column(Integer, nullable=True)
+    total_ativas = Column(Integer, nullable=True)
+    total_consolidated = Column(Integer, nullable=True)
+    tolerance_params = Column(JSONB, nullable=False, server_default="{}")  # snapshot dos limites usados
+
+    # Proveniência/layout
+    file_count = Column(Integer, nullable=True)
+    files_sha256 = Column(JSONB, nullable=True)  # {nome_do_arquivo: sha256}
+    layout_signature = Column(String(64), nullable=True)  # ex.: "estabelecimentos:30campos"
+
+    status = Column(String(24), nullable=False, server_default="running")
+    error_message = Column(Text, nullable=True)
+
+    started_at = Column(DateTime(timezone=True), nullable=False)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/prospect_org.py
+++ b/backend/app/models/prospect_org.py
@@ -52,6 +52,10 @@ class ProspectOrg(Base):
     email = Column(String(255), nullable=True)
     email_domain = Column(String(255), nullable=True)
     email_domain_category = Column(String(20), nullable=True)  # ausente|gratuito|dominio_generico|dominio_nominal
+    # Tipo do endereço (Ordem Complementar, item 6) — independente do domínio:
+    # contato/comercial/financeiro/fiscal/suporte/nome_sobrenome/outro/ausente.
+    # Peso baixo na rubrica (rubric_v2.yaml), só para desempate.
+    email_type = Column(String(20), nullable=True)
 
     # ── Fatos da RF carregados só para não bloquear a Fase 2 (enriquecimento) ──
     cnpj_matriz = Column(String(14), nullable=False)

--- a/backend/app/models/prospect_scoring_run.py
+++ b/backend/app/models/prospect_scoring_run.py
@@ -25,6 +25,7 @@ class ProspectScoringRun(Base):
     )
     rubric_version = Column(String(32), nullable=False)
     rubric_checksum = Column(String(64), nullable=False)  # sha256 do YAML, detecta edição
+    rubric_snapshot = Column(JSONB, nullable=False, server_default="{}")  # pesos completos usados — reprodutibilidade total mesmo se o YAML mudar/sumir
     source_dump_reference = Column(String(32), nullable=False)
     params = Column(JSONB, nullable=False, server_default="{}")  # snapshot dos args da CLI
     candidate_count = Column(Integer, nullable=False)  # pós consolidação+dedup+supressão

--- a/backend/app/services/prospecting/consolidation.py
+++ b/backend/app/services/prospecting/consolidation.py
@@ -18,7 +18,10 @@ milhões de linhas).
 Decisão de design explícita (não ambiguidade silenciosa): registros cuja matriz
 não está com situação cadastral ATIVA são excluídos de todo o universo de
 candidatos aqui, não só do Tier A — não há racional comercial para prospectar
-CNPJ baixado/suspenso/inapto em qualquer tier.
+CNPJ baixado/suspenso/inapto em qualquer tier. Esta decisão foi oficializada pela
+Ordem de Desenvolvimento Complementar à PO-2026-07-SALES-001 (item 7): situação
+cadastral é requisito de elegibilidade, não dimensão pontuada — substitui
+qualquer interpretação anterior do texto da PO original.
 
 Sócios: só a CONTAGEM por cnpj_basico é mantida — nome e CPF de sócio nunca são
 persistidos (minimização LGPD; a Receita já mascara parcialmente o CPF, mas o


### PR DESCRIPTION
## Summary
Fatia 1 de 6 da Ordem de Desenvolvimento Complementar à PO-2026-07-SALES-001 (salvaguardas operacionais antes da Fase 2).

- `prospect_ingestion_runs` — auditoria de cada execução de `ingest_cnpj_dump.py`: métricas de volume (para a guarda de sanidade da fatia 4), hash SHA-256 + assinatura de layout dos arquivos usados (item 2), status incluindo `aborted_sanity_check`/`aborted_layout_mismatch`.
- `prospect_dedup_runs` — auditoria de cada execução de `dedup_prospects.py`, base para a trava de sequenciamento (item 4, fatia 5).
- `prospect_scoring_runs.rubric_snapshot` — pesos completos da rubrica usada, não só o checksum (item 5, reprodutibilidade total).
- `prospect_orgs.email_type` — nova coluna para o critério "tipo do e-mail" (item 6), independente de "domínio do e-mail" já existente.
- Formaliza no docstring de `consolidation.py` a decisão do item 7 (situação cadastral como gate de elegibilidade) — já era assim, agora oficializado.

## Test plan
- [x] `pytest tests/ -q` — 878 passed (nenhum teste novo nesta fatia, só schema)
- [x] `ruff check` — clean
- [x] `npx pyright@1.1.411` — 0 errors