### PR TITLE
fix: correções da auditoria de infra/site de 11/08 (author.url 404, drift no CLAUDE.md, chave SSH)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ execução dele.
 | Backend | FastAPI, SQLAlchemy, Alembic, Python 3.12 |
 | AI/Agents | CrewAI 1.10 (CRM Engagement em produção; Security Crew interna; NFe Validation dormante — ver `knowledge/engineering/crews.md` no Brain), LiteLLM |
 | Workers | Celery 5.6 + Redis 7 (task queue / beat scheduler) |
-| Database | PostgreSQL 16 (multi-tenant, UUID PKs, tenant_id FK em todas as tabelas) |
-| Storage | MinIO (S3-compatible) |
-| Infra | Docker Compose (db, redis, minio, api, worker, beat) |
+| Database | PostgreSQL 16 (multi-tenant, UUID PKs, tenant_id FK em todas as tabelas). **Produção usa instância gerenciada** (host privado na Magalu), não container — o serviço `db` do compose existe só para dev local |
+| Storage | S3-compatible. **Produção: Magalu Object Storage** (`br-se1.magaluobjects.com`); dev local: MinIO (serviço `minio` do compose) |
+| Infra | Docker Compose. Dev local (`infra/docker-compose.yml`): db, redis, minio, migrate, api, worker, beat. **Produção (`infra/docker-compose.prod.yml`): redis, api, worker, beat** — sem `db` nem `minio`, que são serviços gerenciados |
 | CI/Automação | GitHub Actions — backend-gates, frontend-build, deploy-prod, monitor (uptime → alerta Resend), classtrib-sync (re-sync diário cClassTrib SVRS → PR revisado), soro-blog-sync (RSS Soro → PR revisado) |
 
 ## Estrutura do projeto

--- a/frontend/content/blog/api-validacao-xml-nfe-na-pratica.mdx
+++ b/frontend/content/blog/api-validacao-xml-nfe-na-pratica.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-30T01:39:44.000Z"
 tags:
   - "API"

--- a/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
+++ b/frontend/content/blog/classtrib-2026-mapear-ncm-regime-ibs-cbs.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-05"
 updatedAt: "2026-07-26"
 updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Referências à tabela cClassTrib SVRS deixaram de citar número de versão fixo, já que é re-sincronizada diariamente."

--- a/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
+++ b/frontend/content/blog/classtrib-2026-ncm-mapeamento-completo.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-05"
 updatedAt: "2026-07-26"
 updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Seção sobre versões da tabela cClassTrib reescrita: removidas afirmações específicas não verificáveis sobre a V1.36, substituídas por explicação de que a tabela é re-sincronizada diariamente da fonte oficial SVRS."

--- a/frontend/content/blog/como-calcular-aliquota-cbs-ibs.mdx
+++ b/frontend/content/blog/como-calcular-aliquota-cbs-ibs.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-25T14:13:01.000Z"
 tags: ["CBS", "IBS", "alíquota", "Reforma Tributária", "cClassTrib"]
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/4aa3737a-e38b-4624-a082-2472b7b92a70.webp"

--- a/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
+++ b/frontend/content/blog/como-classificar-ncm-corretamente-2026.mdx
@@ -6,7 +6,7 @@ category: "Classificação Fiscal"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-05"
 updatedAt: "2026-07-26"
 updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Referências à tabela cClassTrib SVRS deixaram de citar número de versão fixo, já que é re-sincronizada diariamente."

--- a/frontend/content/blog/como-prevenir-falhas-autorizadoras-emissao-fiscal.mdx
+++ b/frontend/content/blog/como-prevenir-falhas-autorizadoras-emissao-fiscal.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-08-03T05:03:28.000Z"
 tags:
   - "validação fiscal"

--- a/frontend/content/blog/como-revisar-catalogo-fiscal-ibs-cbs.mdx
+++ b/frontend/content/blog/como-revisar-catalogo-fiscal-ibs-cbs.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-26T06:03:37.000Z"
 tags:
   - "catálogo fiscal"

