### PR TITLE
feat(crm): Attio — fatia 3/12, sincronização de Pessoas

### DIFF
--- a/backend/app/integrations/attio/people.py
+++ b/backend/app/integrations/attio/people.py
@@ -1,0 +1,108 @@
+"""Person sync — Attio CRM.
+
+PO-2026-07-CRM-001, fatia 3/12. Same style as companies.py: general-purpose,
+not coupled to any local model. Dedup by email before create — email is the
+natural identity for a person, unlike companies there's no multi-field
+cascade to design here.
+
+The "company" attribute is a record-reference; written via Attio's domain
+shorthand (a record-reference to a company can be set by passing its domain
+string instead of looking up its record_id first — see
+docs.attio.com/rest-api/attribute-types/attribute-types-record-reference).
+The company must already exist in Attio for the link to resolve — callers
+should upsert_company() first (see companies.py) when linking is needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from app.integrations.attio.client import AttioClient, is_enabled, noop
+
+logger = logging.getLogger(__name__)
+
+OBJECT = "people"
+
+# email_addresses and name ship on Attio's default "people" object. job_title,
+# linkedin and phone are workspace custom attributes in our assumption — same
+# caveat as companies.py: no real workspace to confirm slugs against yet.
+_CUSTOM_ATTRS = {
+    "job_title": "job_title",
+    "linkedin": "linkedin",
+    "phone": "phone_numbers",
+}
+
+
+def _find_record_id(client: AttioClient, attribute: str, value: str) -> Optional[str]:
+    result = client.request(
+        "POST",
+        f"/objects/{OBJECT}/records/query",
+        json={"filter": {attribute: {"$eq": value}}, "limit": 1},
+    )
+    records = result.get("records", [])
+    return records[0]["id"]["record_id"] if records else None
+
+
+def _values_payload(
+    email: str,
+    first_name: Optional[str],
+    last_name: Optional[str],
+    job_title: Optional[str],
+    linkedin: Optional[str],
+    phone: Optional[str],
+    company_domain: Optional[str],
+) -> dict[str, Any]:
+    values: dict[str, Any] = {"email_addresses": [email]}
+    if first_name or last_name:
+        values["name"] = {"first_name": first_name or "", "last_name": last_name or ""}
+    if company_domain:
+        values["company"] = [company_domain]
+    optional_fields = {"job_title": job_title, "linkedin": linkedin, "phone": phone}
+    for field, value in optional_fields.items():
+        if value:
+            values[_CUSTOM_ATTRS[field]] = value
+    return values
+
+
+def upsert_person(
+    email: str,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
+    job_title: Optional[str] = None,
+    linkedin: Optional[str] = None,
+    phone: Optional[str] = None,
+    company_domain: Optional[str] = None,
+    attio_person_id: Optional[str] = None,
+    client: Optional[AttioClient] = None,
+) -> dict[str, Any]:
+    """Create or update a person in Attio, deduplicating by email before create.
+
+    Search order: attio_person_id (caller already knows it — skips search) →
+    email. Falls back to creating a new record matched on email when nothing
+    is found. Pass company_domain to link the person to an existing company
+    (see module docstring — the company must already exist).
+    """
+    if not is_enabled():
+        return noop("person")
+
+    client = client or AttioClient()
+    values = _values_payload(email, first_name, last_name, job_title, linkedin, phone, company_domain)
+
+    record_id = attio_person_id or _find_record_id(client, "email_addresses", email)
+
+    if record_id:
+        logger.info("attio_person_update record_id=%s", record_id)
+        return client.request(
+            "PATCH",
+            f"/objects/{OBJECT}/records/{record_id}",
+            json={"data": {"values": values}},
+        )
+
+    logger.info("attio_person_create matching_attribute=email_addresses")
+    return client.request(
+        "PUT",
+        f"/objects/{OBJECT}/records",
+        params={"matching_attribute": "email_addresses"},
+        json={"data": {"values": values}},
+    )

--- a/backend/tests/test_attio_people.py
+++ b/backend/tests/test_attio_people.py
@@ -1,0 +1,131 @@
+"""Tests for the Attio person sync — PO-2026-07-CRM-001, fatia 3/12."""
+
+from __future__ import annotations
+
+import json as _json
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.integrations.attio.client import AttioClient
+from app.integrations.attio.people import upsert_person
+
+
+@pytest.fixture(autouse=True)
+def _attio_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", True)
+    monkeypatch.setattr(settings, "ATTIO_API_KEY", "test-key")
+
+
+def _client(handler) -> AttioClient:
+    return AttioClient(transport=httpx.MockTransport(handler), base_delay_seconds=0.001)
+
+
+def test_disabled_returns_noop(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", False)
+    result = upsert_person(email="ana@exemplo.com.br")
+    assert result == {"attio": "disabled", "entity": "person", "action": "skipped"}
+
+
+def test_creates_when_not_found():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/records/query"):
+            return httpx.Response(200, json={"records": []})
+        assert request.method == "PUT"
+        assert request.url.params["matching_attribute"] == "email_addresses"
+        payload = _json.loads(request.read())
+        values = payload["data"]["values"]
+        assert values["email_addresses"] == ["ana@exemplo.com.br"]
+        assert values["name"] == {"first_name": "Ana", "last_name": "Silva"}
+        return httpx.Response(200, json={"data": {"id": {"record_id": "person-1"}}})
+
+    result = upsert_person(
+        email="ana@exemplo.com.br",
+        first_name="Ana",
+        last_name="Silva",
+        client=_client(handler),
+    )
+    assert result == {"data": {"id": {"record_id": "person-1"}}}
+
+
+def test_updates_when_found_by_email():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/records/query"):
+            payload = _json.loads(request.read())
+            assert payload["filter"] == {"email_addresses": {"$eq": "ana@exemplo.com.br"}}
+            return httpx.Response(200, json={"records": [{"id": {"record_id": "person-2"}}]})
+        assert request.method == "PATCH"
+        assert request.url.path == "/v2/objects/people/records/person-2"
+        return httpx.Response(200, json={"data": {"id": {"record_id": "person-2"}}})
+
+    result = upsert_person(email="ana@exemplo.com.br", client=_client(handler))
+    assert result == {"data": {"id": {"record_id": "person-2"}}}
+
+
+def test_uses_attio_person_id_directly_without_search():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/v2/objects/people/records/known-id"
+        return httpx.Response(200, json={"data": {"id": {"record_id": "known-id"}}})
+
+    result = upsert_person(
+        email="ana@exemplo.com.br",
+        attio_person_id="known-id",
+        client=_client(handler),
+    )
+    assert result == {"data": {"id": {"record_id": "known-id"}}}
+
+
+def test_links_company_by_domain_shorthand():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/records/query"):
+            return httpx.Response(200, json={"records": []})
+        payload = _json.loads(request.read())
+        assert payload["data"]["values"]["company"] == ["exemplo.com.br"]
+        return httpx.Response(200, json={"data": {"id": {"record_id": "person-3"}}})
+
+    result = upsert_person(
+        email="ana@exemplo.com.br",
+        company_domain="exemplo.com.br",
+        client=_client(handler),
+    )
+    assert result == {"data": {"id": {"record_id": "person-3"}}}
+
+
+def test_optional_fields_included_when_present():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/records/query"):
+            return httpx.Response(200, json={"records": []})
+        payload = _json.loads(request.read())
+        values = payload["data"]["values"]
+        assert values["job_title"] == "Diretora Financeira"
+        assert values["linkedin"] == "https://linkedin.com/in/ana-silva"
+        assert values["phone_numbers"] == "+5511999999999"
+        return httpx.Response(200, json={"data": {"id": {"record_id": "person-4"}}})
+
+    result = upsert_person(
+        email="ana@exemplo.com.br",
+        job_title="Diretora Financeira",
+        linkedin="https://linkedin.com/in/ana-silva",
+        phone="+5511999999999",
+        client=_client(handler),
+    )
+    assert result == {"data": {"id": {"record_id": "person-4"}}}
+
+
+def test_optional_fields_omitted_when_absent():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/records/query"):
+            return httpx.Response(200, json={"records": []})
+        payload = _json.loads(request.read())
+        values = payload["data"]["values"]
+        assert "job_title" not in values
+        assert "linkedin" not in values
+        assert "phone_numbers" not in values
+        assert "name" not in values
+        assert "company" not in values
+        return httpx.Response(200, json={"data": {"id": {"record_id": "person-5"}}})
+
+    result = upsert_person(email="ana@exemplo.com.br", client=_client(handler))
+    assert result == {"data": {"id": {"record_id": "person-5"}}}


### PR DESCRIPTION
## Contexto

PO-2026-07-CRM-001, continuação de #561 (mergeada) e #562 (aberta, sincronização
de Empresas). Esta fatia branchea direto de `main` — só depende do `AttioClient`
da fatia 1, já mergeado.

## Fatia 3/12 — sincronização de Pessoas

- `upsert_person()` em `backend/app/integrations/attio/people.py`, mesmo estilo
  de `companies.py` (#562).
- Dedup por email antes de criar (identidade natural de pessoa — sem cascata
  multi-campo).
- Vínculo à empresa via atributo `company` (record-reference), usando o atalho
  de domínio do Attio (`values["company"] = [domain]`) em vez de buscar o
  `record_id` da empresa primeiro.

## Decisões que tomei sozinho (sinalizando para review)

- **Vínculo por domínio, não por record_id**: a empresa precisa já existir no
  Attio para o vínculo resolver — quem chamar `upsert_person()` com
  `company_domain` deve ter rodado `upsert_company()` antes. Não travei essa
  ordem programaticamente (fica a critério de quem orquestra o sync, que ainda
  não existe — é uma fatia futura).
- **Slugs de `job_title`/`linkedin`/`phone_numbers`**: mesma ressalva da fatia
  2 — convenção nossa, sem workspace Attio real para confirmar contra o schema.

## Test plan

- [x] `pytest tests/test_attio_people.py -q` — 7/7 passando (httpx.MockTransport, sem rede real)
- [x] `ruff check app/integrations/attio/people.py tests/test_attio_people.py` — limpo
- [x] `npx pyright@1.1.411` nos arquivos tocados — 0 erros
- [ ] Suíte completa / teste real contra a API — mesma pendência de infra e credencial das fatias anteriores
