### PR TITLE
fix(tools): OB-4 — check_celery_autodiscover cruza com o Brain, timeout 5→1min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Architecture Audit (informativo)
         working-directory: backend
         continue-on-error: true
-        timeout-minutes: 5
+        timeout-minutes: 1
         run: |
           python ../tools/architecture_audit.py
 

--- a/tools/architecture_audit.py
+++ b/tools/architecture_audit.py
@@ -141,20 +141,39 @@ def check_celery_autodiscover() -> list[Finding]:
 
     registered = set(re.findall(r'"([\w.]+)"', match.group(1)))
     registered_modules = {m.rsplit(".", 1)[-1] for m in registered}
+    documented = _brain_documented_tasks()
 
     for path in sorted(tasks_dir.glob("task_*.py")):
         module_name = path.stem
-        if module_name not in registered_modules:
-            findings.append(
-                Finding(
-                    "task-nao-registrada",
-                    f"backend/app/tasks/{path.name} define uma task mas o módulo não está em "
-                    f"autodiscover_tasks (celery_app.py). Se for intencional (ex.: pendente de "
-                    f"decisão de frequência), documentar em knowledge/engineering/crews.md ou "
-                    f"architecture-inventory.md — não deixar implícito.",
-                )
+        if module_name in registered_modules or module_name in documented:
+            continue
+        findings.append(
+            Finding(
+                "task-nao-registrada",
+                f"backend/app/tasks/{path.name} define uma task mas o módulo não está em "
+                f"autodiscover_tasks (celery_app.py). Se for intencional (ex.: pendente de "
+                f"decisão de frequência), documentar em knowledge/engineering/crews.md ou "
+                f"architecture-inventory.md — não deixar implícito.",
             )
+        )
     return findings
+
+
+def _brain_documented_tasks() -> set[str]:
+    """Tasks Celery já documentadas no Brain como intencionalmente fora do
+    autodiscover_tasks (decisão registrada, não esquecimento) — mesmo
+    padrão de check_brain_crews_sync() para Crews, aplicado ao inventário
+    de tasks. Sem Brain disponível, retorna vazio: comportamento antigo
+    (tudo não registrado vira achado), nunca falso-negativo por ausência
+    do Brain."""
+    inventory_md = BRAIN_ROOT / "knowledge" / "engineering" / "architecture-inventory.md"
+    if not inventory_md.exists():
+        return set()
+    return {
+        match.group(1)
+        for line in _read(inventory_md).splitlines()
+        if (match := re.search(r"`(task_\w+)`", line))
+    }
 
 
 # ── 3. Ferramentas órfãs em app/crews/tools/ ────────────────────────────────


### PR DESCRIPTION
## Contexto

ORDEM 2026-08-QA→ENG-001, OB-4 — retifica OS-7 (uma ordem anterior não
vista diretamente por mim, referenciada pelo QA como "documentar
security_audit no Brain").

## Retificação

`task_f_security_audit` **já estava documentada** como intencionalmente
fora do `autodiscover_tasks` — confirmei diretamente em
`knowledge/engineering/architecture-inventory.md:61` (tribultz-brain):

> `task_f_security_audit` | Deprecada (construída, sem schedule) |
> engineering | `crews.md` | Fora do `autodiscover_tasks`/`beat_schedule`
> de propósito — decisão de frequência pendente, não é bug

Não era esquecimento — era decisão já registrada. O bug real era a
auditoria (`check_celery_autodiscover`) nunca cruzar com o Brain antes de
reportar, ao contrário de `check_brain_crews_sync()` (Crews), que já faz
exatamente isso.

## Fix

`_brain_documented_tasks()` replica o padrão do check de Crews: lê
`architecture-inventory.md`, extrai `task_*` mencionadas entre backticks,
suprime o achado para qualquer task já registrada lá. Sem Brain
disponível, retorna vazio — comportamento antigo preservado (nunca
falso-negativo por ausência do Brain).

Timeout do step de CI reduzido de 5min para 1min — a auditoria completa
em ~0.2-0.4s desde o fix da regex catastrófica (#575); 1min é margem
generosa.

## Test plan

- [x] `python tools/architecture_audit.py` — 0 achados (era 1 falso positivo antes)
- [x] `pytest tests/test_architecture_audit_smoke.py -q` — passa
- [x] `ruff check tools/architecture_audit.py` — limpo
- [x] `npx pyright@1.1.411 tools/architecture_audit.py` — 0 erros