### PR TITLE
docs(crm): decisão de arquitetura — backend custom como caminho de automação do Attio (Round 2)

### DIFF
--- a/docs/context/project_crm_attio_decisao_integracao.md
+++ b/docs/context/project_crm_attio_decisao_integracao.md
@@ -1,0 +1,37 @@
+# Decisão — Integração Attio: backend custom é o caminho oficial de automação
+
+> Registrada em 12/08/2026 por ordem do Round 2 (Ermes — Produto/Vendas), seção 1.
+> Decisão de arquitetura **FECHADA**. Contexto do programa: PO-2026-07-CRM-001.
+
+## Decisão
+
+Para o fluxo operacional do Programa Comercial (handoff Rumy → Attio):
+
+- **Backend custom** (`backend/app/integrations/attio/` — cliente HTTP próprio, fatias
+  da PO-2026-07-CRM-001) é o **caminho oficial de integração automática** com o Attio.
+- O **MCP oficial do Attio** (`.mcp.json` → `https://mcp.attio.com/mcp`, PR #572)
+  continua existindo para **operações assistidas/interativas** (consulta e apoio via
+  agente com sessão humana), mas **não é mecanismo de automação** do handoff.
+
+**Motivo funcional**: o handoff precisa ocorrer **por evento**, sem depender de uma
+sessão humana autenticada. O MCP pressupõe sessão interativa autenticada por usuário
+(OAuth); automação orientada a evento exige credencial de serviço e código versionado,
+testável e auditável — o backend custom.
+
+## Tratamento da proposta de revert
+
+- **PR #571** ("revert(crm): remove integração backend do Attio, adota MCP oficial")
+  permanece **fechado sem merge**, como registro histórico da alternativa avaliada. A
+  parte que valia por conta própria (o MCP para uso assistido) foi extraída e mergeada
+  no PR #572.
+- A branch remota **`revert/attio-backend-integration`** fica obsoleta com esta
+  decisão. **Recomendação**: excluí-la após o aceite do Round 2 (o conteúdo permanece
+  preservado no PR #571 fechado). A exclusão **não foi executada** no Round 2, que
+  veda remoção de código.
+
+## Registro canônico
+
+O ADR canônico desta decisão deve entrar no Brain (`knowledge/decisions/`) pelo gate
+de entrada vigente; este arquivo é o registro operacional no repositório do produto.
+Pendência conhecida: clone local do Brain desatualizado nesta máquina (apontada no
+parecer QA do Round 1, bloqueio B-8).


### PR DESCRIPTION
Registra formalmente a decisão FECHADA do Round 2 (Ermes, 12/08/2026, seção 1): **backend custom** (`backend/app/integrations/attio/`) é o caminho oficial de integração automática do handoff comercial; o **MCP oficial** (`.mcp.json`) permanece para operações assistidas/interativas, não automação. Motivo funcional: handoff por evento, sem sessão humana autenticada.

Inclui o tratamento recomendado da proposta de revert: PR #571 permanece fechado sem merge (registro histórico); branch `revert/attio-backend-integration` recomendada para exclusão após aceite do Round 2 (não executada — Round veda remoção de código).

Docs-only — não dispara deploy.