### PR TITLE
feat(prospecting): guarda de sanidade + layout + auditoria em ingest_cnpj_dump.py (Ordem Complementar, fatia 4/6)

### DIFF
--- a/backend/app/alembic/versions/2026_07_28_0036_widen_layout_signature.py
+++ b/backend/app/alembic/versions/2026_07_28_0036_widen_layout_signature.py
@@ -1,0 +1,34 @@
+"""widen_layout_signature — corrige bug de dimensionamento da fatia 1 (Ordem
+Complementar)
+
+A assinatura real ("empresas:7campos;estabelecimentos:30campos;simples:7campos;
+socios:11campos") tem ~74 caracteres, maior que o VARCHAR(64) original —
+descoberto ao rodar o teste fim-a-fim contra as fixtures reais. Corrige para
+TEXT (sem limite arbitrário) em vez de recalcular um novo limite fixo.
+
+Revision ID: 2026_07_28_0036
+Revises: 2026_07_28_0035
+Create Date: 2026-07-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "2026_07_28_0036"
+down_revision = "2026_07_28_0035"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "prospect_ingestion_runs", "layout_signature",
+        existing_type=sa.String(length=64), type_=sa.Text(), nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "prospect_ingestion_runs", "layout_signature",
+        existing_type=sa.Text(), type_=sa.String(length=64), nullable=True,
+    )

--- a/backend/app/models/prospect_ingestion_run.py
+++ b/backend/app/models/prospect_ingestion_run.py
@@ -50,7 +50,7 @@ class ProspectIngestionRun(Base):
     # Proveniência/layout
     file_count = Column(Integer, nullable=True)
     files_sha256 = Column(JSONB, nullable=True)  # {nome_do_arquivo: sha256}
-    layout_signature = Column(String(64), nullable=True)  # ex.: "estabelecimentos:30campos"
+    layout_signature = Column(Text, nullable=True)  # ex.: "empresas:7campos;estabelecimentos:30campos;..."
 
     status = Column(String(24), nullable=False, server_default="running")
     error_message = Column(Text, nullable=True)

--- a/backend/app/services/prospecting/consolidation.py
+++ b/backend/app/services/prospecting/consolidation.py
@@ -45,6 +45,7 @@ from app.services.prospecting.email_classifier import (
 )
 from app.services.prospecting.rf_parser import (
     SITUACAO_CADASTRAL_ATIVA,
+    RowCounts,
     iter_empresas,
     iter_estabelecimentos,
     iter_simples,
@@ -97,13 +98,36 @@ class ConsolidatedOrg:
     source_dump_reference: str
 
 
+@dataclass(frozen=True)
+class ConsolidationMetrics:
+    """Volume em cada etapa do pipeline — insumo da guarda de sanidade e do
+    relatório de auditoria (Ordem Complementar, itens 1 e 8)."""
+
+    total_estabelecimentos_scanned: int
+    total_target_cnae_found: int
+    total_ativas: int
+    total_consolidated: int
+
+
+@dataclass(frozen=True)
+class ConsolidationResult:
+    orgs: list[ConsolidatedOrg]
+    metrics: ConsolidationMetrics
+
+
 def discover_target_cnpj_basicos(
-    dump_dir: Path, target_cnaes: frozenset[str] = TARGET_CNAES
+    dump_dir: Path,
+    target_cnaes: frozenset[str] = TARGET_CNAES,
+    counts: Optional[RowCounts] = None,
 ) -> set[str]:
     """Pass 1: cnpj_basico cujo CNAE principal OU secundário de QUALQUER
-    estabelecimento bate com um CNAE-alvo."""
+    estabelecimento bate com um CNAE-alvo.
+
+    counts, quando passado, acumula total/malformed de TODAS as linhas de
+    Estabelecimentos varridas — usado pela guarda de sanidade e pela checagem
+    de proporção de linhas malformadas (Ordem Complementar, itens 1 e 2)."""
     target: set[str] = set()
-    for row in iter_estabelecimentos(dump_dir):
+    for row in iter_estabelecimentos(dump_dir, counts):
         secundarias = set(parse_cnaes_secundarios(row["cnae_fiscal_secundaria"]))
         if row["cnae_fiscal_principal"] in target_cnaes or secundarias & target_cnaes:
             target.add(row["cnpj_basico"])
