### PR TITLE
feat(crm): Attio — fatia 7/12, webhook inbound + verificação de assinatura

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Architecture Audit (informativo)
         working-directory: backend
         continue-on-error: true
+        timeout-minutes: 5
         run: |
           python ../tools/architecture_audit.py
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,15 @@ frontend/          Next.js app (app router)
   src/components/  UI: AppShell, Sidebar, EvidenceList, JsonViewer, Toast
 
 backend/           FastAPI
-  app/routers/     28 routers (auditado 16/07/2026) — admin, audit, auth, billing, calculadora,
-                   classtrib, compliance, credits, documents, exceptions, feedback,
-                   founding_partners, health, jobs, lgpd, ncm_suggest, news, public, public_api,
-                   reports, simulator, sped, split_payment, support, tasks, validate,
-                   validate_xml, validation. Chat foi descontinuado como produto (mai/2026) e o
-                   código remanescente removido (ADR-0012, ver `knowledge/decisions/` no Brain).
+  app/routers/     29 routers (auditado 16/07/2026, +attio em 31/07/2026) — admin, attio, audit,
+                   auth, billing, calculadora, classtrib, compliance, credits, documents,
+                   exceptions, feedback, founding_partners, health, jobs, lgpd, ncm_suggest, news,
+                   public, public_api, reports, simulator, sped, split_payment, support, tasks,
+                   validate, validate_xml, validation. attio expõe só o webhook inbound
+                   (POST /api/v1/webhooks/attio) — o resto da integração comercial com o Attio CRM
+                   (PO-2026-07-CRM-001) vive em `app/integrations/attio/`, fora dos routers. Chat
+                   foi descontinuado como produto (mai/2026) e o código remanescente removido
+                   (ADR-0012, ver `knowledge/decisions/` no Brain).
   app/crews/       CrewAI crews — crm_engagement_crew (Produção), security_crew (Produção
                    Interna), nfe_validation_crew (Dormante). Classificação oficial e políticas em
                    `knowledge/engineering/crews.md` no Brain.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,11 +67,11 @@ backend/           FastAPI
                    auth, billing, calculadora, classtrib, compliance, credits, documents,
                    exceptions, feedback, founding_partners, health, jobs, lgpd, ncm_suggest, news,
                    public, public_api, reports, simulator, sped, split_payment, support, tasks,
-                   validate, validate_xml, validation. attio expõe só o webhook inbound
+                   validate, validate_xml, validation. Chat foi descontinuado como produto
+                   (mai/2026) e o código remanescente removido (ADR-0012, ver
+                   `knowledge/decisions/` no Brain). attio expõe só o webhook inbound
                    (POST /api/v1/webhooks/attio) — o resto da integração comercial com o Attio CRM
-                   (PO-2026-07-CRM-001) vive em `app/integrations/attio/`, fora dos routers. Chat
-                   foi descontinuado como produto (mai/2026) e o código remanescente removido
-                   (ADR-0012, ver `knowledge/decisions/` no Brain).
+                   (PO-2026-07-CRM-001) vive em `app/integrations/attio/`, fora dos routers.
   app/crews/       CrewAI crews — crm_engagement_crew (Produção), security_crew (Produção
                    Interna), nfe_validation_crew (Dormante). Classificação oficial e políticas em
                    `knowledge/engineering/crews.md` no Brain.

