### PR TITLE
fix(test): remove flakiness de teste de churn no primeiro dia do mês

### DIFF
--- a/backend/tests/test_admin_dashboard_metrics.py
+++ b/backend/tests/test_admin_dashboard_metrics.py
@@ -78,13 +78,17 @@ class TestActivePlanDistribution:
 
 class TestChurnRateMonth:
     def test_churn_rate_counts_cancellations_this_month(self, db_session):
-        now = datetime.now(timezone.utc)
-        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        # Âncora fixa em vez de datetime.now(): "ontem" só está garantido
+        # dentro do mês corrente se o mês não tiver acabado de virar. Com
+        # datetime.now(), esse teste flaka no primeiro dia de todo mês (em
+        # UTC) — visto quebrando em produção às 2026-08-01T00:47Z, quando
+        # "ontem" (31/07) caía antes do month_start calculado (01/08).
+        month_start = datetime(2026, 6, 1, tzinfo=timezone.utc)
 
         # 1 cancelado este mês, 1 cancelado no mês passado (não deve contar)
         _make_subscription(
             db_session, plan_slug="starter", status="cancelled",
-            cancelled_at=now - timedelta(days=1),
+            cancelled_at=month_start + timedelta(days=1),
         )
         _make_subscription(
             db_session, plan_slug="starter", status="cancelled",


### PR DESCRIPTION
## Contexto

Achado ao investigar por que o `backend-gates` da PR #573 (post de blog,
sem relação com billing) falhou — o teste bloqueia qualquer merge no
primeiro dia de cada mês, não só aquela PR.

## Problema

`test_churn_rate_counts_cancellations_this_month` usava `datetime.now()`
pra montar `month_start` e a data "deste mês" como `now - 1 dia`. Isso
assume que "ontem" sempre cai dentro do mês corrente — falso no primeiro
dia de cada mês (em UTC), quando "ontem" ainda é mês anterior.

Visto quebrando de verdade: CI rodou às `2026-08-01T00:47Z`, "ontem"
(31/07) ficou antes do `month_start` calculado (01/08), resultado `0` em
vez de `1`:

```
tests/test_admin_dashboard_metrics.py:96: AssertionError
assert 0 == 1
```

A lógica de produção (`_churn_rate_month` em `app/routers/admin.py`) não
tem bug nenhum — é só filtro `cancelled_at >= month_start`. O bug é
inteiramente do teste, que dependia do relógio de parede sem precisar.

## Fix

Âncora fixa (`datetime(2026, 6, 1, tzinfo=timezone.utc)`) em vez de
`datetime.now()`, com as duas datas de cancelamento construídas por
offset relativo à âncora. O teste fica determinístico, independente de
quando rodar.

## Test plan

- [x] `pytest tests/test_admin_dashboard_metrics.py -v` — 3/3 passando
- [x] `pytest tests/ -q` (suíte completa) — 998 passaram; as 8 falhas em `test_billing_webhook.py` são `ConnectionError` do Redis local (ambiente sem Redis rodando neste momento — CI tem serviço Redis próprio, não deve reproduzir lá), confirmadas sem relação com esta mudança
- [x] `npx pyright@1.1.411 tests/test_admin_dashboard_metrics.py` — 0 erros