### PR TITLE
fix(motor): alíquotas de CBS e IBS estavam trocadas na recomendação

### DIFF
--- a/frontend/src/lib/validation/xmlRules.ts
+++ b/frontend/src/lib/validation/xmlRules.ts
@@ -584,7 +584,7 @@ export function validateXmlWithRules(input: ValidationInput): ValidationResultV1
           snippet: "<!-- Tags ValorCBS, ValorIBS, AliquotaCBS, AliquotaIBS não encontradas -->",
           evidenceId: evId,
           recommendation:
-            "Informar alíquota e valor de IBS (0,90%) e CBS (0,10%) conforme LC 214." +
+            "Informar alíquota e valor de CBS (0,90%) e IBS (0,10%) conforme LC 214." +
             IBSCBS_PRESENCA_SUSPENSA_NOTE +
             (isSimplesOrMei ? SIMPLES_MEI_NOTE : ""),
         }),


### PR DESCRIPTION
A recomendação de `IBSCBS_MISSING` dizia:

> "Informar alíquota e valor de **IBS (0,90%)** e **CBS (0,10%)** conforme LC 214."

Invertido. Na fase de teste é **CBS = 0,9%** e **IBS = 0,1%** — como o CLAUDE.md registra e a NT 2025.002-RTC confirma na `UB56-10` ("Alíquota da CBS deve ser igual a 0,9%", art. 346 da LC 214/2025).

O texto sai para o contribuinte numa nota que já está com problema, e entrega os dois números centrais da reforma trocados entre si.

**Gates:** 201 testes passam, 0 falham.

---

## Nota de escopo

Este PR ia ser a implementação da `UB56-10` (validação do valor da alíquota, #614) — o motor hoje valida o cálculo `vCBS = vBC × pCBS` mas nunca a alíquota em si, então `pCBS` de 8,8% em 2026 passa se o valor for coerente.

Segurei, por dois motivos que apareceram na investigação:

**1.** A `UB56-10` e as análogas de IBS têm exceção baseada em `ind_gTribRegular`, indicador do cClassTrib que **não existe na nossa cópia da tabela** (temos `reduction_ibs_pct`, `tipo_aliquota`, `permite_cred_pres` e outros, mas não esse).

**2.** Mais grave — o limiar da regra depende de resolver **#617**: a NT define `pCBS`/`pIBSUF`/`pIBSMun` como percentuais e divide por 100 em todas as fórmulas, enquanto o motor os trata como fração. Se a NT estiver certa, `IBSCBS_CALC` marca FATAL em toda NF-e correta. Implementar a `UB56-10` antes disso seria construir sobre premissa não verificada.