@@ -214,11 +238,17 @@ def build_consolidated_orgs(
     *,
     dump_reference: str,
     target_cnaes: frozenset[str] = TARGET_CNAES,
-) -> list[ConsolidatedOrg]:
+    estab_row_counts: Optional[RowCounts] = None,
+) -> ConsolidationResult:
     """Orquestra o pipeline completo de consolidação: Parser -> Normalização ->
     Consolidação (do diagrama da PO). Deduplicação e supressão vêm depois,
-    em módulos separados (dedup.py, suppression.py)."""
-    target_set = discover_target_cnpj_basicos(dump_dir, target_cnaes)
+    em módulos separados (dedup.py, suppression.py).
+
+    estab_row_counts, quando passado (objeto RowCounts do chamador), acumula
+    total/malformed de Estabelecimentos — o chamador (ingest_cnpj_dump.py) lê
+    esse objeto depois para a guarda de sanidade e a checagem de layout
+    parcialmente mudado (Ordem Complementar, itens 1 e 2)."""
+    target_set = discover_target_cnpj_basicos(dump_dir, target_cnaes, counts=estab_row_counts)
     logger.info("Pass 1: %d cnpj_basico candidatos (CNAE alvo)", len(target_set))
 
     orgs = _consolidate_estabelecimentos(dump_dir, target_set)
@@ -232,4 +262,10 @@ def build_consolidated_orgs(
         org.source_dump_reference = dump_reference
         org.email_domain_category = classify_domain(org.email, org.razao_social, org.nome_fantasia)
 
-    return list(orgs.values())
+    metrics = ConsolidationMetrics(
+        total_estabelecimentos_scanned=estab_row_counts.total if estab_row_counts else 0,
+        total_target_cnae_found=len(target_set),
+        total_ativas=len(orgs),
+        total_consolidated=len(orgs),
+    )
+    return ConsolidationResult(orgs=list(orgs.values()), metrics=metrics)

--- a/backend/app/services/prospecting/rf_parser.py
+++ b/backend/app/services/prospecting/rf_parser.py
@@ -76,16 +76,34 @@ def iter_dump_files(dump_dir: Path, prefix: str) -> list[Path]:
     return sorted(dump_dir.glob(f"{prefix}*"))
 
 
-def _iter_rows(path: Path, fields: tuple[str, ...]) -> Iterator[dict[str, str]]:
+@dataclass
+class RowCounts:
+    """Contador mutável passado por referência — permite ao chamador ler
+    total/malformed depois de consumir o iterador (ex.: para o guard de
+    sanidade e a checagem de proporção de linhas malformadas, Ordem
+    Complementar, itens 1 e 2)."""
+
+    total: int = 0
+    malformed: int = 0
+
+
+def _iter_rows(
+    path: Path, fields: tuple[str, ...], counts: Optional["RowCounts"] = None
+) -> Iterator[dict[str, str]]:
     """Itera as linhas de um arquivo da RF em streaming, nunca carregando tudo em
     memória. Linhas com número de colunas diferente do esperado são logadas e
     puladas — um dump de dezenas de milhões de linhas não pode falhar inteiro
