### PR TITLE
feat(prospecting): guarda de sanidade + validação de layout (Ordem Complementar, fatia 2/6)

### DIFF
--- a/backend/app/data/prospecting/sanity_thresholds.yaml
+++ b/backend/app/data/prospecting/sanity_thresholds.yaml
@@ -1,0 +1,21 @@
+# Tolerâncias da guarda de sanidade da ingestão (Ordem Complementar à
+# PO-2026-07-SALES-001, item 1). Editável sem mudar código — mesmo padrão da
+# rubrica de score (versionado, mas este arquivo É editado in-place, pois não
+# precisa de reprodutibilidade histórica exata como a rubrica: uma tolerância
+# recalibrada vale para as próximas execuções, não precisa "congelar" o passado).
+#
+# Qualquer violação aborta a execução com erro explícito — nunca um warning.
+
+min_target_cnae_found: 1000
+max_target_cnae_found: 500000
+
+# Proporção mínima de "ativas" sobre o total de CNAE-alvo encontrado.
+min_ativas_ratio: 0.5
+
+# Variação relativa máxima vs. a última execução bem-sucedida com o mesmo
+# --target-cnaes. Sem execução anterior compatível, esta checagem é pulada.
+max_relative_change_vs_last_run: 0.5
+
+# Proporção máxima de linhas malformadas (nº de campos diferente do esperado)
+# por arquivo antes de considerar que o layout mudou parcialmente.
+max_malformed_row_ratio: 0.01

