### PR TITLE
chore(mcp): adiciona servidor MCP oficial do Attio

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "attio": {
+      "type": "http",
+      "url": "https://mcp.attio.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Contexto

Extraído do PR #571 (fechado sem merge — a decisão de reverter a
integração backend do Attio foi revertida; ver comentário lá). Esta parte
continua valendo por conta própria: o MCP é complementar à integração
backend (fatias 1-7 em `backend/app/integrations/attio/`), não um
substituto — dá acesso interativo via agente (eu, Claude Desktop, Cursor)
ao Attio, útil para consulta e operação pontual pelo time.

## O que este PR faz

Adiciona `.mcp.json` com o servidor MCP oficial do Attio
(https://mcp.attio.com/mcp), escopo projeto — versionado, então qualquer
sessão do Claude Code neste repo já propõe o servidor. Autenticação é
OAuth por usuário; nenhuma credencial no arquivo.

## Pendência

Autenticar via `/mcp` numa sessão interativa (OAuth por navegador) — não
dá pra fazer isso a partir de uma sessão não-interativa.