### PR TITLE
feat(crm): Attio — fatia 6/12, histórico automático

### DIFF
--- a/backend/app/integrations/attio/history.py
+++ b/backend/app/integrations/attio/history.py
@@ -1,0 +1,67 @@
+"""History logging — Attio CRM.
+
+PO-2026-07-CRM-001, fatia 6/12. Each call creates a new note (POST /v2/notes,
+docs.attio.com/rest-api/endpoint-reference/notes/create-a-note) — this is an
+append-only history log, not an upsert. Unlike companies.py/people.py there
+is deliberately no dedup here: history is a log of events, so a repeated
+call legitimately creates a second note. The client's retry policy already
+refuses to retry POST on 5xx (see client.py) precisely to avoid an
+ambiguous retry silently duplicating a note.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from app.integrations.attio.client import AttioClient, is_enabled, noop
+
+logger = logging.getLogger(__name__)
+
+# PO seção 8 — os seis tipos de evento de histórico rastreados.
+_EVENT_TITLES: dict[str, str] = {
+    "criacao": "Lead criado",
+    "atualizacao": "Lead atualizado",
+    "mudanca_estagio": "Estágio alterado",
+    "campanha_enviada": "Campanha enviada",
+    "resposta_recebida": "Resposta recebida",
+    "observacao": "Observação automática",
+}
+
+
+def log_history(
+    parent_record_id: str,
+    event_type: str,
+    content: str,
+    parent_object: str = "companies",
+    client: Optional[AttioClient] = None,
+) -> dict[str, Any]:
+    """Append a history note to a record's timeline.
+
+    event_type must be one of the PO's six tracked event kinds; anything
+    else raises ValueError before touching the API.
+    """
+    if event_type not in _EVENT_TITLES:
+        raise ValueError(
+            f"tipo de evento de histórico inválido: {event_type!r} — "
+            f"esperado um de {tuple(_EVENT_TITLES)}"
+        )
+
+    if not is_enabled():
+        return noop("history_note")
+
+    client = client or AttioClient()
+    logger.info("attio_history_log object=%s event_type=%s", parent_object, event_type)
+    return client.request(
+        "POST",
+        "/notes",
+        json={
+            "data": {
+                "parent_object": parent_object,
+                "parent_record_id": parent_record_id,
+                "title": _EVENT_TITLES[event_type],
+                "format": "plaintext",
+                "content": content,
+            }
+        },
+    )

--- a/backend/tests/test_attio_history.py
+++ b/backend/tests/test_attio_history.py
@@ -1,0 +1,98 @@
+"""Tests for the Attio history logging — PO-2026-07-CRM-001, fatia 6/12."""
+
+from __future__ import annotations
+
+import json as _json
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.integrations.attio.client import AttioClient
+from app.integrations.attio.history import log_history
+
+
+@pytest.fixture(autouse=True)
+def _attio_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", True)
+    monkeypatch.setattr(settings, "ATTIO_API_KEY", "test-key")
+
+
+def _client(handler) -> AttioClient:
+    return AttioClient(transport=httpx.MockTransport(handler), base_delay_seconds=0.001)
+
+
+@pytest.mark.parametrize(
+    "event_type,expected_title",
+    [
+        ("criacao", "Lead criado"),
+        ("atualizacao", "Lead atualizado"),
+        ("mudanca_estagio", "Estágio alterado"),
+        ("campanha_enviada", "Campanha enviada"),
+        ("resposta_recebida", "Resposta recebida"),
+        ("observacao", "Observação automática"),
+    ],
+)
+def test_creates_note_for_each_valid_event_type(event_type, expected_title):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v2/notes"
+        payload = _json.loads(request.read())["data"]
+        assert payload == {
+            "parent_object": "companies",
+            "parent_record_id": "company-1",
+            "title": expected_title,
+            "format": "plaintext",
+            "content": "detalhe do evento",
+        }
+        return httpx.Response(200, json={"data": {"id": {"note_id": "note-1"}}})
+
+    result = log_history(
+        "company-1", event_type, "detalhe do evento", client=_client(handler)
+    )
+    assert result == {"data": {"id": {"note_id": "note-1"}}}
+
+
+def test_rejects_invalid_event_type_without_calling_api():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("API não deveria ser chamada com event_type inválido")
+
+    with pytest.raises(ValueError, match="tipo de evento de histórico inválido"):
+        log_history("company-1", "evento_desconhecido", "x", client=_client(handler))
+
+
+def test_disabled_returns_noop(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_ENABLED", False)
+    result = log_history("company-1", "criacao", "novo lead")
+    assert result == {"attio": "disabled", "entity": "history_note", "action": "skipped"}
+
+
+def test_uses_custom_parent_object():
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _json.loads(request.read())["data"]
+        assert payload["parent_object"] == "people"
+        assert payload["parent_record_id"] == "person-1"
+        return httpx.Response(200, json={"data": {}})
+
+    log_history(
+        "person-1",
+        "resposta_recebida",
+        "respondeu o e-mail",
+        parent_object="people",
+        client=_client(handler),
+    )
+
+
+def test_repeated_call_creates_a_new_note_each_time():
+    """History has no dedup by design — two calls are two notes."""
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(200, json={"data": {"id": {"note_id": f"note-{calls['n']}"}}})
+
+    client = _client(handler)
+    first = log_history("company-1", "atualizacao", "primeira", client=client)
+    second = log_history("company-1", "atualizacao", "segunda", client=client)
+    assert first != second
+    assert calls["n"] == 2


### PR DESCRIPTION
## Contexto

PO-2026-07-CRM-001, continuação de #561 (mergeada), #562/#563/#564/#565
(abertas). Branchea direto de `main` — só depende do `AttioClient` da fatia 1.

## Fatia 6/12 — histórico automático

- `log_history()` em `backend/app/integrations/attio/history.py`: `POST
  /v2/notes` ([docs](https://docs.attio.com/rest-api/endpoint-reference/notes/create-a-note))
  pra cada evento rastreado pela PO (seção 8): criação, atualização, mudança
  de estágio, campanha enviada, resposta recebida, observação.
- `event_type` validado contra esse conjunto fechado — `ValueError` sem
  chamar a API se for outro valor, mesmo padrão fail-fast de #564/#565.

## Decisão que tomei sozinho (sinalizando para review)

- **Sem dedup aqui, de propósito** — diferente de `companies.py`/`people.py`
  (que são registros únicos e evitam duplicidade), histórico é log de
  eventos: uma chamada repetida cria uma nota nova legitimamente. O
  `AttioClient` já recusa retry automático de POST em 5xx (fatia 1, #561)
  justamente pra não duplicar nota por causa de um retry ambíguo — então a
  única duplicação possível é o próprio chamador invocando de novo, o que é
  esperado.

## Test plan

- [x] `pytest tests/test_attio_history.py -q` — 10/10 passando (httpx.MockTransport, sem rede real) — parametrizado pelos 6 tipos de evento + rejeição de tipo inválido + disabled + parent_object customizado + confirmação de que chamada repetida cria nota nova
- [x] `ruff check app/integrations/attio/history.py tests/test_attio_history.py` — limpo
- [x] `npx pyright@1.1.411` nos arquivos tocados — 0 erros
- [ ] Suíte completa / teste real contra a API — mesma pendência de infra e credencial das fatias anteriores