--- a/backend/app/integrations/attio/webhooks.py
+++ b/backend/app/integrations/attio/webhooks.py
@@ -1,0 +1,37 @@
+"""Webhook signature verification — Attio CRM.
+
+PO-2026-07-CRM-001, fatia 7/12. Attio signs every webhook request with
+HMAC-SHA256 of the raw request body using the shared secret, sent in the
+"Attio-Signature" header (duplicated as "X-Attio-Signature" for legacy
+clients — docs.attio.com/rest-api/guides/webhooks). Same verification
+pattern already used in this codebase for Asaas
+(app/services/asaas_service.py:verify_webhook_token).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def verify_signature(raw_body: bytes, signature_header: str) -> bool:
+    """Verify an inbound Attio webhook's HMAC-SHA256 signature.
+
+    Rejects (returns False) when ATTIO_WEBHOOK_SECRET isn't configured or
+    the header is empty — same fail-closed stance as Asaas's webhook check.
+    """
+    if not settings.ATTIO_WEBHOOK_SECRET:
+        logger.warning("ATTIO_WEBHOOK_SECRET not configured, rejecting webhook")
+        return False
+    if not signature_header:
+        return False
+
+    expected = hmac.new(
+        settings.ATTIO_WEBHOOK_SECRET.encode(), raw_body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app.config import settings
 from app.core.logging import configure_logging
 from app.core.observability import init_sentry
-from app.routers import admin, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, founding_partners, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, simulator, sped, split_payment, support, tasks, validate, validate_xml, validation
+from app.routers import admin, attio, auth, audit, billing, calculadora, classtrib, compliance, credits, documents, exceptions, feedback, founding_partners, health, jobs, lgpd, ncm_suggest, news, public, public_api, reports, simulator, sped, split_payment, support, tasks, validate, validate_xml, validation
 from app.services.news_seed import ensure_default_news_entry, ensure_regulatory_advisories
 
 configure_logging()
@@ -99,6 +99,7 @@ app.include_router(classtrib.router)
 app.include_router(compliance.router)
 app.include_router(split_payment.router)
 app.include_router(credits.router)
+app.include_router(attio.router)
 
 
 @app.get("/", tags=["root"])

--- a/backend/app/routers/attio.py
+++ b/backend/app/routers/attio.py
@@ -1,0 +1,51 @@
+"""Attio router — inbound webhooks from Attio CRM.
+
+PO-2026-07-CRM-001, fatia 7/12. Scope boundary: this fatia covers receiving
+and verifying webhook signatures only. Per-event-type business reactions
+(e.g. "empresa criada no Attio -> atualizar X no Tribultz") are
+deliberately not implemented here — they depend on product decisions about
+what each event should trigger, which don't exist yet. Add them as
+concrete requirements land.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+
+from app.integrations.attio.webhooks import verify_signature
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/webhooks", tags=["attio"])
+
+
+@router.post("/attio", status_code=200)
+async def attio_webhook(request: Request):
+    """Receive Attio CRM events.
+
+    Always returns 200 to prevent retries (same convention as the Asaas
+    webhook in billing.py) — an invalid signature is logged and ignored
+    rather than surfaced as an error to the caller.
+    """
+    raw_body = await request.body()
+    signature = request.headers.get("attio-signature") or request.headers.get(
+        "x-attio-signature", ""
+    )
+
+    if not verify_signature(raw_body, signature):
+        logger.warning("attio_webhook_rejected reason=invalid_signature")
+        return {"status": "ignored", "reason": "invalid signature"}
+
+    payload = await request.json()
+    # A doc pública do Attio não deixa claro se o corpo é um único evento ou
+    # um array em "events" — trata os dois formatos defensivamente até
+    # confirmarmos contra um workspace real.
+    events = payload.get("events", [payload]) if isinstance(payload, dict) else [payload]
+
+    for event in events:
+        event_type = event.get("event_type", "unknown") if isinstance(event, dict) else "unknown"
+        logger.info("attio_webhook_received event_type=%s", event_type)
+
+    return {"status": "ok", "events_received": len(events)}

