### PR TITLE
fix(motor): VC02-14 — produção é 05/10/2026, não 01/09 (NT 2025.002 v1.51)

### DIFF
--- a/frontend/src/lib/validation/rulesMeta.ts
+++ b/frontend/src/lib/validation/rulesMeta.ts
@@ -49,10 +49,16 @@ export const NT_CURRENT_VERSION: Record<string, string> = {
 /**
  * NT 2025.002 v1.51 (04/08/2026) e NT 2026.002 v1.10 (04/08/2026) foram publicadas
  * mas NÃO disparam bump aqui — decisão deliberada, não esquecimento:
- * - v1.51 é um patch pontual sobre UMA regra (UB12-10/Rejeição 1115 — implementação
- *   em produção passou a "futura, sem data"); todo o resto de v1.40 permanece
- *   ativo/inalterado (CST, cClassTrib, CEST, totais W03 etc.) — um bump aqui
- *   marcaria ~13 posts hoje corretos como desatualizados (falso positivo em massa).
+ * - v1.51 tem DUAS frentes (corrigido em 11/08/2026 — a redação anterior dizia que era
+ *   "um patch pontual sobre UMA regra", o que é falso e fez o diff ser dispensado):
+ *     (a) UB12-10/Rejeição 1115 — implementação em produção passou a "futura, sem data";
+ *     (b) ~22 regras alteradas (B25-80, I08-140, I08-144, família UB13–UB131, VC02-14,
+ *         VC02-30), homologação até 01/09/2026 e produção a partir de 05/10/2026.
+ *   Do grupo (b) o motor implementa só VC02-14, já ajustada (ver DEVOLUCAO_DFEREF_DATE
+ *   em xmlRules.ts). As demais não são cobertas — lacuna de cobertura, não regressão.
+ *   O núcleo que os posts citam (CST, cClassTrib, CEST, totais W03) segue inalterado,
+ *   e é por isso que o bump global continua indevido: marcaria ~13 posts hoje corretos
+ *   como desatualizados (falso positivo em massa).
  * - v1.10 é um lote de regras novas/alteradas (homologação 01/09, produção 05/10)
  *   que o motor ainda não implementa; nosso core coberto (tpImp=6, 706/707/708/715,
  *   I08-150/725) é do lote v1.00 e continua correto citando v1.00.

--- a/frontend/src/lib/validation/xmlRules.test.ts
+++ b/frontend/src/lib/validation/xmlRules.test.ts
@@ -986,14 +986,26 @@ function devFindings(xml: string, pedagogicalMode = false) {
     .findings.filter((f) => f.rule_id === "DEVOLUCAO_DFEREF");
 }
 
-test("#312 devolução sem DFeReferenciado após 01/09 → FATAL", () => {
-  const f = devFindings(devNfe("4", "2026-09-15", 1, 0));
+test("#312 devolução sem DFeReferenciado após 05/10 (produção) → FATAL", () => {
+  const f = devFindings(devNfe("4", "2026-10-15", 1, 0));
   assert.ok(f.some((x) => x.id === "F_DEVOLUCAO_DFEREF" && x.severity === "FATAL"));
 });
 
 test("#312 devolução sem DFeReferenciado antes da vigência → WARNING", () => {
   const f = devFindings(devNfe("4", "2026-08-15", 1, 0));
   assert.ok(f.length > 0 && f.every((x) => x.severity === "WARNING"));
+});
+
+// Guarda de regressão da janela 01/09–04/10/2026: a v1.40 punha produção em 01/09 e a
+// v1.51 adiou para 05/10. Neste intervalo a regra vale em homologação, mas a SEFAZ ainda
+// autoriza em produção — escalar para FATAL aqui é falso positivo. Se alguém restaurar a
+// data antiga, este teste quebra.
+test("#312 devolução sem DFeReferenciado na janela 01/09–04/10 (só homologação) → WARNING", () => {
+  for (const d of ["2026-09-01", "2026-09-15", "2026-10-04"]) {
+    const f = devFindings(devNfe("4", d, 1, 0));
+    assert.ok(f.length > 0, `esperava finding em ${d}`);
+    assert.ok(f.every((x) => x.severity === "WARNING"), `esperava WARNING em ${d}`);
+  }
 });
 
 test("#312 devolução com DFeReferenciado por item → sem finding", () => {

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -104,9 +104,15 @@ function isWithinNoPenaltyWindow(emissionDate: string | undefined): boolean {
 // editar sem checar se um ato mais recente adiou de novo.
 const PF_CNPJ_REQUIRED_DATE = "2027-01-01";
 
-// NF-e de devolução (finNFe=4): a partir de 01/09/2026 referencia a nota original por item,
-// exclusivamente via grupo DFeReferenciado (v1.40, Rejeição 321 — VC02-14/VC03-20).
-const DEVOLUCAO_DFEREF_DATE = "2026-09-01";
+// NF-e de devolução (finNFe=4): referencia a nota original por item, exclusivamente via
+// grupo DFeReferenciado (Rejeição 321 — VC02-14/VC03-20). Data é de PRODUÇÃO, porque é
+// quando a SEFAZ passa a recusar de fato — homologação (até 01/09/2026) não deve escalar
+// severidade de nota real.
+// A v1.40 marcava produção em 01/09/2026; a v1.51 adiou para 05/10/2026 — o texto da NT
+// traz "a partir de 01/09/2026 05/10/2026", com a data antiga tachada (Observação 2 da
+// VC02-14). Manter 01/09 marcaria como FATAL, por 5 semanas, nota que ainda é autorizada.
+// VC03-20 não foi alterada pela v1.51; só VC02-14 e VC02-30 constam do histórico.
+const DEVOLUCAO_DFEREF_DATE = "2026-10-05";
 
 // DANFE Simplificado Tipo 2 (tpImp=6, NT 2026.002 v1.00): a partir de 03/08/2026 (produção,
 // fase 2), a NF-e (modelo 55) restringe-se a saída/interna/sem NFref/finalidade Normal (#405).
@@ -1054,7 +1060,9 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
             evidenceId: evId,
             recommendation:
               "NF-e de devolução (finNFe=4) deve referenciar a nota original POR ITEM, " +
-              "exclusivamente via grupo DFeReferenciado (NT 2025.002-RTC v1.40, vigência 01/09/2026). " +
+              "exclusivamente via grupo DFeReferenciado — é proibido referenciar em refNFe na devolução. " +
+              "Produção a partir de 05/10/2026 (NT 2025.002-RTC v1.51, que adiou a data da v1.40, " +
+              "01/09/2026); homologação desde 01/09/2026. " +
               "Inclua um DFeReferenciado para cada item devolvido. SEFAZ: Rejeição 321 (regras VC02-14 / VC03-20).",
           }),
           makeEvidence({ id: evId, type: "xml", label: "Devolução sem DFeReferenciado por item", xpath: inferXpath("DFeReferenciado", docType), snippet: fin.snippet }),

--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -111,7 +111,11 @@ const PF_CNPJ_REQUIRED_DATE = "2027-01-01";
 // A v1.40 marcava produção em 01/09/2026; a v1.51 adiou para 05/10/2026 — o texto da NT
 // traz "a partir de 01/09/2026 05/10/2026", com a data antiga tachada (Observação 2 da
 // VC02-14). Manter 01/09 marcaria como FATAL, por 5 semanas, nota que ainda é autorizada.
-// VC03-20 não foi alterada pela v1.51; só VC02-14 e VC02-30 constam do histórico.
+// Não citar VC03-20 aqui: ela é Rejeição 1048 ("nItem do DFeReferenciado não informado"),
+// gatilho distinto — nItem ausente DENTRO de um DFeReferenciado presente. Esta regra conta
+// ocorrências do grupo e não inspeciona nItem, então VC03-20 não está coberta. Até 11/08/2026
+// a recomendação citava "Rejeição 321 (regras VC02-14 / VC03-20)", atribuindo à VC03-20 um
+// código que não é dela. VC03-20 e VC02-30 também não foram alteradas pela v1.51.
 const DEVOLUCAO_DFEREF_DATE = "2026-10-05";
 
 // DANFE Simplificado Tipo 2 (tpImp=6, NT 2026.002 v1.00): a partir de 03/08/2026 (produção,
@@ -1063,7 +1067,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
               "exclusivamente via grupo DFeReferenciado — é proibido referenciar em refNFe na devolução. " +
               "Produção a partir de 05/10/2026 (NT 2025.002-RTC v1.51, que adiou a data da v1.40, " +
               "01/09/2026); homologação desde 01/09/2026. " +
-              "Inclua um DFeReferenciado para cada item devolvido. SEFAZ: Rejeição 321 (regras VC02-14 / VC03-20).",
+              "Inclua um DFeReferenciado para cada item devolvido. SEFAZ: Rejeição 321 (regra VC02-14).",
           }),
           makeEvidence({ id: evId, type: "xml", label: "Devolução sem DFeReferenciado por item", xpath: inferXpath("DFeReferenciado", docType), snippet: fin.snippet }),
         );


### PR DESCRIPTION
Fecha #614.

## O defeito

A regra `DEVOLUCAO_DFEREF` escalava de `WARNING` para **`FATAL`** a partir de `2026-09-01`, data herdada da v1.40. A v1.51 adiou a implementação em produção para **05/10/2026**.

**Janela do falso positivo: 01/09 a 04/10/2026 — cinco semanas.** Nesse intervalo marcaríamos como fatal uma devolução sem `DFeReferenciado` que a SEFAZ ainda autoriza. É o erro na direção que mais custa credibilidade num validador: acusar problema onde não há. **01/09 é daqui a três semanas.**

## Fonte primária

NT 2025.002-RTC v1.51, Observação 2 da regra `VC02-14`:

> Implementação em produção a partir de ~~01/09/2026~~ 05/10/2026.

A data antiga aparece tachada no PDF. O Histórico de Alterações confirma — a linha da v1.51 lista `VC02-14` e `VC02-30`:

| Versão | Homologação | Produção |
|---|---|---|
| 1.40 (VC02-14) | Até 01/07/2026 | 01/09/2026 |
| **1.51** (inclui VC02-14, VC02-30) | Até 01/09/2026 | **05/10/2026** |

Modelamos a data de **produção**, porque é quando a SEFAZ passa a recusar. Homologação (desde 01/09) não deve escalar severidade de nota real.

`VC03-20`, citada junto na recomendação, **não** foi alterada — só `VC02-14` e `VC02-30` constam do histórico.

## Correção do comentário que causou o problema

`rulesMeta.ts` afirmava que a v1.51 era *"um patch pontual sobre UMA regra"* e que *"todo o resto de v1.40 permanece ativo/inalterado"*.

É falso. A v1.51 tem duas frentes: a suspensão da `UB12-10` **e** ~22 regras alteradas com produção em 05/10/2026. Essa redação foi a razão de o diff da v1.51 ter sido dispensado — o comentário era convincente e estava errado.

Do segundo grupo o motor implementa só `VC02-14`. As demais seguem como lacuna de cobertura, registrada em #614.

O bump global de `NT_CURRENT_VERSION` continua indevido, e agora pelo motivo certo: o núcleo que os posts citam (CST, cClassTrib, CEST, totais W03) segue inalterado.

## Teste

Guarda de regressão nova cobrindo a janela: `01/09`, `15/09` e `04/10` devem produzir `WARNING`. Quebra se alguém restaurar a data antiga — o teste anterior exigia `FATAL` em 15/09, então os dois não coexistem.

## Gates

- `npm test` — **201 passam, 0 falham** (era 200; +1 é a guarda)
- `npm run build` — **compila**

Backend não foi tocado.