### PR TITLE
fix(ci): timeout dedicado no step de Architecture Audit (informativo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Architecture Audit (informativo)
         working-directory: backend
         continue-on-error: true
+        timeout-minutes: 5
         run: |
           python ../tools/architecture_audit.py
 


### PR DESCRIPTION
## Contexto

Achado ao investigar por que PR #568 (fatia 7 da integração Attio, sendo
revertida separadamente — ver comentário lá) falhou no check `backend-gates`.

## Problema

O step "Architecture Audit (informativo)" já tinha `continue-on-error: true`,
mas sem `timeout-minutes` próprio ele consome o orçamento inteiro do job
(20min) quando trava/demora — e um step **cancelado por timeout de JOB** não
é coberto por `continue-on-error` (isso só protege contra falha do próprio
step, não contra cancelamento externo).

No CI do #568: Pytest/Ruff/Pyright passaram em menos de 2min, mas o
Architecture Audit ficou rodando 17m42s e foi cancelado ao bater o teto de
20min do job inteiro — derrubando o check `backend-gates` (Required),
bloqueando o merge por um step que o próprio `CLAUDE.md` documenta como
"não bloqueia merge".

## Fix

`timeout-minutes: 5` no step. Se ele travar de novo, ele mesmo estoura o
timeout (contabilizado como falha do step, aí sim coberto pelo
`continue-on-error`) em vez de consumir o job inteiro.

Sem relação com a integração Attio — extraído do PR #568 como fix
standalone porque protege qualquer PR futuro, não só aquele.