### PR TITLE
fix(blog): preenche frontmatter dos 4 posts restantes do Lote B/P2

### DIFF
--- a/frontend/content/blog/como-revisar-catalogo-fiscal-ibs-cbs.mdx
+++ b/frontend/content/blog/como-revisar-catalogo-fiscal-ibs-cbs.mdx
@@ -8,13 +8,20 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-26T06:03:37.000Z"
-tags: []
+tags:
+  - "catálogo fiscal"
+  - IBS
+  - CBS
+  - NCM
+  - cClassTrib
+  - "governança de dados"
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/73d164cf-4da1-41d2-a649-2f64d7f0c26a.webp"
-legalRefs: []
+legalRefs:
+  - instrumento: "LC 214/2025"
+    descricao: "Institui CBS e IBS; base legal da transição tributária referida ao longo do texto."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
 soroGuid: "73d164cf-4da1-41d2-a649-2f64d7f0c26a"
 ---
-
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
 
 <p>A revisão de catálogo deixou de ser uma tarefa pontual de cadastro. Para entender <strong>como revisar catálogo fiscal IBS CBS</strong>, a empresa precisa conectar produto, classificação fiscal, regra tributária, ERP e documento eletrônico em um mesmo processo de decisão. Quando essas informações não conversam antes da emissão, a operação transfere incertezas para o faturamento, para a escrituração e para a auditoria.</p>
 <p>Na transição da Reforma Tributária, não basta esperar uma rejeição, uma dúvida do cliente ou o fechamento fiscal para descobrir um cadastro inconsistente. O catálogo fiscal precisa ser tratado como um ativo de governança: versionado, rastreável e submetido a critérios técnicos conforme a legislação e a documentação oficial vigentes.</p>

--- a/frontend/content/blog/evidencia-auditavel-reforma-tributaria.mdx
+++ b/frontend/content/blog/evidencia-auditavel-reforma-tributaria.mdx
@@ -8,13 +8,20 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-16T00:40:40.000Z"
-tags: []
+tags:
+  - "evidência auditável"
+  - "governança fiscal"
+  - "Reforma Tributária"
+  - IBS
+  - CBS
+  - auditoria
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/50f03c5e-4d6a-4cc5-b19c-6d99b5729ddc.webp"
-legalRefs: []
+legalRefs:
+  - instrumento: "LC 214/2025"
+    descricao: "Institui CBS e IBS; base legal da transição tributária referida ao longo do texto."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
 soroGuid: "50f03c5e-4d6a-4cc5-b19c-6d99b5729ddc"
 ---
-
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
 
 <p>Uma divergência fiscal raramente começa na transmissão da NF-e. Ela costuma nascer antes: em um cadastro de produto desatualizado, em uma classificação aplicada sem critério documentado, em uma regra alterada no ERP sem validação ou em uma decisão tomada por mensagem e perdida no fluxo operacional. É nesse ponto que a evidência auditável na Reforma Tributária deixa de ser um tema de auditoria e passa a ser um requisito de continuidade do faturamento.</p>
 <p>A transição para o novo modelo tributário amplia a necessidade de conectar regra, dado e decisão. Não basta calcular ou preencher campos fiscais. A empresa precisa conseguir demonstrar por que determinada classificação, tratamento tributário ou parametrização foi aplicada, com base em qual versão de regra, em qual momento e sobre quais dados de origem.</p>

--- a/frontend/content/blog/exemplo-erro-cst-cclasstrib.mdx
+++ b/frontend/content/blog/exemplo-erro-cst-cclasstrib.mdx
@@ -8,13 +8,22 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-22T01:01:43.000Z"
-tags: []
+tags:
+  - CST
+  - cClassTrib
+  - NF-e
+  - "Reforma Tributária"
+  - IBS
+  - CBS
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/b36ff00d-26c3-4763-8192-68d385aa026b.webp"
-legalRefs: []
+legalRefs:
+  - instrumento: "LC 214/2025"
+    descricao: "Institui CBS e IBS; base das classificações tributárias da tabela cClassTrib."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
+  - instrumento: "NT 2025.002-RTC v1.40"
+    descricao: "Regime de validação CST × cClassTrib na NF-e (Rejeição 1024, referida no texto)."
 soroGuid: "b36ff00d-26c3-4763-8192-68d385aa026b"
 ---
-
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
 
 <p>Um <strong>exemplo de erro CST cClassTrib</strong> costuma parecer um problema simples de preenchimento no ERP. Na prática, ele pode revelar uma falha mais relevante: a regra fiscal aplicada ao produto, à operação ou ao documento não está coerente com a classificação tributária exigida no layout e na legislação aplicável. Quando essa inconsistência é descoberta somente no momento da emissão, o impacto chega ao faturamento, à expedição e à rotina do time fiscal.</p>
 <p>A questão não é apenas saber qual campo deve receber determinado valor. O ponto central é demonstrar que CST, cClassTrib, cadastro de item, natureza da operação e demais informações tributárias contam a mesma história. É essa coerência que reduz retrabalho e cria uma trilha confiável para auditorias, conferências internas e evolução das regras durante a transição da Reforma Tributária.</p>

