### PR TITLE
fix(produto): corrige sede legal + conflação leniência/pedagógico (Fase A/ENG-007)

### DIFF
--- a/backend/app/alembic/versions/2026_05_31_0019_add_pedagogical_mode_2026.py
+++ b/backend/app/alembic/versions/2026_05_31_0019_add_pedagogical_mode_2026.py
@@ -3,10 +3,10 @@
 Adiciona flag pedagogical_mode_2026 à tabela tenants.
 
 Quando True (padrão): findings de obrigação acessória CBS/IBS são
-downgraded de FATAL para WARNING, com badge "Período Pedagógico LC 227
+downgraded de FATAL para WARNING, com badge "Período Pedagógico LC 214
 art. 348" e nota de 60 dias para sanar sem multa.
 
-Referência legal: LC 227/2026 art. 348 §§ 3º e 4º.
+Referência legal: art. 348, §§ 3º e 4º, da LC 214/2025 (incluídos pela LC 227/2026).
 
 Revision ID: 2026_05_31_0019
 Revises: 2026_05_31_0018

--- a/backend/app/services/fiscal_justification.py
+++ b/backend/app/services/fiscal_justification.py
@@ -2,7 +2,7 @@
 Mapa estático de justificativas técnicas por rule_id.
 
 Cada entrada contém:
-  base_legal  — artigo(s) da LC 214/2025, LC 227/2024 ou NT 2025.002-RTC aplicáveis
+  base_legal  — artigo(s) da LC 214/2025, LC 227/2026 ou NT 2025.002-RTC aplicáveis
   explicacao  — por que a regra existe e o que ela verifica
   correcao    — ação recomendada para sanar a não-conformidade
 

