### PR TITLE
feat(prospecting): trava de sequenciamento + snapshot de rubrica (Ordem Complementar, fatia 5/6)

### DIFF
--- a/backend/app/services/prospecting/rubric_loader.py
+++ b/backend/app/services/prospecting/rubric_loader.py
@@ -63,6 +63,18 @@ class Rubric:
                 return tier_name
         return ordered[-1][0] if ordered else "D"
 
+    def to_snapshot(self) -> dict[str, Any]:
+        """Serializa os pesos completos — gravado em
+        prospect_scoring_runs.rubric_snapshot (Ordem Complementar, item 5) para
+        reprodutibilidade total, mesmo se o arquivo YAML mudar ou sumir."""
+        return {
+            "version": self.version,
+            "checksum": self.checksum,
+            "base_score": self.base_score,
+            "tiers": self.tiers,
+            "scoring": self.scoring,
+        }
+
 
 def _resolve_path(version: str | None, path: str | Path | None) -> Path:
     if path is not None:
@@ -112,4 +124,25 @@ def load_rubric(version: str | None = None, path: str | Path | None = None) -> R
         base_score=int(data["base_score"]),
         tiers=data["tiers"],
         scoring=data["scoring"],
+    )
+
+
+_SNAPSHOT_PATH = Path("<rubric_snapshot>")  # placeholder — não há arquivo real
+
+
+def load_rubric_from_snapshot(snapshot: dict[str, Any]) -> Rubric:
+    """Reconstrói uma Rubric a partir de prospect_scoring_runs.rubric_snapshot —
+    usada para reprocessar uma classificação antiga com a EXATA rubrica usada
+    na época, mesmo que o arquivo YAML original tenha sido alterado ou removido
+    (Ordem Complementar, item 5/9 — reclassify_from_snapshot.py)."""
+    missing = [k for k in ("version", "checksum", "base_score", "tiers", "scoring") if k not in snapshot]
+    if missing:
+        raise RubricValidationError(f"Snapshot de rubrica incompleto: faltando {missing}")
+    return Rubric(
+        version=str(snapshot["version"]),
+        checksum=str(snapshot["checksum"]),
+        path=_SNAPSHOT_PATH,
+        base_score=int(snapshot["base_score"]),
+        tiers=snapshot["tiers"],
+        scoring=snapshot["scoring"],
     )

