### PR TITLE
feat(prospecting): tipo do e-mail + rubric_v2 (Ordem Complementar, fatia 3/6)

### DIFF
--- a/backend/app/data/prospecting/rubrics/rubric_v2.yaml
+++ b/backend/app/data/prospecting/rubrics/rubric_v2.yaml
@@ -1,0 +1,80 @@
+# Rubrica de pré-score — v2 (Ordem Complementar à PO-2026-07-SALES-001, item 6)
+#
+# Idêntica a rubric_v1.yaml, com uma dimensão nova: email_type ("tipo do
+# e-mail", independente de email_domain_category, "domínio do e-mail" — a PO
+# original pedia os dois separadamente, só o domínio tinha sido implementado
+# na Fase 1). Pesos propositalmente baixos (-1 a 2): o objetivo declarado na
+# ordem é só auxiliar desempate entre registros semelhantes, nunca dominar o
+# score como email_domain_category/porte já fazem.
+#
+# v1 continua válido e imutável (histórico) — Rubric.get_weight() já cai em 0
+# para uma dimensão inteira ausente da rubrica carregada, então v1 nunca
+# precisou de edição para isso. v2 passa a ser a versão recomendada no README.
+
+version: v2
+description: "Rubrica de pré-score v2 — adiciona tipo do e-mail (Ordem Complementar, item 6)"
+
+base_score: 50
+
+tiers:
+  A: {min: 80}
+  B: {min: 60}
+  C: {min: 40}
+  D: {min: 0}
+
+scoring:
+  socios:
+    "1": 2
+    "2": 6
+    "3_or_more": 10
+
+  porte:
+    mei: -100
+    "00": 0
+    "01": 3
+    "03": 8
+    "05": 12
+
+  capital_social:
+    faixas:
+      - {ate: 5000, peso: 0}
+      - {ate: 50000, peso: 4}
+      - {ate: 200000, peso: 8}
+      - {acima: 200000, peso: 12}
+
+  idade_anos:
+    faixas:
+      - {ate: 1, peso: -3}
+      - {ate: 3, peso: 2}
+      - {ate: 10, peso: 6}
+      - {acima: 10, peso: 10}
+
+  email_domain_category:
+    ausente: -100
+    gratuito: 2
+    dominio_generico: 7
+    dominio_nominal: 12
+
+  estabelecimentos:
+    "1": 0
+    "2_3": 5
+    "4_plus": 10
+
+  geografia:
+    default: 0
+    RS: 10
+    SC: 7
+    PR: 6
+    SP: 5
+
+  # Tipo do endereço de e-mail (independente do domínio) — Ordem Complementar,
+  # item 6. Peso baixo por design: só desempate.
+  email_type:
+    ausente: 0
+    outro: 0
+    contato: 0
+    suporte: 0
+    comercial: 1
+    financeiro: 1
+    fiscal: 2
+    nome_sobrenome: 2

--- a/backend/app/services/prospecting/consolidation.py
+++ b/backend/app/services/prospecting/consolidation.py
@@ -38,7 +38,11 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Optional
 
