### PR TITLE
feat(crm): Attio — fatia 4/12, pipeline comercial + Lead Source

### DIFF
--- a/backend/app/integrations/attio/pipeline.py
+++ b/backend/app/integrations/attio/pipeline.py
@@ -1,0 +1,116 @@
+"""Commercial pipeline sync — Attio CRM.
+
+PO-2026-07-CRM-001, fatia 4/12. Assumes the pipeline List and its "Lead
+Source" attribute already exist in the Attio workspace — schema/workspace
+provisioning is manual admin setup, not this module's job (same stance as
+the custom attribute slugs in companies.py/people.py). This module only
+moves records through stages that must already be configured as select
+options on the list's status attribute.
+
+Upsert shape from docs.attio.com/rest-api/endpoint-reference/entries/upsert-a-list-entry-by-parent:
+PUT /v2/lists/{list}/entries with {"data": {"parent_record_id", "parent_object", "entry_values"}}.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from app.config import settings
+from app.integrations.attio.client import AttioClient, is_enabled, noop
+
+logger = logging.getLogger(__name__)
+
+# PO seção 5 — nomes de estágio exatos, em ordem. Precisam bater com as
+# opções já configuradas no atributo de status da list no workspace.
+PIPELINE_STAGES = (
+    "Lead identificado",
+    "Empresa criada",
+    "Contato identificado",
+    "Primeiro contato",
+    "Resposta recebida",
+    "Discovery",
+    "Diagnóstico",
+    "Proposta enviada",
+    "Negociação",
+    "Fechado ganho",
+    "Fechado perdido",
+)
+
+# PO seção 6 — propriedade obrigatória "Lead Source", valores fixos.
+LEAD_SOURCES = (
+    "Rumy",
+    "LinkedIn",
+    "Cold Email",
+    "Site",
+    "Indicação",
+    "Manual",
+    "Outro",
+)
+
+STAGE_ATTRIBUTE = "stage"
+LEAD_SOURCE_ATTRIBUTE = "lead_source"
+
+
+def add_to_pipeline(
+    parent_record_id: str,
+    parent_object: str,
+    stage: Optional[str] = None,
+    list_slug: Optional[str] = None,
+    client: Optional[AttioClient] = None,
+) -> dict[str, Any]:
+    """Create or move a record's entry in the commercial pipeline list.
+
+    parent_object is whichever Attio object the record belongs to
+    ("companies" or "people") — the pipeline can track either. stage
+    defaults to settings.ATTIO_DEFAULT_STAGE when omitted; list_slug
+    defaults to settings.ATTIO_DEFAULT_PIPELINE. Validates the stage name
+    before doing anything else, even when Attio is disabled.
+    """
+    resolved_stage = stage or settings.ATTIO_DEFAULT_STAGE
+    if resolved_stage not in PIPELINE_STAGES:
+        raise ValueError(f"estágio inválido: {resolved_stage!r} — esperado um de {PIPELINE_STAGES}")
+
+    if not is_enabled():
+        return noop("pipeline_entry")
+
+    client = client or AttioClient()
+    list_id = list_slug or settings.ATTIO_DEFAULT_PIPELINE
+    logger.info("attio_pipeline_move parent_object=%s stage=%s", parent_object, resolved_stage)
+    return client.request(
+        "PUT",
+        f"/lists/{list_id}/entries",
+        json={
+            "data": {
+                "parent_record_id": parent_record_id,
+                "parent_object": parent_object,
+                "entry_values": {STAGE_ATTRIBUTE: resolved_stage},
+            }
+        },
+    )
+
+
+def set_lead_source(
+    record_id: str,
+    source: str,
+    object_type: str = "companies",
+    client: Optional[AttioClient] = None,
+) -> dict[str, Any]:
+    """Write the required Lead Source property on a record.
+
+    Validates against the PO's fixed value list before doing anything else,
+    even when Attio is disabled.
+    """
+    if source not in LEAD_SOURCES:
+        raise ValueError(f"lead source inválido: {source!r} — esperado um de {LEAD_SOURCES}")
+
+    if not is_enabled():
+        return noop("lead_source")
+
+    client = client or AttioClient()
+    logger.info("attio_lead_source_set object=%s source=%s", object_type, source)
+    return client.request(
+        "PATCH",
+        f"/objects/{object_type}/records/{record_id}",
+        json={"data": {"values": {LEAD_SOURCE_ATTRIBUTE: source}}},
+    )

--- a/backend/tests/test_attio_pipeline.py
+++ b/backend/tests/test_attio_pipeline.py
@@ -1,0 +1,116 @@
+"""Tests for the Attio pipeline sync — PO-2026-07-CRM-001, fatia 4/12."""
+
+from __future__ import annotations
+
+import json as _json
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.integrations.attio.client import AttioClient
+from app.integrations.attio.pipeline import add_to_pipeline, set_lead_source
+
+
+@pytest.fixture(autouse=True)
+def _attio_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", True)
+    monkeypatch.setattr(settings, "ATTIO_API_KEY", "test-key")
+    monkeypatch.setattr(settings, "ATTIO_DEFAULT_PIPELINE", "pipeline-comercial")
+    monkeypatch.setattr(settings, "ATTIO_DEFAULT_STAGE", "Lead identificado")
+
+
+def _client(handler) -> AttioClient:
+    return AttioClient(transport=httpx.MockTransport(handler), base_delay_seconds=0.001)
+
+
+# ── add_to_pipeline ──────────────────────────────────────────
+def test_moves_to_given_stage():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        assert request.url.path == "/v2/lists/pipeline-comercial/entries"
+        payload = _json.loads(request.read())
+        assert payload["data"]["parent_record_id"] == "company-1"
+        assert payload["data"]["parent_object"] == "companies"
+        assert payload["data"]["entry_values"] == {"stage": "Discovery"}
+        return httpx.Response(200, json={"data": {"id": {"entry_id": "entry-1"}}})
+
+    result = add_to_pipeline(
+        "company-1", "companies", stage="Discovery", client=_client(handler)
+    )
+    assert result == {"data": {"id": {"entry_id": "entry-1"}}}
+
+
+def test_defaults_to_configured_stage_and_pipeline():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/lists/pipeline-comercial/entries"
+        payload = _json.loads(request.read())
+        assert payload["data"]["entry_values"] == {"stage": "Lead identificado"}
+        return httpx.Response(200, json={"data": {}})
+
+    add_to_pipeline("company-1", "companies", client=_client(handler))
+
+
+def test_rejects_invalid_stage_without_calling_api():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("API não deveria ser chamada com estágio inválido")
+
+    with pytest.raises(ValueError, match="estágio inválido"):
+        add_to_pipeline(
+            "company-1", "companies", stage="Estágio Inexistente", client=_client(handler)
+        )
+
+
+def test_disabled_returns_noop(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", False)
+    result = add_to_pipeline("company-1", "companies", stage="Discovery")
+    assert result == {"attio": "disabled", "entity": "pipeline_entry", "action": "skipped"}
+
+
+def test_uses_custom_list_slug():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/lists/outra-lista/entries"
+        return httpx.Response(200, json={"data": {}})
+
+    add_to_pipeline(
+        "company-1",
+        "companies",
+        stage="Discovery",
+        list_slug="outra-lista",
+        client=_client(handler),
+    )
+
+
+# ── set_lead_source ───────────────────────────────────────────
+def test_sets_valid_lead_source():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/v2/objects/companies/records/company-1"
+        payload = _json.loads(request.read())
+        assert payload["data"]["values"] == {"lead_source": "LinkedIn"}
+        return httpx.Response(200, json={"data": {"id": {"record_id": "company-1"}}})
+
+    result = set_lead_source("company-1", "LinkedIn", client=_client(handler))
+    assert result == {"data": {"id": {"record_id": "company-1"}}}
+
+
+def test_rejects_invalid_lead_source_without_calling_api():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("API não deveria ser chamada com lead source inválido")
+
+    with pytest.raises(ValueError, match="lead source inválido"):
+        set_lead_source("company-1", "Anúncio pago", client=_client(handler))
+
+
+def test_lead_source_disabled_returns_noop(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", False)
+    result = set_lead_source("company-1", "Manual")
+    assert result == {"attio": "disabled", "entity": "lead_source", "action": "skipped"}
+
+
+def test_lead_source_uses_custom_object_type():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/objects/people/records/person-1"
+        return httpx.Response(200, json={"data": {}})
+
+    set_lead_source("person-1", "Indicação", object_type="people", client=_client(handler))


### PR DESCRIPTION
## Contexto

PO-2026-07-CRM-001, continuação de #561 (mergeada), #562 e #563 (abertas).
Branchea direto de `main` — só depende do `AttioClient` da fatia 1.

## Fatia 4/12 — pipeline comercial + Lead Source

- `add_to_pipeline()` em `backend/app/integrations/attio/pipeline.py`: move
  um record (company ou person) pro estágio informado via
  `PUT /v2/lists/{list}/entries` (upsert de list entry por parent record —
  [docs](https://docs.attio.com/rest-api/endpoint-reference/entries/upsert-a-list-entry-by-parent)).
  `stage`/`list_slug` default pra `ATTIO_DEFAULT_STAGE`/`ATTIO_DEFAULT_PIPELINE`
  (env vars já configuradas na fatia 1).
- `set_lead_source()`: escreve a propriedade obrigatória Lead Source
  direto no record via PATCH (não é list entry).
- Ambas validam contra as listas fechadas da PO (11 estágios da seção 5, 7
  origens da seção 6) e levantam `ValueError` **sem chamar a API** quando o
  valor não bate.

## Decisão que tomei sozinho (sinalizando para review)

- **Assumo que a List do pipeline e o atributo Lead Source já existem no
  workspace Attio** — mesmo padrão das fatias 2/3 (provisionar schema é setup
  manual de admin, não responsabilidade deste módulo de sync). Não criei a
  List via API. Se o Techlead preferir que o código também provisione a List
  (idempotente, create-if-not-exists), é mudança pequena a partir daqui — mas
  achei mais seguro não criar estrutura de workspace automaticamente sem
  confirmação.

## Test plan

- [x] `pytest tests/test_attio_pipeline.py -q` — 9/9 passando (httpx.MockTransport, sem rede real)
- [x] `ruff check app/integrations/attio/pipeline.py tests/test_attio_pipeline.py` — limpo
- [x] `npx pyright@1.1.411` nos arquivos tocados — 0 erros
- [ ] Suíte completa / teste real contra a API — mesma pendência de infra e credencial das fatias anteriores

🤖 Generated with [Claude Code](https://claude.com/claude-code)