### PR TITLE
feat(metrics): query pack v1 do cockpit de unit economics

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,4 @@ testcontainers[postgres]>=4.8.2
 crewai==1.10.1
 litellm==1.82.0
 fakeredis==2.36.2
+openpyxl==3.1.5

--- a/tools/metrics/README.md
+++ b/tools/metrics/README.md
@@ -17,11 +17,21 @@ bash tools/metrics/run_extract.sh
 Conecta via SSH na VM de produção (nunca expõe a porta do banco
 localmente), roda as 5 queries lá e traz o CSV de volta pra
 `reports/metrics/<ano-mes>/` — **gitignored**, dado de produção nunca
-entra no git. Os arquivos `.sql` deste diretório são a única coisa
-versionada.
+entra no git. Os arquivos `.sql`/`.py`/`.sh` deste diretório são a única
+coisa versionada.
 
 Pré-requisito: chave SSH autorizada na VM (ver
 `docs/infra/secrets_inventory.md`).
+
+### Consolidar em .xlsx (pra abrir num add-in do Excel)
+
+```bash
+python3 tools/metrics/csv_to_xlsx.py reports/metrics/<ano-mes>
+```
+
+Junta os 5 CSVs num único `cockpit_unit_economics.xlsx` (uma aba por
+query) no mesmo diretório — mais prático que importar 5 arquivos soltos.
+Requer `openpyxl` (`backend/requirements.txt`).
 
 ## Queries
 

--- a/tools/metrics/README.md
+++ b/tools/metrics/README.md
@@ -1,0 +1,41 @@
+# Query Pack — Cockpit de Unit Economics (v1)
+
+Ferramenta interna (ORD-QA-002 / ORD-DADOS-001): extrai as métricas de
+unit economics (MRR, churn, retenção, ativação, consumo) direto do
+Postgres de produção, sem instrumentação nova — todo dado já existe nas
+tabelas do produto.
+
+Scripts standalone, execução manual, mesmo padrão de
+`tools/prospecting/` e `tools/architecture_audit.py`.
+
+## Uso
+
+```bash
+bash tools/metrics/run_extract.sh
+```
+
+Conecta via SSH na VM de produção (nunca expõe a porta do banco
+localmente), roda as 5 queries lá e traz o CSV de volta pra
+`reports/metrics/<ano-mes>/` — **gitignored**, dado de produção nunca
+entra no git. Os arquivos `.sql` deste diretório são a única coisa
+versionada.
+
+Pré-requisito: chave SSH autorizada na VM (ver
+`docs/infra/secrets_inventory.md`).
+
+## Queries
+
+| Arquivo | Métrica | Observação |
+|---|---|---|
+| `q1_mrr.sql` | MRR real por plano | Exclui tenants com Early Grant ativo (Founding Partners) — sem isso, MRR conta como receita algo que não é cobrado |
+| `q2_churn.sql` | Cancelamentos por mês | Aproximação — sem histórico de status, é tendência, não taxa exata por coorte |
+| `q3_retencao.sql` | Retenção por coorte de criação | **Não é conversão trial→pago** — `subscriptions.status` não tem histórico de transição; conversão real vem do funil comercial (Rumy), o banco só mostra o status atual |
+| `q4_ativacao.sql` | Dias até a 1ª validação bem-sucedida | Usa `jobs.job_type='validate_xml'` + `status='SUCCESS'` |
+| `q5_consumo.sql` | Uso do plano por período | Proxy de engajamento no v1; detalhe por rota/feature fica pra v2 |
+
+## Fora desta entrega (v1 termina nessas 5 queries)
+
+- Créditos fiscais de Split Payment (`documents.fiscal_metadata`) — métrica
+  de valor entregue, distinta de unit economics de billing. v2.
+- Uso por rota/feature individual — v2, pela matriz de priorização.
+- CAC e funil comercial — vêm do extrato de Vendas (Attio), não do banco.