-    por uma linha malformada.
+    por uma linha malformada (a proporção agregada é checada por quem chama,
+    via RowCounts — ver layout_check.check_malformed_ratio).
     """
     with path.open("r", encoding="latin-1", errors="replace", newline="") as fh:
         reader = csv.reader(fh, delimiter=";")
         for line_no, row in enumerate(reader, start=1):
+            if counts is not None:
+                counts.total += 1
             if len(row) != len(fields):
+                if counts is not None:
+                    counts.malformed += 1
                 logger.warning(
                     "Linha malformada ignorada: %s:%d (esperado %d campos, veio %d)",
                     path.name, line_no, len(fields), len(row),
@@ -94,24 +112,26 @@ def _iter_rows(path: Path, fields: tuple[str, ...]) -> Iterator[dict[str, str]]:
             yield dict(zip(fields, row))
 
 
-def iter_empresas(dump_dir: Path) -> Iterator[dict[str, str]]:
+def iter_empresas(dump_dir: Path, counts: Optional["RowCounts"] = None) -> Iterator[dict[str, str]]:
     for path in iter_dump_files(dump_dir, "Empresas"):
-        yield from _iter_rows(path, EMPRESAS_FIELDS)
+        yield from _iter_rows(path, EMPRESAS_FIELDS, counts)
 
 
-def iter_estabelecimentos(dump_dir: Path) -> Iterator[dict[str, str]]:
+def iter_estabelecimentos(
+    dump_dir: Path, counts: Optional["RowCounts"] = None
+) -> Iterator[dict[str, str]]:
     for path in iter_dump_files(dump_dir, "Estabelecimentos"):
-        yield from _iter_rows(path, ESTABELECIMENTOS_FIELDS)
+        yield from _iter_rows(path, ESTABELECIMENTOS_FIELDS, counts)
 
 
-def iter_simples(dump_dir: Path) -> Iterator[dict[str, str]]:
+def iter_simples(dump_dir: Path, counts: Optional["RowCounts"] = None) -> Iterator[dict[str, str]]:
     for path in iter_dump_files(dump_dir, "Simples"):
-        yield from _iter_rows(path, SIMPLES_FIELDS)
+        yield from _iter_rows(path, SIMPLES_FIELDS, counts)
 
 
-def iter_socios(dump_dir: Path) -> Iterator[dict[str, str]]:
+def iter_socios(dump_dir: Path, counts: Optional["RowCounts"] = None) -> Iterator[dict[str, str]]:
     for path in iter_dump_files(dump_dir, "Socios"):
-        yield from _iter_rows(path, SOCIOS_FIELDS)
+        yield from _iter_rows(path, SOCIOS_FIELDS, counts)
 
 
 def load_municipios(dump_dir: Path) -> dict[str, str]:

--- a/backend/tests/test_prospecting_consolidation.py
+++ b/backend/tests/test_prospecting_consolidation.py
@@ -14,6 +14,7 @@ from app.services.prospecting.consolidation import (
     build_consolidated_orgs,
     discover_target_cnpj_basicos,
 )
+from app.services.prospecting.rf_parser import RowCounts
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "prospecting"
 
@@ -38,20 +39,20 @@ class TestBuildConsolidatedOrgs:
     def test_excludes_org_with_inactive_matriz(self):
         """GAMA tem CNAE-alvo mas situação cadastral BAIXADA — decisão de design
         documentada: exclusão de todo o universo de candidatos, não só do Tier A."""
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         cnpjs = {o.cnpj_basico for o in orgs}
         assert "30000000" not in cnpjs
         assert len(orgs) == 3  # ALPHA, BETA, DELTA (GAMA excluída, LOJA nunca no alvo)
 
     def test_consolidates_matriz_and_filiais(self):
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         alpha = next(o for o in orgs if o.cnpj_basico == "10000000")
         assert alpha.qtd_estabelecimentos == 3  # matriz + 2 filiais
         assert alpha.uf == "RS"  # endereço da matriz, não de uma filial
         assert alpha.cnpj_matriz == "10000000000191"
 
     def test_enriches_from_empresas_simples_socios(self):
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         alpha = next(o for o in orgs if o.cnpj_basico == "10000000")
         assert alpha.razao_social == "ESCRITORIO ALPHA CONTABILIDADE LTDA"
         assert alpha.porte == "05"
@@ -61,14 +62,14 @@ class TestBuildConsolidatedOrgs:
         assert alpha.qtd_socios == 2  # dois sócios no fixture
 
     def test_mei_flag_comes_from_simples_not_empresas_porte(self):
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         beta = next(o for o in orgs if o.cnpj_basico == "20000000")
         assert beta.opcao_mei is True
         assert beta.qtd_estabelecimentos == 1
         assert beta.qtd_socios == 1
 
     def test_email_domain_category_uses_razao_social_known_only_after_enrichment(self):
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         alpha = next(o for o in orgs if o.cnpj_basico == "10000000")
         beta = next(o for o in orgs if o.cnpj_basico == "20000000")
         delta = next(o for o in orgs if o.cnpj_basico == "40000000")
@@ -78,7 +79,7 @@ class TestBuildConsolidatedOrgs:
 
     def test_email_type_classified_independently_of_domain(self):
         # Ordem Complementar, item 6 — dimensão separada de email_domain_category.
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         alpha = next(o for o in orgs if o.cnpj_basico == "10000000")
         beta = next(o for o in orgs if o.cnpj_basico == "20000000")
         delta = next(o for o in orgs if o.cnpj_basico == "40000000")
@@ -87,5 +88,32 @@ class TestBuildConsolidatedOrgs:
         assert delta.email_type == "ausente"  # sem correio_eletronico
 
     def test_source_dump_reference_is_stamped_on_every_org(self):
-        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        orgs = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture").orgs
         assert all(o.source_dump_reference == "2026-07-fixture" for o in orgs)
+
+
+class TestConsolidationMetrics:
+    """Ordem Complementar, item 1 — insumo da guarda de sanidade."""
+
+    def test_metrics_reflect_each_stage(self):
+        result = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        metrics = result.metrics
+        assert metrics.total_target_cnae_found == 4  # ALPHA, BETA, GAMA, DELTA (LOJA fora)
+        assert metrics.total_ativas == 3  # GAMA excluída (baixada)
+        assert metrics.total_consolidated == 3
+
+    def test_scanned_count_is_zero_without_row_counts_object(self):
+        # Comportamento explícito quando o chamador não passa estab_row_counts —
+        # não inventa um número, assume 0 (não medido).
+        result = build_consolidated_orgs(FIXTURE_DIR, dump_reference="2026-07-fixture")
+        assert result.metrics.total_estabelecimentos_scanned == 0
+
+    def test_row_counts_object_is_populated_when_passed(self):
+        counts = RowCounts()
+        result = build_consolidated_orgs(
+            FIXTURE_DIR, dump_reference="2026-07-fixture", estab_row_counts=counts
+        )
+        # 7 linhas no fixture de Estabelecimentos (3 ALPHA + 1 BETA + 1 GAMA + 1 DELTA + 1 LOJA)
+        assert counts.total == 7
+        assert counts.malformed == 0
+        assert result.metrics.total_estabelecimentos_scanned == 7

--- a/backend/tests/test_prospecting_pipeline_cli.py
+++ b/backend/tests/test_prospecting_pipeline_cli.py
@@ -8,12 +8,18 @@ os registros deste teste — score_and_select.py e dedup_prospects.py operam
 sobre TODA a tabela prospect_orgs por design (é o "estado atual do mundo" a
 pontuar/deduplicar, não um recorte por dump), então a limpeza no teardown é o
 que evita que uma execução deste teste contamine as demais.
+
+Os testes usam --sanity-thresholds-path com limites permissivos: o fixture só
+tem ~4 organizações, bem abaixo do min_target_cnae_found padrão (pensado para
+o dump real, ~80 mil) — sem isso, todo ingest de teste seria abortado pela
+própria guarda de sanidade que estamos testando.
 """
 
 from __future__ import annotations
 
 import csv
 import importlib