--- a/frontend/content/blog/evidencia-auditavel-reforma-tributaria.mdx
+++ b/frontend/content/blog/evidencia-auditavel-reforma-tributaria.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-16T00:40:40.000Z"
 tags:
   - "evidência auditável"

--- a/frontend/content/blog/exemplo-erro-cst-cclasstrib.mdx
+++ b/frontend/content/blog/exemplo-erro-cst-cclasstrib.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-22T01:01:43.000Z"
 tags:
   - CST

--- a/frontend/content/blog/guia-campos-fiscais-nfe.mdx
+++ b/frontend/content/blog/guia-campos-fiscais-nfe.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-08-07T05:34:03.000Z"
 tags:
   - NF-e

--- a/frontend/content/blog/guia-rejeicoes-nt-2026-002-nf-e.mdx
+++ b/frontend/content/blog/guia-rejeicoes-nt-2026-002-nf-e.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-28T06:21:30.000Z"
 updatedAt: "2026-08-08"
 updateNote: "NT 2026.002 v1.10, publicada em 04/08/2026, traz regras novas/alteradas (homologação 01/09/2026, produção 05/10/2026) — fora do escopo deste guia. A cobertura descrita aqui (DANFE Simplificado Tipo 2/tpImp=6, lote v1.00) não foi afetada e segue com produção a partir de 03/08/2026 para o Regime Normal."

--- a/frontend/content/blog/guia-sped-fiscal-reforma-tributaria.mdx
+++ b/frontend/content/blog/guia-sped-fiscal-reforma-tributaria.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-30T06:07:11.000Z"
 tags:
   - "SPED Fiscal"

--- a/frontend/content/blog/guia-testes-cbs-ibs-2026.mdx
+++ b/frontend/content/blog/guia-testes-cbs-ibs-2026.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-08-05T05:09:31.000Z"
 tags:
   - CBS

--- a/frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx
+++ b/frontend/content/blog/nfe-rejeitada-03-08-2026-regime-normal-crt3.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-14T12:00:00.000Z"
 updatedAt: "2026-08-08"
 updateNote: "NT 2025.002 v1.51 (04/08/2026): a Rejeição 1115 (regra UB12-10 — item sem IBS/CBS) teve a implementação em produção alterada de \"03/08/2026\" para \"implementação futura, sem data\" — hoje só bloqueia em homologação, não em produção. A Rejeição 1119 (totais, regra W34-20) segue inalterada, bloqueando desde 03/08/2026. A obrigação legal e a multa por obrigação acessória (desde 01/08/2026) não mudaram — só a rejeição técnica da 1115 foi suspensa. Título e corpo mantidos por precisar de contexto histórico; ver atualização e trechos corrigidos abaixo."

--- a/frontend/content/blog/penalidades-cbs-ibs-2026.mdx
+++ b/frontend/content/blog/penalidades-cbs-ibs-2026.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-26T06:48:06.000Z"
 updatedAt: "2026-08-08"
 updateNote: "NT 2025.002 v1.51 (04/08/2026): a implementação em produção da Rejeição 1115 (grupo IBS/CBS ausente do item, regra UB12-10) foi suspensa, sem data prevista — só a rejeição técnica na autorização, não a obrigação legal (LC 214) nem a multa por obrigação acessória (Ato Conjunto RFB/CGIBS nº 1/2025, art. 3º, desde 01/08/2026), que seguem valendo como descrito abaixo. Este post não cita a 1115 especificamente, mas trata do risco de penalidade em geral — registrado para não sugerir bloqueio de emissão que hoje não existe para esse caso."

--- a/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
+++ b/frontend/content/blog/rejeicao-1024-nfe-cbs-ibs-como-corrigir.mdx
@@ -6,7 +6,7 @@ category: "Compliance Fiscal"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-06-05"
 updatedAt: "2026-07-26"
 updateNote: "NT 2025.002 citada como V1.36 (desatualizada) — corrigido para a versão vigente, v1.40. Referências à tabela cClassTrib SVRS deixaram de citar número de versão fixo, já que é re-sincronizada diariamente."

