### PR TITLE
fix(tests): remove data hardcoded de test_fluxo_completo_grant

### DIFF
--- a/backend/tests/test_founding_partners_admin.py
+++ b/backend/tests/test_founding_partners_admin.py
@@ -102,7 +102,7 @@ def client_fixture(session):
 @pytestmark_db
 def test_fluxo_completo_grant(client, session):
     email = f"fp-{uuid.uuid4().hex[:8]}@empresa.com"
-    hoje = date(2026, 7, 8)
+    hoje = date.today()
     # 1. Admite empresa já com Grant (Plano Contador, vigência).
     r = client.post("/api/v1/admin/founding-partners", json={
         "empresa": "Contabilidade Duquesa", "email": email, "origem": "indicacao",


### PR DESCRIPTION
## Resumo

`test_fluxo_completo_grant` (`test_founding_partners_admin.py`) usava `hoje = date(2026, 7, 8)` fixo, com o Grant expirando em `hoje + 30 dias` = 2026-08-07. O teste passava enquanto a data real do ambiente ficava dentro dessa janela; a partir de 08/08/2026 o Grant já nasce expirado.

## Root cause (não é bug de produto)

`effective_grant_status()` (`app/models/founding_partner.py:238`) compara contra `datetime.now(timezone.utc)` por padrão — corretamente. Com a data real passando de 2026-08-07, o Grant criado pelo teste expira antes mesmo de o teste rodar, `effective_grant_status` retorna `"expired"` (não `"active"`), e `_ea_out` (`app/routers/founding_partners.py:80/112`) corretamente retorna `effective_plan: None` para um Grant expirado — é exatamente o comportamento que o Grant Adapter (ADR-0008) deve ter.

A massa de teste é que ficou obsoleta, não o código. `test_encerramento_revoga_e_bloqueia`, no mesmo arquivo, já usa `date.today()` corretamente — este PR alinha `test_fluxo_completo_grant` ao mesmo padrão.

## Mudança

Uma linha: `hoje = date(2026, 7, 8)` → `hoje = date.today()`.

## Test plan

- [x] `pytest tests/test_founding_partners_admin.py -q` — 4/4 passando
- [x] `ruff check tests/test_founding_partners_admin.py` — limpo