### PR TITLE
fix(motor): NT 2025.002 v1.51 — Rejeição 1115 com produção suspensa (Fase 2/ENG-010)

### DIFF
--- a/backend/app/routers/validate_xml.py
+++ b/backend/app/routers/validate_xml.py
@@ -243,11 +243,14 @@ def _extract_regime_comparison(xml: str, has_ibscbs: bool) -> RegimeComparison |
 _PEDAGOGICAL_ACCESSORY_RULES = {
     "CST_3_DIGITS", "CCLASSTRIB_6_DIGITS", "SERVICE_CODE_6_DIGITS",
     "CST_VALID", "CST_GROUP_MATCH", "CST_SEMANTIC",
-    "IBSCBS_MISSING", "CEST_MISSING", "CEST_FORMAT",
+    "CEST_MISSING", "CEST_FORMAT",
     "LAYOUT_NFE", "LAYOUT_PORTAL", "IMPORT_IBSCBS_REQUIRED",
     "NCM_FORMAT", "NCM_VALID", "CLASSTRIB_VALID",
     "IBSCBSTOT_MISSING",
 }
+# IBSCBS_MISSING (Rejeição 1115/UB12-10) NÃO está mais aqui: desde a NT 2025.002
+# v1.51, sua severidade é WARNING incondicional (implementação em produção
+# suspensa pela própria NT, não pelo Período Pedagógico) — ver Rule 6.
 
 # CSTs que legitimamente não destacam IBS/CBS no estágio atual — imunidade/isenção
 # (070), suspensão (410), diferimento (200, tributo postergado p/ operação seguinte)
