### PR TITLE
fix(frontend): aceita CNPJ alfanumérico no formulário de cadastro

### DIFF
--- a/docs/infra/secrets_inventory.md
+++ b/docs/infra/secrets_inventory.md
@@ -66,14 +66,14 @@ Para comparar cópia local com a VM sem expor valores, compare o md5 de cada val
 
 Válidos: Magalu (API key, SSH, Object Storage), Cloudflare, Turnstile, Asaas produção, OpenRouter, HubSpot, GitHub.
 
-## Pendência (2026-07-22): `CLOUDFLARE_ANALYTICS_TOKEN`
+## Resolvido (2026-07-29): `CLOUDFLARE_ANALYTICS_TOKEN`
 
 Gerado e testado (E2E, local) para a seção de tráfego do site no painel admin
 (#518) — token dedicado, escopo mínimo (`Zone:Analytics:Read` + `Zone:Zone:Read`
-só na zona `tribultz.com.br`), sem custo. **Ainda não adicionado a
-`/opt/tribultz/.env` na VM** — até isso acontecer, o painel admin em produção
-mostra a seção como "não configurado" (degradação graciosa, não quebra o
-resto do dashboard). `CLOUDFLARE_ZONE_ID` (`0dca11f87046e628725aba0347548ccf`)
+só na zona `tribultz.com.br`), sem custo. Adicionado a `/opt/tribultz/.env` na
+VM entre 22/07 e 29/07 (fora desta sessão); a cópia local do `.env.prod` estava
+desatualizada e foi resincronizada em 29/07 via `bash tools/check_access.sh`
+(seção 5 apontou o drift). `CLOUDFLARE_ZONE_ID` (`0dca11f87046e628725aba0347548ccf`)
 não é segredo — já tem default no `app/config.py`.
 
 > 🔒 **Ordem vigente (2026-07-15): NÃO rotacionar, revogar nem encerrar sessão de credencial alguma enquanto o produto não escala.** Vale inclusive para as pendências listadas abaixo — inclusive as comprovadamente vazadas ou já revogadas. Documentar e seguir; não propor rotação de novo. O objetivo da fase é acesso livre e sem atrito a partir de Windows e Mac. Reavaliar quando o produto escalar.

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -46,12 +46,14 @@ const PLANS: { slug: PlanSlug; name: string; price: string; features: string[]; 
 ];
 
 function formatCnpj(value: string): string {
-  const digits = value.replace(/\D/g, "").slice(0, 14);
-  if (digits.length <= 2) return digits;
-  if (digits.length <= 5) return `${digits.slice(0, 2)}.${digits.slice(2)}`;
-  if (digits.length <= 8) return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5)}`;
-  if (digits.length <= 12) return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8)}`;
-  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
+  // CNPJ alfanumérico (RFB, produção 27/07/2026): as 12 primeiras posições
+  // aceitam letras, só os 2 dígitos verificadores finais são numéricos.
+  const chars = value.replace(/[^A-Za-z0-9]/g, "").toUpperCase().slice(0, 14);
+  if (chars.length <= 2) return chars;
+  if (chars.length <= 5) return `${chars.slice(0, 2)}.${chars.slice(2)}`;
+  if (chars.length <= 8) return `${chars.slice(0, 2)}.${chars.slice(2, 5)}.${chars.slice(5)}`;
+  if (chars.length <= 12) return `${chars.slice(0, 2)}.${chars.slice(2, 5)}.${chars.slice(5, 8)}/${chars.slice(8)}`;
+  return `${chars.slice(0, 2)}.${chars.slice(2, 5)}.${chars.slice(5, 8)}/${chars.slice(8, 12)}-${chars.slice(12)}`;
 }
 
 function formatPhone(value: string): string {
@@ -61,8 +63,8 @@ function formatPhone(value: string): string {
   return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
 }
 
-function cnpjDigits(formatted: string): string {
-  return formatted.replace(/\D/g, "");
+function normalizeCnpj(formatted: string): string {
+  return formatted.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
 }
 
 export default function RegisterPage() {
@@ -110,9 +112,9 @@ export default function RegisterPage() {
       setToast({ tone: "error", msg: "Preencha todos os campos obrigatórios." });
       return false;
     }
-    const digits = cnpjDigits(cnpj);
-    if (digits.length !== 14) {
-      setToast({ tone: "error", msg: "CNPJ deve ter 14 dígitos." });
+    const normalized = normalizeCnpj(cnpj);
+    if (normalized.length !== 14) {
+      setToast({ tone: "error", msg: "CNPJ deve ter 14 caracteres (12 alfanuméricos + 2 dígitos verificadores)." });
       return false;
     }
     if (password !== confirmPassword) {
@@ -162,7 +164,7 @@ export default function RegisterPage() {
         email: email.trim(),
         password,
         full_name: fullName.trim(),
-        cnpj: cnpjDigits(cnpj),
+        cnpj: normalizeCnpj(cnpj),
         phone: phone.replace(/\D/g, ""),
         account_type: accountType,
         plan_slug: planSlug,
@@ -376,7 +378,7 @@ export default function RegisterPage() {
               <span className="mb-1 block text-slate-600">
                 {planSlug === "contador" ? "CNPJ do escritório" : "CNPJ da empresa"}
               </span>
-              <input type="text" value={cnpj} onChange={(e) => setCnpj(formatCnpj(e.target.value))} placeholder="00.000.000/0000-00" className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono" inputMode="numeric" />
+              <input type="text" value={cnpj} onChange={(e) => setCnpj(formatCnpj(e.target.value))} placeholder="00.000.000/0000-00" className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono" inputMode="text" />
             </label>
             <label className="block text-sm">
               <span className="mb-1 block text-slate-600">Email corporativo</span>


### PR DESCRIPTION
## Resumo

- Corrige `frontend/src/app/register/page.tsx`: `formatCnpj`/`normalizeCnpj` descartavam qualquer letra digitada no campo de CNPJ, então mesmo com o backend já corrigido (#514) o CNPJ alfanumérico da RFB (produção 27/07/2026, primeira emissão 31/07/2026) nunca chegava a sair do navegador — as letras eram removidas a cada tecla, antes de qualquer validação ou envio.
- Preserva `A-Z0-9`, normaliza para maiúsculas (paridade com `normalize_cnpj` do backend), atualiza a mensagem de erro e troca `inputMode="numeric"` por `"text"` no input.
- Também inclui um commit de manutenção de doc (`docs/infra/secrets_inventory.md`): corrige a pendência de 22/07 do `CLOUDFLARE_ANALYTICS_TOKEN`, que já foi resolvida (drift do `.env.prod` local corrigido nesta mesma sessão).

Closes #558

## Test plan

- [x] `cd frontend && npm test --silent` — 193/193 passando
- [x] `cd frontend && npm run build` — build limpo
- [x] Verificado no navegador via Playwright: `12ABC34501DE35` → `12.ABC.345/01DE-35` (letras preservadas); `12345678000199` → `12.345.678/0001-99` (caso numérico sem regressão)