--- a/tools/metrics/csv_to_xlsx.py
+++ b/tools/metrics/csv_to_xlsx.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Consolida os CSVs de tools/metrics/run_extract.sh num único .xlsx
+(uma aba por query) — mais prático pra abrir num add-in do Excel do que
+5 arquivos CSV soltos.
+
+Uso:
+    python3 tools/metrics/csv_to_xlsx.py reports/metrics/2026-08
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Uso: python3 tools/metrics/csv_to_xlsx.py <diretório com os q*.csv>", file=sys.stderr)
+        return 1
+
+    src_dir = Path(sys.argv[1])
+    csv_files = sorted(src_dir.glob("q*.csv"))
+    if not csv_files:
+        print(f"Nenhum q*.csv encontrado em {src_dir}", file=sys.stderr)
+        return 1
+
+    wb = Workbook()
+    default_sheet = wb.active
+    if default_sheet is not None:
+        wb.remove(default_sheet)  # remove a aba default vazia
+
+    for csv_path in csv_files:
+        sheet_name = csv_path.stem[:31]  # limite de 31 caracteres do Excel
+        ws = wb.create_sheet(sheet_name)
+        with csv_path.open(encoding="utf-8", newline="") as f:
+            for row in csv.reader(f):
+                ws.append(row)
+        # Autofit aproximado — largura pela maior célula de cada coluna.
+        for col_idx in range(1, ws.max_column + 1):
+            width = max((len(str(cell.value or "")) for cell in ws[get_column_letter(col_idx)]), default=10)
+            ws.column_dimensions[get_column_letter(col_idx)].width = min(width + 2, 40)
+
+    out_path = src_dir / "cockpit_unit_economics.xlsx"
+    wb.save(out_path)
+    print(f"Gerado: {out_path} ({len(csv_files)} abas)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/metrics/q1_mrr.sql
+++ b/tools/metrics/q1_mrr.sql
@@ -1,0 +1,18 @@
+-- MRR real por plano — exclui tenants com Early Grant ativo (Founding
+-- Partners/early adopters não geram receita, mesmo com subscription
+-- "active" apontando pra um plano pago). Sem isso, MRR fica inflado
+-- exatamente na métrica que sustenta o cálculo de payback do CAC.
+SELECT p.slug AS plano,
+       COUNT(s.id) FILTER (WHERE eg.id IS NULL) AS assinantes_pagantes,
+       COUNT(s.id) FILTER (WHERE eg.id IS NOT NULL) AS assinantes_via_grant,
+       p.price_cents / 100.0 AS preco_reais,
+       COALESCE(SUM(p.price_cents) FILTER (WHERE eg.id IS NULL), 0) / 100.0 AS mrr_reais
+FROM subscriptions s
+JOIN plans p ON s.plan_id = p.id
+LEFT JOIN early_grants eg
+       ON eg.tenant_id = s.tenant_id
+      AND eg.status = 'active'
+      AND now() BETWEEN eg.starts_at AND eg.ends_at
+WHERE s.status = 'active'
+GROUP BY p.slug, p.price_cents
+ORDER BY mrr_reais DESC;

--- a/tools/metrics/q2_churn.sql
+++ b/tools/metrics/q2_churn.sql
@@ -1,0 +1,9 @@
+-- Cancelamentos por mês. Aproximação: sem snapshot histórico de status,
+-- não dá pra calcular taxa exata sobre a base ativa no início de cada mês
+-- — isto é tendência (contagem absoluta), não taxa precisa por coorte.
+SELECT date_trunc('month', cancelled_at)::date AS mes,
+       COUNT(*)                                 AS cancelados
+FROM subscriptions
+WHERE cancelled_at IS NOT NULL
+GROUP BY 1
+ORDER BY 1;

--- a/tools/metrics/q3_retencao.sql
+++ b/tools/metrics/q3_retencao.sql
@@ -1,0 +1,16 @@
+-- Retenção por coorte de criação — NÃO é conversão trial→pago de verdade.
+-- subscriptions.status é uma máquina de estado de uma coluna só, sem
+-- histórico de transição, e trial_days=3 faz "trial" tender a 0 pra
+-- qualquer coorte com mais de poucos dias. Isto mostra o status ATUAL de
+-- cada coorte de cadastro — conversão trial→pago real vem do funil
+-- comercial (Rumy), não do banco.
+SELECT date_trunc('month', created_at)::date AS coorte,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE status = 'trial') AS trial,
+       COUNT(*) FILTER (WHERE status = 'active') AS active,
+       COUNT(*) FILTER (WHERE status IN ('pending','past_due')) AS pagamento_pendente,
+       COUNT(*) FILTER (WHERE status IN ('cancelled','expired')) AS encerrado,
+       ROUND(COUNT(*) FILTER (WHERE status = 'active')::numeric / NULLIF(COUNT(*), 0), 4) AS taxa_retencao
+FROM subscriptions
+GROUP BY 1
+ORDER BY 1;

--- a/tools/metrics/q4_ativacao.sql
+++ b/tools/metrics/q4_ativacao.sql
@@ -1,0 +1,14 @@
+-- Ativação: tempo entre criação do tenant e a primeira validação (validate_xml)
+-- concluída com sucesso.
+WITH primeira_validacao AS (
+  SELECT tenant_id, MIN(created_at) AS primeira_ok
+  FROM jobs
+  WHERE job_type = 'validate_xml'
+    AND status   = 'SUCCESS'
+  GROUP BY tenant_id
+)
+SELECT COUNT(*)                                                          AS tenants_ativados,
+       ROUND(AVG(EXTRACT(EPOCH FROM (pv.primeira_ok - t.created_at))
+             / 86400.0)::numeric, 1)                                     AS dias_medios_ate_ativar
+FROM primeira_validacao pv
+JOIN tenants t ON t.id = pv.tenant_id;