--- a/frontend/content/blog/guia-sped-fiscal-reforma-tributaria.mdx
+++ b/frontend/content/blog/guia-sped-fiscal-reforma-tributaria.mdx
@@ -8,15 +8,22 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-30T06:07:11.000Z"
-tags: []
+tags:
+  - "SPED Fiscal"
+  - "EFD ICMS IPI"
+  - "Reforma Tributária"
+  - IBS
+  - CBS
+  - escrituração
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/4811ffa8-ba16-4ef7-8284-9db488aa396c.webp"
-legalRefs: []
+legalRefs:
+  - instrumento: "LC 214/2025"
+    descricao: "Institui CBS e IBS; base legal da transição que o guia relaciona à escrituração."
+    link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
 soroGuid: "4811ffa8-ba16-4ef7-8284-9db488aa396c"
 ---
 
-{/* Gerado pelo Soro — REVISAR antes do merge: precisão fiscal, legalRefs, tags, category. */}
-
-<p>A <strong>guia SPED Fiscal reforma tributária</strong> não começa na geração do arquivo. Ela começa no cadastro do produto, na classificação fiscal, na regra aplicada pelo ERP e na decisão tomada antes da emissão da NF-e. Quando essas camadas não conversam, o SPED Fiscal deixa de ser apenas uma obrigação acessória e passa a revelar inconsistências que já afetaram faturamento, margem, crédito e governança.</p>
+<p>O <strong>guia SPED Fiscal reforma tributária</strong> não começa na geração do arquivo. Ela começa no cadastro do produto, na classificação fiscal, na regra aplicada pelo ERP e na decisão tomada antes da emissão da NF-e. Quando essas camadas não conversam, o SPED Fiscal deixa de ser apenas uma obrigação acessória e passa a revelar inconsistências que já afetaram faturamento, margem, crédito e governança.</p>
 <p>A Reforma Tributária amplia a necessidade de controle porque introduz novos conceitos, classificações e regras operacionais em uma transição que exige acompanhamento constante da legislação e da documentação técnica vigente. Para empresas com catálogos extensos, múltiplas filiais e alto volume de documentos, revisar o arquivo apenas no fechamento é tarde demais. A prevenção precisa acontecer na origem.</p>
 <h2>O que muda na relação entre SPED Fiscal e Reforma Tributária</h2>
 <p>O SPED Fiscal, especialmente a EFD ICMS IPI, consolida informações que dependem da qualidade dos documentos fiscais e das parametrizações que os produziram. Em regra, ele registra operações, apurações, inventários e demais dados exigidos conforme o perfil e a obrigatoriedade aplicáveis à empresa. Por isso, não deve ser tratado como um arquivo isolado da operação.</p>


### PR DESCRIPTION
## Contexto

Lote B/P2 — último item do gate editorial pulado no #580. Fecha a Fase 3 da ORDEM 2026-08-QA→ENG-005.

## Parecer da QA (evidência)

> **Resumo: 4 × APROVADA COM AJUSTES (só frontmatter — nenhuma inexatidão fiscal).** Nenhum dos 4 posts contém alegação fiscal dura incorreta. Todos são metodológicos, com hedging correto e claims de produto verdadeiros. A fabricação do post da Rejeição 960 foi caso único entre os 10 do gate pulado.

Li os 4 posts na íntegra antes de aplicar — confere com o parecer: nenhuma alegação fiscal dura, hedging consistente, links internos e a rota `/changelog` conferidos como reais.

## Mudança

Frontmatter aplicado em `como-revisar-catalogo-fiscal-ibs-cbs`, `evidencia-auditavel-reforma-tributaria`, `exemplo-erro-cst-cclasstrib`, `guia-sped-fiscal-reforma-tributaria` (tags/legalRefs conforme parecer), marcador REVISAR removido dos 4.

Ajuste editorial não-bloqueante incluído (sinalizado no parecer): "A guia SPED Fiscal" → "O guia SPED Fiscal" — guia como documento é substantivo masculino; "a guia" é guia de recolhimento.

## Verificação do aceite

Com este PR, **zero** ocorrência de marcador REVISAR ou `tags`/`legalRefs` vazios em `frontend/content/blog/*.mdx` — os 10/10 posts do #580 estão regularizados. Isso destrava `#586` (trava de error em `blogFiscalLint.ts`) para sair de draft e mergear verde, sem allowlist — Caminho 1 concluído.

## Testes

- `npm test --silent` — 193/193 ok.

Ref.: ORDEM 2026-08-QA→ENG-003 rev.2 (Lote B/P2). Fecha a Fase 3 de ENG-005. Ver também #585, #587, #588, #589, #590.
