### PR TITLE
fix(ci): OS-1+OS-2 — roda testes do frontend no CI + glob no script test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,10 @@ jobs:
             package-lock.json
             frontend/package-lock.json
 
-      - name: Install + build
+      - name: Install + test + build
         run: |
-          if [ -f package-lock.json ]; then npm ci && npm run build; exit 0; fi
-          if [ -f frontend/package-lock.json ]; then cd frontend && npm ci && npm run build; exit 0; fi
+          if [ -f package-lock.json ]; then npm ci && npm test --silent && npm run build; exit 0; fi
+          if [ -f frontend/package-lock.json ]; then cd frontend && npm ci && npm test --silent && npm run build; exit 0; fi
           echo "No frontend detected (package-lock.json not found). Skipping build." && exit 0
 
       - name: Install Playwright browser

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "vercel-build": "node node_modules/next/dist/bin/next build",
     "start": "node node_modules/next/dist/bin/next start",
     "lint": "eslint",
-    "test": "tsx --test src/lib/validation/xmlRules.test.ts src/lib/validation/rulesMeta.test.ts src/lib/soroSync.test.ts src/lib/contentLint.test.ts src/lib/blogFiscalLint.test.ts src/lib/closing/aggregate.test.ts src/lib/export/jobEvidenceBundle.test.ts src/lib/export/jobEvidenceZip.test.ts src/lib/export/evidenceExportUi.test.ts src/lib/export/auditableReport.test.ts src/lib/export/batchReport.test.ts src/lib/api.test.ts src/lib/deadlineCountdown.test.ts src/lib/formatDateTimeBR.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "test:rules": "tsx --test src/lib/validation/xmlRules.test.ts",
     "content:lint": "tsx scripts/content-lint.ts",
     "content:lint:fix": "tsx scripts/content-lint.ts --fix",


### PR DESCRIPTION
## Contexto

ORDEM 2026-08-QA→ENG-001 (Bloco A, OS-1 e OS-2) — fecha as Issues #576 e
parte da #577.

## OS-1 — npm test ausente do CI

`frontend-build` fazia `npm ci && npm run build` sem nunca rodar
`npm test` — os 193 testes unitários (incluindo o anti-drift de
`RULES_COUNT`) nunca executavam em CI. Adiciona `npm test --silent` antes
do build.

## OS-2 — script test hardcoded

`package.json` enumerava 14 arquivos de teste à mão. Trocado por glob
(`tsx --test "src/**/*.test.ts"`). Verificado com arquivo dummy: descoberto
automaticamente sem editar `package.json` (removido depois da verificação).

## Test plan

- [x] `npm test --silent` — 193/193 (mesmo total do script antigo)
- [x] Glob descobre arquivo novo sem editar `package.json` (testado com dummy, removido)
- [x] `npm run build` — compila sem erro