--- a/backend/app/services/prospecting/layout_check.py
+++ b/backend/app/services/prospecting/layout_check.py
@@ -1,0 +1,101 @@
+"""Validação de layout dos arquivos da RF (Ordem Complementar à
+PO-2026-07-SALES-001, item 2).
+
+Pré-checagem rápida (lê só a primeira linha de cada tabela) antes de qualquer
+passada completa — se o número de colunas não bater com o layout oficial já
+validado (rf_parser.py), aborta antes de processar qualquer linha. Também
+expõe uma checagem de proporção de linhas malformadas por arquivo — usada por
+ingest_cnpj_dump.py durante o parsing normal para detectar mudança parcial de
+layout que a pré-checagem (só a 1ª linha) não pegaria.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from app.services.prospecting.rf_parser import (
+    EMPRESAS_FIELDS,
+    ESTABELECIMENTOS_FIELDS,
+    SIMPLES_FIELDS,
+    SOCIOS_FIELDS,
+    iter_dump_files,
+)
+
+_TABLE_FIELDS: dict[str, tuple[str, ...]] = {
+    "Empresas": EMPRESAS_FIELDS,
+    "Estabelecimentos": ESTABELECIMENTOS_FIELDS,
+    "Simples": SIMPLES_FIELDS,
+    "Socios": SOCIOS_FIELDS,
+}
+
+
+class LayoutMismatchError(Exception):
+    """Layout dos arquivos não bate com o esperado — abortar antes de processar."""
+
+
+class MalformedRowRatioError(Exception):
+    """Proporção de linhas malformadas acima do limite — sinal de layout parcialmente mudado."""
+
+
+def _first_row_field_count(path: Path) -> int:
+    with path.open("r", encoding="latin-1", errors="replace", newline="") as fh:
+        first_line = fh.readline()
+    return len(first_line.rstrip("\r\n").split(";"))
+
+
+def detect_layout_signature(dump_dir: Path) -> str:
+    """Confere a primeira linha de cada tabela contra o número de campos
+    esperado. Levanta LayoutMismatchError na primeira divergência — não
+    processa nenhuma linha antes desta checagem passar.
+
+    Retorna uma assinatura textual estável (ex.: "empresas:7campos;
+    estabelecimentos:30campos;...") gravada em ProspectIngestionRun para
+    auditoria de qual layout foi usado em cada execução.
+    """
+    signature_parts: list[str] = []
+    for table_name, fields in _TABLE_FIELDS.items():
+        files = iter_dump_files(dump_dir, table_name)
+        if not files:
+            raise LayoutMismatchError(
+                f"Nenhum arquivo encontrado para a tabela {table_name} em {dump_dir}"
+            )
+        actual = _first_row_field_count(files[0])
+        expected = len(fields)
+        if actual != expected:
+            raise LayoutMismatchError(
+                f"{table_name}: {actual} campos encontrados na primeira linha, {expected} "
+                "esperados (layout pode ter mudado — revalidar contra "
+                "gov.br/receitafederal/dados/cnpj-metadados.pdf antes de prosseguir)."
+            )
+        signature_parts.append(f"{table_name.lower()}:{expected}campos")
+    return ";".join(signature_parts)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compute_file_hashes(dump_dir: Path) -> dict[str, str]:
+    """Hash de cada arquivo usado nesta execução — item 2 (proveniência)."""
+    hashes: dict[str, str] = {}
+    for table_name in (*_TABLE_FIELDS, "Municipios"):
+        for path in iter_dump_files(dump_dir, table_name):
+            hashes[path.name] = sha256_file(path)
+    return hashes
+
+
+def check_malformed_ratio(file_name: str, malformed: int, total: int, max_ratio: float) -> None:
+    """Levanta MalformedRowRatioError se malformed/total ultrapassar max_ratio."""
+    if total == 0:
+        return
+    ratio = malformed / total
+    if ratio > max_ratio:
+        raise MalformedRowRatioError(
+            f"{file_name}: {malformed}/{total} linhas malformadas ({ratio:.1%}), acima do "
+            f"limite ({max_ratio:.1%}) — layout pode ter mudado parcialmente."
+        )

--- a/backend/app/services/prospecting/sanity.py
+++ b/backend/app/services/prospecting/sanity.py
@@ -1,0 +1,118 @@
+"""Guarda de sanidade de volume da ingestão (Ordem Complementar à
+PO-2026-07-SALES-001, item 1).
+
+Compara as métricas de uma execução contra limites absolutos e, quando existe
+uma execução anterior compatível (mesmo target_cnaes), contra a variação
+relativa. Qualquer violação levanta SanityCheckError — nunca um warning
+silencioso; quem chama decide o que fazer (ingest_cnpj_dump.py aborta antes de
+gravar qualquer linha em prospect_orgs).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+THRESHOLDS_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "data" / "prospecting" / "sanity_thresholds.yaml"
+)
+
+_REQUIRED_KEYS = (
+    "min_target_cnae_found",
+    "max_target_cnae_found",
+    "min_ativas_ratio",
+    "max_relative_change_vs_last_run",
+    "max_malformed_row_ratio",
+)
+
+
+class SanityCheckError(Exception):
+    """Guarda de sanidade violada — a execução deve abortar sem escrever dados."""
+
+
+@dataclass(frozen=True)
+class IngestionMetrics:
+    total_estabelecimentos_scanned: int
+    total_target_cnae_found: int
+    total_ativas: int
+    total_consolidated: int
+
+
+def load_thresholds(path: Optional[Path] = None) -> dict[str, Any]:
+    resolved = path or THRESHOLDS_PATH
+    if not resolved.exists():
+        raise SanityCheckError(f"Arquivo de tolerâncias não encontrado: {resolved}")
+    data = yaml.safe_load(resolved.read_bytes())
+    if not isinstance(data, dict):
+        raise SanityCheckError(f"{resolved}: YAML inválido (esperado mapeamento no topo).")
+    missing = [k for k in _REQUIRED_KEYS if k not in data]
+    if missing:
+        raise SanityCheckError(f"{resolved}: faltando chave(s) obrigatória(s): {missing}")
+    return data
+
+
+def thresholds_checksum(path: Optional[Path] = None) -> str:
+    resolved = path or THRESHOLDS_PATH
+    return hashlib.sha256(resolved.read_bytes()).hexdigest()
+
+
+def validate_metrics(
+    metrics: IngestionMetrics,
+    thresholds: dict[str, Any],
+    previous: Optional[IngestionMetrics] = None,
+) -> None:
+    """Levanta SanityCheckError na primeira violação encontrada."""
+    if metrics.total_target_cnae_found == 0:
+        raise SanityCheckError(
+            "Zero empresas elegíveis encontradas (CNAE-alvo) — layout pode ter mudado."
+        )
+
+    if not (
+        thresholds["min_target_cnae_found"]
+        <= metrics.total_target_cnae_found
+        <= thresholds["max_target_cnae_found"]
+    ):
+        raise SanityCheckError(
+            f"Quantidade de CNAE-alvo encontrada ({metrics.total_target_cnae_found}) fora da "
+            f"faixa esperada [{thresholds['min_target_cnae_found']}, "
+            f"{thresholds['max_target_cnae_found']}]."
+        )
+
+    ativas_ratio = metrics.total_ativas / metrics.total_target_cnae_found
+    if ativas_ratio < thresholds["min_ativas_ratio"]:
+        raise SanityCheckError(
+            f"Proporção de empresas ativas ({ativas_ratio:.1%}) abaixo do mínimo esperado "
+            f"({thresholds['min_ativas_ratio']:.1%})."
+        )
+
+    if previous is not None and previous.total_target_cnae_found > 0:
+        rel_change = (
+            abs(metrics.total_target_cnae_found - previous.total_target_cnae_found)
+            / previous.total_target_cnae_found
+        )
+        if rel_change > thresholds["max_relative_change_vs_last_run"]:
+            raise SanityCheckError(
+                f"Variação de {rel_change:.1%} no total de CNAE-alvo encontrado vs. a última "
+                f"execução compatível ({previous.total_target_cnae_found} -> "
+                f"{metrics.total_target_cnae_found}), acima da tolerância "
+                f"({thresholds['max_relative_change_vs_last_run']:.1%})."
+            )
+
+
+def reduction_summary(metrics: IngestionMetrics) -> dict[str, str]:
+    """Percentuais de redução em cada etapa, para o relatório de auditoria (item 8)."""
+
+    def pct(num: int, den: int) -> str:
+        if den == 0:
+            return "n/a"
+        return f"{(1 - num / den):.1%}"
+
+    return {
+        "scanned_to_target": pct(metrics.total_target_cnae_found, metrics.total_estabelecimentos_scanned),
+        "target_to_ativas": pct(metrics.total_ativas, metrics.total_target_cnae_found),
+        "ativas_to_consolidated": pct(metrics.total_consolidated, metrics.total_ativas),
+    }