--- a/frontend/content/blog/rejeicao-960-nf-e.mdx
+++ b/frontend/content/blog/rejeicao-960-nf-e.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-24T06:15:58.000Z"
 updatedAt: "2026-08-08"
 updateNote: "Post reescrito após revisão fiscal: a versão anterior descrevia a Rejeição 960 como divergência entre ICMS desonerado e redução de base de cálculo — definição incorreta, sem correspondência na regra oficial. A 960 pertence à família de validações do cClassTrib (regra N12-110, NT 2025.002-RTC v1.40). Atualização (08/08/2026): a NT 2025.002 v1.51 (04/08/2026) alterou apenas a Rejeição 1115 (grupo IBS/CBS ausente do item, regra UB12-10) — implementação em produção suspensa, sem data. A Rejeição 960, tratada neste post, e a 1106 (regra LA01-30) não foram afetadas: seguem bloqueando a emissão desde 03/08/2026 quando o grupo IBS/CBS já está presente no item, mas o cClassTrib dentro dele está ausente ou malformado. Parágrafo sobre 03/08/2026 esclarecido abaixo para não confundir as duas regras."

--- a/frontend/content/blog/validacao-deterministica-versus-conferencia-manual.mdx
+++ b/frontend/content/blog/validacao-deterministica-versus-conferencia-manual.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-08-01T04:18:29.000Z"
 tags:
   - "validação determinística"

--- a/frontend/content/blog/validacao-previa-ou-pos-emissao.mdx
+++ b/frontend/content/blog/validacao-previa-ou-pos-emissao.mdx
@@ -6,7 +6,7 @@ category: "Reforma Tributária"
 author:
   name: "Equipe Tribultz"
   jobTitle: "Conteúdo Fiscal"
-  url: "https://tribultz.com.br/sobre"
+  url: "https://tribultz.com.br"
 publishedAt: "2026-07-19T16:56:38.000Z"
 tags: ["validação", "NF-e", "ERP", "Reforma Tributária", "evidência auditável"]
 coverImage: "https://afocirmbqdxnkyescnev.supabase.co/storage/v1/object/public/featured-images/76fc4d86-d528-4294-a3c6-020f77cb3995/930e45c6-e657-4cd2-9b3c-b619c27e3527.webp"

--- a/frontend/src/lib/soroSync.ts
+++ b/frontend/src/lib/soroSync.ts
@@ -85,10 +85,15 @@ export function parseFeedToPosts(xml: string): SoroPost[] {
   });
 }
 
+// `url` alimenta o `author.url` e o `@id` (`${url}#person`) do JSON-LD do post
+// (ver `articleSchema` em components/seo/schemas.ts). Precisa resolver 200: até
+// 10/08/2026 apontava para `/sobre`, rota que nunca existiu, e 19 posts saíram
+// com autoria em 404. Aponta para a home, que é a URL canônica da Organization
+// — o autor editorial é a própria equipe, não uma pessoa com página própria.
 const EDITORIAL_AUTHOR = {
   name: "Equipe Tribultz",
   jobTitle: "Conteúdo Fiscal",
-  url: "https://tribultz.com.br/sobre",
+  url: "https://tribultz.com.br",
 };
 
 const yamlStr = (s: string) => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;

--- a/tools/check_access.sh
+++ b/tools/check_access.sh
@@ -10,12 +10,19 @@
 
 VM_HOST="201.54.20.18"
 VM_USER="ubuntu"