--- a/tools/metrics/q5_consumo.sql
+++ b/tools/metrics/q5_consumo.sql
@@ -1,0 +1,8 @@
+-- Consumo do plano contratado por período (proxy de engajamento no v1;
+-- detalhe por rota/feature fica pra v2).
+SELECT period,
+       SUM(validations_used)  AS validacoes,
+       SUM(ai_messages_used)  AS mensagens_ia
+FROM usage_tracking
+GROUP BY period
+ORDER BY period;

--- a/tools/metrics/run_extract.sh
+++ b/tools/metrics/run_extract.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Query pack v1 — Cockpit de Unit Economics (ORD-QA-002 / ORD-DADOS-001).
+#
+# Roda as 5 queries deste diretório contra o Postgres de produção via SSH na
+# VM (nunca expõe a porta do banco localmente) e traz o resultado como CSV
+# para reports/metrics/ (gitignored — dado de produção nunca vai pro git).
+#
+# Uso: bash tools/metrics/run_extract.sh
+# Pré-requisito: chave SSH autorizada na VM (ver docs/infra/secrets_inventory.md).
+
+set -euo pipefail
+
+VM_HOST="ubuntu@201.54.20.18"
+SSH_KEY="$HOME/.ssh/id_ed25519"
+REMOTE_DIR="/tmp/qa_extract_$(date +%Y%m%d%H%M%S)"
+LOCAL_DIR="reports/metrics/$(date +%Y-%m)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+mkdir -p "$LOCAL_DIR"
+ssh -i "$SSH_KEY" "$VM_HOST" "mkdir -p $REMOTE_DIR"
+scp -i "$SSH_KEY" "$SCRIPT_DIR"/q*.sql "$VM_HOST:$REMOTE_DIR/"
+
+ssh -i "$SSH_KEY" "$VM_HOST" bash -s "$REMOTE_DIR" << 'REMOTE'
+set -e
+cd "$1"
+DB_URL=$(sudo grep "^DATABASE_URL=" /opt/tribultz/.env | cut -d= -f2- | sed 's/postgresql+psycopg2:/postgresql:/')
+for f in q1_mrr q2_churn q3_retencao q4_ativacao q5_consumo; do
+  psql "$DB_URL" -v ON_ERROR_STOP=1 --csv -f "${f}.sql" -o "${f}.csv" 2>"${f}.err" \
+    && echo "OK: ${f} — $(($(wc -l < "${f}.csv") - 1)) linha(s)" \
+    || { echo "FALHOU: ${f}"; cat "${f}.err"; exit 1; }
+done
+REMOTE
+
+scp -i "$SSH_KEY" "$VM_HOST:$REMOTE_DIR/*.csv" "$LOCAL_DIR/"
+ssh -i "$SSH_KEY" "$VM_HOST" "rm -rf $REMOTE_DIR"
+
+echo "Extrato salvo em $LOCAL_DIR/ (fora do git — reports/ é gitignored)."


### PR DESCRIPTION
## Contexto

ORD-QA-002 / ORD-DADOS-001 — pipeline de métricas de produto/negócio pro
cockpit de unit economics. Já rodado ponta a ponta contra produção
(2026-08-02), extrato entregue fora deste PR (CSV local, gitignored).

## O que adiciona

`tools/metrics/`: 5 queries read-only versionadas + script de execução
(`run_extract.sh`, SSH na VM → psql em produção → CSV local em
`reports/metrics/<ano-mes>/`, gitignored).

## Duas correções de schema no rascunho original (revisão antes de rodar)

- **`q1_mrr.sql`**: exclui tenants com Early Grant ativo do cálculo de
  MRR. Confirmado com dado real: existem tenants com plano pago via Grant
  (Founding Partners), sem gerar receita — sem a exclusão, MRR ficava
  inflado exatamente na métrica que sustenta o cálculo de payback do CAC.
- **`q3_retencao.sql`**: renomeada de "conversão trial→pago" — o banco não
  tem histórico de transição de status, então não mede conversão de
  verdade (conversão real vem do funil comercial/Rumy). Passa a se chamar
  retenção por coorte, com balde `pending`/`past_due` explícito.

## Test plan

- [x] Todas as 5 queries testadas contra Postgres local (dev) antes de ir pra produção
- [x] Rodadas ponta a ponta contra produção via `run_extract.sh` — 5/5 OK, sem erro
- [x] Confirmado `reports/` já é gitignored — nenhum dado de produção tocou o git