--- a/backend/tests/test_prospecting_layout_check.py
+++ b/backend/tests/test_prospecting_layout_check.py
@@ -1,0 +1,67 @@
+"""Validação de layout dos arquivos da RF (Ordem Complementar, item 2) — puro, sem DB."""
+
+from pathlib import Path
+
+import pytest
+
+from app.services.prospecting.layout_check import (
+    LayoutMismatchError,
+    MalformedRowRatioError,
+    check_malformed_ratio,
+    compute_file_hashes,
+    detect_layout_signature,
+    sha256_file,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "prospecting"
+
+
+class TestDetectLayoutSignature:
+    def test_real_fixtures_match_expected_layout(self):
+        signature = detect_layout_signature(FIXTURE_DIR)
+        assert "estabelecimentos:30campos" in signature
+        assert "empresas:7campos" in signature
+        assert "simples:7campos" in signature
+        assert "socios:11campos" in signature
+
+    def test_raises_when_field_count_mismatches(self, tmp_path):
+        (tmp_path / "Empresas0.csv").write_text("10000000;RAZAO;2062;49;100000,00;5\n")  # 6 campos, faltou 1
+        (tmp_path / "Estabelecimentos0.csv").write_text(
+            ";".join(["x"] * 30) + "\n"
+        )
+        (tmp_path / "Simples0.csv").write_text(";".join(["x"] * 7) + "\n")
+        (tmp_path / "Socios0.csv").write_text(";".join(["x"] * 11) + "\n")
+
+        with pytest.raises(LayoutMismatchError, match="Empresas"):
+            detect_layout_signature(tmp_path)
+
+    def test_raises_when_table_file_missing(self, tmp_path):
+        with pytest.raises(LayoutMismatchError):
+            detect_layout_signature(tmp_path)
+
+
+class TestFileHashing:
+    def test_sha256_file_is_deterministic(self):
+        path = FIXTURE_DIR / "Municipios0.csv"
+        assert sha256_file(path) == sha256_file(path)
+
+    def test_compute_file_hashes_covers_all_tables(self):
+        hashes = compute_file_hashes(FIXTURE_DIR)
+        assert any(name.startswith("Empresas") for name in hashes)
+        assert any(name.startswith("Estabelecimentos") for name in hashes)
+        assert any(name.startswith("Simples") for name in hashes)
+        assert any(name.startswith("Socios") for name in hashes)
+        assert any(name.startswith("Municipios") for name in hashes)
+        assert all(len(h) == 64 for h in hashes.values())
+
+
+class TestMalformedRowRatio:
+    def test_within_tolerance_does_not_raise(self):
+        check_malformed_ratio("Estabelecimentos0.csv", malformed=1, total=1000, max_ratio=0.01)
+
+    def test_above_tolerance_raises(self):
+        with pytest.raises(MalformedRowRatioError, match="Estabelecimentos0.csv"):
+            check_malformed_ratio("Estabelecimentos0.csv", malformed=50, total=1000, max_ratio=0.01)
+
+    def test_zero_total_does_not_raise(self):
+        check_malformed_ratio("vazio.csv", malformed=0, total=0, max_ratio=0.01)

--- a/backend/tests/test_prospecting_sanity.py
+++ b/backend/tests/test_prospecting_sanity.py
@@ -1,0 +1,103 @@
+"""Guarda de sanidade de volume (Ordem Complementar, item 1) — puro, sem DB."""
+
+import pytest
+import yaml
+
+from app.services.prospecting.sanity import (
+    IngestionMetrics,
+    SanityCheckError,
+    load_thresholds,
+    reduction_summary,
+    thresholds_checksum,
+    validate_metrics,
+)
+
+
+def _metrics(**overrides) -> IngestionMetrics:
+    defaults = dict(
+        total_estabelecimentos_scanned=1_000_000,
+        total_target_cnae_found=80_000,
+        total_ativas=70_000,
+        total_consolidated=70_000,
+    )
+    defaults.update(overrides)
+    return IngestionMetrics(**defaults)
+
+
+class TestLoadThresholds:
+    def test_loads_real_thresholds_file(self):
+        thresholds = load_thresholds()
+        assert thresholds["min_target_cnae_found"] > 0
+        assert 0 < thresholds["min_ativas_ratio"] <= 1
+
+    def test_checksum_is_stable(self):
+        assert thresholds_checksum() == thresholds_checksum()
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(SanityCheckError):
+            load_thresholds(tmp_path / "nao_existe.yaml")
+
+    def test_missing_key_raises(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(yaml.safe_dump({"min_target_cnae_found": 1}))
+        with pytest.raises(SanityCheckError, match="max_target_cnae_found"):
+            load_thresholds(bad)
+
+
+class TestValidateMetrics:
+    def test_healthy_metrics_pass(self):
+        thresholds = load_thresholds()
+        validate_metrics(_metrics(), thresholds)  # não deve levantar
+
+    def test_zero_eligible_raises(self):
+        thresholds = load_thresholds()
+        with pytest.raises(SanityCheckError, match="Zero empresas elegíveis"):
+            validate_metrics(_metrics(total_target_cnae_found=0, total_ativas=0), thresholds)
+
+    def test_below_min_target_raises(self):
+        thresholds = load_thresholds()
+        with pytest.raises(SanityCheckError, match="fora da"):
+            validate_metrics(_metrics(total_target_cnae_found=10, total_ativas=8), thresholds)
+
+    def test_above_max_target_raises(self):
+        thresholds = load_thresholds()
+        with pytest.raises(SanityCheckError, match="fora da"):
+            validate_metrics(
+                _metrics(total_target_cnae_found=10_000_000, total_ativas=9_000_000), thresholds
+            )
+
+    def test_low_ativas_ratio_raises(self):
+        thresholds = load_thresholds()
+        with pytest.raises(SanityCheckError, match="ativas"):
+            validate_metrics(_metrics(total_target_cnae_found=80_000, total_ativas=1_000), thresholds)
+
+    def test_first_run_without_baseline_does_not_check_relative_change(self):
+        thresholds = load_thresholds()
+        # Sem "previous" — mesmo uma métrica que seria uma variação absurda vs.
+        # qualquer coisa não deve travar por falta de comparação.
+        validate_metrics(_metrics(total_target_cnae_found=200_000, total_ativas=150_000), thresholds)
+
+    def test_relative_change_within_tolerance_passes(self):
+        thresholds = load_thresholds()
+        previous = _metrics(total_target_cnae_found=80_000, total_ativas=70_000)
+        current = _metrics(total_target_cnae_found=100_000, total_ativas=90_000)  # +25%
+        validate_metrics(current, thresholds, previous=previous)
+
+    def test_relative_change_above_tolerance_raises(self):
+        thresholds = load_thresholds()
+        previous = _metrics(total_target_cnae_found=80_000, total_ativas=70_000)
+        current = _metrics(total_target_cnae_found=200_000, total_ativas=150_000)  # +150%
+        with pytest.raises(SanityCheckError, match="[Vv]aria"):
+            validate_metrics(current, thresholds, previous=previous)
+
+
+class TestReductionSummary:
+    def test_computes_percentages_for_each_stage(self):
+        summary = reduction_summary(_metrics())
+        assert "scanned_to_target" in summary
+        assert "target_to_ativas" in summary
+        assert "ativas_to_consolidated" in summary
+
+    def test_handles_zero_denominator_gracefully(self):
+        summary = reduction_summary(_metrics(total_estabelecimentos_scanned=0))
+        assert summary["scanned_to_target"] == "n/a"


### PR DESCRIPTION
## Summary
Fatia 2 de 6 da Ordem de Desenvolvimento Complementar. Lógica pura (sem DB, sem arquivo real) — o wiring nos scripts vem na fatia 4.

- `sanity.py` — guarda de volume (item 1): limites absolutos + variação relativa vs. a última execução compatível, configurável via `sanity_thresholds.yaml`. Qualquer violação levanta `SanityCheckError` (nunca warning silencioso).
- `layout_check.py` — validação de layout (item 2): pré-checagem por contagem de campos antes de qualquer parsing, hash SHA-256 dos arquivos usados, checagem de proporção de linhas malformadas.

## Test plan
- [x] `pytest tests/ -q` — 900 passed (22 novos)
- [x] `ruff check` — clean
- [x] `npx pyright@1.1.411` — 0 errors