+# Prefere a chave dedicada de infra (sem passphrase) e cai para a pessoal se não
+# existir. Antes o default era `id_ed25519` fixo — no MacBook a chave que a VM
+# aceita é `id_tribultz`, então o script só rodava com SSH_KEY sobrescrito à mão.
+if [ -z "${SSH_KEY:-}" ] && [ -f "$HOME/.ssh/id_tribultz" ]; then
+  SSH_KEY="$HOME/.ssh/id_tribultz"
+fi
 SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
 # Fingerprints das chaves autorizadas na VM (públicos — não são segredo).
 # Ao adicionar uma máquina, autorize a chave em ~/.ssh/authorized_keys na VM e liste aqui.
 KEY_FPS="SHA256:ydI3GwtHcGHjUvcCzFQgOp7zypbiVwqqiicGlhun7gg=tribultz-infra (Windows)
 SHA256:6DqZCh26dT2Ce0KPD8ZwMXPtZ9++3siBctZKD1E+8ig=tribultz-infra (Mac)
-SHA256:9JtQfvh8yIebGMewdoenxW92w0XtRXJ/A8Ru9CYy9D0=tribultz-infra (MacBook Mickel)"
+SHA256:9JtQfvh8yIebGMewdoenxW92w0XtRXJ/A8Ru9CYy9D0=tribultz-infra (MacBook Mickel, id_ed25519 — pessoal, com passphrase)
+SHA256:wmgdpFALqdZQVqtkfrIjgjBNRK2lqr8mQJ/ClUcgLps=tribultz-infra (MacBook Mickel, id_tribultz — dedicada, sem passphrase)"
 API="https://api.tribultz.com.br"
 FRONTEND="https://tribultz.com.br"
 


### PR DESCRIPTION
Três correções levantadas na avaliação de infraestrutura e funcionalidades do site em 11/08/2026. Todas são correção de fato errado — nenhuma é evolução arquitetural.

## 1. `author.url` apontava para `/sobre` (404) em 19 posts

O JSON-LD de cada post emitia:

```json
{"@type":"Person","@id":"https://tribultz.com.br/sobre#person",
 "url":"https://tribultz.com.br/sobre"}
```

`/sobre` nunca existiu no app router. `author.url` é o sinal de autoria lido pelo Google para E-E-A-T — apontá-lo para 404 num site cuja proposta é autoridade fiscal enfraquece exatamente o que se quer provar.

A origem era `EDITORIAL_AUTHOR` em `soroSync.ts`, que carimba o frontmatter de todo post gerado do RSS. Corrigir só os 19 existentes deixaria o próximo nascer quebrado, então a fonte muda junto.

Alvo: `SITE_URL` (a home), URL canônica da Organization. Uma página `/sobre` dedicada seria mais forte para E-E-A-T, mas é trabalho de produto, não correção.

## 2. `CLAUDE.md` descrevia MinIO e `db`/`minio` como produção

Produção usa Postgres gerenciado e Magalu Object Storage; os containers na VM são só `redis`, `api`, `worker`, `beat`. O erro não era imprecisão — era misturar dois ambientes: `db` e `minio` estão corretos para dev local. A correção separa os dois em vez de trocar um pelo outro.

O `operations_runbook.md` já documentava a topologia certa (linhas 36, 198-203). O drift era só neste resumo.

## 3. `check_access.sh` não reconhecia a chave que autentica no Mac

`KEY_FPS` não listava `id_tribultz`, e `SSH_KEY` defaultava para `id_ed25519` (pessoal, com passphrase) — o script só rodava com override manual. Agora prefere a dedicada com fallback preservado para as outras máquinas. Nenhuma entrada foi removida.

`10 ok / 1 aviso / 0 falhas`, contra `9 ok / 2 avisos` antes.

## Gates

- `npm test` — **200 passam, 0 falham**
- `npm run build` — **passa**
- `npm run content:lint` — **exit 0**, 0 auto-fixes pendentes (os 4 warnings `PROMESSA` são pré-existentes e não relacionados)
- `check_access.sh` — 10 ok / 1 aviso / 0 falhas

Correção do item 1 verificada no HTML gerado pelo build: `Person.url` resolve 200 e nenhuma ocorrência de `/sobre` permanece.

Backend não foi tocado.

## Nota de escopo

Três correções num PR só, em commits atômicos, por virem da mesma auditoria e serem de baixo risco. Se preferirem o padrão de um PR por issue, dá para separar — o item 1 é o único que toca código de produção.