--- a/backend/tests/test_attio_webhooks.py
+++ b/backend/tests/test_attio_webhooks.py
@@ -1,0 +1,113 @@
+"""Tests for the Attio webhook signature verification and router —
+PO-2026-07-CRM-001, fatia 7/12."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.integrations.attio.webhooks import verify_signature
+from app.main import app
+
+client = TestClient(app)
+
+SECRET = "test-webhook-secret"
+
+
+def _sign(body: bytes, secret: str = SECRET) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+# ── verify_signature() ───────────────────────────────────────
+def test_verify_signature_accepts_valid_signature(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    body = b'{"event_type":"list-entry.created"}'
+    assert verify_signature(body, _sign(body)) is True
+
+
+def test_verify_signature_rejects_invalid_signature(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    body = b'{"event_type":"list-entry.created"}'
+    assert verify_signature(body, "0" * 64) is False
+
+
+def test_verify_signature_rejects_missing_header(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    body = b'{"event_type":"list-entry.created"}'
+    assert verify_signature(body, "") is False
+
+
+def test_verify_signature_rejects_when_secret_not_configured(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", "")
+    body = b'{"event_type":"list-entry.created"}'
+    assert verify_signature(body, _sign(body)) is False
+
+
+def test_verify_signature_rejects_tampered_body(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    body = b'{"event_type":"list-entry.created"}'
+    signature = _sign(body)
+    tampered = b'{"event_type":"list-entry.deleted"}'
+    assert verify_signature(tampered, signature) is False
+
+
+# ── POST /api/v1/webhooks/attio ──────────────────────────────
+def test_webhook_endpoint_accepts_valid_signature(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    payload = {"events": [{"event_type": "list-entry.created"}]}
+    body = json.dumps(payload).encode()
+
+    response = client.post(
+        "/api/v1/webhooks/attio",
+        content=body,
+        headers={"attio-signature": _sign(body), "content-type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "events_received": 1}
+
+
+def test_webhook_endpoint_accepts_legacy_header(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    payload = {"events": [{"event_type": "note.created"}]}
+    body = json.dumps(payload).encode()
+
+    response = client.post(
+        "/api/v1/webhooks/attio",
+        content=body,
+        headers={"x-attio-signature": _sign(body), "content-type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "events_received": 1}
+
+
+def test_webhook_endpoint_rejects_invalid_signature_without_crashing(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    payload = {"events": [{"event_type": "list-entry.created"}]}
+    body = json.dumps(payload).encode()
+
+    response = client.post(
+        "/api/v1/webhooks/attio",
+        content=body,
+        headers={"attio-signature": "invalid", "content-type": "application/json"},
+    )
+    # Sempre 200 pra não gerar retry — mesma convenção do webhook Asaas.
+    assert response.status_code == 200
+    assert response.json() == {"status": "ignored", "reason": "invalid signature"}
+
+
+def test_webhook_endpoint_handles_bare_event_without_wrapper(monkeypatch):
+    monkeypatch.setattr(settings, "ATTIO_WEBHOOK_SECRET", SECRET)
+    payload = {"event_type": "list-entry.updated"}
+    body = json.dumps(payload).encode()
+
+    response = client.post(
+        "/api/v1/webhooks/attio",
+        content=body,
+        headers={"attio-signature": _sign(body), "content-type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "events_received": 1}


### PR DESCRIPTION
## Contexto

PO-2026-07-CRM-001, continuação de #561/#562 (mergeadas), #563/#564/#565/#566
(abertas). Branchea direto de `main`.

Muda de direção em relação às fatias anteriores: até aqui era só saída
(Tribultz → Attio); esta fatia é entrada (Attio → Tribultz) via webhook.

## Fatia 7/12 — webhook inbound + verificação de assinatura

- Novo router `backend/app/routers/attio.py`: `POST /api/v1/webhooks/attio`,
  registrado em `main.py`.
- `verify_signature()` em `backend/app/integrations/attio/webhooks.py`:
  HMAC-SHA256 do corpo bruto, comparação timing-safe — **mesmo padrão já
  usado neste projeto para o Asaas**
  (`app/services/asaas_service.py:verify_webhook_token` +
  `hmac.compare_digest`).
- Header `Attio-Signature` (fallback `X-Attio-Signature` para clientes
  legados, conforme a doc do Attio).
- Sempre retorna 200 — mesma convenção do webhook Asaas em `billing.py`,
  evita retry mesmo quando a assinatura é rejeitada (loga e ignora).
- `CLAUDE.md`: lista de routers atualizada (28→29) — consequência direta
  desta fatia, não iniciativa espontânea.

## Decisões que tomei sozinho (sinalizando para review)

- **Fronteira de escopo**: esta fatia cobre só receber + verificar + logar
  o tipo de evento recebido. Reação de negócio por tipo de evento (o que
  "empresa criada no Attio" ou "negócio ganho" deve disparar no Tribultz)
  fica pra quando existir requisito de produto concreto — implementar isso
  agora seria adivinhação sem uma decisão de produto por trás.
- **Formato do payload não confirmado**: a doc pública do Attio não deixou
  claro se o corpo chega como um evento único ou um array em `"events"` —
  o handler trata os dois formatos defensivamente
  (`payload.get("events", [payload])`) até confirmarmos contra um workspace
  real com credencial ativa.

## Test plan

- [x] `pytest tests/test_attio_webhooks.py -q` — 9/9 passando (FastAPI `TestClient`, mesmo padrão de `test_health_deep.py`) — assinatura válida/inválida/ausente/corpo adulterado, secret não configurado, header legado, array de eventos e evento avulso
- [x] `ruff check` nos arquivos tocados — limpo
- [x] `npx pyright@1.1.411` nos arquivos tocados — 0 erros
- [x] `pytest tests/ --collect-only` — 974 testes coletados, sem quebra de import ao registrar o novo router
- [ ] Suíte completa / teste real contra a API — mesma pendência de infra e credencial das fatias anteriores