### PR TITLE
docs(prospecting): corrige destino do pipeline (HubSpot → Attio)

### DIFF
--- a/tools/prospecting/README.md
+++ b/tools/prospecting/README.md
@@ -68,6 +68,12 @@ completo. `dedup_prospects.py` e `score_and_select.py` operam só sobre os
 
 ## Fora desta entrega (Fase 1 termina no Top 2.000)
 
-Agente de enriquecimento externo, reclassificação, exportação para a API
-comercial (HubSpot), telemetria e scripts de feedback loop são fases
-seguintes — ver o plano da Fase 1 para o desenho completo.
+Agente de enriquecimento externo, reclassificação, exportação para o CRM
+comercial (**Attio** — corrigido em 07/08/2026; a fase seguinte NÃO exporta
+para o HubSpot, que fica isolado no pós-venda), telemetria e scripts de
+feedback loop são fases seguintes — ver o plano da Fase 1 para o desenho
+completo.
+
+Este pipeline é **outra origem de aquisição** dentro da arquitetura
+comercial (Receita Federal → Pipeline Prospecting → Attio), não um CRM
+paralelo — decisão de Produto/Vendas, 07/08/2026.


### PR DESCRIPTION
## Contexto

Parecer de Ermes (Produto/Vendas) fechou a arquitetura comercial Rumy → Attio → HubSpot em 07/08/2026: Attio é o único CRM comercial, todas as origens de aquisição convergem pra ele; HubSpot só entra pós-venda (evento Deal Won). O README deste pipeline apontava exportação futura pra HubSpot — desatualizado frente a essa decisão.

## Mudança

- Corrige "exportação para a API comercial (HubSpot)" → **Attio**.
- Explicita que o pipeline de CNPJ é "outra origem de aquisição", não um CRM paralelo — mesmo destino do Rumy.

Mudança só de documentação — nenhum código do pipeline foi alterado (a Fase 2, que faria a exportação de verdade, ainda não foi construída).

Ref.: parecer Ermes (Produto/Vendas), 07/08/2026, item 5.