### PR TITLE
fix(tools): regex catastrófica em architecture_audit.py travava a auditoria indefinidamente

### DIFF
--- a/backend/tests/test_architecture_audit_smoke.py
+++ b/backend/tests/test_architecture_audit_smoke.py
@@ -1,0 +1,46 @@
+"""Smoke test para tools/architecture_audit.py.
+
+A auditoria roda no CI atrás de continue-on-error (é informativa, não
+bloqueia merge — ver knowledge/process/architecture-audit-policy.md no
+Brain), o que mascarou um bug real por muito tempo: uma regex com
+backtracking catastrófico em check_routers_vs_claude_md() travava a
+ferramenta indefinidamente (nunca completou um run). Este teste garante que
+uma regressão desse tipo estoura em segundos, não em CI silenciosamente
+lento — o timeout aqui é a asserção.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "tools" / "architecture_audit.py"
+BACKEND = REPO_ROOT / "backend"
+
+
+def test_architecture_audit_completes_quickly():
+    """Roda a auditoria de verdade (mesma invocação do CI/uso local) com um
+    timeout curto. Um TimeoutExpired aqui indica uma regressão de
+    performance (ex.: regex com backtracking catastrófico), não uma falha
+    de achado — a auditoria pode legitimamente reportar findings (exit 1)."""
+    try:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            cwd=BACKEND,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        raise AssertionError(
+            "architecture_audit.py não completou em 30s — suspeita de "
+            "regressão de performance (ex.: regex com backtracking "
+            "catastrófico), não falha de achado."
+        )
+
+    assert result.returncode in (0, 1), (
+        f"exit code inesperado {result.returncode} (0=sem achados, "
+        f"1=achados encontrados). stderr:\n{result.stderr[-2000:]}"
+    )

--- a/tools/architecture_audit.py
+++ b/tools/architecture_audit.py
@@ -32,13 +32,36 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND = REPO_ROOT / "backend"
-BRAIN_ROOT = REPO_ROOT.parent / "tribultz-brain"
+
+
+def _main_repo_root() -> Path:
+    """Resolve the main repository root even when running from a git worktree.
+
+    REPO_ROOT.parent is wrong inside a worktree — it resolves to the
+    worktree's parent (e.g. .claude/worktrees/) instead of the actual
+    sibling of tribultz/, which silently no-ops the Brain-sync check below.
+    `git rev-parse --git-common-dir` always points at the main repo's .git,
+    worktree or not. Falls back to REPO_ROOT if git is unavailable (e.g. a
+    tarball checkout) — same soft-skip behavior as before this fix.
+    """
+    try:
+        common_dir = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, check=True, timeout=5,
+        ).stdout.strip()
+        return (REPO_ROOT / common_dir).resolve().parent
+    except Exception:
+        return REPO_ROOT
+
+
+BRAIN_ROOT = _main_repo_root().parent / "tribultz-brain"
 
 SEVERITY_CRITICO = "Crítico"
 SEVERITY_ALTO = "Alto"
@@ -184,7 +207,13 @@ def check_routers_vs_claude_md() -> list[Finding]:
     }
 
     claude_text = _read(claude_md)
-    doc_match = re.search(r"app/routers/\s+\d+ routers[^\n]*—\s*([^\n]+(?:\n\s+[^\n]+)*?)\.\s*Chat", claude_text)
+    # [\s\S]*? em vez de [^\n]+(?:\n\s+[^\n]+)*?: o quantificador aninhado
+    # original tinha backtracking catastrófico — \s+ e [^\n]+ competiam pelos
+    # mesmos espaços em runs de \n seguido de espaços, explodindo
+    # exponencialmente (trava a auditoria inteira, mascarado no CI por
+    # continue-on-error + timeout). [\s\S]*? não tem essa ambiguidade: casa
+    # qualquer caractere sem precisar decidir entre dois grupos concorrentes.
+    doc_match = re.search(r"app/routers/\s+\d+ routers[^\n]*—\s*([\s\S]*?)\.\s*Chat", claude_text)
     if not doc_match:
         findings.append(
             Finding(


### PR DESCRIPTION
## Contexto

Achado por QA independente ("relatório de dissecação do diretório
Tribultz") — a auditoria arquitetural do ADR-0013 nunca completou um run
na vida. Verificado e reproduzido de forma independente antes de aplicar
qualquer correção (ver abaixo).

## Achado Crítico: regex com backtracking catastrófico

O check `check_routers_vs_claude_md()` usa:

```python
re.search(r"app/routers/\s+\d+ routers[^\n]*—\s*([^\n]+(?:\n\s+[^\n]+)*?)\.\s*Chat", claude_text)
```

`\s+` e `[^\n]+` competem pelos mesmos espaços em runs de `\n` seguido de
espaço — clássico backtracking catastrófico. Reproduzi com `SIGALRM`:
trava (>5s, nunca retorna sozinho) contra o `CLAUDE.md` atual.

**Efeito real**: mascarado no CI por `continue-on-error` (adicionado no
#570 tratando o sintoma, não a causa) — o step ficava rodando até estourar
o `timeout-minutes`, queimando minutos de CI a cada push sem que o check
jamais produzisse um resultado de verdade.

**Fix**: `[\s\S]*?` no lugar do quantificador aninhado — sem grupos
concorrentes pelo mesmo texto. Confirmado: `0.00015s` no CLAUDE.md atual
(era timeout antes).

## Achado relacionado: `BRAIN_ROOT` quebrado em worktree

```python
BRAIN_ROOT = REPO_ROOT.parent / "tribultz-brain"
```

Resolve errado quando rodado de dentro de um git worktree — `REPO_ROOT`
vira o diretório do worktree, `.parent` aponta pra `.claude/worktrees/`
em vez do repo principal, e a checagem de sincronia com o Brain é pulada
silenciosamente (soft-skip por design, mas silenciosamente errado).

**Fix**: resolve o repo principal via `git rev-parse --git-common-dir`
(funciona dentro ou fora de worktree), com fallback pro comportamento
antigo se git não estiver disponível.

## Prevenção de regressão

`backend/tests/test_architecture_audit_smoke.py`: roda a auditoria de
verdade (mesma invocação documentada no próprio script) com timeout de
30s. Uma regressão desse tipo estoura em segundos no teste, não fica
mascarada de novo atrás de `continue-on-error`.

## Test plan

- [x] Reprodução do bug confirmada antes do fix (regex trava com SIGALRM de 5s)
- [x] `pytest tests/test_architecture_audit_smoke.py -v` — passa, script completa em ~0.2s
- [x] `python tools/architecture_audit.py` (invocação real) — completa em 0.2-0.4s, reporta só o achado já conhecido e rastreado (#490, task_f_security_audit.py)
- [x] `ruff check tools/architecture_audit.py backend/tests/test_architecture_audit_smoke.py` — limpo
- [x] `npx pyright@1.1.411` nos dois arquivos — 0 erros