### PR TITLE
fix(ci): OS-3 — explica no corpo do PR por que os checks obrigatórios não disparam

### DIFF
--- a/.github/workflows/classtrib-sync.yml
+++ b/.github/workflows/classtrib-sync.yml
@@ -53,6 +53,12 @@ jobs:
             - Se o **total de códigos mudou**, atualizar `CLASSTRIB_COUNT` em `frontend/src/lib/validation/rulesMeta.ts` (stat do site).
             - (Follow-up) re-seed do DB `cclass_trib_items` (endpoint público `/classtrib`) — exige migration própria.
 
+            ⚠️ **Checks obrigatórios não disparam sozinhos:** este PR foi aberto com o
+            `GITHUB_TOKEN` padrão, que por design do GitHub não aciona outros workflows
+            (`pull_request`) — proteção contra loop infinito de Action disparando Action.
+            `backend-gates`/`frontend-build` só rodam depois de um commit novo (ex.: qualquer
+            ajuste seu na revisão) ou de fechar e reabrir o PR.
+
             Gerado por `.github/workflows/classtrib-sync.yml`.
 
       # #446 — sem isto, uma falha (SVRS fora do ar, guard de diff abortando)

--- a/.github/workflows/soro-blog-sync.yml
+++ b/.github/workflows/soro-blog-sync.yml
@@ -53,4 +53,10 @@ jobs:
             - Preencher `legalRefs`, `tags` e ajustar `category`.
             - Confirmar que o `frontend-build` passou (valida o MDX).
 
+            ⚠️ **Checks obrigatórios não disparam sozinhos:** este PR foi aberto com o
+            `GITHUB_TOKEN` padrão, que por design do GitHub não aciona outros workflows
+            (`pull_request`) — proteção contra loop infinito de Action disparando Action.
+            `backend-gates`/`frontend-build` só rodam depois de um commit novo (ex.: preencher
+            `legalRefs`/`tags` na revisão) ou de fechar e reabrir o PR.
+
             Nada vai ao ar até o merge. Gerado por `.github/workflows/soro-blog-sync.yml`.


### PR DESCRIPTION
## Contexto

ORDEM 2026-08-QA→ENG-001, Bloco A, OS-3.

## Problema confirmado

`classtrib-sync.yml` e `soro-blog-sync.yml` abrem PR via
`peter-evans/create-pull-request` com o `GITHUB_TOKEN` padrão. Por design
do GitHub, um workflow disparado por esse token **não aciona outros
workflows** (`pull_request`) — proteção contra loop infinito de Action
disparando Action. Resultado: `backend-gates`/`frontend-build`
(*required*) nunca rodavam nesses PRs automáticos, sem nenhuma explicação
pra quem revisa.

## Ação (mínima, conforme ordem)

Body do PR agora explica o destravamento — um commit novo na revisão (ou
fechar/reabrir) dispara os checks normalmente. Não troquei para GitHub App
token — isso ficaria para quando/se justificar um registro de decisão de
credencial própria no Brain, fora do escopo desta ordem.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` nos dois arquivos — YAML válido