### PR TITLE
feat(crm): Attio — fatia 5/12, enriquecimento de registros

### DIFF
--- a/backend/app/integrations/attio/enrichment.py
+++ b/backend/app/integrations/attio/enrichment.py
@@ -1,0 +1,99 @@
+"""Enrichment sync — Attio CRM.
+
+PO-2026-07-CRM-001, fatia 5/12. Writes computed enrichment data (Tribultz
+score, ranking, financial indicators, ...) onto an existing record via a
+partial PATCH — no dedup/create here, this assumes the record already
+exists (created by upsert_company()/upsert_person() in earlier fatias).
+
+financial_indicators has no matching native Attio attribute type (Attio's
+17 attribute types are text/number/checkbox/date/select/multi_select/
+currency/rating/email/phone/url/person_reference/company_reference/... —
+no arbitrary JSON/object type, per
+docs.attio.com/rest-api/attribute-types/attribute-types), so it's
+serialized as a JSON string into a text attribute. Revisit if a structured
+breakdown per indicator is needed later.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from app.integrations.attio.client import AttioClient, is_enabled, noop
+
+logger = logging.getLogger(__name__)
+
+# Slugs de atributo custom — mesma ressalva das fatias anteriores: convenção
+# nossa, não confirmados contra um workspace Attio real.
+_ATTRS = {
+    "score": "score_tribultz",
+    "ranking": "ranking",
+    "score_reason": "score_reason",
+    "analysis_date": "analysis_date",
+    "last_updated_date": "last_updated_date",
+    "rf_origin": "rf_origin",
+    "financial_indicators": "financial_indicators",
+    "segment": "segment",
+    "cnae": "cnae",
+}
+
+
+def sync_enrichment(
+    record_id: str,
+    score: Optional[float] = None,
+    ranking: Optional[int] = None,
+    score_reason: Optional[str] = None,
+    analysis_date: Optional[str] = None,
+    last_updated_date: Optional[str] = None,
+    rf_origin: Optional[str] = None,
+    financial_indicators: Optional[dict[str, Any]] = None,
+    segment: Optional[str] = None,
+    cnae: Optional[str] = None,
+    object_type: str = "companies",
+    client: Optional[AttioClient] = None,
+) -> dict[str, Any]:
+    """Write enrichment fields onto an existing record via partial PATCH.
+
+    Only fields actually passed are sent — None means "don't touch this
+    attribute", not "clear it" (so score=0 or an empty financial_indicators
+    dict are still written). Raises ValueError if nothing was passed, since
+    that's a caller bug — there'd be nothing to sync, without ever calling
+    the API, consistent with the fail-fast validation in pipeline.py.
+    """
+    raw_fields = {
+        "score": score,
+        "ranking": ranking,
+        "score_reason": score_reason,
+        "analysis_date": analysis_date,
+        "last_updated_date": last_updated_date,
+        "rf_origin": rf_origin,
+        "financial_indicators": financial_indicators,
+        "segment": segment,
+        "cnae": cnae,
+    }
+    values: dict[str, Any] = {}
+    for field, value in raw_fields.items():
+        if value is None:
+            continue
+        if field == "financial_indicators":
+            values[_ATTRS[field]] = json.dumps(value, ensure_ascii=False)
+        else:
+            values[_ATTRS[field]] = value
+
+    if not values:
+        raise ValueError("sync_enrichment: nenhum campo informado — nada para sincronizar")
+
+    if not is_enabled():
+        return noop("enrichment")
+
+    client = client or AttioClient()
+    logger.info(
+        "attio_enrichment_sync object=%s record_id=%s fields=%s",
+        object_type, record_id, list(values),
+    )
+    return client.request(
+        "PATCH",
+        f"/objects/{object_type}/records/{record_id}",
+        json={"data": {"values": values}},
+    )

--- a/backend/tests/test_attio_enrichment.py
+++ b/backend/tests/test_attio_enrichment.py
@@ -1,0 +1,96 @@
+"""Tests for the Attio enrichment sync — PO-2026-07-CRM-001, fatia 5/12."""
+
+from __future__ import annotations
+
+import json as _json
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.integrations.attio.client import AttioClient
+from app.integrations.attio.enrichment import sync_enrichment
+
+
+@pytest.fixture(autouse=True)
+def _attio_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", True)
+    monkeypatch.setattr(settings, "ATTIO_API_KEY", "test-key")
+
+
+def _client(handler) -> AttioClient:
+    return AttioClient(transport=httpx.MockTransport(handler), base_delay_seconds=0.001)
+
+
+def test_syncs_all_fields():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/v2/objects/companies/records/company-1"
+        values = _json.loads(request.read())["data"]["values"]
+        assert values == {
+            "score_tribultz": 87.5,
+            "ranking": 12,
+            "score_reason": "Alto potencial de conversão — segmento contábil",
+            "analysis_date": "2026-07-31",
+            "last_updated_date": "2026-07-31",
+            "rf_origin": "Receita Federal — Dados Abertos CNPJ 2026-07",
+            "financial_indicators": '{"faturamento_estimado": 500000}',
+            "segment": "Contabilidade",
+            "cnae": "6920-6/01",
+        }
+        return httpx.Response(200, json={"data": {"id": {"record_id": "company-1"}}})
+
+    result = sync_enrichment(
+        "company-1",
+        score=87.5,
+        ranking=12,
+        score_reason="Alto potencial de conversão — segmento contábil",
+        analysis_date="2026-07-31",
+        last_updated_date="2026-07-31",
+        rf_origin="Receita Federal — Dados Abertos CNPJ 2026-07",
+        financial_indicators={"faturamento_estimado": 500000},
+        segment="Contabilidade",
+        cnae="6920-6/01",
+        client=_client(handler),
+    )
+    assert result == {"data": {"id": {"record_id": "company-1"}}}
+
+
+def test_syncs_partial_subset_and_omits_none_fields():
+    def handler(request: httpx.Request) -> httpx.Response:
+        values = _json.loads(request.read())["data"]["values"]
+        assert values == {"score_tribultz": 42.0, "ranking": 5}
+        return httpx.Response(200, json={"data": {}})
+
+    sync_enrichment("company-1", score=42.0, ranking=5, client=_client(handler))
+
+
+def test_preserves_falsy_but_meaningful_values():
+    def handler(request: httpx.Request) -> httpx.Response:
+        values = _json.loads(request.read())["data"]["values"]
+        assert values == {"score_tribultz": 0, "financial_indicators": "{}"}
+        return httpx.Response(200, json={"data": {}})
+
+    sync_enrichment("company-1", score=0, financial_indicators={}, client=_client(handler))
+
+
+def test_raises_without_calling_api_when_nothing_passed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("API não deveria ser chamada sem nenhum campo")
+
+    with pytest.raises(ValueError, match="nenhum campo informado"):
+        sync_enrichment("company-1", client=_client(handler))
+
+
+def test_disabled_returns_noop(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", False)
+    result = sync_enrichment("company-1", score=10)
+    assert result == {"attio": "disabled", "entity": "enrichment", "action": "skipped"}
+
+
+def test_uses_custom_object_type():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/objects/people/records/person-1"
+        return httpx.Response(200, json={"data": {}})
+
+    sync_enrichment("person-1", score=10, object_type="people", client=_client(handler))


### PR DESCRIPTION
## Contexto

PO-2026-07-CRM-001, continuação de #561 (mergeada), #562/#563/#564 (abertas).
Branchea direto de `main` — só depende do `AttioClient` da fatia 1.

## Fatia 5/12 — enriquecimento

- `sync_enrichment()` em `backend/app/integrations/attio/enrichment.py`: PATCH
  parcial com só os campos passados. `None` significa "não mexer no
  atributo", não "limpar" — diferente do `if value:` usado nas fatias 2/3,
  aqui `score=0` ou `financial_indicators={}` são escritos normalmente
  (usei `is None` em vez de truthy check, mais correto para números/dicts
  que podem ser legitimamente zero/vazios).
- Levanta `ValueError` sem chamar a API quando nada é passado (mesmo padrão
  fail-fast da fatia 4, #564).
- Campos da PO (seção 7): Score Tribultz, Ranking, Motivo do Score, Data da
  análise, Data da última atualização, Origem da Receita Federal,
  indicadores financeiros calculados, Segmento, CNAE.

## Decisão que tomei sozinho (sinalizando para review)

- **`financial_indicators` não tem `attribute_type` nativo no Attio** — os 17
  tipos documentados (text/number/checkbox/date/select/multi_select/
  currency/rating/email/phone/url/person_reference/company_reference/...)
  não incluem JSON/objeto arbitrário. Serializei como string JSON num
  atributo de texto. Se precisarmos consultar/filtrar indicadores
  individualmente dentro do Attio no futuro, isso vira campos separados —
  por ora não há esse requisito na PO.

## Test plan

- [x] `pytest tests/test_attio_enrichment.py -q` — 6/6 passando (httpx.MockTransport, sem rede real)
- [x] `ruff check app/integrations/attio/enrichment.py tests/test_attio_enrichment.py` — limpo
- [x] `npx pyright@1.1.411` nos arquivos tocados — 0 erros
- [ ] Suíte completa / teste real contra a API — mesma pendência de infra e credencial das fatias anteriores