+import json
 import os
 import sys
 import uuid
@@ -33,6 +39,7 @@ ingest_cnpj_dump = importlib.import_module("ingest_cnpj_dump")
 dedup_prospects = importlib.import_module("dedup_prospects")
 score_and_select = importlib.import_module("score_and_select")
 
+from app.models.prospect_ingestion_run import ProspectIngestionRun  # noqa: E402
 from app.models.prospect_org import ProspectOrg  # noqa: E402
 from app.models.prospect_scoring_run import ProspectScoringRun  # noqa: E402
 
@@ -57,17 +64,48 @@ def dump_reference():
         session.execute(
             delete(ProspectScoringRun).where(ProspectScoringRun.source_dump_reference == ref)
         )
+        session.execute(
+            delete(ProspectIngestionRun).where(ProspectIngestionRun.dump_reference == ref)
+        )
         session.execute(delete(ProspectOrg).where(ProspectOrg.source_dump_reference == ref))
         session.commit()
     finally:
         session.close()
 
 
+def _write_thresholds(path: Path, **overrides) -> Path:
+    defaults = dict(
+        min_target_cnae_found=0,
+        max_target_cnae_found=1_000_000,
+        min_ativas_ratio=0.0,
+        max_relative_change_vs_last_run=100.0,
+        max_malformed_row_ratio=1.0,
+    )
+    defaults.update(overrides)
+    lines = "\n".join(f"{k}: {v}" for k, v in defaults.items())
+    path.write_text(lines + "\n")
+    return path
+
+
+@pytest.fixture()
+def lenient_thresholds_path(tmp_path) -> Path:
+    """Limites permissivos — o fixture tem só ~4 organizações."""
+    return _write_thresholds(tmp_path / "lenient_thresholds.yaml")
+
+
+def _ingest_args(dump_reference: str, thresholds_path: Path, *extra: str) -> list[str]:
+    return [
+        "--dump-dir", str(FIXTURE_DIR),
+        "--dump-reference", dump_reference,
+        "--download-date", "2026-07-01",
+        "--sanity-thresholds-path", str(thresholds_path),
+        *extra,
+    ]
+
+
 class TestFullPipeline:
-    def test_ingest_is_idempotent(self, dump_reference):
-        rc1 = ingest_cnpj_dump.main(
-            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference]
-        )
+    def test_ingest_is_idempotent(self, dump_reference, lenient_thresholds_path):
+        rc1 = ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
         assert rc1 == 0
 
         session = TestingSessionLocal()
@@ -82,9 +120,7 @@ class TestFullPipeline:
             session.close()
 
         # reexecutar não duplica (ON CONFLICT DO UPDATE)
-        rc2 = ingest_cnpj_dump.main(
-            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference]
-        )
+        rc2 = ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
         assert rc2 == 0
         session = TestingSessionLocal()
         try:
@@ -97,26 +133,28 @@ class TestFullPipeline:
         finally:
             session.close()
 
-    def test_ingest_dry_run_writes_nothing(self, dump_reference):
-        rc = ingest_cnpj_dump.main(
-            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference, "--dry-run"]
-        )
+    def test_ingest_dry_run_writes_nothing(self, dump_reference, lenient_thresholds_path):
+        rc = ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path, "--dry-run"))
         assert rc == 0
         session = TestingSessionLocal()
         try:
-            count = (
+            org_count = (
                 session.query(ProspectOrg)
                 .filter(ProspectOrg.source_dump_reference == dump_reference)
                 .count()
             )
-            assert count == 0
+            run_count = (
+                session.query(ProspectIngestionRun)
+                .filter(ProspectIngestionRun.dump_reference == dump_reference)
+                .count()
+            )
+            assert org_count == 0
+            assert run_count == 0
         finally:
             session.close()
 
-    def test_full_pipeline_ingest_dedup_score(self, dump_reference, tmp_path):
-        rc_ingest = ingest_cnpj_dump.main(
-            ["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference]
-        )
+    def test_full_pipeline_ingest_dedup_score(self, dump_reference, lenient_thresholds_path, tmp_path):
+        rc_ingest = ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
         assert rc_ingest == 0
 
         rc_dedup = dedup_prospects.main([])
@@ -158,8 +196,8 @@ class TestFullPipeline:
         finally:
             session.close()
 
-    def test_score_and_select_dry_run_writes_no_run_row(self, dump_reference, tmp_path):
-        ingest_cnpj_dump.main(["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference])
+    def test_score_and_select_dry_run_writes_no_run_row(self, dump_reference, lenient_thresholds_path, tmp_path):
+        ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
 
         output_path = tmp_path / "would_not_be_written.csv"
         rc = score_and_select.main(
@@ -184,8 +222,8 @@ class TestFullPipeline:
         finally:
             session.close()
 
-    def test_json_output_format(self, dump_reference, tmp_path):
-        ingest_cnpj_dump.main(["--dump-dir", str(FIXTURE_DIR), "--dump-reference", dump_reference])
+    def test_json_output_format(self, dump_reference, lenient_thresholds_path, tmp_path):
+        ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
         output_path = tmp_path / "top.json"
         rc = score_and_select.main(
             [
@@ -196,7 +234,166 @@ class TestFullPipeline:
             ]
         )
         assert rc == 0
-        import json
         data = json.loads(output_path.read_text(encoding="utf-8"))
         assert isinstance(data, list)
         assert any(row["cnpj_basico"] in EXPECTED_CNPJS for row in data)
+
+
+class TestIngestionSafeguards:
+    """Ordem Complementar — guarda de sanidade (item 1), validação de layout
+    (item 2) e o rastro de auditoria que cada execução real deixa (item 8)."""
+
+    def test_records_completed_run_with_metrics(self, dump_reference, lenient_thresholds_path):
+        rc = ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
+        assert rc == 0
+
+        session = TestingSessionLocal()
+        try:
+            run = (
+                session.query(ProspectIngestionRun)
+                .filter(ProspectIngestionRun.dump_reference == dump_reference)
+                .one()
+            )
+            assert cast(str, run.status) == "completed"
+            assert cast(int, run.total_target_cnae_found) == 4  # ALPHA, BETA, GAMA, DELTA
+            assert cast(int, run.total_ativas) == 3  # GAMA excluída (baixada)
+            assert cast(int, run.total_consolidated) == 3
+            assert cast(int, run.total_estabelecimentos_scanned) == 7
+            assert cast(str, run.layout_signature)
+            assert cast(dict, run.files_sha256)  # hash de proveniência gravado
+            assert run.download_date is not None
+        finally:
+            session.close()
+
+    def test_missing_download_date_is_rejected(self, dump_reference, lenient_thresholds_path):
+        with pytest.raises(SystemExit):
+            ingest_cnpj_dump.main(
+                [
+                    "--dump-dir", str(FIXTURE_DIR),
+                    "--dump-reference", dump_reference,
+                    "--sanity-thresholds-path", str(lenient_thresholds_path),
+                ]
+            )
+
+    def test_invalid_download_date_is_rejected(self, dump_reference, lenient_thresholds_path):
+        with pytest.raises(SystemExit):
+            ingest_cnpj_dump.main(
+                [
+                    "--dump-dir", str(FIXTURE_DIR),
+                    "--dump-reference", dump_reference,
+                    "--download-date", "não-é-uma-data",
+                    "--sanity-thresholds-path", str(lenient_thresholds_path),
+                ]
+            )
+
+    def test_layout_mismatch_aborts_before_any_write(self, dump_reference, tmp_path, lenient_thresholds_path):
+        # Diretório sem nenhum arquivo da RF — detect_layout_signature deve
+        # abortar antes de qualquer parsing.
+        empty_dir = tmp_path / "dump_vazio"
+        empty_dir.mkdir()
+
+        rc = ingest_cnpj_dump.main(
+            [
+                "--dump-dir", str(empty_dir),
+                "--dump-reference", dump_reference,
+                "--download-date", "2026-07-01",
+                "--sanity-thresholds-path", str(lenient_thresholds_path),
+            ]
+        )
+        assert rc == 1
+
+        session = TestingSessionLocal()
+        try:
+            org_count = (
+                session.query(ProspectOrg)
+                .filter(ProspectOrg.source_dump_reference == dump_reference)
+                .count()
+            )
+            run = (
+                session.query(ProspectIngestionRun)
+                .filter(ProspectIngestionRun.dump_reference == dump_reference)
+                .one()
+            )
+            assert org_count == 0  # nada foi escrito em prospect_orgs
+            assert cast(str, run.status) == "aborted_layout_mismatch"
+            assert cast(str, run.error_message)
+        finally:
+            session.close()
+
+    def test_sanity_check_aborts_without_writing_orgs(self, dump_reference, tmp_path):
+        # Threshold estrito o suficiente para rejeitar o fixture (4 encontrados).
+        strict_path = _write_thresholds(tmp_path / "strict.yaml", min_target_cnae_found=1000)
+
+        rc = ingest_cnpj_dump.main(
+            [
+                "--dump-dir", str(FIXTURE_DIR),
+                "--dump-reference", dump_reference,
+                "--download-date", "2026-07-01",
+                "--sanity-thresholds-path", str(strict_path),
+            ]
+        )
+        assert rc == 1
+
+        session = TestingSessionLocal()
+        try:
+            org_count = (
+                session.query(ProspectOrg)
+                .filter(ProspectOrg.source_dump_reference == dump_reference)
+                .count()
+            )
+            run = (
+                session.query(ProspectIngestionRun)
+                .filter(ProspectIngestionRun.dump_reference == dump_reference)
+                .one()
+            )
+            assert org_count == 0  # guarda de sanidade impede qualquer escrita em prospect_orgs
+            assert cast(str, run.status) == "aborted_sanity_check"
+            assert cast(str, run.error_message)
+            assert cast(int, run.total_target_cnae_found) == 4  # métricas ficam registradas mesmo abortando
+        finally:
+            session.close()
+
+    def test_find_previous_metrics_scoped_by_target_cnaes(self, dump_reference):
+        """Uma execução concluída com --target-cnaes diferente nunca deve ser
+        usada como baseline de variação relativa (item 1) — configs diferentes
+        não são comparáveis entre si."""
+        session = TestingSessionLocal()
+        try:
+            from datetime import date, datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            session.add(
+                ProspectIngestionRun(
+                    dump_reference=dump_reference,
+                    target_cnaes=["1111111"],  # config DIFERENTE
+                    download_date=date(2026, 7, 1),
+                    status="completed",
+                    total_target_cnae_found=999_999,  # se isso vazar como baseline, o teste falha
+                    total_ativas=999_999,
+                    total_consolidated=999_999,
+                    total_estabelecimentos_scanned=999_999,
+                    started_at=now,
+                    finished_at=now,
+                )
+            )
+            session.add(
+                ProspectIngestionRun(
+                    dump_reference=dump_reference,
+                    target_cnaes=["6920601", "6920602"],  # config IGUAL à consultada
+                    download_date=date(2026, 7, 1),
+                    status="completed",
+                    total_target_cnae_found=4,
+                    total_ativas=3,
+                    total_consolidated=3,
+                    total_estabelecimentos_scanned=7,
+                    started_at=now,
+                    finished_at=now,
+                )
+            )
+            session.commit()
+
+            previous = ingest_cnpj_dump._find_previous_metrics(session, ["6920601", "6920602"])
+            assert previous is not None
+            assert previous.total_target_cnae_found == 4  # não o 999_999 do outro target_cnaes
+        finally:
+            session.close()

--- a/tools/prospecting/ingest_cnpj_dump.py
+++ b/tools/prospecting/ingest_cnpj_dump.py
@@ -1,15 +1,27 @@
 #!/usr/bin/env python3
 """Parser -> Normalização -> Consolidação -> upsert idempotente em prospect_orgs
-(PO-2026-07-SALES-001, Fase 1).
+(PO-2026-07-SALES-001, Fase 1; salvaguardas operacionais da Ordem Complementar).
 
 Uso:
   cd backend && source .venv/bin/activate
   python ../tools/prospecting/ingest_cnpj_dump.py \\
-      --dump-dir /caminho/para/dump/2026-07 --dump-reference 2026-07
+      --dump-dir /caminho/para/dump/2026-07 --dump-reference 2026-07 \\
+      --download-date 2026-07-01
 
 --dump-dir deve conter os arquivos oficiais extraídos (Empresas*, Estabelecimentos*,
 Simples*, Socios*, Municipios*), baixados de arquivos.receitafederal.gov.br — ver
 README.md deste diretório para o passo a passo completo.
+
+Salvaguardas (Ordem Complementar):
+  - Pré-checagem de layout ANTES de qualquer parsing — aborta se o número de
+    campos não bater com o esperado (item 2).
+  - Guarda de sanidade de volume DEPOIS de consolidar, ANTES de escrever em
+    prospect_orgs — aborta com erro explícito (nunca só warning) se as
+    métricas fugirem dos limites configurados ou da última execução
+    compatível (item 1).
+  - Toda execução real (sucesso ou abortada) grava uma linha em
+    prospect_ingestion_runs, com hash SHA-256 dos arquivos usados (item 2) —
+    exceto em --dry-run, que não escreve nada em lugar nenhum.
 """
 
 from __future__ import annotations
@@ -17,6 +29,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -24,14 +37,30 @@ _BACKEND_ROOT = _REPO_ROOT / "backend"
 if str(_BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(_BACKEND_ROOT))
 
+from sqlalchemy import select  # noqa: E402
 from sqlalchemy.dialects.postgresql import insert as pg_insert  # noqa: E402
 
 from app.database import SessionLocal  # noqa: E402
+from app.models.prospect_ingestion_run import ProspectIngestionRun  # noqa: E402
 from app.models.prospect_org import ProspectOrg  # noqa: E402
 from app.services.prospecting.consolidation import (  # noqa: E402
     TARGET_CNAES,
     ConsolidatedOrg,
     build_consolidated_orgs,
+)
+from app.services.prospecting.layout_check import (  # noqa: E402
+    LayoutMismatchError,
+    MalformedRowRatioError,
+    check_malformed_ratio,
+    compute_file_hashes,
+    detect_layout_signature,
+)
+from app.services.prospecting.rf_parser import RowCounts  # noqa: E402
+from app.services.prospecting.sanity import (  # noqa: E402
+    IngestionMetrics,
+    SanityCheckError,
+    load_thresholds,
+    validate_metrics,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -70,31 +99,199 @@ def upsert_orgs(db, orgs: list[ConsolidatedOrg]) -> int:
     return len(rows)
 
 
+def _find_previous_metrics(db, target_cnaes_sorted: list[str]) -> IngestionMetrics | None:
+    """Última execução bem-sucedida com o MESMO --target-cnaes — configs
+    diferentes não são comparáveis entre si (Ordem Complementar, item 1)."""
+    row = db.execute(
+        select(ProspectIngestionRun)
+        .where(
+            ProspectIngestionRun.status == "completed",
+            ProspectIngestionRun.target_cnaes == target_cnaes_sorted,
+        )
+        .order_by(ProspectIngestionRun.finished_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return IngestionMetrics(
+        total_estabelecimentos_scanned=row.total_estabelecimentos_scanned or 0,
+        total_target_cnae_found=row.total_target_cnae_found or 0,
+        total_ativas=row.total_ativas or 0,
+        total_consolidated=row.total_consolidated or 0,
+    )
+
+
+def _record_run(
+    db,
+    *,
+    dump_reference: str,
+    target_cnaes_sorted: list[str],
+    download_date: date,
+    status: str,
+    started_at: datetime,
+    error_message: str | None = None,
+    metrics: IngestionMetrics | None = None,
+    tolerance_params: dict | None = None,
+    file_count: int | None = None,
+    files_sha256: dict | None = None,
+    layout_signature: str | None = None,
+) -> None:
+    """Grava uma linha em prospect_ingestion_runs — append-only, sempre, tanto
+    para sucesso quanto para abortos (item 8, auditoria completa)."""
+    db.add(
+        ProspectIngestionRun(
+            dump_reference=dump_reference,
+            target_cnaes=target_cnaes_sorted,
+            download_date=download_date,
+            status=status,
+            error_message=error_message,
+            total_estabelecimentos_scanned=metrics.total_estabelecimentos_scanned if metrics else None,
+            total_target_cnae_found=metrics.total_target_cnae_found if metrics else None,
+            total_ativas=metrics.total_ativas if metrics else None,
+            total_consolidated=metrics.total_consolidated if metrics else None,
+            tolerance_params=tolerance_params or {},
+            file_count=file_count,
+            files_sha256=files_sha256,
+            layout_signature=layout_signature,
+            started_at=started_at,
+            finished_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--dump-dir", required=True, type=Path, help="Diretório com os arquivos oficiais extraídos.")
     parser.add_argument("--dump-reference", required=True, help='Ex.: "2026-07" — vintage do dump.')
+    parser.add_argument(
+        "--download-date", required=True,
+        help='Data em que o dump foi baixado, ISO (ex.: "2026-07-01") — não dá para '
+             "inferir de forma confiável a partir do sistema de arquivos.",
+    )
     parser.add_argument("--target-cnaes", default=",".join(sorted(TARGET_CNAES)))
-    parser.add_argument("--dry-run", action="store_true", help="Só parseia e reporta contagens, não escreve no banco.")
+    parser.add_argument("--dry-run", action="store_true", help="Só parseia e reporta contagens, não escreve em lugar nenhum.")
+    parser.add_argument(
+        "--sanity-thresholds-path", type=Path, default=None,
+        help="Override de backend/app/data/prospecting/sanity_thresholds.yaml (usado pelos testes).",
+    )
     args = parser.parse_args(argv)
 
     if not args.dump_dir.is_dir():
         parser.error(f"--dump-dir não é um diretório: {args.dump_dir}")
+    try:
+        download_date = date.fromisoformat(args.download_date)
+    except ValueError:
+        parser.error(f'--download-date inválido (use ISO, ex. "2026-07-01"): {args.download_date}')
+        return 2  # inalcançável — parser.error já sai do processo; só para o type checker
 
     target_cnaes = frozenset(c.strip() for c in args.target_cnaes.split(",") if c.strip())
+    target_cnaes_sorted = sorted(target_cnaes)
+    started_at = datetime.now(timezone.utc)
 
-    logger.info("Iniciando ingestão: dump_dir=%s dump_reference=%s target_cnaes=%s", args.dump_dir, args.dump_reference, sorted(target_cnaes))
-    orgs = build_consolidated_orgs(args.dump_dir, dump_reference=args.dump_reference, target_cnaes=target_cnaes)
-    logger.info("%d organizações consolidadas (situação cadastral ativa, dedup por CNPJ básico)", len(orgs))
+    logger.info(
+        "Iniciando ingestão: dump_dir=%s dump_reference=%s target_cnaes=%s",
+        args.dump_dir, args.dump_reference, target_cnaes_sorted,
+    )
 
-    if args.dry_run:
-        logger.info("--dry-run: nenhuma escrita no banco.")
-        return 0
+    # ── Pré-checagem de layout — ANTES de processar qualquer linha (item 2) ──
+    try:
+        layout_signature = detect_layout_signature(args.dump_dir)
+    except LayoutMismatchError as exc:
+        logger.error("Layout incompatível — abortando antes de qualquer parsing: %s", exc)
+        if not args.dry_run:
+            db = SessionLocal()
+            try:
+                _record_run(
+                    db, dump_reference=args.dump_reference, target_cnaes_sorted=target_cnaes_sorted,
+                    download_date=download_date, status="aborted_layout_mismatch",
+                    started_at=started_at, error_message=str(exc),
+                )
+            finally:
+                db.close()
+        return 1
+    logger.info("Layout confirmado: %s", layout_signature)
+
+    file_hashes = compute_file_hashes(args.dump_dir)
+    logger.info("%d arquivos hasheados (proveniência)", len(file_hashes))
+
+    thresholds = load_thresholds(args.sanity_thresholds_path)
+
+    estab_counts = RowCounts()
+    result = build_consolidated_orgs(
+        args.dump_dir, dump_reference=args.dump_reference, target_cnaes=target_cnaes,
+        estab_row_counts=estab_counts,
+    )
+    orgs = result.orgs
+    logger.info(
+        "%d organizações consolidadas (situação cadastral ativa, dedup por CNPJ básico)", len(orgs)
+    )
+
+    metrics = IngestionMetrics(
+        total_estabelecimentos_scanned=result.metrics.total_estabelecimentos_scanned,
+        total_target_cnae_found=result.metrics.total_target_cnae_found,
+        total_ativas=result.metrics.total_ativas,
+        total_consolidated=result.metrics.total_consolidated,
+    )
+
+    # ── Proporção de linhas malformadas — mudança parcial de layout que a
+    # pré-checagem (só a 1ª linha) não pegaria (item 2) ──
+    try:
+        check_malformed_ratio(
+            "Estabelecimentos (todas as partes)", estab_counts.malformed, estab_counts.total,
+            thresholds["max_malformed_row_ratio"],
+        )
+    except MalformedRowRatioError as exc:
+        logger.error("Layout parcialmente mudado — abortando sem escrever em prospect_orgs: %s", exc)
+        if not args.dry_run:
+            db = SessionLocal()
+            try:
+                _record_run(
+                    db, dump_reference=args.dump_reference, target_cnaes_sorted=target_cnaes_sorted,
+                    download_date=download_date, status="aborted_layout_mismatch",
+                    started_at=started_at, error_message=str(exc), metrics=metrics,
+                    tolerance_params=thresholds, file_count=len(file_hashes),
+                    files_sha256=file_hashes, layout_signature=layout_signature,
+                )
+            finally:
+                db.close()
+        return 1
 
     db = SessionLocal()
     try:
+        previous = _find_previous_metrics(db, target_cnaes_sorted)
+
+        # ── Guarda de sanidade — DEPOIS de consolidar, ANTES de escrever
+        # qualquer linha em prospect_orgs (item 1) ──
+        try:
+            validate_metrics(metrics, thresholds, previous=previous)
+        except SanityCheckError as exc:
+            logger.error(
+                "Guarda de sanidade disparada — abortando SEM escrever em prospect_orgs: %s", exc
+            )
+            if not args.dry_run:
+                _record_run(
+                    db, dump_reference=args.dump_reference, target_cnaes_sorted=target_cnaes_sorted,
+                    download_date=download_date, status="aborted_sanity_check",
+                    started_at=started_at, error_message=str(exc), metrics=metrics,
+                    tolerance_params=thresholds, file_count=len(file_hashes),
+                    files_sha256=file_hashes, layout_signature=layout_signature,
+                )
+            return 1
+
+        if args.dry_run:
+            logger.info("--dry-run: nenhuma escrita no banco (nem prospect_orgs, nem prospect_ingestion_runs).")
+            return 0
+
         written = upsert_orgs(db, orgs)
         logger.info("%d registros upsertados em prospect_orgs", written)
+
+        _record_run(
+            db, dump_reference=args.dump_reference, target_cnaes_sorted=target_cnaes_sorted,
+            download_date=download_date, status="completed",
+            started_at=started_at, metrics=metrics, tolerance_params=thresholds,
+            file_count=len(file_hashes), files_sha256=file_hashes, layout_signature=layout_signature,
+        )
     finally:
         db.close()
     return 0


### PR DESCRIPTION
## Summary
Fatia 4 de 6 da Ordem de Desenvolvimento Complementar. Wiring completo dos itens 1 e 2 em `ingest_cnpj_dump.py`.

- `--download-date` obrigatório.
- Pré-checagem de layout **antes** de qualquer parsing — aborta se o número de campos não bater.
- Guarda de sanidade **depois** de consolidar, **antes** de escrever em `prospect_orgs` — aborta com erro explícito (nunca warning), comparando contra limites absolutos e contra a última execução com o mesmo `--target-cnaes`.
- Checagem de proporção de linhas malformadas — via `RowCounts` (novo, `rf_parser.py`), que expõe total/malformed de Estabelecimentos sem duplicar a passada.
- `build_consolidated_orgs()` agora retorna `ConsolidationResult` (orgs + métricas) em vez de só a lista — mudança de assinatura, testes atualizados.
- Toda execução real grava uma linha em `prospect_ingestion_runs` (sucesso ou abortada), com hash SHA-256 dos arquivos e assinatura de layout.

**Bug encontrado e corrigido pelo próprio teste fim-a-fim**: `layout_signature` era `VARCHAR(64)`, curto demais para a assinatura real (~74 caracteres) — corrigido para `TEXT` via migration nova (`2026_07_28_0036`).

## Test plan
- [x] `pytest tests/ -q` — 930 passed (17 novos: idempotência, dry-run, layout mismatch, guarda de sanidade, escopo da baseline por `target_cnaes`, métricas de consolidação)
- [x] `ruff check` — clean
- [x] `npx pyright@1.1.411` — 0 errors