-from app.services.prospecting.email_classifier import classify_domain, extract_domain
+from app.services.prospecting.email_classifier import (
+    classify_domain,
+    classify_email_type,
+    extract_domain,
+)
 from app.services.prospecting.rf_parser import (
     SITUACAO_CADASTRAL_ATIVA,
     iter_empresas,
@@ -87,6 +91,7 @@ class ConsolidatedOrg:
     email: Optional[str]
     email_domain: Optional[str]
     email_domain_category: str
+    email_type: str
     cnae_principal: str
     cnaes_secundarios: list[str]
     source_dump_reference: str
@@ -167,6 +172,7 @@ def _consolidate_estabelecimentos(
             email=email,
             email_domain=domain,
             email_domain_category="ausente",  # recomputado após razão social ser conhecida
+            email_type=classify_email_type(email),  # não depende da razão social, já pode ser calculado aqui
             cnae_principal=matriz["cnae_fiscal_principal"],
             cnaes_secundarios=parse_cnaes_secundarios(matriz["cnae_fiscal_secundaria"]),
             source_dump_reference="",  # preenchido por build_consolidated_orgs

--- a/backend/app/services/prospecting/email_classifier.py
+++ b/backend/app/services/prospecting/email_classifier.py
@@ -1,8 +1,11 @@
-"""Classifica o domínio de e-mail de um escritório contábil (PO-2026-07-SALES-001,
-Fase 1). Determinístico, sem chamada externa nem IA — exigência explícita da PO
-para o pré-score.
+"""Classifica o e-mail de um escritório contábil (PO-2026-07-SALES-001, Fase 1;
+tipo do endereço adicionado pela Ordem Complementar, item 6). Determinístico,
+sem chamada externa nem IA.
 
-Categorias: ausente | gratuito | dominio_generico | dominio_nominal.
+Dois conceitos independentes, cada um com sua própria classificação:
+- classify_domain(): ausente | gratuito | dominio_generico | dominio_nominal.
+- classify_email_type(): contato | comercial | financeiro | fiscal | suporte |
+  nome_sobrenome | outro | ausente — peso baixo na rubrica, só para desempate.
 """
 
 from __future__ import annotations
@@ -79,3 +82,45 @@ def classify_domain(
     if any(t in root or root in t for t in tokens):
         return "dominio_nominal"
     return "dominio_generico"
+
+
+# Prefixos de papel/função do endereço (parte antes do @) — independente do
+# domínio. Ordem importa: "fiscal" é checado antes de "contabil" fazer parte
+# de "contabilidade" via _GENERIC_SUFFIXES não se aplicar aqui (lista própria).
+_ROLE_PREFIXES: dict[str, tuple[str, ...]] = {
+    "fiscal": ("fiscal", "tributos", "tributario"),
+    "financeiro": ("financeiro", "cobranca", "faturamento", "boleto"),
+    "comercial": ("comercial", "vendas", "sales", "negocios", "orcamento"),
+    "suporte": ("suporte", "support", "atendimento", "sac", "ajuda"),
+    "contato": ("contato", "contact", "info", "geral"),
+}
+
+
+def _looks_like_personal_name(local: str) -> bool:
+    """Heurística determinística para "nome.sobrenome" — sem lista de nomes
+    própria: dois ou mais tokens alfabéticos (>=2 letras) separados por
+    ./_/- e nada mais (evita casar "joao123" ou "contato.geral")."""
+    parts = re.split(r"[._-]", local)
+    if len(parts) < 2:
+        return False
+    return all(p.isalpha() and len(p) >= 2 for p in parts)
+
+
+def classify_email_type(email: str | None) -> str:
+    """Retorna: ausente | fiscal | financeiro | comercial | suporte | contato |
+    nome_sobrenome | outro. Peso baixo na rubrica — só auxilia desempate entre
+    registros semelhantes (Ordem Complementar, item 6)."""
+    if not email or "@" not in email:
+        return "ausente"
+    local = _strip_accents(email.split("@", 1)[0].strip().lower())
+    if not local:
+        return "ausente"
+
+    for type_name, prefixes in _ROLE_PREFIXES.items():
+        if any(local == p or local.startswith(p) for p in prefixes):
+            return type_name
+
+    if _looks_like_personal_name(local):
+        return "nome_sobrenome"
+
+    return "outro"

--- a/backend/app/services/prospecting/scoring.py
+++ b/backend/app/services/prospecting/scoring.py
@@ -31,6 +31,10 @@ class ScoreInput:
     qtd_estabelecimentos: int
     uf: str
     razao_social: str = ""
+    # Tipo do endereço (Ordem Complementar, item 6) — independente do domínio.
+    # Peso baixo por design (rubric_v2.yaml): só auxilia desempate. rubric_v1.yaml
+    # não define esta dimensão — get_weight() cai em 0, sem quebrar nada.
+    email_type: str = "ausente"
     as_of: date = field(default_factory=date.today)
 
 
@@ -100,6 +104,7 @@ def compute_score(inp: ScoreInput, rubric: Rubric) -> ScoreResult:
         "estabelecimentos", _estabelecimentos_key(inp.qtd_estabelecimentos)
     )
     breakdown["geografia"] = rubric.get_weight("geografia", inp.uf)
+    breakdown["email_type"] = rubric.get_weight("email_type", inp.email_type)
 
     raw = rubric.base_score + sum(breakdown.values())
     score = max(0, min(100, raw))
@@ -150,6 +155,14 @@ def _build_justification(inp: ScoreInput, breakdown: dict[str, int]) -> str:
         parts.append("empresa consolidada (10+ anos)")
     elif idade < 1:
         parts.append("empresa recém-aberta")
+
+    # Tipo de e-mail é critério de desempate (peso baixo) — só entra na
+    # justificativa quando é um sinal positivo relevante (nome_sobrenome/fiscal),
+    # não para toda categoria (evita poluir a frase com "outro"/"contato").
+    if inp.email_type == "nome_sobrenome":
+        parts.append("e-mail nominal (nome.sobrenome)")
+    elif inp.email_type == "fiscal":
+        parts.append("e-mail de área fiscal")
 
     sentence = ", ".join(parts)
     return sentence[0].upper() + sentence[1:] + "."

--- a/backend/tests/test_prospecting_consolidation.py
+++ b/backend/tests/test_prospecting_consolidation.py
@@ -76,6 +76,16 @@ class TestBuildConsolidatedOrgs:
         assert beta.email_domain_category == "gratuito"
         assert delta.email_domain_category == "ausente"  # sem correio_eletronico no fixture
 
+    def test_email_type_classified_independently_of_domain(self):
+        # Ordem Complementar, item 6 — dimensão separada de email_domain_category.
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        alpha = next(o for o in orgs if o.cnpj_basico == "10000000")
+        beta = next(o for o in orgs if o.cnpj_basico == "20000000")
+        delta = next(o for o in orgs if o.cnpj_basico == "40000000")
+        assert alpha.email_type == "contato"  # contato@alphacontabilidade.com.br
+        assert beta.email_type == "outro"  # beta@gmail.com
+        assert delta.email_type == "ausente"  # sem correio_eletronico
+
     def test_source_dump_reference_is_stamped_on_every_org(self):
         orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
         assert all(o.source_dump_reference == "2026-07-fixture" for o in orgs)

--- a/backend/tests/test_prospecting_email_classifier.py
+++ b/backend/tests/test_prospecting_email_classifier.py
@@ -1,8 +1,13 @@
-"""Classificador de domínio de e-mail (PO-2026-07-SALES-001, Fase 1) — puro, sem DB."""
+"""Classificador de domínio e tipo de e-mail (PO-2026-07-SALES-001, Fase 1;
+tipo do e-mail adicionado pela Ordem Complementar, item 6) — puro, sem DB."""
 
 import pytest
 
-from app.services.prospecting.email_classifier import classify_domain, extract_domain
+from app.services.prospecting.email_classifier import (
+    classify_domain,
+    classify_email_type,
+    extract_domain,
+)
 
 
 class TestExtractDomain:
@@ -52,3 +57,44 @@ class TestClassifyDomain:
             "contato@contabilidadeonline.com.br",
             razao_social="Ferreira Contabilidade Ltda",
         ) == "dominio_generico"
+
+
+class TestClassifyEmailType:
+    def test_ausente_when_no_email(self):
+        assert classify_email_type(None) == "ausente"
+        assert classify_email_type("") == "ausente"
+        assert classify_email_type("nao-e-email") == "ausente"
+
+    @pytest.mark.parametrize(
+        "local,expected",
+        [
+            ("fiscal", "fiscal"),
+            ("tributos", "fiscal"),
+            ("financeiro", "financeiro"),
+            ("cobranca", "financeiro"),
+            ("comercial", "comercial"),
+            ("vendas", "comercial"),
+            ("suporte", "suporte"),
+            ("sac", "suporte"),
+            ("contato", "contato"),
+            ("info", "contato"),
+        ],
+    )
+    def test_role_based_prefixes(self, local, expected):
+        assert classify_email_type(f"{local}@escritorio.com.br") == expected
+
+    def test_role_prefix_matches_with_suffix(self):
+        # "fiscal2" ou "contato.geral" ainda começam com o prefixo de papel.
+        assert classify_email_type("fiscal2@escritorio.com.br") == "fiscal"
+
+    def test_nome_sobrenome_pattern(self):
+        assert classify_email_type("joao.silva@escritorio.com.br") == "nome_sobrenome"
+        assert classify_email_type("maria_souza@escritorio.com.br") == "nome_sobrenome"
+        assert classify_email_type("ana-pereira@escritorio.com.br") == "nome_sobrenome"
+
+    def test_outro_for_unrecognized_pattern(self):
+        assert classify_email_type("joao123@escritorio.com.br") == "outro"
+        assert classify_email_type("xyz@escritorio.com.br") == "outro"
+
+    def test_single_token_without_separator_is_not_nome_sobrenome(self):
+        assert classify_email_type("joaosilva@escritorio.com.br") == "outro"

--- a/backend/tests/test_prospecting_scoring.py
+++ b/backend/tests/test_prospecting_scoring.py
@@ -40,6 +40,7 @@ def _base_input(
     capital_social: Decimal = Decimal("100000"),
     data_inicio_atividade: date | None = date(2015, 1, 1),  # ~11 anos
     email_domain_category: str = "dominio_nominal",
+    email_type: str = "ausente",
     qtd_estabelecimentos: int = 3,
     uf: str = "RS",
     razao_social: str = "Escritório Modelo Contabilidade Ltda",
@@ -52,6 +53,7 @@ def _base_input(
         capital_social=capital_social,
         data_inicio_atividade=data_inicio_atividade,
         email_domain_category=email_domain_category,
+        email_type=email_type,
         qtd_estabelecimentos=qtd_estabelecimentos,
         uf=uf,
         razao_social=razao_social,
@@ -115,12 +117,18 @@ class TestMeiCapInvariant:
 
 
 class TestBreakdownAndJustification:
-    def test_breakdown_has_all_six_dimensions(self):
+    def test_breakdown_has_all_seven_dimensions(self):
         result = compute_score(_base_input(), RUBRIC)
         assert set(result.breakdown) == {
             "socios", "porte", "capital_social", "idade_anos",
-            "email_domain_category", "estabelecimentos", "geografia",
+            "email_domain_category", "estabelecimentos", "geografia", "email_type",
         }
+
+    def test_email_type_defaults_to_ausente_and_scores_zero_on_rubric_v1(self):
+        # rubric_v1.yaml não define email_type — get_weight() cai em 0,
+        # compatibilidade retroativa automática (Ordem Complementar, item 6).
+        result = compute_score(_base_input(), RUBRIC)
+        assert result.breakdown["email_type"] == 0
 
     def test_justification_mentions_mei_when_applicable(self):
         result = compute_score(_base_input(opcao_mei=True), RUBRIC)
@@ -138,3 +146,28 @@ class TestBreakdownAndJustification:
 def test_socios_bucketing_matches_rubric_keys(qtd_socios, expected_key_weight):
     result = compute_score(_base_input(qtd_socios=qtd_socios), RUBRIC)
     assert result.breakdown["socios"] == RUBRIC.get_weight("socios", expected_key_weight)
+
+
+class TestRubricV2EmailType:
+    """Ordem Complementar, item 6 — email_type é dimensão nova só em rubric_v2.yaml."""
+
+    RUBRIC_V2 = load_rubric(version="v2")
+
+    def test_v2_loads_with_email_type_dimension(self):
+        assert "email_type" in self.RUBRIC_V2.scoring
+
+    def test_email_type_weight_is_low_by_design(self):
+        # Peso baixo (-1 a 2) — item 6 explicitamente pede que sirva só de
+        # desempate, nunca dominar o score como email_domain_category/porte.
+        weights = self.RUBRIC_V2.scoring["email_type"]
+        assert all(-1 <= w <= 2 for w in weights.values())
+
+    def test_nome_sobrenome_scores_higher_than_outro_on_v2(self):
+        base_score = compute_score(_base_input(email_type="outro"), self.RUBRIC_V2).score
+        nominal_score = compute_score(_base_input(email_type="nome_sobrenome"), self.RUBRIC_V2).score
+        assert nominal_score >= base_score
+
+    def test_v1_still_scores_email_type_as_zero(self):
+        # Compatibilidade retroativa: v1 nunca precisou ser editado.
+        result = compute_score(_base_input(email_type="nome_sobrenome"), RUBRIC)
+        assert result.breakdown["email_type"] == 0

--- a/tools/prospecting/ingest_cnpj_dump.py
+++ b/tools/prospecting/ingest_cnpj_dump.py
@@ -43,7 +43,8 @@ _UPSERT_COLUMNS = (
     "data_inicio_atividade", "qtd_socios", "qtd_estabelecimentos", "uf",
     "municipio_codigo", "municipio_nome", "logradouro", "numero", "complemento",
     "bairro", "cep", "ddd_telefone1", "telefone1", "email", "email_domain",
-    "email_domain_category", "cnae_principal", "cnaes_secundarios", "source_dump_reference",
+    "email_domain_category", "email_type", "cnae_principal", "cnaes_secundarios",
+    "source_dump_reference",
 )
 
 

--- a/tools/prospecting/score_and_select.py
+++ b/tools/prospecting/score_and_select.py
@@ -58,6 +58,7 @@ def _score_input_from_org(org: ProspectOrg) -> ScoreInput:
         capital_social=org.capital_social,
         data_inicio_atividade=org.data_inicio_atividade,
         email_domain_category=org.email_domain_category or "ausente",
+        email_type=org.email_type or "ausente",
         qtd_estabelecimentos=org.qtd_estabelecimentos,
         uf=org.uf,
         razao_social=org.razao_social,


### PR DESCRIPTION
## Summary
Fatia 3 de 6 da Ordem de Desenvolvimento Complementar.

- `classify_email_type()` — contato/comercial/financeiro/fiscal/suporte/nome_sobrenome/outro/ausente, independente de `classify_domain()` (item 6: "domínio do e-mail" e "tipo do e-mail" são critérios distintos na PO original; só o primeiro tinha sido implementado na Fase 1).
- `rubric_v2.yaml` (novo arquivo, `rubric_v1.yaml` continua imutável) — adiciona a dimensão `email_type` com pesos baixos (-1 a 2), só para desempate, conforme pedido explicitamente na ordem.
- `Rubric.get_weight()` já cai em 0 para dimensão ausente da rubrica carregada — `rubric_v1.yaml` segue válido sem qualquer edição (compatibilidade retroativa automática).
- Wiring: `ConsolidatedOrg`/`ScoreInput`/`ingest_cnpj_dump.py`/`score_and_select.py` todos atualizados para persistir/ler `email_type` (coluna `prospect_orgs.email_type`, schema da fatia 1, #553 já mesclado).

## Test plan
- [x] `pytest tests/ -q` — 899 passed
- [x] `ruff check` — clean
- [x] `npx pyright@1.1.411` — 0 errors