@@ -266,8 +269,10 @@ _LC227_RECOMMENDATION = (
 # para o usuário saber como a SEFAZ rejeitará. Precedente: Rejeição 1157.
 _REJECTION_CODES = {
     "IBSCBS_MISSING": (
-        " — SEFAZ: Rejeição 1115 (regra UB12-10): preenchimento de IBS/CBS obrigatório — "
-        "produção a partir de 03/08/2026 (Regime Normal/CRT 3) e 04/01/2027 (Simples/MEI), NT 2025.002 v1.40."
+        " — SEFAZ: Rejeição 1115 (regra UB12-10): preenchimento de IBS/CBS obrigatório pela "
+        "legislação desde 03/08/2026 (Regime Normal/CRT 3) e 04/01/2027 (Simples/MEI); a rejeição "
+        "técnica na autorização está com implementação em produção SUSPENSA — \"implementação futura\", "
+        "sem data (NT 2025.002 v1.51). Homologação segue ativa desde 01/07/2026."
     ),
     "CCLASSTRIB_6_DIGITS": (
         " — SEFAZ: Rejeição 1106 (regra LA01-30) / 960 (regra N12-110): cClassTrib obrigatório "
@@ -503,21 +508,37 @@ def validate_xml(
 
     # ── Rule 6: IBSCBS_MISSING ───────────────────────────────────────────────
 
-    # NT 2025.002 v1.40 (#311): obrigatoriedade de IBS/CBS é faseada por regime —
-    # Simples/MEI (CRT 1/2/4) só a partir de 04/01/2027. Não emitir FATAL por ausência
-    # nesses regimes; Regime Normal (CRT 3) segue o cronograma (03/08/2026).
+    # Rejeição 1115 (UB12-10, grupo IBSCBS ausente) — NT 2025.002 v1.51 (04/08/2026):
+    # implementação em produção passou de "≥ 03/08/2026" para "implementação futura,
+    # sem data". A obrigação legal (LC 214) e a multa por obrigação acessória (Ato
+    # Conjunto RFB/CGIBS nº 1/2025, desde 01/08/2026) não mudaram — só a rejeição
+    # técnica na autorização foi suspensa. WARNING incondicional: não depende mais de
+    # CRT nem de pedagogical_mode (a suspensão é da própria NT, não do Período
+    # Pedagógico art. 348 LC 214, que é um mecanismo distinto). IBSCBS_MISSING foi
+    # retirado de _PEDAGOGICAL_ACCESSORY_RULES por não ser mais governado por ele.
     _crt_val = crt["value"].strip() if crt else ""
     _is_simples_mei = _crt_val in ("1", "2", "4")
-    _ibscbs_sev = "WARNING" if _is_simples_mei else _pedagogical_severity("IBSCBS_MISSING", pedagogical_mode)
-    _simples_note = " Simples Nacional/MEI: obrigatório a partir de 04/01/2027 (NT 2025.002 v1.40)."
+    _ibscbs_sev = "WARNING"
+    # NT 2025.002 v1.51 retirou do texto vigente a data técnica específica
+    # (04/01/2027) pra Simples/MEI; cronograma futuro fica pra NT ainda não
+    # publicada — citar só o marco legal (art. 348, LC 214) até lá.
+    _simples_note = (
+        " Simples Nacional/MEI: obrigatório a partir de 2027 (art. 348, LC 214/2025) —"
+        " NT 2025.002 v1.51 retirou a data técnica específica do texto vigente; NT"
+        " futura deve fixá-la."
+    )
+    _ibscbs_presenca_suspensa_note = (
+        " Obrigatório pela legislação desde 03/08/2026 (Regime Normal/CRT 3); a rejeição"
+        " técnica na autorização (UB12-10/Rejeição 1115) está com implementação em produção"
+        ' SUSPENSA — "implementação futura", sem data (NT 2025.002 v1.51). A multa por'
+        " obrigação acessória segue aplicável desde 01/08/2026 (Ato Conjunto RFB/CGIBS nº 1/2025)."
+    )
     if has_ibscbs:
         if not ibscbs_block:
             ev_id = "E_XML_IBSCBS_MISSING"
-            _rec = "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo."
+            _rec = "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo." + _ibscbs_presenca_suspensa_note
             if _is_simples_mei:
                 _rec += _simples_note
-            elif _ibscbs_sev == "WARNING":
-                _rec += _LC227_RECOMMENDATION
             _add(
                 Finding(id="F_IBSCBS_MISSING", severity=_ibscbs_sev, rule_id="IBSCBS_MISSING", title="Grupo IBSCBS ausente — obrigatório conforme NT 2025.002", where=FindingWhere(field="IBSCBS", xpath=_xpath("imposto", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="IBSCBS — grupo ausente", xpath=_xpath("imposto", doc_type)),
@@ -526,11 +547,9 @@ def validate_xml(
         has_legacy = all([valor_cbs, valor_ibs, aliq_cbs, aliq_ibs])
         if not has_legacy:
             ev_id = "E_XML_IBSCBS_MISSING"
-            _rec = "Informar alíquota e valor de IBS e CBS conforme LC 214."
+            _rec = "Informar alíquota e valor de IBS e CBS conforme LC 214." + _ibscbs_presenca_suspensa_note
             if _is_simples_mei:
                 _rec += _simples_note
-            elif _ibscbs_sev == "WARNING":
-                _rec += _LC227_RECOMMENDATION
             _add(
                 Finding(id="F_IBSCBS_MISSING", severity=_ibscbs_sev, rule_id="IBSCBS_MISSING", title="IBS/CBS ausentes na nota", where=FindingWhere(field="IBS/CBS", xpath=_xpath("Valores", doc_type)), recommendation=_rec, evidence_ids=[ev_id]),
                 Evidence(id=ev_id, type="xml", label="IBS/CBS — campos ausentes", xpath=_xpath("Valores", doc_type)),

--- a/backend/tests/test_validate_xml.py
+++ b/backend/tests/test_validate_xml.py
@@ -117,7 +117,9 @@ class TestNfseValidation:
           </PrestacaoServico>
         </infNfse></NFS-e>"""
         result = validate_xml(xml)
-        rules = [f.rule_id for f in result.findings if f.severity == "FATAL"]
+        # NT 2025.002 v1.51 (04/08/2026): IBSCBS_MISSING (Rejeição 1115/UB12-10) deixou
+        # de ser FATAL — implementação em produção da rejeição está suspensa, sem data.
+        rules = [f.rule_id for f in result.findings if f.severity == "WARNING"]
         assert "IBSCBS_MISSING" in rules
 
 
@@ -368,13 +370,16 @@ class TestNfeValidation:
         assert missing and all(f.severity == "WARNING" for f in missing), \
             f"CRT 4 (MEI) deve ser WARNING: {[f.severity for f in missing]}"
 
-    def test_ibscbs_missing_regime_normal_crt3_is_fatal(self):
-        """Regime Normal (CRT 3) sem IBS/CBS → FATAL (obrigatório 03/08/2026)."""
+    def test_ibscbs_missing_regime_normal_crt3_is_warning(self):
+        """Regime Normal (CRT 3) sem IBS/CBS → WARNING (NT 2025.002 v1.51: rejeição
+        1115/UB12-10 com implementação em produção suspensa, sem data; a obrigação
+        legal desde 03/08/2026 e a multa por obrigação acessória desde 01/08/2026
+        seguem valendo, mas não bloqueiam mais a emissão)."""
         result = validate_xml(self._NFE_SEM_IBSCBS.format(crt="3"), "NFE")
         missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
         assert missing, "IBSCBS_MISSING esperado"
-        assert all(f.severity == "FATAL" for f in missing), \
-            f"CRT 3 (Regime Normal) deve ser FATAL: {[f.severity for f in missing]}"
+        assert all(f.severity == "WARNING" for f in missing), \
+            f"CRT 3 (Regime Normal) deve ser WARNING (v1.51): {[f.severity for f in missing]}"
 
 
 # ── NFC-e validation ─────────────────────────────────────────────────────────
@@ -417,7 +422,47 @@ class TestRouterRegistered:
 class TestNoPenaltyWindow:
     """Multas por obrigação acessória suspensas para fatos geradores até 31/07/2026.
     A partir de 01/08/2026 a penalidade volta a ser FATAL. pedagogical_mode (LC 227)
-    permanece como override manual independente da data."""
+    permanece como override manual independente da data.
+
+    Veículo: IBSCBSTOT_MISSING (Rejeição 1119/W34-20), não IBSCBS_MISSING — desde a
+    NT 2025.002 v1.51 (04/08/2026), IBSCBS_MISSING (Rejeição 1115/UB12-10) é WARNING
+    incondicional (implementação em produção da rejeição suspensa, sem data; ver
+    TestIbscbsMissingV151 abaixo) e não participa mais deste mecanismo de janela/
+    pedagogical_mode. IBSCBSTOT_MISSING permanece com o comportamento antigo,
+    inalterado (mapa NT v1.51 §2/§6b), por isso segue como veículo certo pra testar
+    a janela sem penalidades em si. Usa `_nfe_w03` (definido mais abaixo, #403)."""
+
+    def test_dentro_da_janela_downgrade_para_warning(self):
+        result = validate_xml(_nfe_w03(dh_emi="2026-07-31T10:00:00-03:00", tot=False), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBSTOT_MISSING"]
+        assert missing, "IBSCBSTOT_MISSING esperado"
+        assert all(f.severity == "WARNING" for f in missing)
+        assert any("Ato Conjunto RFB/CGIBS" in (f.recommendation or "") for f in missing)
+
+    def test_limite_01_08_2026_volta_a_fatal(self):
+        result = validate_xml(_nfe_w03(dh_emi="2026-08-01T10:00:00-03:00", tot=False), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBSTOT_MISSING"]
+        assert missing and all(f.severity == "FATAL" for f in missing)
+
+    def test_fora_da_janela_fatal(self):
+        result = validate_xml(_nfe_w03(dh_emi="2026-08-15T10:00:00-03:00", tot=False), "NFE")
+        missing = [f for f in result.findings if f.rule_id == "IBSCBSTOT_MISSING"]
+        assert missing and all(f.severity == "FATAL" for f in missing)
+
+    def test_pedagogical_mode_fora_da_janela_warning(self):
+        result = validate_xml(
+            _nfe_w03(dh_emi="2026-09-10T10:00:00-03:00", tot=False), "NFE", pedagogical_mode=True,
+        )
+        missing = [f for f in result.findings if f.rule_id == "IBSCBSTOT_MISSING"]
+        assert missing and all(f.severity == "WARNING" for f in missing)
+        assert any("LC 227/2026" in (f.recommendation or "") for f in missing)
+
+
+class TestIbscbsMissingV151:
+    """NT 2025.002 v1.51 (04/08/2026): IBSCBS_MISSING sempre WARNING. Rejeição
+    1115/UB12-10 com implementação em produção suspensa (sem data) — diferente de
+    IBSCBSTOT_MISSING (TestNoPenaltyWindow acima), não depende mais de CRT, janela
+    do Ato Conjunto 1/25 nem de pedagogical_mode."""
 
     _NFE = """<nfeProc><NFe><infNFe>
       <ide><mod>55</mod>{dh}</ide>
@@ -432,33 +477,21 @@ class TestNoPenaltyWindow:
     def _nfe(self, dh=None):
         return self._NFE.format(dh=f"<dhEmi>{dh}</dhEmi>" if dh else "")
 
-    def test_dentro_da_janela_downgrade_para_warning(self):
-        result = validate_xml(self._nfe("2026-07-31T10:00:00-03:00"), "NFE")
+    def test_pos_01_08_2026_sem_pedagogical_mode_ainda_warning(self):
+        result = validate_xml(self._nfe("2026-08-15T10:00:00-03:00"), "NFE")
         missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
         assert missing, "IBSCBS_MISSING esperado"
         assert all(f.severity == "WARNING" for f in missing)
-        assert any("Ato Conjunto RFB/CGIBS" in (f.recommendation or "") for f in missing)
+        assert any("implementação em produção SUSPENSA" in (f.recommendation or "") for f in missing)
+        assert any(
+            "multa por obrigação acessória segue aplicável desde 01/08/2026" in (f.recommendation or "")
+            for f in missing
+        )
 
-    def test_limite_01_08_2026_volta_a_fatal(self):
-        result = validate_xml(self._nfe("2026-08-01T10:00:00-03:00"), "NFE")
-        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
-        assert missing and all(f.severity == "FATAL" for f in missing)
-
-    def test_fora_da_janela_fatal(self):
-        result = validate_xml(self._nfe("2026-08-15T10:00:00-03:00"), "NFE")
-        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
-        assert missing and all(f.severity == "FATAL" for f in missing)
-
-    def test_sem_dhemi_preserva_fatal(self):
+    def test_sem_dhemi_ainda_warning(self):
         result = validate_xml(self._nfe(), "NFE")
         missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
-        assert missing and all(f.severity == "FATAL" for f in missing)
-
-    def test_pedagogical_mode_fora_da_janela_warning(self):
-        result = validate_xml(self._nfe("2026-09-10T10:00:00-03:00"), "NFE", pedagogical_mode=True)
-        missing = [f for f in result.findings if f.rule_id == "IBSCBS_MISSING"]
         assert missing and all(f.severity == "WARNING" for f in missing)
-        assert any("LC 227/2026" in (f.recommendation or "") for f in missing)
 
     def test_regra_nao_acessoria_permanece_fatal_na_janela(self):
         # IBSCBS_SPLIT é regra de cálculo, não obrigação acessória → não entra na janela.

--- a/frontend/content/blog/guia-rejeicoes-nt-2026-002-nf-e.mdx
+++ b/frontend/content/blog/guia-rejeicoes-nt-2026-002-nf-e.mdx
@@ -8,6 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-28T06:21:30.000Z"
+updatedAt: "2026-08-08"
+updateNote: "NT 2026.002 v1.10, publicada em 04/08/2026, traz regras novas/alteradas (homologação 01/09/2026, produção 05/10/2026) — fora do escopo deste guia. A cobertura descrita aqui (DANFE Simplificado Tipo 2/tpImp=6, lote v1.00) não foi afetada e segue com produção a partir de 03/08/2026 para o Regime Normal."
 tags:
   - "NT 2026.002"
   - NF-e
@@ -18,6 +20,8 @@ coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/f
 legalRefs:
   - instrumento: "NT 2026.002 v1.00"
     descricao: "Nota Técnica cujas rejeições o guia orienta a triar; DANFE Simplificado Tipo 2 (tpImp=6), com produção a partir de 03/08/2026 para o Regime Normal (CRT 3)."
+  - instrumento: "NT 2026.002 v1.10"
+    descricao: "Publicada em 04/08/2026: regras novas/alteradas (homologação 01/09/2026, produção 05/10/2026), fora do escopo deste guia. Não afeta a cobertura do lote v1.00 (DANFE Simplificado Tipo 2) descrita aqui."
   - instrumento: "LC 214/2025"
     descricao: "Base legal da CBS/IBS citada na seção sobre a transição da Reforma Tributária."
 soroGuid: "ff4d410b-45de-4c1c-8a8e-9f1a7c16490d"

--- a/frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx
+++ b/frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx
@@ -8,8 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-14T12:00:00.000Z"
-updatedAt: "2026-07-31"
-updateNote: "Ato Conjunto RFB/CGIBS nº 4/2026 (30/07/2026) confirma oficialmente o cronograma de emissão obrigatória com IBS/CBS — 03/08/2026 mantido para NF-e/NFC-e, com prazos individualizados por tipo de documento para os demais. Adicionado como referência legal."
+updatedAt: "2026-08-08"
+updateNote: "NT 2025.002 v1.51 (04/08/2026): a Rejeição 1115 (regra UB12-10 — item sem IBS/CBS) teve a implementação em produção alterada de \"03/08/2026\" para \"implementação futura, sem data\" — hoje só bloqueia em homologação, não em produção. A Rejeição 1119 (totais, regra W34-20) segue inalterada, bloqueando desde 03/08/2026. A obrigação legal e a multa por obrigação acessória (desde 01/08/2026) não mudaram — só a rejeição técnica da 1115 foi suspensa. Título e corpo mantidos por precisar de contexto histórico; ver atualização e trechos corrigidos abaixo."
 tags:
   - "Reforma Tributária"
   - NF-e
@@ -20,7 +20,9 @@ tags:
   - "CRT 3"
 legalRefs:
   - instrumento: "NT 2025.002-RTC v1.40"
-    descricao: "Regras UB12-10 (Rejeição 1115) e W34-20 (Rejeição 1119) — produção obrigatória a partir de 03/08/2026 para o Regime Normal (CRT 3) e 04/01/2027 para Simples Nacional/MEI."
+    descricao: "Regras UB12-10 (Rejeição 1115) e W34-20 (Rejeição 1119) — produção obrigatória a partir de 03/08/2026 para o Regime Normal (CRT 3) e 04/01/2027 para Simples Nacional/MEI (texto vigente até a v1.51)."
+  - instrumento: "NT 2025.002 v1.51"
+    descricao: "Publicada em 04/08/2026: implementação em produção da Rejeição 1115 (UB12-10) alterada para \"implementação futura, sem data\". A Rejeição 1119 (W34-20) não foi afetada."
   - instrumento: "Ato Conjunto RFB/CGIBS nº 4/2026"
     descricao: "Publicado em 30/07/2026, confirma oficialmente o cronograma de obrigatoriedade de emissão de Documentos Fiscais Eletrônicos com IBS/CBS: 03/08/2026 mantido para NF-e (modelo 55) e NFC-e (modelo 65); demais documentos (NFS-e, CT-e etc.) recebem prazos individualizados por tipo."
   - instrumento: "Ato Conjunto RFB/CGIBS nº 1/2025"
@@ -40,13 +42,15 @@ legalRefs:
 
 <p><strong>Atualização (31/07/2026):</strong> o cronograma deixou de ser só previsão da NT 2025.002-RTC. O Ato Conjunto RFB/CGIBS nº 4/2026, publicado em 30/07/2026, confirma oficialmente 03/08/2026 para NF-e e NFC-e — e individualiza prazos por tipo de documento para o restante (NFS-e, CT-e etc.). Para quem emite pelo Regime Normal, nada mudou na prática: a data já era essa, agora está formalizada.</p>
 
+<p><strong>Atualização (08/08/2026):</strong> a NT 2025.002 v1.51, publicada em 04/08/2026, alterou o status da <strong>Rejeição 1115</strong> (regra UB12-10 — item sem IBS/CBS): a implementação em produção passou de "03/08/2026" para "implementação futura, sem data". Ou seja, hoje a SEFAZ ainda <strong>não</strong> rejeita a emissão só por um item estar sem IBS/CBS — essa checagem segue ativa apenas em homologação. A <strong>Rejeição 1119</strong> (grupo de totais ausente ou inconsistente, regra W34-20) não foi afetada e continua bloqueando a emissão desde 03/08/2026, como descrito abaixo. A obrigação legal de preencher IBS/CBS (LC 214) e a multa por obrigação acessória (Ato Conjunto RFB/CGIBS nº 1/2025, desde 01/08/2026) também não mudaram — só a rejeição técnica da 1115 na autorização foi suspensa. O restante deste texto foi escrito antes desse achado; onde citar bloqueio pela Rejeição 1115 especificamente, vale este parágrafo, não o texto original.</p>
+
 <h2>O que muda em 03/08/2026</h2>
 <p>A partir dessa data entram em produção obrigatória, para quem emite no Regime Normal (CRT 3), duas regras da NT 2025.002-RTC v1.40 que hoje já existem no ambiente de homologação, mas que passam a valer de verdade no ambiente de produção da SEFAZ:</p>
 <ul>
-<li>Regra <strong>UB12-10</strong>, associada à <strong>Rejeição 1115</strong>: item da NF-e sem preenchimento de IBS/CBS.</li>
-<li>Regra <strong>W34-20</strong>, associada à <strong>Rejeição 1119</strong>: grupo de totais da nota (o total de IBS/CBS/IS, tecnicamente chamado de IBSCBSTot) ausente quando ao menos um item já informa IBS/CBS.</li>
+<li>Regra <strong>UB12-10</strong>, associada à <strong>Rejeição 1115</strong>: item da NF-e sem preenchimento de IBS/CBS. <strong>Atualização:</strong> a implementação em produção desta regra foi suspensa pela NT 2025.002 v1.51 (04/08/2026) — ver atualização no início do texto. Hoje só bloqueia em homologação.</li>
+<li>Regra <strong>W34-20</strong>, associada à <strong>Rejeição 1119</strong>: grupo de totais da nota (o total de IBS/CBS/IS, tecnicamente chamado de IBSCBSTot) ausente quando ao menos um item já informa IBS/CBS. Não afetada pela v1.51 — segue no cronograma abaixo.</li>
 </ul>
-<p>Na prática: se um item da nota tem os campos de IBS/CBS preenchidos mas o bloco de totais da NF-e não reflete essa soma, ou se algum item simplesmente não traz esses campos, o documento não é mais aceito. Antes dessa data, esse tipo de inconsistência tende a passar; depois, não passa.</p>
+<p>Na prática, hoje: se o bloco de totais da NF-e não reflete a soma dos campos de IBS/CBS já preenchidos nos itens (Rejeição 1119), o documento não é aceito. Se algum item simplesmente não traz esses campos (Rejeição 1115), a nota ainda passa em produção — a rejeição por esse motivo específico está suspensa, sem data prevista.</p>
 
 <h2>Quem é afetado primeiro: Regime Normal x Simples Nacional/MEI</h2>
 <p>Essa obrigatoriedade é faseada por CRT (Código de Regime Tributário), o campo que identifica o regime do emitente na própria NF-e:</p>
@@ -60,7 +64,7 @@ legalRefs:
 <p>Esse é o ponto onde a maioria das análises apressadas erra. Existem duas datas próximas, mas com significados distintos:</p>
 <ul>
 <li><strong>01/08/2026</strong> — fim do prazo de carência de <em>multa por obrigação acessória</em> de IBS/CBS (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º). Até 31/07/2026, o descumprimento dessa obrigação acessória não gera multa; a partir de 01/08/2026, gera.</li>
-<li><strong>03/08/2026</strong> — data em que a <em>rejeição na emissão</em> (Rejeições 1115 e 1119, Regime Normal) passa a valer em produção na SEFAZ. É o primeiro dia útil após 01/08/2026 (sábado) e 02/08/2026 (domingo).</li>
+<li><strong>03/08/2026</strong> — data em que a <em>rejeição na emissão</em> por totais ausentes/inconsistentes (Rejeição 1119, Regime Normal) passa a valer em produção na SEFAZ. É o primeiro dia útil após 01/08/2026 (sábado) e 02/08/2026 (domingo). A Rejeição 1115 (item sem IBS/CBS) tinha a mesma data prevista, mas está com produção suspensa desde a NT 2025.002 v1.51 (04/08/2026) — ver atualização no início do texto.</li>
 </ul>
 <p>Ou seja: a partir de 01/08 já existe risco de multa por obrigação acessória descumprida, e a partir de 03/08 o documento simplesmente para de ser aceito se o problema persistir. Uma coisa reforça a outra, mas não são o mesmo evento.</p>
 <p>Há ainda um detalhe pouco divulgado: se a autuação decorrer <em>exclusivamente</em> do descumprimento dessa obrigação acessória de IBS/CBS, a LC 214/2025 (art. 348, §§ 3º e 4º, incluídos pela LC 227/2026) prevê mais 60 dias de prazo para regularizar antes da aplicação efetiva da multa. Isso não reduz o risco, mas muda o cronograma de reação em caso de autuação — vale conhecer antes de entrar em pânico.</p>

--- a/frontend/content/blog/penalidades-cbs-ibs-2026.mdx
+++ b/frontend/content/blog/penalidades-cbs-ibs-2026.mdx
@@ -8,6 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-06-26T06:48:06.000Z"
+updatedAt: "2026-08-08"
+updateNote: "NT 2025.002 v1.51 (04/08/2026): a implementação em produção da Rejeição 1115 (grupo IBS/CBS ausente do item, regra UB12-10) foi suspensa, sem data prevista — só a rejeição técnica na autorização, não a obrigação legal (LC 214) nem a multa por obrigação acessória (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º, desde 01/08/2026), que seguem valendo como descrito abaixo. Este post não cita a 1115 especificamente, mas trata do risco de penalidade em geral — registrado para não sugerir bloqueio de emissão que hoje não existe para esse caso."
 tags:
   - "penalidades"
   - CBS
@@ -31,6 +33,8 @@ legalRefs:
     descricao: "Caráter educativo em 2026 — obrigação acessória de IBS/CBS sem penalidade para fatos geradores no período; a multa por descumprimento passa a ser aplicável a partir do fim dessa janela."
   - instrumento: "NT 2025.002-RTC v1.40"
     descricao: "Regras de validação da NF-e/NFC-e para IBS/CBS — rejeições na emissão (ex.: incompatibilidade CST × cClassTrib, Rejeição 1024)."
+  - instrumento: "NT 2025.002 v1.51"
+    descricao: "Publicada em 04/08/2026: implementação em produção da Rejeição 1115 (UB12-10) suspensa, sem data. Obrigação legal e multa por obrigação acessória não mudaram."
   - instrumento: "Tabela cClassTrib SVRS"
     descricao: "Tabela oficial de classificação tributária (NCM × CST × cClassTrib) usada na validação dos documentos."
     link: "https://dfe-portal.svrs.rs.gov.br/Cff/ClassificacaoTributaria"

--- a/frontend/content/blog/rejeicao-960-nf-e.mdx
+++ b/frontend/content/blog/rejeicao-960-nf-e.mdx
@@ -8,8 +8,8 @@ author:
   jobTitle: "Conteúdo Fiscal"
   url: "https://tribultz.com.br/sobre"
 publishedAt: "2026-07-24T06:15:58.000Z"
-updatedAt: "2026-08-02"
-updateNote: "Post reescrito após revisão fiscal: a versão anterior descrevia a Rejeição 960 como divergência entre ICMS desonerado e redução de base de cálculo — definição incorreta, sem correspondência na regra oficial. A 960 pertence à família de validações do cClassTrib (regra N12-110, NT 2025.002-RTC v1.40)."
+updatedAt: "2026-08-08"
+updateNote: "Post reescrito após revisão fiscal: a versão anterior descrevia a Rejeição 960 como divergência entre ICMS desonerado e redução de base de cálculo — definição incorreta, sem correspondência na regra oficial. A 960 pertence à família de validações do cClassTrib (regra N12-110, NT 2025.002-RTC v1.40). Atualização (08/08/2026): a NT 2025.002 v1.51 (04/08/2026) alterou apenas a Rejeição 1115 (grupo IBS/CBS ausente do item, regra UB12-10) — implementação em produção suspensa, sem data. A Rejeição 960, tratada neste post, e a 1106 (regra LA01-30) não foram afetadas: seguem bloqueando a emissão desde 03/08/2026 quando o grupo IBS/CBS já está presente no item, mas o cClassTrib dentro dele está ausente ou malformado. Parágrafo sobre 03/08/2026 esclarecido abaixo para não confundir as duas regras."
 tags:
   - cClassTrib
   - "Rejeição 960"
@@ -21,6 +21,8 @@ coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/f
 legalRefs:
   - instrumento: "NT 2025.002-RTC v1.40"
     descricao: "Cataloga as regras do cClassTrib — Rejeições 960 (N12-110) e 1106 (LA01-30); produção a partir de 03/08/2026 para o Regime Normal (CRT 3)."
+  - instrumento: "NT 2025.002 v1.51"
+    descricao: "Publicada em 04/08/2026: altera apenas a Rejeição 1115 (grupo IBS/CBS ausente, UB12-10), com implementação em produção suspensa. Não afeta a Rejeição 960 (N12-110) nem a 1106 (LA01-30), tema deste post."
   - instrumento: "LC 214/2025"
     descricao: "Institui CBS e IBS; base das classificações tributárias da tabela cClassTrib (ex.: arts. 11 e 311 citados em códigos da família do CST 000)."
     link: "https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp214.htm"
@@ -47,7 +49,7 @@ soroGuid: "d8049955-7d7b-4aa1-9c92-e9ec045bf007"
 <ul><li><strong>CST 000</strong> (tributação integral): só 5 códigos — `000001` (situações tributadas integralmente), `000002` (exploração de via, art. 11 da LC 214/2025), `000003` (regime automotivo, art. 311 da LC 214/2025), entre outros.</li><li><strong>CST 200</strong> (alíquota reduzida): 54 códigos — a maior família da tabela.</li><li><strong>CST 410</strong> (imunidade/não incidência): 38 códigos.</li><li><strong>CST 550</strong> (suspensão): 25 códigos.</li><li><strong>CST 620</strong> (monofásica): 7 códigos.</li><li><strong>CST 820</strong> (split payment): 9 códigos.</li></ul>
 <p>Um cClassTrib da família 200 usado num item com CST 000, ou um código da família 000 usado num item CST 620, não passa na verificação de compatibilidade — mas essa é a <strong>1024</strong>, não a 960. Se a nota rejeitada citar 1024, o problema não é ausência ou formato: é a combinação entre os dois campos, e vale revisar o post específico sobre ela.</p>
 <h2>Por que isso ganha urgência a partir de 03/08/2026</h2>
-<p>A obrigatoriedade do grupo IBS/CBS — e, portanto, do cClassTrib dentro dele — segue o cronograma faseado da NT 2025.002 v1.40: produção a partir de <strong>03/08/2026</strong> para o Regime Normal (CRT 3) e <strong>04/01/2027</strong> para Simples Nacional/MEI. A partir dessa data, um item do Regime Normal sem cClassTrib válido deixa de ser um alerta e passa a travar a emissão.</p>
+<p>A obrigatoriedade do cClassTrib <strong>dentro de um item que já preenche o grupo IBS/CBS</strong> segue o cronograma faseado da NT 2025.002 v1.40: produção a partir de <strong>03/08/2026</strong> para o Regime Normal (CRT 3) e <strong>04/01/2027</strong> para Simples Nacional/MEI. A partir dessa data, um item do Regime Normal com o grupo IBS/CBS presente mas cClassTrib ausente ou malformado deixa de ser um alerta e passa a travar a emissão (Rejeição 960/1106). <strong>Atenção para não confundir com outra rejeição:</strong> se o item não tiver o grupo IBS/CBS de jeito nenhum, isso é a Rejeição 1115 (regra UB12-10) — e essa, diferente da 960, está com a implementação em produção suspensa pela NT 2025.002 v1.51 (04/08/2026), sem data prevista.</p>
 <p>Há também uma janela de penalidade que já se encerrou: o Ato Conjunto RFB/CGIBS nº 1/2025 (art. 3º) isentou de multa as obrigações acessórias de IBS/CBS para fatos geradores até 31/07/2026 — a partir de 01/08/2026, a penalidade voltou a ser aplicável. O art. 348, §§ 3º e 4º, da LC 214/2025 (incluídos pela LC 227/2026) ainda garante um Período Pedagógico: quem for autuado exclusivamente por essa obrigação acessória é notificado a regularizar em 60 dias contados da notificação (§ 3º); o cumprimento extingue a penalidade (§ 4º).</p>
 <h2>Como diagnosticar e corrigir a rejeição 960 NF-e</h2>
 <p>A correção deve seguir uma sequência que preserve rastreabilidade:</p>

--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -45,3 +45,20 @@ export const NT_CURRENT_VERSION: Record<string, string> = {
   "NT 2025.002": "1.40",
   "NT 2026.002": "1.00",
 };
+
+/**
+ * NT 2025.002 v1.51 (04/08/2026) e NT 2026.002 v1.10 (04/08/2026) foram publicadas
+ * mas NÃO disparam bump aqui — decisão deliberada, não esquecimento:
+ * - v1.51 é um patch pontual sobre UMA regra (UB12-10/Rejeição 1115 — implementação
+ *   em produção passou a "futura, sem data"); todo o resto de v1.40 permanece
+ *   ativo/inalterado (CST, cClassTrib, CEST, totais W03 etc.) — um bump aqui
+ *   marcaria ~13 posts hoje corretos como desatualizados (falso positivo em massa).
+ * - v1.10 é um lote de regras novas/alteradas (homologação 01/09, produção 05/10)
+ *   que o motor ainda não implementa; nosso core coberto (tpImp=6, 706/707/708/715,
+ *   I08-150/725) é do lote v1.00 e continua correto citando v1.00.
+ * O achado de v1.51 sobre a 1115 foi absorvido nos textos do motor (ver
+ * `ibscbsGroupPresenceSev`/`IBSCBS_PRESENCA_SUSPENSA_NOTE` em xmlRules.ts, que já
+ * citam v1.51 nesse ponto específico) e no updateNote dos posts afetados — não
+ * por este bump global. Reavaliar se uma NT futura alterar mais do que uma regra
+ * pontual, ou se o motor vier a implementar rules do lote v1.10.
+ */

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -19,13 +19,18 @@ test("NFSe com erros gera findings FATAL esperados", () => {
 
   const fatalIds = result.findings.filter((f) => f.severity === "FATAL").map((f) => f.rule_id);
   // Regulamento 30/abr/2026: CEST_MISSING downgraded to ALERT (apenas ST) — issue #275
-  // Original 3 format rules + IBSCBS_MISSING + LAYOUT_PORTAL
+  // NT 2025.002 v1.51 (04/08/2026): IBSCBS_MISSING (Rejeição 1115/UB12-10) deixou de
+  // ser FATAL — implementação em produção da rejeição está suspensa, sem data.
+  // Original 3 format rules + LAYOUT_PORTAL
   assert.ok(fatalIds.includes("CST_3_DIGITS"), "expected CST_3_DIGITS");
   assert.ok(fatalIds.includes("CCLASSTRIB_6_DIGITS"), "expected CCLASSTRIB_6_DIGITS");
   assert.ok(fatalIds.includes("SERVICE_CODE_6_DIGITS"), "expected SERVICE_CODE_6_DIGITS");
-  assert.ok(fatalIds.includes("IBSCBS_MISSING"), "expected IBSCBS_MISSING");
+  assert.ok(!fatalIds.includes("IBSCBS_MISSING"), "IBSCBS_MISSING não deve mais ser FATAL (v1.51)");
   assert.ok(fatalIds.includes("LAYOUT_PORTAL"), "expected LAYOUT_PORTAL");
-  assert.equal(fatalIds.length, 5);
+  assert.equal(fatalIds.length, 4);
+
+  const ibscbsFinding = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.equal(ibscbsFinding?.severity, "WARNING");
 });
 
 test("NFSe ok não gera FATAL", () => {
@@ -73,7 +78,7 @@ test("determinismo: mesmo XML + tipo gera mesmos finding ids e ordem", () => {
 
 // ── New rules (S7) — IBSCBS_MISSING ─────────────────────────────────────────
 
-test("IBSCBS_MISSING: nota sem tags IBS/CBS gera FATAL", () => {
+test("IBSCBS_MISSING: nota sem tags IBS/CBS gera WARNING (v1.51 — produção suspensa)", () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <NFS-e><infNfse>
   <PrestadorServico><RazaoSocial>X</RazaoSocial></PrestadorServico>
@@ -90,7 +95,7 @@ test("IBSCBS_MISSING: nota sem tags IBS/CBS gera FATAL", () => {
   const result = validateXmlWithRules({ tenantId: "t", documentType: "NFSE", xml });
   const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
   assert.ok(f, "IBSCBS_MISSING finding expected");
-  assert.equal(f!.severity, "FATAL");
+  assert.equal(f!.severity, "WARNING");
 });
 
 // ── New rules (S7) — IBSCBS_CALC ────────────────────────────────────────────
@@ -355,11 +360,11 @@ test("IBSCBS_MISSING: CRT 4 (MEI) sem IBS/CBS → WARNING (#311)", () => {
   assert.equal(f?.severity, "WARNING");
 });
 
-test("IBSCBS_MISSING: CRT 3 (Regime Normal) sem IBS/CBS → FATAL (#311)", () => {
+test("IBSCBS_MISSING: CRT 3 (Regime Normal) sem IBS/CBS → WARNING (v1.51 — produção suspensa, #311)", () => {
   const result = validateXmlWithRules({ tenantId: "t", documentType: "NFE", xml: nfeSemIbscbs("3") });
   const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
   assert.ok(f, "IBSCBS_MISSING esperado");
-  assert.equal(f!.severity, "FATAL");
+  assert.equal(f!.severity, "WARNING");
 });
 
 // ── S11: NFC-e ok — no FATALs ──────────────────────────────────────────────
@@ -670,6 +675,15 @@ test("SPLIT_PAYMENT_INDPAG: indPag=0 (à vista) sem CBS/IBS não gera finding", 
 // 31/07/2026 (regulamentos publicados 30/04/2026). A partir de 01/08/2026 a
 // penalidade volta a ser aplicável → severidade FATAL. pedagogicalMode (LC 227)
 // permanece como override manual independente da data.
+//
+// Veículo: IBSCBSTOT_MISSING (Rejeição 1119/W34-20), não IBSCBS_MISSING — desde a
+// NT 2025.002 v1.51 (04/08/2026), IBSCBS_MISSING (Rejeição 1115/UB12-10) é WARNING
+// incondicional (implementação em produção da rejeição suspensa, sem data — ver
+// testes dedicados logo abaixo) e não participa mais deste mecanismo de janela/
+// pedagogicalMode. IBSCBSTOT_MISSING permanece com o comportamento antigo,
+// inalterado (mapa NT v1.51 §2/§6b), e por isso segue sendo o veículo certo pra
+// testar a janela sem penalidades em si. Usa o fixture `nfeW03` (definido mais
+// abaixo, #403) — item com IBSCBS preenchido, IBSCBSTot ausente.
 
 const nfeAcessoriaErr = (crt: string, dhEmi?: string) => `<?xml version="1.0" encoding="UTF-8"?>
 <nfeProc><NFe><infNFe>
@@ -682,46 +696,69 @@ const nfeAcessoriaErr = (crt: string, dhEmi?: string) => `<?xml version="1.0" en
   <total></total>
 </infNFe></NFe></nfeProc>`;
 
-test("janela: CRT 3 com dhEmi 2026-07-31 → IBSCBS_MISSING WARNING (sem penalidade)", () => {
+test("janela: CRT 3, item c/ IBSCBS sem IBSCBSTot, dhEmi 2026-07-31 → IBSCBSTOT_MISSING WARNING (sem penalidade)", () => {
   const result = validateXmlWithRules({
-    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-07-31T10:00:00-03:00"),
+    tenantId: "t", documentType: "NFE", xml: nfeW03({ crt: "3", dhEmi: "2026-07-31T10:00:00-03:00", tot: false }),
   });
-  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
-  assert.ok(f, "IBSCBS_MISSING esperado");
+  const f = result.findings.find((f) => f.rule_id === "IBSCBSTOT_MISSING");
+  assert.ok(f, "IBSCBSTOT_MISSING esperado");
   assert.equal(f!.severity, "WARNING");
   assert.match(f!.recommendation ?? "", /Ato Conjunto RFB\/CGIBS/);
 });
 
-test("janela: CRT 3 com dhEmi 2026-08-01 → IBSCBS_MISSING FATAL (janela fechada)", () => {
+test("janela: CRT 3, dhEmi 2026-08-01 → IBSCBSTOT_MISSING FATAL (janela fechada)", () => {
   const result = validateXmlWithRules({
-    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-08-01T10:00:00-03:00"),
+    tenantId: "t", documentType: "NFE", xml: nfeW03({ crt: "3", dhEmi: "2026-08-01T10:00:00-03:00", tot: false }),
   });
-  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  const f = result.findings.find((f) => f.rule_id === "IBSCBSTOT_MISSING");
   assert.equal(f?.severity, "FATAL");
 });
 
-test("janela: CRT 3 com dhEmi 2026-08-15 → IBSCBS_MISSING FATAL", () => {
+test("janela: CRT 3, dhEmi 2026-08-15 → IBSCBSTOT_MISSING FATAL", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeW03({ crt: "3", dhEmi: "2026-08-15T10:00:00-03:00", tot: false }),
+  });
+  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBSTOT_MISSING")?.severity, "FATAL");
+});
+
+test("janela: CRT 3, dhEmi vazio → IBSCBSTOT_MISSING FATAL (comportamento preservado)", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeW03({ crt: "3", dhEmi: "", tot: false }),
+  });
+  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBSTOT_MISSING")?.severity, "FATAL");
+});
+
+test("janela: fora da janela + pedagogicalMode → IBSCBSTOT_MISSING WARNING com nota LC 227", () => {
+  const result = validateXmlWithRules({
+    tenantId: "t", documentType: "NFE", xml: nfeW03({ crt: "3", dhEmi: "2026-09-10T10:00:00-03:00", tot: false }),
+    pedagogicalMode: true,
+  });
+  const f = result.findings.find((f) => f.rule_id === "IBSCBSTOT_MISSING");
+  assert.equal(f?.severity, "WARNING");
+  assert.match(f!.recommendation ?? "", /LC 227\/2026/);
+});
+
+// ── NT 2025.002 v1.51 (04/08/2026): IBSCBS_MISSING sempre WARNING ────────────
+// Rejeição 1115/UB12-10 com implementação em produção suspensa (sem data) —
+// diferente de IBSCBSTOT_MISSING acima, não depende mais de CRT, janela do Ato
+// Conjunto 1/25 nem de pedagogicalMode.
+
+test("IBSCBS_MISSING v1.51: CRT 3, pós-01/08/2026, sem pedagogicalMode → ainda WARNING", () => {
   const result = validateXmlWithRules({
     tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-08-15T10:00:00-03:00"),
   });
-  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBS_MISSING")?.severity, "FATAL");
+  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
+  assert.ok(f, "IBSCBS_MISSING esperado");
+  assert.equal(f!.severity, "WARNING");
+  assert.match(f!.recommendation ?? "", /implementação em produção SUSPENSA/);
+  assert.match(f!.recommendation ?? "", /multa por obrigação acessória segue aplicável desde 01\/08\/2026/);
 });
 
-test("janela: CRT 3 sem dhEmi → IBSCBS_MISSING FATAL (comportamento preservado)", () => {
+test("IBSCBS_MISSING v1.51: CRT 3, sem dhEmi → ainda WARNING (não depende mais da janela)", () => {
   const result = validateXmlWithRules({
     tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3"),
   });
-  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBS_MISSING")?.severity, "FATAL");
-});
-
-test("janela: fora da janela + pedagogicalMode → WARNING com nota LC 227", () => {
-  const result = validateXmlWithRules({
-    tenantId: "t", documentType: "NFE", xml: nfeAcessoriaErr("3", "2026-09-10T10:00:00-03:00"),
-    pedagogicalMode: true,
-  });
-  const f = result.findings.find((f) => f.rule_id === "IBSCBS_MISSING");
-  assert.equal(f?.severity, "WARNING");
-  assert.match(f!.recommendation ?? "", /LC 227\/2026/);
+  assert.equal(result.findings.find((f) => f.rule_id === "IBSCBS_MISSING")?.severity, "WARNING");
 });
 
 test("janela: regra de formato (CST_3_DIGITS) dentro da janela → WARNING", () => {

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -47,8 +47,10 @@ const LC227_NOTE =
 // para o usuário saber exatamente como a SEFAZ rejeitará. Precedente: Rejeição 1157.
 const REJECTION_CODES: Record<string, string> = {
   IBSCBS_MISSING:
-    " — SEFAZ: Rejeição 1115 (regra UB12-10): preenchimento de IBS/CBS obrigatório — " +
-    "produção a partir de 03/08/2026 (Regime Normal/CRT 3) e 04/01/2027 (Simples/MEI), NT 2025.002 v1.40.",
+    " — SEFAZ: Rejeição 1115 (regra UB12-10): preenchimento de IBS/CBS obrigatório pela " +
+    "legislação desde 03/08/2026 (Regime Normal/CRT 3) e 04/01/2027 (Simples/MEI); a rejeição " +
+    "técnica na autorização está com implementação em produção SUSPENSA — \"implementação futura\", " +
+    "sem data (NT 2025.002 v1.51). Homologação segue ativa desde 01/07/2026.",
   CCLASSTRIB_6_DIGITS:
     " — SEFAZ: Rejeição 1106 (regra LA01-30) / 960 (regra N12-110): cClassTrib obrigatório " +
     "e com classificação tributária adequada (NT 2025.002 v1.40).",
@@ -350,8 +352,25 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
   // o downgrade por pedagogicalMode (LC 227) e pela janela sem penalidades (Ato
   // Conjunto 1/25) é centralizado no passe final, como nas outras regras acessórias.
   const ibsCbsMissingSev: FindingSeverity = isSimplesOrMei ? "WARNING" : "FATAL";
+  // NT 2025.002 v1.51 retirou do texto vigente a data técnica específica (04/01/2027)
+  // pra Simples/MEI; cronograma futuro fica pra NT ainda não publicada — citar só o
+  // marco legal (art. 348, LC 214) até lá, sem inventar data técnica que a NT não tem.
   const SIMPLES_MEI_NOTE =
-    " Simples Nacional/MEI: obrigatório a partir de 04/01/2027 (NT 2025.002 v1.40).";
+    " Simples Nacional/MEI: obrigatório a partir de 2027 (art. 348, LC 214/2025) —" +
+    " NT 2025.002 v1.51 retirou a data técnica específica do texto vigente; NT futura" +
+    " deve fixá-la.";
+  // Rejeição 1115 (UB12-10, grupo IBSCBS ausente) — NT 2025.002 v1.51 (04/08/2026):
+  // implementação em produção passou de "≥ 03/08/2026" para "implementação futura,
+  // sem data". A obrigação legal de preenchimento (LC 214) e a multa por obrigação
+  // acessória (Ato Conjunto RFB/CGIBS nº 1/2025, desde 01/08/2026) NÃO mudaram — só a
+  // rejeição técnica na autorização foi suspensa. WARNING para todo CRT (não mais
+  // faseado por Regime Normal × Simples/MEI, que já era WARNING antes por outro motivo).
+  const ibscbsGroupPresenceSev: FindingSeverity = "WARNING";
+  const IBSCBS_PRESENCA_SUSPENSA_NOTE =
+    " Obrigatório pela legislação desde 03/08/2026 (Regime Normal/CRT 3); a rejeição" +
+    " técnica na autorização (UB12-10/Rejeição 1115) está com implementação em produção" +
+    " SUSPENSA — \"implementação futura\", sem data (NT 2025.002 v1.51). A multa por" +
+    " obrigação acessória segue aplicável desde 01/08/2026 (Ato Conjunto RFB/CGIBS nº 1/2025).";
 
   // NF-e totals
   const ibscbsTot = firstTag(xml, ["IBSCBSTot"]);
@@ -524,7 +543,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
       pushFindingAndEvidence(findings, evidences, evidenceById,
         makeFinding({
           id: "F_IBSCBS_MISSING",
-          severity: ibsCbsMissingSev,
+          severity: ibscbsGroupPresenceSev,
           ruleId: "IBSCBS_MISSING",
           title: "Grupo IBSCBS ausente — obrigatório conforme NT 2025.002",
           field: "IBSCBS",
@@ -533,6 +552,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           evidenceId: evId,
           recommendation:
             "Informar grupo IBSCBS com CST, cClassTrib e campos de cálculo conforme NT 2025.002." +
+            IBSCBS_PRESENCA_SUSPENSA_NOTE +
             (isSimplesOrMei ? SIMPLES_MEI_NOTE : ""),
         }),
         makeEvidence({ id: evId, type: "xml", label: "IBSCBS — grupo ausente", xpath: inferXpath("imposto", docType), snippet: "<!-- Grupo <IBSCBS> não encontrado -->" }),
@@ -546,7 +566,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
       pushFindingAndEvidence(findings, evidences, evidenceById,
         makeFinding({
           id: "F_IBSCBS_MISSING",
-          severity: ibsCbsMissingSev,
+          severity: ibscbsGroupPresenceSev,
           ruleId: "IBSCBS_MISSING",
           title: "IBS/CBS ausentes na nota — obrigatório informar percentual e valor",
           field: "IBS/CBS",
@@ -555,6 +575,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           evidenceId: evId,
           recommendation:
             "Informar alíquota e valor de IBS (0,90%) e CBS (0,10%) conforme LC 214." +
+            IBSCBS_PRESENCA_SUSPENSA_NOTE +
             (isSimplesOrMei ? SIMPLES_MEI_NOTE : ""),
         }),
         makeEvidence({ id: evId, type: "xml", label: "IBS/CBS — campos ausentes", xpath: inferXpath("Valores", docType), snippet: "<!-- Tags ValorCBS, ValorIBS, AliquotaCBS, AliquotaIBS não encontradas -->" }),


### PR DESCRIPTION
## Resumo

Fase 2 do fechamento ENG-010: a NT 2025.002 v1.51 (04/08/2026) alterou o status da Rejeição 1115 (regra UB12-10 — grupo IBS/CBS ausente do item). Implementação em produção passou de "03/08/2026" para **"implementação futura, sem data"** — via Ato Técnico Conjunto CGIBS/RFB nº 1, de 31/07/2026. Homologação segue ativa desde 01/07/2026.

- A **obrigação legal** (LC 214) e a **multa por obrigação acessória** (Ato Conjunto RFB/CGIBS nº 1/2025, desde 01/08/2026) **não mudaram** — só a rejeição técnica na autorização da 1115 foi suspensa.
- A Rejeição **1119** (W34-20, grupo de totais) e as demais regras do lote v1.40 (960/N12-110, 1106/LA01-30, 1118, 1085, 1091 etc.) **não foram afetadas**.

Brain: PR companheiro em [mickbap/tribultz-brain#30](https://github.com/mickbap/tribultz-brain/pull/30) (base-legal.md + monitoramento.md).

## Mudanças

- **`xmlRules.ts` / `validate_xml.py`**: `IBSCBS_MISSING` vira WARNING incondicional (não depende mais de CRT, da janela do Ato Conjunto nº 1/2025 nem de `pedagogicalMode`) — a suspensão é da própria NT, não do faseamento legal. `IBSCBSTOT_MISSING` (1119) mantida sem alteração. Nota de Simples/MEI ajustada: a v1.51 retirou a data técnica específica (04/01/2027) do texto vigente.
- **`rulesMeta.ts`**: `NT_CURRENT_VERSION` deliberadamente **não** bumpado para v1.51/v1.10 — o check do `blogFiscalLint` compara por NT inteira, não por regra; bumpar marcaria ~13 posts hoje corretos (v1.40, regras não afetadas pela v1.51) como desatualizados. Decisão documentada inline no arquivo.
- **Testes**: os 5 testes de "janela sem penalidades" que usavam `IBSCBS_MISSING` como veículo foram migrados para `IBSCBSTOT_MISSING` (comportamento inalterado, ainda governado pela janela); nova cobertura confirma `IBSCBS_MISSING` sempre WARNING independente de CRT/janela.
- **4 posts do blog** (`nfe-rejeitada-03-08-2026-regime-normal-crt3`, `guia-rejeicoes-nt-2026-002-nf-e`, `rejeicao-960-nf-e`, `penalidades-cbs-ibs-2026`): `updateNote` + correções pontuais no corpo onde citavam bloqueio de emissão pela 1115 especificamente.

## Test plan

- [x] Frontend: `npm test --silent` — 200/200
- [x] Frontend: `npm run build` — limpo
- [x] Backend: `pytest tests/ -q` — 984 testes relevantes passando, `ruff check app/ tests/` limpo
- [x] Backend: 3 testes de exportação de PDF (`test_credits.py`, `test_prospect_diagnostic.py` ×2) excluídos da rodada — segfault pré-existente do WeasyPrint/cffi, confirmado **não relacionado** a esta mudança (reproduzido isoladamente na base antes desta branch); registrado à parte, fora do escopo desta PR
- [x] `test_founding_partners_admin.py::test_fluxo_completo_grant` — falha pré-existente e não relacionada (confirmada em isolamento, sem tocar nada de founding partners nesta branch); fora do escopo desta PR