--- a/backend/tests/test_prospecting_dedup_run_tracking.py
+++ b/backend/tests/test_prospecting_dedup_run_tracking.py
@@ -1,0 +1,92 @@
+"""Rastreamento de execução de dedup_prospects.py (Ordem Complementar, item 4) —
+Postgres real. Cobre a gravação de ProspectDedupRun a cada execução, que é o
+que permite a score_and_select.py verificar sequenciamento sem depender de
+ordem manual de scripts."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOLS_PROSPECTING = _REPO_ROOT / "tools" / "prospecting"
+if str(_TOOLS_PROSPECTING) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_PROSPECTING))
+
+dedup_prospects = importlib.import_module("dedup_prospects")
+
+from app.models.prospect_dedup_run import ProspectDedupRun  # noqa: E402
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def cleanup_dedup_runs():
+    """dedup_prospects.py usa SessionLocal() próprio e commita de verdade —
+    sem rollback de transação de teste, então a limpeza no teardown é
+    obrigatória (mesmo padrão de test_prospecting_pipeline_cli.py)."""
+    session = TestingSessionLocal()
+    try:
+        before_ids = set(session.execute(select(ProspectDedupRun.id)).scalars().all())
+    finally:
+        session.close()
+
+    yield
+
+    session = TestingSessionLocal()
+    try:
+        after = session.execute(select(ProspectDedupRun)).scalars().all()
+        for run in after:
+            if run.id not in before_ids:
+                session.delete(run)
+        session.commit()
+    finally:
+        session.close()
+
+
+class TestDedupRunTracking:
+    def test_records_completed_run_with_metrics(self, cleanup_dedup_runs):
+        rc = dedup_prospects.main([])
+        assert rc == 0
+
+        session = TestingSessionLocal()
+        try:
+            latest = (
+                session.query(ProspectDedupRun)
+                .order_by(ProspectDedupRun.created_at.desc())
+                .first()
+            )
+            assert latest is not None
+            assert latest.status == "completed"
+            assert latest.groups_merged is not None
+            assert latest.orgs_merged is not None
+            assert latest.domains_skipped_too_large is not None
+            assert latest.started_at is not None
+            assert latest.finished_at is not None
+            assert latest.finished_at >= latest.started_at
+        finally:
+            session.close()
+
+    def test_respects_max_group_size_argument(self, cleanup_dedup_runs):
+        rc = dedup_prospects.main(["--max-group-size", "3"])
+        assert rc == 0
+
+        session = TestingSessionLocal()
+        try:
+            latest = (
+                session.query(ProspectDedupRun)
+                .order_by(ProspectDedupRun.created_at.desc())
+                .first()
+            )
+            assert latest is not None
+            assert latest.status == "completed"
+        finally:
+            session.close()

--- a/backend/tests/test_prospecting_dedup_run_tracking.py
+++ b/backend/tests/test_prospecting_dedup_run_tracking.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -65,13 +67,13 @@ class TestDedupRunTracking:
                 .first()
             )
             assert latest is not None
-            assert latest.status == "completed"
+            assert cast(str, latest.status) == "completed"
             assert latest.groups_merged is not None
             assert latest.orgs_merged is not None
             assert latest.domains_skipped_too_large is not None
             assert latest.started_at is not None
             assert latest.finished_at is not None
-            assert latest.finished_at >= latest.started_at
+            assert cast(datetime, latest.finished_at) >= cast(datetime, latest.started_at)
         finally:
             session.close()
 
@@ -87,6 +89,6 @@ class TestDedupRunTracking:
                 .first()
             )
             assert latest is not None
-            assert latest.status == "completed"
+            assert cast(str, latest.status) == "completed"
         finally:
             session.close()

--- a/backend/tests/test_prospecting_pipeline_cli.py
+++ b/backend/tests/test_prospecting_pipeline_cli.py
@@ -193,11 +193,15 @@ class TestFullPipeline:
             assert cast(int, run.candidate_count) >= 3
             assert cast(int, run.selected_count) >= 3
             assert cast(str, run.output_uri) == str(output_path)
+            snapshot = cast(dict, run.rubric_snapshot)
+            assert snapshot["version"] == "v1"
+            assert "scoring" in snapshot and "tiers" in snapshot
         finally:
             session.close()
 
     def test_score_and_select_dry_run_writes_no_run_row(self, dump_reference, lenient_thresholds_path, tmp_path):
         ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
+        dedup_prospects.main([])
 
         output_path = tmp_path / "would_not_be_written.csv"
         rc = score_and_select.main(
@@ -224,6 +228,7 @@ class TestFullPipeline:
 
     def test_json_output_format(self, dump_reference, lenient_thresholds_path, tmp_path):
         ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
+        dedup_prospects.main([])
         output_path = tmp_path / "top.json"
         rc = score_and_select.main(
             [
@@ -397,3 +402,53 @@ class TestIngestionSafeguards:
             assert previous.total_target_cnae_found == 4  # não o 999_999 do outro target_cnaes
         finally:
             session.close()
+
+
+class TestSequencingGate:
+    """Ordem Complementar, item 4 — score_and_select.py não pode rodar sobre
+    dados parcialmente processados. Cobertura de unidade da regra em si está
+    em test_prospecting_score_sequencing.py; aqui cobrimos que main() de fato
+    aplica a trava e bloqueia antes de qualquer escrita."""
+
+    def test_blocked_without_dedup_after_ingest(self, dump_reference, lenient_thresholds_path, tmp_path):
+        rc_ingest = ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
+        assert rc_ingest == 0
+        # dedup_prospects.main([]) deliberadamente NÃO chamado aqui.
+
+        output_path = tmp_path / "would_not_be_written.csv"
+        rc_score = score_and_select.main(
+            [
+                "--rubric-version", "v1",
+                "--dump-reference", dump_reference,
+                "--output", str(output_path),
+            ]
+        )
+        assert rc_score == 1
+        assert not output_path.exists()
+
+        session = TestingSessionLocal()
+        try:
+            count = (
+                session.query(ProspectScoringRun)
+                .filter(ProspectScoringRun.source_dump_reference == dump_reference)
+                .count()
+            )
+            assert count == 0
+        finally:
+            session.close()
+
+    def test_passes_once_dedup_runs_after_ingest(self, dump_reference, lenient_thresholds_path, tmp_path):
+        ingest_cnpj_dump.main(_ingest_args(dump_reference, lenient_thresholds_path))
+        rc_dedup = dedup_prospects.main([])
+        assert rc_dedup == 0
+
+        output_path = tmp_path / "top.csv"
+        rc_score = score_and_select.main(
+            [
+                "--rubric-version", "v1",
+                "--dump-reference", dump_reference,
+                "--output", str(output_path),
+            ]
+        )
+        assert rc_score == 0
+        assert output_path.exists()

--- a/backend/tests/test_prospecting_rubric_loader.py
+++ b/backend/tests/test_prospecting_rubric_loader.py
@@ -6,6 +6,7 @@ import yaml
 from app.services.prospecting.rubric_loader import (
     RubricValidationError,
     load_rubric,
+    load_rubric_from_snapshot,
 )
 
 
@@ -67,3 +68,27 @@ class TestLoadRubricValidation:
     def test_no_version_and_no_path_raises(self):
         with pytest.raises(RubricValidationError):
             load_rubric()
+
+
+class TestRubricSnapshotRoundTrip:
+    def test_to_snapshot_and_back_preserves_scoring_fields(self):
+        original = load_rubric(version="v1")
+        snapshot = original.to_snapshot()
+        reconstructed = load_rubric_from_snapshot(snapshot)
+
+        assert reconstructed.version == original.version
+        assert reconstructed.checksum == original.checksum
+        assert reconstructed.base_score == original.base_score
+        assert reconstructed.tiers == original.tiers
+        assert reconstructed.scoring == original.scoring
+
+    def test_reconstructed_rubric_scores_identically(self):
+        original = load_rubric(version="v1")
+        reconstructed = load_rubric_from_snapshot(original.to_snapshot())
+
+        assert reconstructed.get_weight("geografia", "RS") == original.get_weight("geografia", "RS")
+        assert reconstructed.tier_for_score(85) == original.tier_for_score(85)
+
+    def test_snapshot_missing_required_keys_raises(self):
+        with pytest.raises(RubricValidationError, match="checksum"):
+            load_rubric_from_snapshot({"version": "v1", "base_score": 50, "tiers": {}, "scoring": {}})

--- a/backend/tests/test_prospecting_score_sequencing.py
+++ b/backend/tests/test_prospecting_score_sequencing.py
@@ -1,0 +1,129 @@
+"""Trava de sequenciamento de score_and_select.py (Ordem Complementar, item 4) — DB-backed.
+
+check_sequencing() bloqueia a pontuação sem exceção quando não há ingestão
+concluída, ou quando a deduplicação concluída mais recente é anterior à
+ingestão concluída mais recente — "não será permitido utilizar dados
+parcialmente processados". Sem flag de bypass.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, delete
+from sqlalchemy.orm import sessionmaker
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOLS_PROSPECTING = _REPO_ROOT / "tools" / "prospecting"
+if str(_TOOLS_PROSPECTING) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_PROSPECTING))
+
+score_and_select = importlib.import_module("score_and_select")
+
+from app.models.prospect_dedup_run import ProspectDedupRun  # noqa: E402
+from app.models.prospect_ingestion_run import ProspectIngestionRun  # noqa: E402
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def session():
+    """check_sequencing() consulta a execução mais recente por tabela inteira
+    (sem escopo por dump_reference) — precisamos de uma tabela limpa para que
+    as asserções sejam determinísticas, independente de outras suítes terem
+    deixado ProspectIngestionRun/ProspectDedupRun reais para trás. Limpeza é
+    um DELETE real e comprometido, porque essas linhas residuais vêm de
+    sessões próprias (SessionLocal real) de outros testes, não desta
+    transação — um rollback nosso não as desfaria."""
+    cleanup = TestingSessionLocal()
+    try:
+        cleanup.execute(delete(ProspectDedupRun))
+        cleanup.execute(delete(ProspectIngestionRun))
+        cleanup.commit()
+    finally:
+        cleanup.close()
+
+    connection = engine.connect()
+    transaction = connection.begin()
+    db = TestingSessionLocal(bind=connection)
+    yield db
+    db.close()
+    transaction.rollback()
+    connection.close()
+
+
+def _make_ingestion_run(session, *, finished_at, status="completed") -> ProspectIngestionRun:
+    run = ProspectIngestionRun(
+        dump_reference=f"seq-{uuid.uuid4().hex[:8]}",
+        target_cnaes=["6920601"],
+        download_date=finished_at.date(),
+        status=status,
+        started_at=finished_at - timedelta(minutes=5),
+        finished_at=finished_at if status == "completed" else None,
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+def _make_dedup_run(session, *, finished_at, status="completed") -> ProspectDedupRun:
+    run = ProspectDedupRun(
+        status=status,
+        started_at=finished_at - timedelta(minutes=5),
+        finished_at=finished_at if status == "completed" else None,
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+class TestCheckSequencing:
+    def test_blocks_when_no_ingestion_exists(self, session):
+        with pytest.raises(score_and_select.SequencingError, match="ingest_cnpj_dump"):
+            score_and_select.check_sequencing(session)
+
+    def test_blocks_when_no_dedup_exists(self, session):
+        _make_ingestion_run(session, finished_at=datetime.now(timezone.utc))
+        with pytest.raises(score_and_select.SequencingError, match="dedup_prospects"):
+            score_and_select.check_sequencing(session)
+
+    def test_blocks_when_dedup_is_older_than_ingestion(self, session):
+        now = datetime.now(timezone.utc)
+        _make_dedup_run(session, finished_at=now - timedelta(hours=1))
+        _make_ingestion_run(session, finished_at=now)
+        with pytest.raises(score_and_select.SequencingError, match="dedup_prospects"):
+            score_and_select.check_sequencing(session)
+
+    def test_ignores_failed_ingestion_run(self, session):
+        now = datetime.now(timezone.utc)
+        _make_ingestion_run(session, finished_at=now, status="failed")
+        _make_dedup_run(session, finished_at=now)
+        with pytest.raises(score_and_select.SequencingError, match="ingest_cnpj_dump"):
+            score_and_select.check_sequencing(session)
+
+    def test_ignores_failed_dedup_run(self, session):
+        now = datetime.now(timezone.utc)
+        _make_ingestion_run(session, finished_at=now - timedelta(hours=1))
+        _make_dedup_run(session, finished_at=now, status="failed")
+        with pytest.raises(score_and_select.SequencingError, match="dedup_prospects"):
+            score_and_select.check_sequencing(session)
+
+    def test_passes_when_dedup_follows_ingestion(self, session):
+        now = datetime.now(timezone.utc)
+        _make_ingestion_run(session, finished_at=now - timedelta(hours=1))
+        _make_dedup_run(session, finished_at=now)
+        score_and_select.check_sequencing(session)  # não deve levantar
+
+    def test_passes_when_dedup_and_ingestion_finish_at_same_instant(self, session):
+        now = datetime.now(timezone.utc)
+        _make_ingestion_run(session, finished_at=now)
+        _make_dedup_run(session, finished_at=now)
+        score_and_select.check_sequencing(session)  # >= é aceito, não só >

--- a/tools/prospecting/dedup_prospects.py
+++ b/tools/prospecting/dedup_prospects.py
@@ -8,6 +8,10 @@ qualquer momento (ex.: depois de um novo ingest).
 Uso:
   cd backend && source .venv/bin/activate
   python ../tools/prospecting/dedup_prospects.py [--max-group-size 5]
+
+Toda execução grava uma linha em prospect_dedup_runs (Ordem Complementar,
+item 4) — é o que permite a score_and_select.py verificar se existe uma
+deduplicação posterior à ingestão mais recente antes de pontuar.
 """
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -23,6 +28,7 @@ if str(_BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(_BACKEND_ROOT))
 
 from app.database import SessionLocal  # noqa: E402
+from app.models.prospect_dedup_run import ProspectDedupRun  # noqa: E402
 from app.services.prospecting.dedup import DEFAULT_MAX_GROUP_SIZE, apply_dedup  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -38,9 +44,35 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    started_at = datetime.now(timezone.utc)
     db = SessionLocal()
     try:
-        summary = apply_dedup(db, max_group_size=args.max_group_size)
+        try:
+            summary = apply_dedup(db, max_group_size=args.max_group_size)
+        except Exception as exc:
+            logger.exception("Falha inesperada na deduplicação")
+            db.rollback()
+            db.add(
+                ProspectDedupRun(
+                    status="failed",
+                    started_at=started_at,
+                    finished_at=datetime.now(timezone.utc),
+                )
+            )
+            db.commit()
+            raise SystemExit(1) from exc
+
+        db.add(
+            ProspectDedupRun(
+                groups_merged=summary.groups_merged,
+                orgs_merged=summary.orgs_merged,
+                domains_skipped_too_large=summary.domains_skipped_too_large,
+                status="completed",
+                started_at=started_at,
+                finished_at=datetime.now(timezone.utc),
+            )
+        )
+        db.commit()
     finally:
         db.close()
 

--- a/tools/prospecting/score_and_select.py
+++ b/tools/prospecting/score_and_select.py
@@ -32,6 +32,8 @@ if str(_BACKEND_ROOT) not in sys.path:
 from sqlalchemy import select  # noqa: E402
 
 from app.database import SessionLocal  # noqa: E402
+from app.models.prospect_dedup_run import ProspectDedupRun  # noqa: E402
+from app.models.prospect_ingestion_run import ProspectIngestionRun  # noqa: E402
 from app.models.prospect_org import ProspectOrg  # noqa: E402
 from app.models.prospect_scoring_run import ProspectScoringRun  # noqa: E402
 from app.services.prospecting.rubric_loader import load_rubric  # noqa: E402
@@ -43,6 +45,40 @@ from app.services.prospecting.suppression import (  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("prospecting.score_and_select")
+
+
+class SequencingError(RuntimeError):
+    """Pontuação bloqueada — dados de entrada não estão totalmente processados
+    (Ordem Complementar, item 4: "não será permitido utilizar dados parcialmente
+    processados"). Sem flag de bypass."""
+
+
+def check_sequencing(db) -> None:
+    latest_ingestion = db.execute(
+        select(ProspectIngestionRun)
+        .where(ProspectIngestionRun.status == "completed")
+        .order_by(ProspectIngestionRun.finished_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if latest_ingestion is None:
+        raise SequencingError(
+            "Nenhuma execução de ingest_cnpj_dump.py concluída encontrada. "
+            "Rode a ingestão antes de pontuar."
+        )
+
+    latest_dedup = db.execute(
+        select(ProspectDedupRun)
+        .where(ProspectDedupRun.status == "completed")
+        .order_by(ProspectDedupRun.finished_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if latest_dedup is None or latest_dedup.finished_at < latest_ingestion.finished_at:
+        raise SequencingError(
+            "Nenhuma deduplicação concluída posterior à ingestão mais recente "
+            f"(ingestão concluída em {latest_ingestion.finished_at}). "
+            "Rode dedup_prospects.py antes de pontuar."
+        )
+
 
 CSV_FIELDS = [
     "cnpj_basico", "razao_social", "nome_fantasia", "municipio_nome", "uf",
@@ -122,6 +158,12 @@ def main(argv: list[str] | None = None) -> int:
     started_at = datetime.now(timezone.utc)
     db = SessionLocal()
     try:
+        try:
+            check_sequencing(db)
+        except SequencingError as exc:
+            logger.error("Pontuação bloqueada por sequenciamento: %s", exc)
+            return 1
+
         all_orgs = list(
             db.execute(select(ProspectOrg).where(ProspectOrg.dedup_status != "merged")).scalars().all()
         )
@@ -159,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
         run = ProspectScoringRun(
             rubric_version=rubric.version,
             rubric_checksum=rubric.checksum,
+            rubric_snapshot=rubric.to_snapshot(),
             source_dump_reference=args.dump_reference,
             params={
                 "top_n": args.top_n,


### PR DESCRIPTION
## Contexto

Fatia 5/6 da Ordem Complementar à PO-2026-07-SALES-001 (salvaguardas operacionais do pipeline de prospecção CNPJ). Base: #553, #554, #555, #556 (já merged).

## O que muda

- **`dedup_prospects.py`** grava uma linha `ProspectDedupRun` a cada execução (status `completed`/`failed` + métricas de `apply_dedup`), append-only — item 4 da ordem.
- **`score_and_select.py`** ganha `check_sequencing()`: bloqueia com erro explícito (`SequencingError`, sem flag de bypass) se não existir nenhum `ProspectIngestionRun` concluído, ou se o `ProspectDedupRun` concluído mais recente for anterior ao `ProspectIngestionRun` concluído mais recente. "Não será permitido utilizar dados parcialmente processados" é aplicado incondicionalmente, inclusive em `--dry-run`.
- **`rubric_loader.py`** ganha `Rubric.to_snapshot()` e `load_rubric_from_snapshot()` — `score_and_select.py` agora grava o snapshot completo dos pesos (não só o checksum) em `prospect_scoring_runs.rubric_snapshot`, habilitando reprodutibilidade exata de qualquer classificação passada (usado pelo `reclassify_from_snapshot.py` da fatia 6).

## Testes

- `test_prospecting_score_sequencing.py` (novo): 7 testes unitários de `check_sequencing()` contra Postgres real, com limpeza de tabela isolando de estado global deixado por outras suítes (dedup/ingestion são tabelas não escopadas por dump).
- `test_prospecting_dedup_run_tracking.py` (novo): cobre gravação de `ProspectDedupRun` via `dedup_prospects.main()`.
- `test_prospecting_rubric_loader.py`: round-trip `to_snapshot()`/`load_rubric_from_snapshot()` + validação de snapshot incompleto.
- `test_prospecting_pipeline_cli.py`: testes fim-a-fim existentes atualizados para rodar dedup antes de pontuar (agora obrigatório); nova classe `TestSequencingGate` cobrindo bloqueio via `main()` e o caminho feliz; asserção de `rubric_snapshot` persistido.

## Test plan

- [x] `pytest tests/ -q` (944 passed)
- [x] `ruff check app/ tests/ ../tools/prospecting/`
- [x] `npx pyright@1.1.411` (0 erros)
