### PR TITLE
chore(blog): remove marcador REVISAR de 3 posts já revisados

### DIFF
--- a/frontend/content/blog/api-validacao-xml-nfe-na-pratica.mdx
+++ b/frontend/content/blog/api-validacao-xml-nfe-na-pratica.mdx
@@ -29,8 +29,6 @@ legalRefs:
 soroGuid: "56b66e58-90c4-4774-8703-bdff208c3c64"
 ---
 
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
-
 <p>Quem já precisou segurar uma emissão porque o XML da NF-e voltou com inconsistência sabe o tamanho do problema. O ponto não é só técnico. Quando a empresa depende de uma api validação xml nf-e para conferir campos críticos antes da transmissão, ela está protegendo operação, prazo de faturamento e exposição fiscal no mesmo movimento.</p>
 <p>Na prática, validar XML não é apenas checar se a estrutura do arquivo “abre” ou se o schema foi respeitado. Isso resolve uma parte pequena do risco. O que pesa mesmo, especialmente com a transição das novas regras tributárias, é validar coerência fiscal entre CST, classificação tributária, cadastros de produto e regras vigentes de preenchimento conforme a NT e a legislação aplicável. É aqui que muitas rotinas de ERP ainda deixam brechas.</p>
 <h2>O que uma API de validação XML NF-e precisa verificar de verdade</h2>

--- a/frontend/content/blog/penalidades-cbs-ibs-2026.mdx
+++ b/frontend/content/blog/penalidades-cbs-ibs-2026.mdx
@@ -34,8 +34,6 @@ legalRefs:
 soroGuid: "9e6efe9b-666e-4737-8248-e6ff765afef0"
 ---
 
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
-
 <p>Se a sua operação ainda trata a <a href="https://www.gov.br/fazenda/pt-br/acesso-a-informacao/acoes-e-programas/reforma-tributaria">Reforma Tributária</a> como tema de projeto, e não de execução, as penalidades CBS IBS 2026 já deveriam estar no radar do fiscal, do ERP e da controladoria ao mesmo tempo. O ponto crítico não é só o valor do tributo na fase de teste. É o erro estrutural que nasce no cadastro, passa pela classificação, chega na NF-e e depois vira passivo, retrabalho e exposição desnecessária quando o Fisco cruza documento, XML e escrituração.</p>
 <p>Em 2026, o risco não estará apenas em calcular CBS e IBS de forma incorreta. Estará, em regra, na consistência entre dados fiscais que antes muitas empresas tratavam como campos acessórios e que passam a ter função operacional real na emissão e na auditoria. Quando esse alinhamento falha, o problema aparece cedo, na rejeição do documento, ou tarde, na fiscalização. Nos dois cenários, o custo costuma ser maior do que parecia na etapa de cadastro.</p>
 <h2>O que realmente entra em jogo nas penalidades CBS IBS 2026</h2>

--- a/frontend/content/blog/validacao-previa-ou-pos-emissao.mdx
+++ b/frontend/content/blog/validacao-previa-ou-pos-emissao.mdx
@@ -19,8 +19,6 @@ legalRefs:
 soroGuid: "930e45c6-e657-4cd2-9b3c-b619c27e3527"
 ---
 
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
-
 <p>Uma NF-e rejeitada no momento da expedição não é apenas uma pendência fiscal. Ela pode interromper faturamento, atrasar a saída de mercadorias, mobilizar TI e fiscal e expor falhas que já estavam presentes no cadastro ou na parametrização do ERP. É nesse ponto que a escolha entre <strong>validação prévia ou pós emissão</strong> deixa de ser técnica e passa a ser uma decisão de continuidade operacional.</p>
 <p>Validar depois de emitir ainda tem valor para auditoria, correção de processos e identificação de padrões. Mas esperar o documento existir para descobrir uma inconsistência significa lidar com o problema quando ele já alcançou a operação. Em ambientes com alto volume, múltiplas filiais, catálogos extensos e regras tributárias em transição, a prevenção tende a oferecer mais controle do que a remediação.</p>
 <h2>Validação prévia ou pós emissão: a diferença prática</h2>


### PR DESCRIPTION
## Contexto

Lote A da ORDEM 2026-08-QA→ENG-003 rev.2. Dos 9 posts com o gate de revisão pulado (achado do parecer de OS-11b, #586), 3 já foram revisados de verdade — `tags`/`legalRefs` estão preenchidos com conteúdo real — mas o marcador `{/* Gerado pelo Soro — REVISAR antes do merge */}` ficou esquecido no corpo.

## Mudança

Remove só o marcador (linha + linha em branco) de:
- `api-validacao-xml-nfe-na-pratica.mdx`
- `penalidades-cbs-ibs-2026.mdx`
- `validacao-previa-ou-pos-emissao.mdx`

Zero alteração de conteúdo ou frontmatter — só limpeza mecânica. Reduz o blast radius do #586 de 9 para 6 posts pendentes (os 6 restantes exigem revisão fiscal real da QA antes de qualquer edição, não são mecânicos como estes 3 — ver Lote B da mesma ordem).

## Testes

- `npm test --silent` — 193/193 ok.

Ref.: ORDEM 2026-08-QA→ENG-003 rev.2 (Lote A). Relacionado: #585, #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)