### PR TITLE
fix(blog): preenche tags/legalRefs e remove marcador REVISAR (#580)

### DIFF
--- a/frontend/content/blog/validacao-deterministica-versus-conferencia-manual.mdx
+++ b/frontend/content/blog/validacao-deterministica-versus-conferencia-manual.mdx
@@ -8,13 +8,23 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-08-01T04:18:29.000Z"
-tags: []
+tags:
+  - "validação determinística"
+  - "NF-e"
+  - "CST"
+  - "cClassTrib"
+  - "auditoria fiscal"
+  - "ERP"
+  - "Reforma Tributária"
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/7f4c38a5-f11b-44ad-8a50-38e8a582d13f.webp"
-legalRefs: []
+legalRefs:
+  - instrumento: "LC 214/2025"
+    descricao: "Institui CBS, IBS e o Imposto Seletivo; base da obrigatoriedade do grupo gIBSCBS e do campo cClassTrib na NF-e, mencionados na coerência de validação descrita no artigo."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
+  - instrumento: "NT 2025.002-RTC v1.40"
+    descricao: "Regras de validação da NF-e/NFC-e para IBS/CBS na emissão — base técnica da distinção entre validação determinística e conferência manual discutida no artigo."
 soroGuid: "7f4c38a5-f11b-44ad-8a50-38e8a582d13f"
 ---
-
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
 
 <p>Uma NF-e pode ser autorizada e, ainda assim, carregar uma decisão fiscal inconsistente. Esse é o ponto que torna a <strong>validação determinística versus conferência manual</strong> uma discussão operacional, não apenas uma escolha de método. Quando a verificação acontece tarde, a empresa já pode ter comprometido faturamento, expedição, escrituração e capacidade de responder a uma auditoria.</p>
 <p>A conferência humana continua necessária para analisar exceções, interpretar contextos e decidir situações que exigem julgamento técnico. O problema aparece quando ela é tratada como o principal controle para milhares de combinações entre produtos, clientes, operações, regras fiscais e parametrizações de ERP. Nesse cenário, o processo depende de memória, disponibilidade e consistência individual - justamente onde a escala costuma expor fragilidades.</p>


### PR DESCRIPTION
## Contexto

Gate de revisão editorial (#349) foi pulado no merge do PR #580 — o `GITHUB_TOKEN` padrão usado por `peter-evans/create-pull-request` não dispara checks `pull_request` (proteção anti-loop do GitHub), então `frontend-build` nunca rodou nesse PR e ele mergeou com `tags: []`, `legalRefs: []` e o marcador `{/* Gerado pelo Soro — REVISAR antes do merge */}` ainda no corpo.

## Mudança

Preenche `tags`/`legalRefs` (seguindo o padrão já usado em posts do mesmo tema — `LC 214/2025` + `NT 2025.002-RTC v1.40`) e remove o marcador REVISAR do único post tocado pelo #580: `validacao-deterministica-versus-conferencia-manual.mdx`.

Conteúdo já foi auditado pelo QA — este PR só ajusta frontmatter, sem reescrever o corpo do artigo.

## Testes

- `npm test --silent` — 193/193 ok (inclui `blogFiscalLint.test.ts`, que já escaneava este post sem apontar problema fiscal).

Ref.: ORDEM 2026-08-QA→ENG-002 (OS-11a). Ver também PR de OS-11b (checks de erro pra evitar recorrência).