--- a/frontend/src/app/calculadora/page.tsx
+++ b/frontend/src/app/calculadora/page.tsx
@@ -43,9 +43,9 @@ const LEGAL_REFS = [
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm",
   },
   {
-    instrumento: "LC 227/2026",
-    artigo: "art. 348",
-    descricao: "Regulamentação operacional 2026, período pedagógico, transição 2026-2033.",
+    instrumento: "LC 214/2025",
+    artigo: "art. 348, §§ 3º e 4º (incluídos pela LC 227/2026)",
+    descricao: "Período Pedagógico — autuado exclusivamente por obrigação acessória de IBS/CBS tem 60 dias contados da notificação para regularizar, extinguindo a penalidade.",
   },
   {
     instrumento: "Regulamento IBS",
@@ -163,8 +163,11 @@ export default function CalculadoraPage() {
             </div>
             <p className="mt-3 text-sm text-slate-600">
               Em 2026 não há recolhimento efetivo do CBS/IBS (LC 214 art. 348 — período de aprendizado).
-              Após agosto/2026 termina a leniência da LC 227 sobre obrigações acessórias e a partir
-              de 2027 o CBS começa a ser cobrado efetivamente.
+              Desde 01/08/2026 a multa por obrigação acessória de IBS/CBS é aplicável (Ato Conjunto
+              RFB/CGIBS nº 1/2025, art. 3º); se autuado exclusivamente por essa obrigação, o contribuinte
+              tem 60 dias contados da notificação para regularizar, extinguindo a penalidade (art. 348,
+              §§ 3º e 4º, da LC 214/2025, incluídos pela LC 227/2026). A partir de 2027 o CBS começa a
+              ser cobrado efetivamente.
             </p>
           </div>
 

--- a/frontend/src/app/classificacao/page.tsx
+++ b/frontend/src/app/classificacao/page.tsx
@@ -18,7 +18,7 @@ const FAQ = [
   },
   {
     q: "Quando começam as penalidades por cClassTrib incorreto?",
-    a: "As penalidades efetivas por erros de CBS/IBS em NF-e começam em agosto/2026, encerrando o período pedagógico previsto pela LC 227/2026 (art. 348 §§ 3º e 4º). Até lá, autuações exclusivamente por obrigação acessória dão 60 dias para sanar sem multa. Após agosto/2026 essa leniência cessa.",
+    a: "Desde 01/08/2026 a multa por obrigação acessória de IBS/CBS é aplicável (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º). Se autuado exclusivamente por essa obrigação, o contribuinte é notificado e tem 60 dias contados da notificação para regularizar, extinguindo a penalidade (art. 348, §§ 3º e 4º, da LC 214/2025, incluídos pela LC 227/2026).",
   },
   {
     q: "Como funciona a classificação automática NCM → cClassTrib?",
@@ -46,9 +46,9 @@ const LEGAL_REFS = [
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm",
   },
   {
-    instrumento: "LC 227/2026",
-    artigo: "art. 348 §§ 3º e 4º",
-    descricao: "Período pedagógico 2026 — 60 dias para sanar obrigação acessória sem multa.",
+    instrumento: "LC 214/2025",
+    artigo: "art. 348, §§ 3º e 4º (incluídos pela LC 227/2026)",
+    descricao: "Período Pedagógico — autuado exclusivamente por obrigação acessória de IBS/CBS tem 60 dias contados da notificação para regularizar, extinguindo a penalidade.",
   },
   {
     instrumento: "NT 2025.002-RTC v1.36",

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -86,8 +86,9 @@ export default function SettingsPage() {
             <p className="mt-1 text-sm text-slate-500">
               Quando ativo, irregularidades em <strong>obrigações acessórias</strong> CBS/IBS
               (formato CST, cClassTrib, layout XML) são sinalizadas como{" "}
-              <strong>Aviso</strong> em vez de bloqueio — conforme a{" "}
-              <strong>LC 227/2026 art. 348 §§ 3º e 4º</strong>: 60 dias para sanar sem multa.
+              <strong>Aviso</strong> em vez de bloqueio — conforme o{" "}
+              <strong>art. 348, §§ 3º e 4º, da LC 214/2025</strong> (incluídos pela LC 227/2026): 60 dias
+              contados da notificação para regularizar, extinguindo a penalidade.
             </p>
             <p className="mt-2 text-xs text-blue-700 font-medium">
               ⚖️ Válido durante o período pedagógico de 2026. Recomendado manter ativo.

--- a/frontend/src/app/validate-xml/page.tsx
+++ b/frontend/src/app/validate-xml/page.tsx
@@ -18,7 +18,7 @@ function severityClasses(severity: Finding["severity"]): string {
 
 function severityLabel(severity: Finding["severity"]): string {
   if (severity === "FATAL") return "FATAL (bloqueante)";
-  if (severity === "WARNING") return "Período Pedagógico LC 227";
+  if (severity === "WARNING") return "Período Pedagógico LC 214, art. 348";
   return "ALERT";
 }
 
@@ -406,7 +406,7 @@ export default function ValidateXmlPage() {
                         <p className="text-xs font-semibold uppercase tracking-wide">{severityLabel(finding.severity)}</p>
                         {finding.severity === "WARNING" && (
                           <span className="inline-flex items-center gap-1 rounded-full border border-blue-300 bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-800">
-                            ⚖️ LC 227 art. 348 — 60 dias para sanar
+                            ⚖️ LC 214 art. 348 — 60 dias para sanar
                           </span>
                         )}
                       </div>


### PR DESCRIPTION
## Contexto

Fase A da ORDEM 2026-08-QA→ENG-007 — achado da Fase 5 de ENG-005 que ficou registrado para hoje (não corrigido lá por decisão explícita: "não execute agora"). "LC 227/2026, art. 348" como sede errada aparecia em páginas voltadas ao usuário pagante, não só em blog e código.

## Erro substantivo (mais grave que a sede)

`classificacao/page.tsx` e `calculadora/page.tsx` afirmavam que o direito aos 60 dias de regularização **"cessa"** após agosto/2026 — falso. São dois mecanismos legais distintos e combináveis (já documentado no próprio código, `xmlRules.ts:350`):

- **Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º**: janela sem multa até 31/07/2026; multa aplicável desde 01/08/2026.
- **Art. 348, §§ 3º e 4º, da LC 214/2025** (incluídos pela LC 227/2026): Período Pedagógico — **continua vigente em 2026**, sem data de término. Quem é autuado exclusivamente por obrigação acessória tem 60 dias contados da notificação, sempre, não só antes de agosto.

Verifiquei a conflação lendo o texto real de cada arquivo antes de corrigir (não assumi pela descrição da ordem) — confirmado em ambos, inclusive uma inconsistência interna em `calculadora/page.tsx:165-166` (uma linha cita corretamente "LC 214 art. 348", a seguinte já erra para "LC 227").

## Mudança

- `classificacao/page.tsx` (:21 FAQ + :49 legalRef)
- `calculadora/page.tsx` (:46 legalRef + :166 parágrafo)
- `settings/page.tsx` (:90)
- `validate-xml/page.tsx` (:21 label + :409 badge)

**Achado extra durante a verificação** (bug diferente do que a ordem descrevia — não é sede do art. 348, é erro de digitação no ano): `fiscal_justification.py:5` citava "LC 227/2024" — corrigido para 2026.

**Cosmético** (marcado como opcional na ordem): comentário da migration `2026_05_31_0019` também corrigido.

**NÃO alterado** (achado não confere com a ordem — verificado antes de tocar): `simulator.py:135` não cita art. 348 nem faz afirmação de sede incorreta — é um disclaimer genérico "LC 214/2025 + LC 227/2026" sem problema factual identificável. Sinalizando de volta em vez de inventar uma correção onde não há defeito.

## Testes

- `npm test` — 198/198 ok.
- `npm run build` — ok.
- `pytest -q` (suíte completa) — 1007/1007 ok.
- `ruff check app/ tests/` — limpo.

## Aceite

```
grep -rn "LC 227" frontend/src backend/app
```
Zero ocorrência como sede do art. 348 (menções como lei alteradora/regulamentadora são legítimas e permanecem). Zero afirmação de que os 60 dias "cessam".

Ref.: ORDEM 2026-08-QA→ENG-007, Fase A.