### PR TITLE
feat(crm): fundações do handoff Rumy→Attio — F1 persistência + F3 domínio local (Round 4)

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -8,9 +8,10 @@ from alembic import context
 from app.database import Base
 from app.config import settings
 from app.models import (  # noqa: F401
-    api_key, auth, billing, documents, feedback, founding_partner, jobs, news,
-    partner, prospect_dedup_run, prospect_diagnostic, prospect_ingestion_run,
-    prospect_org, prospect_scoring_run, prospect_suppression, reports,
+    api_key, auth, billing, crm_handoff, documents, feedback, founding_partner,
+    jobs, news, partner, prospect_dedup_run, prospect_diagnostic,
+    prospect_ingestion_run, prospect_org, prospect_scoring_run,
+    prospect_suppression, reports,
 )
 
 # Import models to register them with metadata

--- a/backend/app/alembic/versions/2026_08_12_0037_add_crm_handoff_foundations.py
+++ b/backend/app/alembic/versions/2026_08_12_0037_add_crm_handoff_foundations.py
@@ -1,0 +1,216 @@
+"""Fundações do handoff comercial Rumy→Tribultz→Attio — F1 do Round 4 (PO-2026-07-CRM-001).
+
+Cria as quatro tabelas do domínio de handoff: identidade de pessoa (DEC-5),
+vínculo operacional do lead, ledger append-only de eventos e trilha de
+transições de estado. Espelha app/models/crm_handoff.py coluna a coluna
+(fonte única do schema é o Alembic, #409).
+
+Revision ID: 2026_08_12_0037
+Revises: 2026_07_28_0036
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "2026_08_12_0037"
+down_revision = "2026_07_28_0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "crm_person_identities",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("email_normalized", sa.String(length=320), nullable=True),
+        sa.Column("linkedin_normalized", sa.String(length=255), nullable=True),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.CheckConstraint(
+            "email_normalized IS NOT NULL OR linkedin_normalized IS NOT NULL",
+            name="ck_crm_person_identities_has_key",
+        ),
+    )
+    op.create_index(
+        "uq_crm_person_identities_tenant_email",
+        "crm_person_identities",
+        ["tenant_id", "email_normalized"],
+        unique=True,
+        postgresql_where=sa.text("email_normalized IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_crm_person_identities_tenant_linkedin",
+        "crm_person_identities",
+        ["tenant_id", "linkedin_normalized"],
+        unique=True,
+        postgresql_where=sa.text("linkedin_normalized IS NOT NULL"),
+    )
+
+    op.create_table(
+        "crm_lead_links",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("source_system", sa.String(length=32), nullable=False, server_default="rumy"),
+        sa.Column("external_lead_id", sa.String(length=128), nullable=False),
+        sa.Column(
+            "person_identity_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("crm_person_identities.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "identity_conflict", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "provider_ids", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")
+        ),
+        sa.Column("attio_person_id", sa.String(length=64), nullable=True),
+        sa.Column("attio_company_id", sa.String(length=64), nullable=True),
+        sa.Column("attio_deal_id", sa.String(length=64), nullable=True),
+        sa.Column("commercial_state", sa.String(length=32), nullable=True),
+        sa.Column(
+            "ownership_state", sa.String(length=24), nullable=False, server_default="AUTOMATED"
+        ),
+        sa.Column(
+            "automation_state", sa.String(length=32), nullable=False, server_default="ACTIVE"
+        ),
+        sa.Column("owner_ref", sa.String(length=128), nullable=True),
+        sa.Column("handoff_requested_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("handoff_accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("first_human_action_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("suppression_requested_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("suppression_confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_applied_event_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("last_occurred_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.UniqueConstraint(
+            "tenant_id", "source_system", "external_lead_id", name="uq_crm_lead_links_identity"
+        ),
+    )
+    op.create_index("ix_crm_lead_links_person", "crm_lead_links", ["person_identity_id"])
+
+    op.create_table(
+        "crm_lead_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("source_system", sa.String(length=32), nullable=False),
+        sa.Column("external_lead_id", sa.String(length=128), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+        sa.Column("provider_event_id", sa.String(length=128), nullable=True),
+        sa.Column("schema_version", sa.String(length=16), nullable=False),
+        sa.Column("adapter_version", sa.String(length=32), nullable=True),
+        sa.Column("event_type_raw", sa.String(length=128), nullable=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "occurred_at_source", sa.String(length=16), nullable=False, server_default="provider"
+        ),
+        sa.Column(
+            "received_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column("payload_raw", postgresql.JSONB(), nullable=True),
+        sa.Column("payload_normalized", postgresql.JSONB(), nullable=True),
+        sa.Column("payload_hash", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="received"),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("applied_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("processing_result", postgresql.JSONB(), nullable=True),
+        sa.UniqueConstraint("idempotency_key", name="uq_crm_lead_events_idempotency"),
+    )
+    op.create_index(
+        "ix_crm_lead_events_lead",
+        "crm_lead_events",
+        ["tenant_id", "source_system", "external_lead_id", "occurred_at"],
+    )
+
+    op.create_table(
+        "crm_state_transitions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "lead_link_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("crm_lead_links.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("axis", sa.String(length=16), nullable=False),
+        sa.Column("from_state", sa.String(length=32), nullable=True),
+        sa.Column("to_state", sa.String(length=32), nullable=False),
+        sa.Column("actor_type", sa.String(length=16), nullable=False),
+        sa.Column("actor_ref", sa.String(length=128), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+    )
+    op.create_index(
+        "ix_crm_state_transitions_link", "crm_state_transitions", ["lead_link_id", "created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_crm_state_transitions_link", table_name="crm_state_transitions")
+    op.drop_table("crm_state_transitions")
+    op.drop_index("ix_crm_lead_events_lead", table_name="crm_lead_events")
+    op.drop_table("crm_lead_events")
+    op.drop_index("ix_crm_lead_links_person", table_name="crm_lead_links")
+    op.drop_table("crm_lead_links")
+    op.drop_index("uq_crm_person_identities_tenant_linkedin", table_name="crm_person_identities")
+    op.drop_index("uq_crm_person_identities_tenant_email", table_name="crm_person_identities")
+    op.drop_table("crm_person_identities")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -47,6 +47,18 @@ class Settings(BaseSettings):
     ATTIO_DEFAULT_PIPELINE: str = ""
     ATTIO_DEFAULT_STAGE: str = ""
     ATTIO_WEBHOOK_SECRET: str = ""
+
+    # ── Rumy (AI SDR — handoff comercial, Round 4 da PO-2026-07-CRM-001) ────
+    # Fundações locais apenas (F1/F3): flags OFF por padrão e nenhum efeito
+    # externo. Endpoint do webhook, supressão real no Rumy e handoff automático
+    # aguardam Rounds futuros (F2/F5). Regra fail-safe transversal: desligar
+    # qualquer flag NUNCA re-permite outbound — a permissão é conjuntiva e a
+    # proteção de pessoa (DEC-5) persiste independente de flag.
+    RUMY_WEBHOOK_ENABLED: bool = False
+    HANDOFF_APPLY_ENABLED: bool = False
+    RUMY_SUPPRESSION_ENABLED: bool = False
+    RUMY_WEBHOOK_SECRET: str = ""
+
     # ── Security ────────────────────────────────────────────
     ALLOWED_ORIGINS: str = "http://localhost:3000,https://tribultz.com.br,https://*.vercel.app"
     ENVIRONMENT: str = "development"  # development | staging | production

--- a/backend/app/models/crm_handoff.py
+++ b/backend/app/models/crm_handoff.py
@@ -1,0 +1,210 @@
+"""Fundações do handoff comercial Rumy → Tribultz → Attio (Round 4, PO-2026-07-CRM-001).
+
+Quatro tabelas, dois papéis:
+
+- Estado corrente: ``crm_person_identities`` (identidade de pessoa, DEC-5) e
+  ``crm_lead_links`` (vínculo operacional lead externo ↔ Tribultz ↔ Attio, com os
+  eixos ownership/automation).
+- Ledger: ``crm_lead_events`` (append-only, dedupe-store de idempotência e fonte
+  de auditoria) e ``crm_state_transitions`` (trilha de toda transição de estado).
+
+Identidade lógica de lead: (tenant_id, source_system, external_lead_id) — nunca
+um id externo global (Round 4 §11). A proteção contra retomada de automação é
+por PESSOA (DEC-5): um novo external_lead_id não é nova permissão de abordagem.
+
+Nada aqui tem efeito comercial externo: nenhum router/task importa estes models
+em runtime nesta fatia; consumo real chega em fatias futuras atrás de flags.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.database import Base
+
+
+class CrmPersonIdentity(Base):
+    """Registro determinístico de pessoa (DEC-5) — chaves exatas, nunca fuzzy.
+
+    Uma identidade exige ao menos uma chave (e-mail OU LinkedIn normalizados).
+    Matching probabilístico é proibido pela DEC-5; a resolução vive em
+    app/services/handoff/identity.py e só usa igualdade exata pós-normalização.
+    """
+
+    __tablename__ = "crm_person_identities"
+    __table_args__ = (
+        CheckConstraint(
+            "email_normalized IS NOT NULL OR linkedin_normalized IS NOT NULL",
+            name="ck_crm_person_identities_has_key",
+        ),
+        Index(
+            "uq_crm_person_identities_tenant_email",
+            "tenant_id",
+            "email_normalized",
+            unique=True,
+            postgresql_where=text("email_normalized IS NOT NULL"),
+        ),
+        Index(
+            "uq_crm_person_identities_tenant_linkedin",
+            "tenant_id",
+            "linkedin_normalized",
+            unique=True,
+            postgresql_where=text("linkedin_normalized IS NOT NULL"),
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False
+    )
+    email_normalized = Column(String(320), nullable=True)
+    linkedin_normalized = Column(String(255), nullable=True)
+    display_name = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class CrmLeadLink(Base):
+    """Vínculo operacional corrente de um lead externo (Round 3 §11, Round 4 F1).
+
+    Eixos independentes: commercial_state (espelho do funil), ownership_state
+    (quem controla a conversa) e automation_state (permissão de outbound).
+    A autoridade destes eixos é este banco — o Attio é espelho.
+    """
+
+    __tablename__ = "crm_lead_links"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "source_system", "external_lead_id", name="uq_crm_lead_links_identity"
+        ),
+        Index("ix_crm_lead_links_person", "person_identity_id"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False
+    )
+    source_system = Column(String(32), nullable=False, server_default="rumy")
+    external_lead_id = Column(String(128), nullable=False)
+    person_identity_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("crm_person_identities.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Resolução de identidade ambígua (e-mail aponta pessoa A, LinkedIn pessoa B).
+    # Fail-safe: conflito bloqueia outbound até curadoria humana; nunca há merge.
+    identity_conflict = Column(Boolean, nullable=False, server_default=text("false"))
+    provider_ids = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+    attio_person_id = Column(String(64), nullable=True)
+    attio_company_id = Column(String(64), nullable=True)
+    attio_deal_id = Column(String(64), nullable=True)
+
+    commercial_state = Column(String(32), nullable=True)
+    ownership_state = Column(String(24), nullable=False, server_default="AUTOMATED")
+    automation_state = Column(String(32), nullable=False, server_default="ACTIVE")
+    owner_ref = Column(String(128), nullable=True)
+
+    handoff_requested_at = Column(DateTime(timezone=True), nullable=True)
+    handoff_accepted_at = Column(DateTime(timezone=True), nullable=True)
+    first_human_action_at = Column(DateTime(timezone=True), nullable=True)
+    suppression_requested_at = Column(DateTime(timezone=True), nullable=True)
+    suppression_confirmed_at = Column(DateTime(timezone=True), nullable=True)
+
+    last_applied_event_id = Column(UUID(as_uuid=True), nullable=True)
+    last_occurred_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class CrmLeadEvent(Base):
+    """Ledger append-only dos eventos recebidos (Round 3 A9, Round 4 F1).
+
+    É simultaneamente o dedupe-store (UNIQUE em idempotency_key) e a fonte de
+    auditoria/reconstrução. Linhas nunca são apagadas; reprocessos incrementam
+    ``attempts`` e o desfecho fica em ``status``/``processing_result``.
+    """
+
+    __tablename__ = "crm_lead_events"
+    __table_args__ = (
+        UniqueConstraint("idempotency_key", name="uq_crm_lead_events_idempotency"),
+        Index(
+            "ix_crm_lead_events_lead",
+            "tenant_id",
+            "source_system",
+            "external_lead_id",
+            "occurred_at",
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False
+    )
+    source_system = Column(String(32), nullable=False)
+    external_lead_id = Column(String(128), nullable=False)
+    idempotency_key = Column(String(128), nullable=False)
+    provider_event_id = Column(String(128), nullable=True)
+    schema_version = Column(String(16), nullable=False)
+    adapter_version = Column(String(32), nullable=True)
+    event_type_raw = Column(String(128), nullable=True)
+    event_type = Column(String(64), nullable=False)
+    occurred_at = Column(DateTime(timezone=True), nullable=True)
+    # 'provider' = veio do produtor; 'received' = aproximado pelo recebimento
+    occurred_at_source = Column(String(16), nullable=False, server_default="provider")
+    received_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    payload_raw = Column(JSONB, nullable=True)
+    payload_normalized = Column(JSONB, nullable=True)
+    payload_hash = Column(String(64), nullable=False)
+    # received|applied|duplicate|quarantined|superseded|unmapped|failed
+    status = Column(String(16), nullable=False, server_default="received")
+    attempts = Column(Integer, nullable=False, server_default="1")
+    error = Column(Text, nullable=True)
+    applied_at = Column(DateTime(timezone=True), nullable=True)
+    processing_result = Column(JSONB, nullable=True)
+
+
+class CrmStateTransition(Base):
+    """Trilha append-only de transições de estado (auditoria do Round 4 F3).
+
+    axis: 'ownership' | 'automation' | 'activity' — cada mudança registra quem
+    (actor_type/actor_ref), de onde, para onde, por quê e por qual evento.
+    """
+
+    __tablename__ = "crm_state_transitions"
+    __table_args__ = (Index("ix_crm_state_transitions_link", "lead_link_id", "created_at"),)
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False
+    )
+    lead_link_id = Column(
+        UUID(as_uuid=True), ForeignKey("crm_lead_links.id", ondelete="CASCADE"), nullable=False
+    )
+    axis = Column(String(16), nullable=False)
+    from_state = Column(String(32), nullable=True)
+    to_state = Column(String(32), nullable=False)
+    # HUMAN | SYSTEM | PROVIDER_EVENT — distinção bot×humano é invariante (E-3)
+    actor_type = Column(String(16), nullable=False)
+    actor_ref = Column(String(128), nullable=True)
+    reason = Column(Text, nullable=True)
+    event_id = Column(UUID(as_uuid=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/services/handoff/__init__.py
+++ b/backend/app/services/handoff/__init__.py
@@ -1,0 +1,13 @@
+"""Domínio local do handoff comercial Rumy → Tribultz → Attio (Round 4, F3).
+
+Módulos:
+- contract  — HandoffEvent v1.1 (envelope interno; known/absent explícito)
+- adapter   — interface do adapter Rumy (F2 definitivo BLOQUEADO até payload real)
+- identity  — resolução determinística de pessoa (DEC-5)
+- ownership — máquinas de ownership/automation, guards, SLA, auditoria
+- service   — ingestão idempotente de eventos (ledger + transições)
+- metrics   — métricas locais derivadas do banco
+
+Sem efeito externo: nenhum router/task registra estes módulos nesta fatia; o
+consumo real chega em fatias futuras atrás das flags RUMY_*/HANDOFF_* (OFF).
+"""

--- a/backend/app/services/handoff/adapter.py
+++ b/backend/app/services/handoff/adapter.py
@@ -1,0 +1,46 @@
+"""Interface do adapter Rumy → Handoff Event v1.1 (Round 4 §3 — F2 preparação).
+
+F2 DEFINITIVO ESTÁ BLOQUEADO: o contrato real do webhook do Rumy (eventos,
+payload, event_id, assinatura, retry) ainda não foi validado tecnicamente —
+capacidade de webhook foi confirmada por Produto, o contrato não. Esta fatia
+entrega somente a interface e a validação interna; a implementação concreta
+nasce quando houver payload/documentação reais ("nada de construir ficção
+muito bem testada — continua sendo ficção").
+
+Regra permanente do adapter (Round 3 A2): traduzir SEM deformar o domínio.
+`rumy.qualificado` é sinal externo → `handoff.requested`; NUNCA vira
+qualificação comercial Tribultz (Round 4 §7).
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Any
+
+from app.services.handoff.contract import HandoffEvent
+
+
+@dataclass(frozen=True)
+class UnmappedEvent:
+    """Evento do provedor sem mapeamento — vai ao ledger como 'unmapped' (auditoria)."""
+
+    event_type_raw: str
+    raw: dict[str, Any]
+    note: str = ""
+
+
+class RumyAdapter(abc.ABC):
+    """Contrato do adapter. Implementação concreta: aguarda payload real (F2)."""
+
+    #: versão do mapeamento gravada no ledger (adapter_version)
+    version: str = "unimplemented"
+
+    @abc.abstractmethod
+    def to_handoff_event(self, raw: dict[str, Any]) -> HandoffEvent | UnmappedEvent:
+        """Converte payload bruto do Rumy no evento interno, sem fabricar campos.
+
+        - campo desconhecido/ausente ⇒ MaybeStr.absent(), nunca placeholder;
+        - IDs preservados byte a byte em provider_ids;
+        - evento não reconhecido ⇒ UnmappedEvent (auditar, zero efeito).
+        """

--- a/backend/app/services/handoff/contract.py
+++ b/backend/app/services/handoff/contract.py
@@ -1,0 +1,133 @@
+"""Handoff Event v1.1 — contrato interno do handoff (Rounds 2–4, PO-2026-07-CRM-001).
+
+Modelo INTERNO do domínio, não uma afirmação sobre o payload real do Rumy
+(Round 4 §3: o adapter definitivo aguarda payload/documentação reais). Campos
+com risco de fabricação usam semântica explícita known/absent — ausência nunca
+vira valor inventado (Round 1 D-1/D-3): string vazia é rejeitada na validação.
+
+Identidade lógica do lead: (tenant, source_system, external_lead_id) — o tenant
+não viaja no evento; é resolvido pelo ingestor (Round 4 §11).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+SCHEMA_VERSION = "1.1"
+
+# ULID canônico (Crockford base32, 26 chars) — gerado no produtor do evento.
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+
+EventType = Literal["handoff.requested"]
+HandoffReason = Literal["positive_reply", "meeting_request", "manual_flag", "other"]
+
+
+class MaybeStr(BaseModel):
+    """Campo com presença explícita: known exige valor não-vazio; absent proíbe valor."""
+
+    status: Literal["known", "absent"]
+    value: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _coherent(self) -> "MaybeStr":
+        if self.status == "known":
+            if self.value is None or not self.value.strip():
+                raise ValueError("status=known exige value não-vazio")
+        elif self.value is not None:
+            raise ValueError("status=absent proíbe value")
+        return self
+
+    @classmethod
+    def known(cls, value: str) -> "MaybeStr":
+        return cls(status="known", value=value)
+
+    @classmethod
+    def absent(cls) -> "MaybeStr":
+        return cls(status="absent")
+
+    @property
+    def is_known(self) -> bool:
+        return self.status == "known"
+
+
+class PersonIdentityPayload(BaseModel):
+    full_name: str
+    email: MaybeStr = Field(default_factory=MaybeStr.absent)
+    linkedin_url: MaybeStr = Field(default_factory=MaybeStr.absent)
+
+    @field_validator("full_name")
+    @classmethod
+    def _name_not_blank(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("full_name não pode ser vazio")
+        return v.strip()
+
+
+class CompanyIdentityPayload(BaseModel):
+    name: MaybeStr = Field(default_factory=MaybeStr.absent)
+    cnpj: MaybeStr = Field(default_factory=MaybeStr.absent)
+    domain: MaybeStr = Field(default_factory=MaybeStr.absent)
+
+
+class LastInteraction(BaseModel):
+    channel: str  # ex.: "linkedin" (Rumy é LinkedIn-only)
+    kind: str  # ex.: "reaction", "reply", "message"
+    at: Optional[datetime] = None
+    ref: Optional[str] = None
+
+
+class HandoffEvent(BaseModel):
+    """Evento de handoff normalizado — o que o domínio Tribultz consome."""
+
+    schema_version: Literal["1.1"] = SCHEMA_VERSION
+    event_id: str
+    event_type: EventType = "handoff.requested"
+    occurred_at: datetime
+    producer: str = "rumy"
+    source_system: str = "rumy"
+    external_lead_id: str
+    person: PersonIdentityPayload
+    company: CompanyIdentityPayload
+    campaign_id: Optional[str] = None
+    source_id: Optional[str] = None
+    reason: HandoffReason = "other"
+    last_interaction: Optional[LastInteraction] = None
+    owner: MaybeStr = Field(default_factory=MaybeStr.absent)  # SUGERIDO, nunca imposto
+
+    @field_validator("event_id")
+    @classmethod
+    def _ulid(cls, v: str) -> str:
+        if not _ULID_RE.match(v or ""):
+            raise ValueError("event_id deve ser ULID (26 chars Crockford base32)")
+        return v
+
+    @field_validator("external_lead_id", "source_system", "producer")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("campo obrigatório não pode ser vazio")
+        return v.strip()
+
+    @field_validator("occurred_at")
+    @classmethod
+    def _tz_aware_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            raise ValueError("occurred_at deve ser timezone-aware (UTC)")
+        return v.astimezone(timezone.utc)
+
+    @property
+    def has_identity_minimum(self) -> bool:
+        """Mínimo do Round 2 D-2: nome + (e-mail OU LinkedIn) + nome da empresa.
+
+        Sem o mínimo o evento vai à quarentena (fila de exceção humana) — nunca
+        gera escrita parcial nem placeholder.
+        """
+        return bool(
+            self.person.full_name
+            and (self.person.email.is_known or self.person.linkedin_url.is_known)
+            and self.company.name.is_known
+        )

--- a/backend/app/services/handoff/identity.py
+++ b/backend/app/services/handoff/identity.py
@@ -1,0 +1,159 @@
+"""Resolução determinística de identidade de pessoa — DEC-5 (Round 4 §1).
+
+A unidade de proteção contra retomada da automação é a PESSOA, não o lead
+externo: novo external_lead_id ≠ nova permissão de abordagem. A resolução usa
+SOMENTE igualdade exata pós-normalização (e-mail e/ou LinkedIn) — matching
+probabilístico é proibido ("falso positivo também é incidente comercial").
+
+Casos de borda decididos aqui (e testados):
+- chaves apontando para identidades DIFERENTES ⇒ CONFLITO: nada é mesclado,
+  nada é criado; fail-safe bloqueia outbound até curadoria humana.
+- identidade encontrada por uma chave e a outra chave livre ⇒ enriquecimento
+  determinístico (preenche a chave vazia); jamais sobrescreve chave existente.
+- dado compartilhado por pessoas legitimamente distintas (ex.: e-mail comum):
+  colapsa na mesma identidade POR DESENHO (mesma semântica do Attio, onde
+  e-mail é chave única de pessoa). Modo de falha é conservador — bloqueia
+  outbound a mais, nunca a menos; separação exige curadoria humana.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import urlsplit
+
+from sqlalchemy.orm import Session
+
+from app.models.crm_handoff import CrmLeadLink, CrmPersonIdentity
+
+#: estados de ownership que protegem a pessoa contra automação (DEC-1 + DEC-5)
+PROTECTED_OWNERSHIP_STATES: frozenset[str] = frozenset({"HANDOFF_REQUESTED", "HUMAN_OWNED"})
+
+
+def normalize_email(raw: Optional[str]) -> Optional[str]:
+    """Normalização determinística: trim + lowercase. Sem heurística de provedor."""
+    if raw is None:
+        return None
+    v = raw.strip().lower()
+    if not v or "@" not in v:
+        return None
+    return v
+
+
+def normalize_linkedin(raw: Optional[str]) -> Optional[str]:
+    """Canonicaliza URL/handle de LinkedIn de forma determinística.
+
+    'https://www.LinkedIn.com/in/Foo-Bar/?utm=x', 'linkedin.com/in/foo-bar' e
+    'in/foo-bar' → 'in/foo-bar'. Handle nu ('foo-bar') é interpretado como
+    /in/<handle> (mapeamento fixo e documentado, não heurística fuzzy).
+    """
+    if raw is None:
+        return None
+    v = raw.strip().lower()
+    if not v:
+        return None
+    if "://" not in v:
+        v = "//" + v  # urlsplit trata como netloc+path
+    parts = urlsplit(v)
+    host = (parts.netloc or "").split(":")[0]
+    path = (parts.path or "").strip("/")
+    if host and not (host == "linkedin.com" or host.endswith(".linkedin.com")):
+        # não é linkedin: o "host" era na verdade o início de um handle/caminho
+        path = f"{host}/{path}".strip("/") if path else host
+    if not path:
+        return None
+    if "/" not in path:
+        path = f"in/{path}"
+    return path
+
+
+@dataclass
+class PersonResolution:
+    identity: Optional[CrmPersonIdentity]
+    created: bool = False
+    conflict: bool = False
+    matched: list[CrmPersonIdentity] = field(default_factory=list)
+
+
+def resolve_person(
+    session: Session,
+    tenant_id: uuid.UUID,
+    email_raw: Optional[str],
+    linkedin_raw: Optional[str],
+    display_name: Optional[str] = None,
+) -> PersonResolution:
+    """Resolve (ou cria) a identidade da pessoa por igualdade exata das chaves."""
+    email = normalize_email(email_raw)
+    linkedin = normalize_linkedin(linkedin_raw)
+    if email is None and linkedin is None:
+        return PersonResolution(identity=None)
+
+    by_email = (
+        session.query(CrmPersonIdentity)
+        .filter(
+            CrmPersonIdentity.tenant_id == tenant_id,
+            CrmPersonIdentity.email_normalized == email,
+        )
+        .one_or_none()
+        if email
+        else None
+    )
+    by_linkedin = (
+        session.query(CrmPersonIdentity)
+        .filter(
+            CrmPersonIdentity.tenant_id == tenant_id,
+            CrmPersonIdentity.linkedin_normalized == linkedin,
+        )
+        .one_or_none()
+        if linkedin
+        else None
+    )
+
+    if by_email is not None and by_linkedin is not None and by_email.id != by_linkedin.id:
+        # Chaves apontam para pessoas diferentes: conflito. Sem merge silencioso.
+        return PersonResolution(identity=None, conflict=True, matched=[by_email, by_linkedin])
+
+    found = by_email or by_linkedin
+    if found is not None:
+        # Enriquecimento determinístico: só preenche chave vazia; nunca sobrescreve.
+        if email and found.email_normalized is None and by_email is None:
+            found.email_normalized = email
+        if linkedin and found.linkedin_normalized is None and by_linkedin is None:
+            found.linkedin_normalized = linkedin
+        if display_name and found.display_name is None:
+            found.display_name = display_name
+        return PersonResolution(identity=found, matched=[found])
+
+    identity = CrmPersonIdentity(
+        tenant_id=tenant_id,
+        email_normalized=email,
+        linkedin_normalized=linkedin,
+        display_name=display_name,
+    )
+    session.add(identity)
+    session.flush()
+    return PersonResolution(identity=identity, created=True, matched=[identity])
+
+
+def person_protected(
+    session: Session, tenant_id: uuid.UUID, identity_ids: list[uuid.UUID]
+) -> bool:
+    """True se QUALQUER vínculo da(s) pessoa(s) está em estado protegido.
+
+    É o coração da DEC-5: a consulta cruza por person_identity_id, então um novo
+    external_lead_id da mesma pessoa herda a proteção existente. Em conflito de
+    identidade, o chamador passa TODAS as identidades candidatas — proteger a
+    mais é o modo de falha correto (fail-safe), desproteger jamais.
+    """
+    if not identity_ids:
+        return False
+    return session.query(
+        session.query(CrmLeadLink)
+        .filter(
+            CrmLeadLink.tenant_id == tenant_id,
+            CrmLeadLink.person_identity_id.in_(identity_ids),
+            CrmLeadLink.ownership_state.in_(PROTECTED_OWNERSHIP_STATES),
+        )
+        .exists()
+    ).scalar()

--- a/backend/app/services/handoff/metrics.py
+++ b/backend/app/services/handoff/metrics.py
@@ -1,0 +1,67 @@
+"""Métricas locais do handoff — F3 do Round 4 (derivadas do banco, sem push).
+
+Estas funções materializam as propriedades observáveis do Round 2 §11 que já
+são mensuráveis SEM o Rumy (rumy_send_after_block exige o log de envios do
+provedor — RUMY-O15..O19 — e por ordem do Round 4 §5 NÃO é declarada zero sem
+instrumento: ausência de evidência não equivale a zero).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.crm_handoff import CrmLeadEvent, CrmLeadLink
+from app.services.handoff.identity import PROTECTED_OWNERSHIP_STATES
+from app.services.handoff.ownership import OwnershipState, accept_sla_breached
+
+
+def local_snapshot(session: Session, tenant_id: Optional[uuid.UUID] = None) -> dict[str, Any]:
+    """Fotografia das métricas locais (contadores derivados, sempre recomputáveis)."""
+    ev = session.query(CrmLeadEvent.status, func.count()).group_by(CrmLeadEvent.status)
+    lk = session.query(CrmLeadLink)
+    if tenant_id is not None:
+        ev = ev.filter(CrmLeadEvent.tenant_id == tenant_id)
+        lk = lk.filter(CrmLeadLink.tenant_id == tenant_id)
+
+    events_by_status = {status: count for status, count in ev.all()}
+    links = lk.all()
+
+    ownership_counts: dict[str, int] = {}
+    for link in links:
+        ownership_counts[link.ownership_state] = ownership_counts.get(link.ownership_state, 0) + 1
+
+    handoff_without_owner = sum(
+        1
+        for link in links
+        if link.ownership_state == OwnershipState.HANDOFF_REQUESTED.value
+        and link.owner_ref is None
+    )
+    sla_breaches = sum(1 for link in links if accept_sla_breached(link))
+    protected_persons = len(
+        {
+            link.person_identity_id
+            for link in links
+            if link.person_identity_id is not None
+            and link.ownership_state in PROTECTED_OWNERSHIP_STATES
+        }
+    )
+    identity_conflicts = sum(1 for link in links if link.identity_conflict)
+
+    return {
+        "events_by_status": events_by_status,
+        "handoff_requested": events_by_status.get("applied", 0),
+        "duplicate_handoff": events_by_status.get("duplicate", 0),
+        "quarantined": events_by_status.get("quarantined", 0),
+        "links_by_ownership": ownership_counts,
+        "handoff_without_owner": handoff_without_owner,
+        "accept_sla_breaches": sla_breaches,
+        "protected_persons": protected_persons,
+        "identity_conflicts": identity_conflicts,
+        # Round 4 §5: sem instrumento (log de envios do Rumy) esta métrica é
+        # explicitamente NÃO-OBSERVÁVEL — nunca reportar zero por ausência.
+        "rumy_send_after_block": "UNOBSERVABLE (RUMY-O15..O19 pendentes)",
+    }

--- a/backend/app/services/handoff/ownership.py
+++ b/backend/app/services/handoff/ownership.py
@@ -1,0 +1,382 @@
+"""Máquinas de ownership/automation, guards e SLA — F3 do Round 4.
+
+Dois eixos independentes do estágio comercial (Round 3 §7, Round 4 §7):
+
+- ownership_state: AUTOMATED → HANDOFF_REQUESTED → HUMAN_OWNED → RELEASED →
+  (re-arme explícito) AUTOMATED; CLOSED encerra. A supressão começa em
+  HANDOFF_REQUESTED (DEC-1) — o SLA humano não autoriza a automação a falar.
+- automation_state: ACTIVE → SUPPRESSION_REQUESTED → SUPPRESSION_CONFIRMED.
+  Round 4 §15: distinção formal entre pedido e confirmação de supressão.
+
+Dupla trava (Round 4 §11): RELEASED ≠ AUTOMATED. Liberar o controle humano não
+religa outbound; religar exige transição explícita RELEASED→AUTOMATED por ator
+humano E confirmação de que a supressão foi desfeita no provedor
+(suppression_lift_confirmed) — sem a confirmação, o outbound segue bloqueado.
+
+Toda transição é auditada em crm_state_transitions com ator (bot × humano
+nunca se confundem). Nenhuma função aqui consulta feature flag: proteção
+persiste com flags OFF (desligar flag nunca re-permite outbound).
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import uuid
+from datetime import datetime, time, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.orm import Session
+
+from app.models.crm_handoff import CrmLeadLink, CrmStateTransition
+from app.models.prospect_suppression import ProspectSuppression
+from app.services.handoff.identity import person_protected
+
+logger = logging.getLogger(__name__)
+
+_DEC5_REASON_PREFIX = "DEC-5 handoff protection"
+
+
+class OwnershipState(str, enum.Enum):
+    AUTOMATED = "AUTOMATED"
+    HANDOFF_REQUESTED = "HANDOFF_REQUESTED"
+    HUMAN_OWNED = "HUMAN_OWNED"
+    RELEASED = "RELEASED"
+    CLOSED = "CLOSED"
+
+
+class AutomationState(str, enum.Enum):
+    ACTIVE = "ACTIVE"
+    SUPPRESSION_REQUESTED = "SUPPRESSION_REQUESTED"
+    SUPPRESSION_CONFIRMED = "SUPPRESSION_CONFIRMED"
+
+
+class ActorType(str, enum.Enum):
+    HUMAN = "HUMAN"
+    SYSTEM = "SYSTEM"
+    PROVIDER_EVENT = "PROVIDER_EVENT"
+
+
+class InvalidTransition(Exception):
+    """Transição fora da matriz (ou ator não autorizado para ela)."""
+
+
+_H = frozenset({ActorType.HUMAN})
+_ANY = frozenset({ActorType.HUMAN, ActorType.SYSTEM, ActorType.PROVIDER_EVENT})
+
+# Matriz oficial (Round 3 A10 revista no Round 4 §7). Ausência = proibido.
+# Proibições estruturais: HANDOFF_REQUESTED→AUTOMATED (timeout ESCALA, nunca
+# devolve ao bot) e HUMAN_OWNED→AUTOMATED direto (só via RELEASED).
+_ALLOWED: dict[tuple[OwnershipState, OwnershipState], frozenset[ActorType]] = {
+    (OwnershipState.AUTOMATED, OwnershipState.HANDOFF_REQUESTED): _ANY,
+    (OwnershipState.AUTOMATED, OwnershipState.HUMAN_OWNED): _H,  # assume espontâneo
+    (OwnershipState.AUTOMATED, OwnershipState.CLOSED): _H,
+    (OwnershipState.HANDOFF_REQUESTED, OwnershipState.HUMAN_OWNED): _H,
+    (OwnershipState.HANDOFF_REQUESTED, OwnershipState.CLOSED): _H,
+    (OwnershipState.HUMAN_OWNED, OwnershipState.HANDOFF_REQUESTED): _H,  # re-pedido
+    (OwnershipState.HUMAN_OWNED, OwnershipState.RELEASED): _H,
+    (OwnershipState.HUMAN_OWNED, OwnershipState.CLOSED): _H,
+    (OwnershipState.RELEASED, OwnershipState.AUTOMATED): _H,  # re-arme explícito
+    (OwnershipState.RELEASED, OwnershipState.HANDOFF_REQUESTED): _ANY,  # novo sinal
+    (OwnershipState.RELEASED, OwnershipState.HUMAN_OWNED): _H,
+    (OwnershipState.RELEASED, OwnershipState.CLOSED): _H,
+    (OwnershipState.CLOSED, OwnershipState.HANDOFF_REQUESTED): _H,  # reabertura humana
+}
+
+
+def _now(now: Optional[datetime]) -> datetime:
+    return now or datetime.now(timezone.utc)
+
+
+def _audit(
+    session: Session,
+    link: CrmLeadLink,
+    axis: str,
+    from_state: Optional[str],
+    to_state: str,
+    actor_type: ActorType,
+    actor_ref: Optional[str],
+    reason: Optional[str],
+    event_id: Optional[uuid.UUID],
+) -> None:
+    session.add(
+        CrmStateTransition(
+            tenant_id=link.tenant_id,
+            lead_link_id=link.id,
+            axis=axis,
+            from_state=from_state,
+            to_state=to_state,
+            actor_type=actor_type.value,
+            actor_ref=actor_ref,
+            reason=reason,
+            event_id=event_id,
+        )
+    )
+
+
+def _sync_dec5_suppression(session: Session, link: CrmLeadLink) -> None:
+    """Espelha a proteção DEC-5 na lista de supressão da prospecção em lote.
+
+    ProspectSuppression já é filtro DURO e incondicional na geração de listas
+    (PO-2026-07-SALES-001) — inserir a pessoa ali estende a proteção ao pipeline
+    de lote existente sem nenhum efeito externo (é banco local). Limitação
+    documentada: a tabela casa por e-mail/CNPJ; identidade só-LinkedIn não é
+    espelhável ali (fica coberta pelo guard outbound_allowed).
+    """
+    if link.person_identity_id is None:
+        return
+    from app.models.crm_handoff import CrmPersonIdentity  # import local: evita ciclo
+
+    identity = session.get(CrmPersonIdentity, link.person_identity_id)
+    if identity is None or identity.email_normalized is None:
+        return
+    reason = f"{_DEC5_REASON_PREFIX} (person={identity.id})"
+    exists = (
+        session.query(ProspectSuppression)
+        .filter(
+            ProspectSuppression.email == identity.email_normalized,
+            ProspectSuppression.status == "lead_ativo",
+            ProspectSuppression.reason == reason,
+        )
+        .one_or_none()
+    )
+    if exists is None:
+        session.add(
+            ProspectSuppression(
+                email=identity.email_normalized, status="lead_ativo", reason=reason
+            )
+        )
+
+
+def _lift_dec5_suppression(session: Session, link: CrmLeadLink) -> None:
+    """Remove APENAS as linhas de supressão criadas pela DEC-5 para esta pessoa."""
+    if link.person_identity_id is None:
+        return
+    from app.models.crm_handoff import CrmPersonIdentity
+
+    identity = session.get(CrmPersonIdentity, link.person_identity_id)
+    if identity is None or identity.email_normalized is None:
+        return
+    reason = f"{_DEC5_REASON_PREFIX} (person={identity.id})"
+    session.query(ProspectSuppression).filter(
+        ProspectSuppression.email == identity.email_normalized,
+        ProspectSuppression.status == "lead_ativo",
+        ProspectSuppression.reason == reason,
+    ).delete(synchronize_session=False)
+
+
+def transition_ownership(
+    session: Session,
+    link: CrmLeadLink,
+    to_state: OwnershipState,
+    actor_type: ActorType,
+    actor_ref: Optional[str] = None,
+    reason: Optional[str] = None,
+    event_id: Optional[uuid.UUID] = None,
+    now: Optional[datetime] = None,
+    suppression_lift_confirmed: bool = False,
+) -> CrmLeadLink:
+    """Aplica uma transição de ownership com guards, timestamps e auditoria."""
+    ts = _now(now)
+    frm = OwnershipState(link.ownership_state)
+    if frm == to_state:
+        raise InvalidTransition(f"transição nula {frm.value}→{to_state.value}")
+    allowed_actors = _ALLOWED.get((frm, to_state))
+    if allowed_actors is None:
+        raise InvalidTransition(f"transição proibida {frm.value}→{to_state.value}")
+    if actor_type not in allowed_actors:
+        raise InvalidTransition(
+            f"ator {actor_type.value} não autorizado para {frm.value}→{to_state.value}"
+        )
+    if to_state in (OwnershipState.RELEASED, OwnershipState.AUTOMATED) and not reason:
+        raise InvalidTransition(
+            f"transição para {to_state.value} exige reason auditável (Round 4 §11)"
+        )
+
+    link.ownership_state = to_state.value
+    _audit(
+        session, link, "ownership", frm.value, to_state.value, actor_type, actor_ref, reason,
+        event_id,
+    )
+
+    if to_state == OwnershipState.HANDOFF_REQUESTED:
+        link.handoff_requested_at = ts
+        # DEC-1: supressão começa AQUI, localmente, antes de qualquer remoto.
+        if link.automation_state == AutomationState.ACTIVE.value:
+            link.automation_state = AutomationState.SUPPRESSION_REQUESTED.value
+            link.suppression_requested_at = ts
+            _audit(
+                session, link, "automation", AutomationState.ACTIVE.value,
+                AutomationState.SUPPRESSION_REQUESTED.value, ActorType.SYSTEM, None,
+                "DEC-1: supressão local no pedido de handoff", event_id,
+            )
+        _sync_dec5_suppression(session, link)
+    elif to_state == OwnershipState.HUMAN_OWNED:
+        link.handoff_accepted_at = ts
+        if actor_ref:
+            link.owner_ref = actor_ref
+        _sync_dec5_suppression(session, link)
+    elif to_state == OwnershipState.AUTOMATED:
+        # Dupla trava: religar automação exige confirmação de que a supressão
+        # foi desfeita no provedor. Sem ela, ownership volta mas outbound
+        # permanece bloqueado (automation_state intacto).
+        if suppression_lift_confirmed:
+            prev = link.automation_state
+            link.automation_state = AutomationState.ACTIVE.value
+            _audit(
+                session, link, "automation", prev, AutomationState.ACTIVE.value, actor_type,
+                actor_ref, "re-arme explícito com supressão desfeita comprovada", event_id,
+            )
+            _lift_dec5_suppression(session, link)
+        else:
+            logger.info(
+                "handoff_rearm_without_lift link=%s: ownership=AUTOMATED mas outbound segue "
+                "bloqueado (automation_state=%s)",
+                link.id,
+                link.automation_state,
+            )
+
+    session.flush()
+    return link
+
+
+def confirm_suppression(
+    session: Session,
+    link: CrmLeadLink,
+    actor_type: ActorType = ActorType.SYSTEM,
+    actor_ref: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> CrmLeadLink:
+    """SUPPRESSION_REQUESTED → SUPPRESSION_CONFIRMED (Round 4 §15).
+
+    Nesta fatia só é alcançável por teste/uso interno — o comando real ao Rumy
+    (F5) não está autorizado; quando existir, a confirmação vem da resposta/
+    consulta do provedor.
+    """
+    if link.automation_state != AutomationState.SUPPRESSION_REQUESTED.value:
+        raise InvalidTransition(
+            f"confirmação exige SUPPRESSION_REQUESTED (atual: {link.automation_state})"
+        )
+    link.automation_state = AutomationState.SUPPRESSION_CONFIRMED.value
+    link.suppression_confirmed_at = _now(now)
+    _audit(
+        session, link, "automation", AutomationState.SUPPRESSION_REQUESTED.value,
+        AutomationState.SUPPRESSION_CONFIRMED.value, actor_type, actor_ref, None, None,
+    )
+    session.flush()
+    return link
+
+
+#: atividades que CONTAM como primeira ação humana (Round 4 §12)
+SUBSTANTIVE_ACTION_KINDS: frozenset[str] = frozenset(
+    {"message", "call", "meeting", "substantive_activity"}
+)
+#: atividades que NÃO contam (abrir/visualizar/assumir/trocar owner/nota administrativa)
+NON_COUNTING_ACTION_KINDS: frozenset[str] = frozenset(
+    {"open", "view", "assume", "owner_change", "admin_note"}
+)
+
+
+def register_human_action(
+    session: Session,
+    link: CrmLeadLink,
+    kind: str,
+    actor_ref: str,
+    now: Optional[datetime] = None,
+) -> bool:
+    """Registra ação humana; retorna True se contou como PRIMEIRA ação substantiva.
+
+    handoff_accepted ≠ human_first_action: 'assume' e afins nunca param o
+    relógio de time_to_human_action.
+    """
+    if kind not in SUBSTANTIVE_ACTION_KINDS:
+        if kind not in NON_COUNTING_ACTION_KINDS:
+            raise ValueError(f"kind desconhecido: {kind!r}")
+        return False
+    counted = False
+    if link.first_human_action_at is None:
+        link.first_human_action_at = _now(now)
+        counted = True
+    _audit(
+        session, link, "activity", None, f"human_action:{kind}", ActorType.HUMAN, actor_ref,
+        None, None,
+    )
+    session.flush()
+    return counted
+
+
+def outbound_allowed(session: Session, link: CrmLeadLink) -> tuple[bool, str]:
+    """Permissão CONJUNTIVA de outbound automatizado (Round 3 A11, Round 4 §15).
+
+    Qualquer incerteza ⇒ bloqueado. Flags não entram aqui de propósito: elas só
+    podem bloquear a montante (nunca re-permitir), e a proteção de pessoa
+    (DEC-5) vale mesmo com o sistema inteiro desligado.
+    """
+    if link.identity_conflict:
+        return False, "identity_conflict"
+    if link.ownership_state != OwnershipState.AUTOMATED.value:
+        return False, f"ownership={link.ownership_state}"
+    if link.automation_state != AutomationState.ACTIVE.value:
+        return False, f"automation={link.automation_state}"
+    ids = [link.person_identity_id] if link.person_identity_id else []
+    if ids and person_protected(session, link.tenant_id, ids):
+        return False, "person_protected"  # DEC-5: outro lead da MESMA pessoa protege este
+    return True, "ok"
+
+
+# ── SLA (Round 4 §12 — dois relógios) ────────────────────────────────────────
+
+_BUSINESS_TZ = ZoneInfo("America/Sao_Paulo")
+_BUSINESS_START = time(9, 0)
+_BUSINESS_END = time(18, 0)
+ACCEPT_SLA = timedelta(hours=4)  # HANDOFF_REQUESTED → HUMAN_OWNED ≤ 4h úteis
+
+
+def business_hours_between(start: datetime, end: datetime) -> timedelta:
+    """Tempo útil (seg–sex, 09:00–18:00 America/Sao_Paulo) entre dois instantes.
+
+    Feriados ficam fora do escopo do piloto (documentado; calendário entra em
+    fatia futura se Produto exigir).
+    """
+    if end <= start:
+        return timedelta(0)
+    start_l = start.astimezone(_BUSINESS_TZ)
+    end_l = end.astimezone(_BUSINESS_TZ)
+    total = timedelta(0)
+    cursor = start_l.date()
+    while cursor <= end_l.date():
+        if cursor.weekday() < 5:  # seg–sex
+            day_open = datetime.combine(cursor, _BUSINESS_START, tzinfo=_BUSINESS_TZ)
+            day_close = datetime.combine(cursor, _BUSINESS_END, tzinfo=_BUSINESS_TZ)
+            lo = max(start_l, day_open)
+            hi = min(end_l, day_close)
+            if hi > lo:
+                total += hi - lo
+        cursor += timedelta(days=1)
+    return total
+
+
+def time_to_accept(link: CrmLeadLink, now: Optional[datetime] = None) -> Optional[timedelta]:
+    if link.handoff_requested_at is None:
+        return None
+    end = link.handoff_accepted_at or _now(now)
+    return business_hours_between(link.handoff_requested_at, end)
+
+
+def time_to_human_action(link: CrmLeadLink, now: Optional[datetime] = None) -> Optional[timedelta]:
+    if link.handoff_accepted_at is None:
+        return None
+    end = link.first_human_action_at or _now(now)
+    return business_hours_between(link.handoff_accepted_at, end)
+
+
+def accept_sla_breached(link: CrmLeadLink, now: Optional[datetime] = None) -> bool:
+    """True se o pedido de handoff estourou o SLA de aceite sem HUMAN_OWNED.
+
+    Estouro ESCALA para humano — jamais devolve o lead à automação (matriz).
+    """
+    if link.ownership_state != OwnershipState.HANDOFF_REQUESTED.value:
+        return False
+    elapsed = time_to_accept(link, now=now)
+    return elapsed is not None and elapsed > ACCEPT_SLA

--- a/backend/app/services/handoff/service.py
+++ b/backend/app/services/handoff/service.py
@@ -1,0 +1,219 @@
+"""Ingestão idempotente de eventos de handoff — F3 do Round 4.
+
+Pipeline interno (camadas 1–3 do kill switch do Round 3 §15): ledger →
+idempotência → identidade (DEC-5) → vínculo → transição de ownership com trava
+local. As camadas 4–5 (comando/confirmação de supressão no Rumy) e a
+orquestração do Attio NÃO existem nesta fatia — não autorizadas.
+
+Garantias (Round 4 §6): o mesmo evento N vezes ⇒ 1 handoff lógico, 1 transição,
+zero duplicação de pessoa, zero Deal (não existe código de Deal aqui — nasce
+apenas por ato humano em Qualificado), zero histórico duplicado.
+
+Sem efeito externo: nenhum router/task chama este módulo em runtime; o fio até
+o endpoint (F2) chega em fatia futura atrás de RUMY_WEBHOOK_ENABLED /
+HANDOFF_APPLY_ENABLED (OFF por padrão).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.crm_handoff import CrmLeadEvent, CrmLeadLink
+from app.services.handoff.contract import HandoffEvent
+from app.services.handoff.identity import resolve_person
+from app.services.handoff.ownership import (
+    ActorType,
+    OwnershipState,
+    transition_ownership,
+)
+
+PROTECTED = {OwnershipState.HANDOFF_REQUESTED.value, OwnershipState.HUMAN_OWNED.value}
+
+
+def canonical_payload_hash(payload: Any) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def compute_idempotency_key(
+    tenant_id: uuid.UUID, event: HandoffEvent, provider_event_id: Optional[str] = None
+) -> str:
+    """Hierarquia do Round 3 A5: id do provedor > hash determinístico de negócio."""
+    if provider_event_id:
+        return f"prov:{event.source_system}:{provider_event_id}"[:128]
+    basis = "|".join(
+        [
+            str(tenant_id),
+            event.source_system,
+            event.external_lead_id,
+            event.event_type,
+            event.occurred_at.isoformat(),
+        ]
+    )
+    return "det:" + hashlib.sha256(basis.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class IngestResult:
+    status: str  # applied | duplicate | quarantined | superseded
+    ledger: CrmLeadEvent
+    link: Optional[CrmLeadLink] = None
+    detail: str = ""
+
+
+def ingest_handoff_event(
+    session: Session,
+    tenant_id: uuid.UUID,
+    event: HandoffEvent,
+    payload_raw: Optional[dict[str, Any]] = None,
+    provider_event_id: Optional[str] = None,
+    adapter_version: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> IngestResult:
+    """Processa um HandoffEvent de ponta a ponta, com idempotência perpétua."""
+    ts = now or datetime.now(timezone.utc)
+    normalized = event.model_dump(mode="json")
+    p_hash = canonical_payload_hash(payload_raw if payload_raw is not None else normalized)
+    key = compute_idempotency_key(tenant_id, event, provider_event_id)
+
+    existing = (
+        session.query(CrmLeadEvent).filter(CrmLeadEvent.idempotency_key == key).one_or_none()
+    )
+    if existing is not None:
+        return _register_duplicate(session, existing, p_hash)
+
+    ledger = CrmLeadEvent(
+        tenant_id=tenant_id,
+        source_system=event.source_system,
+        external_lead_id=event.external_lead_id,
+        idempotency_key=key,
+        provider_event_id=provider_event_id,
+        schema_version=event.schema_version,
+        adapter_version=adapter_version,
+        event_type=event.event_type,
+        occurred_at=event.occurred_at,
+        occurred_at_source="provider",
+        payload_raw=payload_raw,
+        payload_normalized=normalized,
+        payload_hash=p_hash,
+        status="received",
+    )
+    session.add(ledger)
+    try:
+        with session.begin_nested():
+            session.flush()
+    except IntegrityError:
+        # Corrida entre consumidores: outro venceu o UNIQUE — vira duplicado.
+        session.expunge(ledger)
+        winner = (
+            session.query(CrmLeadEvent).filter(CrmLeadEvent.idempotency_key == key).one()
+        )
+        return _register_duplicate(session, winner, p_hash)
+
+    # Quarentena: mínimo de identidade ausente ⇒ fila de exceção humana,
+    # nada fabricado, nada escrito além do ledger (Round 2 D-2, Round 4 §3).
+    if not event.has_identity_minimum:
+        ledger.status = "quarantined"
+        ledger.processing_result = {"detail": "identity_minimum_missing"}
+        return IngestResult(status="quarantined", ledger=ledger, detail="identity_minimum_missing")
+
+    resolution = resolve_person(
+        session,
+        tenant_id,
+        event.person.email.value if event.person.email.is_known else None,
+        event.person.linkedin_url.value if event.person.linkedin_url.is_known else None,
+        display_name=event.person.full_name,
+    )
+
+    link = (
+        session.query(CrmLeadLink)
+        .filter(
+            CrmLeadLink.tenant_id == tenant_id,
+            CrmLeadLink.source_system == event.source_system,
+            CrmLeadLink.external_lead_id == event.external_lead_id,
+        )
+        .one_or_none()
+    )
+    if link is None:
+        link = CrmLeadLink(
+            tenant_id=tenant_id,
+            source_system=event.source_system,
+            external_lead_id=event.external_lead_id,
+            ownership_state=OwnershipState.AUTOMATED.value,
+            automation_state="ACTIVE",
+            provider_ids={"provider_event_id": provider_event_id} if provider_event_id else {},
+        )
+        session.add(link)
+        session.flush()
+
+    if resolution.conflict:
+        # Fail-safe DEC-5: sem merge; conflito bloqueia outbound até curadoria.
+        link.identity_conflict = True
+    elif resolution.identity is not None and link.person_identity_id is None:
+        link.person_identity_id = resolution.identity.id
+
+    # Fora de ordem (Round 3 A7): evento mais velho nunca regride estado.
+    if link.last_occurred_at is not None and event.occurred_at <= link.last_occurred_at:
+        ledger.status = "superseded"
+        ledger.processing_result = {
+            "detail": "out_of_order",
+            "last_occurred_at": link.last_occurred_at.isoformat(),
+        }
+        return IngestResult(status="superseded", ledger=ledger, link=link, detail="out_of_order")
+
+    current = link.ownership_state
+    if current in (OwnershipState.AUTOMATED.value, OwnershipState.RELEASED.value):
+        transition_ownership(
+            session,
+            link,
+            OwnershipState.HANDOFF_REQUESTED,
+            ActorType.PROVIDER_EVENT,
+            actor_ref=event.producer,
+            reason=f"handoff.requested ({event.reason})",
+            event_id=ledger.id,
+            now=ts,
+        )
+        detail = "transitioned"
+    elif current in PROTECTED:
+        # Pessoa/lead já sob atenção: evento é real e fica registrado; estado
+        # não muda (idempotência lógica do handoff).
+        detail = "already_protected"
+    else:  # CLOSED
+        # Round 3 A10: reabertura de CLOSED é ato humano; sinal de provedor
+        # não reabre sozinho — registra e alerta.
+        detail = "closed_requires_human"
+
+    link.last_applied_event_id = ledger.id
+    link.last_occurred_at = event.occurred_at
+    ledger.status = "applied"
+    ledger.applied_at = ts
+    ledger.processing_result = {
+        "detail": detail,
+        "ownership_state": link.ownership_state,
+        "automation_state": link.automation_state,
+        "identity_conflict": link.identity_conflict,
+    }
+    return IngestResult(status="applied", ledger=ledger, link=link, detail=detail)
+
+
+def _register_duplicate(
+    session: Session, existing: CrmLeadEvent, incoming_hash: str
+) -> IngestResult:
+    existing.attempts = (existing.attempts or 1) + 1
+    if existing.payload_hash != incoming_hash:
+        # Mesmo event_id, payload diferente: nunca reprocessa em silêncio.
+        result = dict(existing.processing_result or {})
+        result["divergent_payload_hashes"] = sorted(
+            set(result.get("divergent_payload_hashes", []) + [incoming_hash])
+        )
+        existing.processing_result = result
+        return IngestResult(status="duplicate", ledger=existing, detail="duplicate_divergent")
+    return IngestResult(status="duplicate", ledger=existing, detail="duplicate")

--- a/backend/tests/test_handoff_contract.py
+++ b/backend/tests/test_handoff_contract.py
@@ -1,0 +1,97 @@
+"""Round 4 F2-prep: validação do contrato HandoffEvent v1.1 (sem DB).
+
+Payloads 100% sintéticos e claramente identificados — nenhum dado real
+(Edgard/Rödl fora de qualquer teste, gate do Round 4).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.services.handoff.contract import (
+    CompanyIdentityPayload,
+    HandoffEvent,
+    MaybeStr,
+    PersonIdentityPayload,
+)
+
+ULID = "01J8ZM7WVX2Q9RKTHB3F6D5A1C"
+
+
+def _event(**overrides):
+    base = dict(
+        event_id=ULID,
+        occurred_at=datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc),
+        external_lead_id="lead-sintetico-001",
+        person=PersonIdentityPayload(
+            full_name="Pessoa Sintética [QA]",
+            email=MaybeStr.known("pessoa.sintetica@example.test"),
+        ),
+        company=CompanyIdentityPayload(name=MaybeStr.known("Empresa Sintética QA Ltda")),
+        reason="positive_reply",
+    )
+    base.update(overrides)
+    return HandoffEvent(**base)
+
+
+def test_known_exige_valor_nao_vazio():
+    with pytest.raises(ValidationError):
+        MaybeStr(status="known")
+    with pytest.raises(ValidationError):
+        MaybeStr(status="known", value="   ")
+
+
+def test_absent_proibe_valor():
+    with pytest.raises(ValidationError):
+        MaybeStr(status="absent", value="x@example.test")
+
+
+def test_ausencia_explicita_nao_vira_placeholder():
+    ev = _event()
+    assert ev.person.linkedin_url.status == "absent"
+    assert ev.person.linkedin_url.value is None
+    assert ev.owner.status == "absent"
+
+
+def test_event_id_deve_ser_ulid():
+    with pytest.raises(ValidationError):
+        _event(event_id="nao-e-ulid")
+    with pytest.raises(ValidationError):
+        _event(event_id=ULID.lower())  # ULID canônico é maiúsculo
+
+
+def test_occurred_at_naive_rejeitado():
+    with pytest.raises(ValidationError):
+        _event(occurred_at=datetime(2026, 8, 12, 12, 0))
+
+
+def test_occurred_at_normalizado_para_utc():
+    from zoneinfo import ZoneInfo
+
+    ev = _event(occurred_at=datetime(2026, 8, 12, 9, 0, tzinfo=ZoneInfo("America/Sao_Paulo")))
+    assert ev.occurred_at.tzinfo == timezone.utc
+    assert ev.occurred_at.hour == 12
+
+
+def test_minimo_identidade():
+    assert _event().has_identity_minimum is True
+
+    sem_chaves = _event(person=PersonIdentityPayload(full_name="Só Nome [QA]"))
+    assert sem_chaves.has_identity_minimum is False
+
+    sem_empresa = _event(company=CompanyIdentityPayload())
+    assert sem_empresa.has_identity_minimum is False
+
+    so_linkedin = _event(
+        person=PersonIdentityPayload(
+            full_name="Pessoa Sintética [QA]",
+            linkedin_url=MaybeStr.known("linkedin.com/in/pessoa-sintetica-qa"),
+        )
+    )
+    assert so_linkedin.has_identity_minimum is True
+
+
+def test_external_lead_id_vazio_rejeitado():
+    with pytest.raises(ValidationError):
+        _event(external_lead_id="  ")

--- a/backend/tests/test_handoff_identity.py
+++ b/backend/tests/test_handoff_identity.py
@@ -1,0 +1,140 @@
+"""Round 4 §1: os 9 cenários de identidade da DEC-5 (campanha QA).
+
+Resolução determinística de pessoa — igualdade exata pós-normalização, sem
+matching probabilístico. DB real (Postgres migrado) com rollback por teste,
+padrão de test_support_tenancy.py. Dados 100% sintéticos.
+"""
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.auth import Tenant
+from app.services.handoff.identity import (
+    normalize_email,
+    normalize_linkedin,
+    person_protected,
+    resolve_person,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="tenant_id")
+def tenant_fixture(session):
+    tenant = Tenant(name=f"Tenant QA {uuid.uuid4().hex[:6]}", slug=f"tenant-qa-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+    return tenant.id
+
+
+EMAIL = "pessoa.sintetica@example.test"
+LINKEDIN = "https://www.linkedin.com/in/Pessoa-Sintetica-QA/"
+
+
+def test_normalizacao_email():
+    assert normalize_email("  Pessoa.Sintetica@Example.TEST ") == EMAIL
+    assert normalize_email("sem-arroba") is None
+    assert normalize_email("   ") is None
+    assert normalize_email(None) is None
+
+
+def test_cenario_6_linkedin_igual_em_formatos_diferentes():
+    canonical = "in/pessoa-sintetica-qa"
+    assert normalize_linkedin("https://www.LinkedIn.com/in/Pessoa-Sintetica-QA/?utm=x") == canonical
+    assert normalize_linkedin("linkedin.com/in/pessoa-sintetica-qa") == canonical
+    assert normalize_linkedin("in/pessoa-sintetica-qa/") == canonical
+    assert normalize_linkedin("pessoa-sintetica-qa") == canonical  # handle nu → /in/<handle>
+    assert normalize_linkedin("br.linkedin.com/in/pessoa-sintetica-qa") == canonical
+
+
+def test_cenario_1_mesma_pessoa_mesmo_dado_resolve_uma_vez(session, tenant_id):
+    r1 = resolve_person(session, tenant_id, EMAIL, None)
+    r2 = resolve_person(session, tenant_id, EMAIL, None)
+    assert r1.created is True and r2.created is False
+    assert r1.identity.id == r2.identity.id
+
+
+def test_cenario_4_mesmo_linkedin_email_diferente_nao_sobrescreve(session, tenant_id):
+    r1 = resolve_person(session, tenant_id, EMAIL, LINKEDIN)
+    r2 = resolve_person(session, tenant_id, "outro.email@example.test", LINKEDIN)
+    assert r2.identity.id == r1.identity.id  # LinkedIn exato identifica a pessoa
+    assert r2.identity.email_normalized == EMAIL  # chave existente jamais sobrescrita
+
+
+def test_cenario_5_mesmo_email_linkedin_ausente(session, tenant_id):
+    r1 = resolve_person(session, tenant_id, EMAIL, LINKEDIN)
+    r2 = resolve_person(session, tenant_id, EMAIL, None)
+    assert r2.identity.id == r1.identity.id
+
+
+def test_enriquecimento_deterministico_preenche_chave_vazia(session, tenant_id):
+    r1 = resolve_person(session, tenant_id, EMAIL, None)
+    assert r1.identity.linkedin_normalized is None
+    r2 = resolve_person(session, tenant_id, EMAIL, LINKEDIN)
+    assert r2.identity.id == r1.identity.id
+    assert r2.identity.linkedin_normalized == "in/pessoa-sintetica-qa"
+
+
+def test_cenario_7_identidade_parcial_nao_resolve(session, tenant_id):
+    r = resolve_person(session, tenant_id, None, None)
+    assert r.identity is None and r.conflict is False
+
+
+def test_cenario_8_identidade_conflitante_sem_merge(session, tenant_id):
+    a = resolve_person(session, tenant_id, "pessoa.a@example.test", "in/pessoa-a-qa").identity
+    b = resolve_person(session, tenant_id, "pessoa.b@example.test", "in/pessoa-b-qa").identity
+
+    r = resolve_person(session, tenant_id, "pessoa.a@example.test", "in/pessoa-b-qa")
+    assert r.conflict is True and r.identity is None
+    assert {m.id for m in r.matched} == {a.id, b.id}
+    # nada foi mesclado nem alterado
+    session.refresh(a), session.refresh(b)
+    assert a.email_normalized == "pessoa.a@example.test"
+    assert a.linkedin_normalized == "in/pessoa-a-qa"
+    assert b.email_normalized == "pessoa.b@example.test"
+    assert b.linkedin_normalized == "in/pessoa-b-qa"
+
+
+def test_cenario_9_dado_compartilhado_colapsa_por_desenho(session, tenant_id):
+    """Duas pessoas legitimamente distintas com o MESMO e-mail colapsam na mesma
+    identidade — comportamento explícito e documentado (mesma semântica do
+    Attio, onde e-mail é chave única). Modo de falha conservador: bloqueia
+    outbound a mais, nunca a menos; separação é curadoria humana."""
+    r1 = resolve_person(session, tenant_id, "caixa.compartilhada@example.test", None,
+                        display_name="Pessoa Um [QA]")
+    r2 = resolve_person(session, tenant_id, "caixa.compartilhada@example.test", None,
+                        display_name="Pessoa Dois [QA]")
+    assert r2.identity.id == r1.identity.id
+    assert r2.created is False
+
+
+def test_protecao_por_pessoa_sem_vinculos_e_falsa(session, tenant_id):
+    r = resolve_person(session, tenant_id, EMAIL, None)
+    assert person_protected(session, tenant_id, [r.identity.id]) is False
+
+
+def test_isolamento_entre_tenants(session, tenant_id):
+    """Mesmo dado em tenants distintos = pessoas distintas (Round 4 §11)."""
+    other = Tenant(name=f"Tenant QA2 {uuid.uuid4().hex[:6]}", slug=f"tenant-qa2-{uuid.uuid4()}")
+    session.add(other)
+    session.flush()
+    r1 = resolve_person(session, tenant_id, EMAIL, None)
+    r2 = resolve_person(session, other.id, EMAIL, None)
+    assert r1.identity.id != r2.identity.id

--- a/backend/tests/test_handoff_ownership.py
+++ b/backend/tests/test_handoff_ownership.py
@@ -1,0 +1,249 @@
+"""Round 4 F3: matriz de ownership, dupla trava RELEASED≠AUTOMATED, SLA, ações.
+
+Campanha QA §11: verificar que liberar controle humano NÃO religa outbound,
+que timeout de SLA nunca devolve ao bot, e que a supressão DEC-5 espelha na
+lista dura da prospecção. DB real com rollback por teste; dados sintéticos.
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.auth import Tenant
+from app.models.crm_handoff import CrmLeadLink, CrmStateTransition
+from app.models.prospect_suppression import ProspectSuppression
+from app.services.handoff.identity import resolve_person
+from app.services.handoff.ownership import (
+    ActorType,
+    AutomationState,
+    InvalidTransition,
+    OwnershipState,
+    accept_sla_breached,
+    business_hours_between,
+    confirm_suppression,
+    outbound_allowed,
+    register_human_action,
+    transition_ownership,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SP = ZoneInfo("America/Sao_Paulo")
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="tenant_id")
+def tenant_fixture(session):
+    tenant = Tenant(name=f"Tenant QA {uuid.uuid4().hex[:6]}", slug=f"tenant-qa-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+    return tenant.id
+
+
+def _link(session, tenant_id, *, email=None, external_id=None) -> CrmLeadLink:
+    person_id = None
+    if email:
+        person_id = resolve_person(session, tenant_id, email, None).identity.id
+    link = CrmLeadLink(
+        tenant_id=tenant_id,
+        source_system="rumy",
+        external_lead_id=external_id or f"lead-sintetico-{uuid.uuid4().hex[:8]}",
+        person_identity_id=person_id,
+    )
+    session.add(link)
+    session.flush()
+    return link
+
+
+def _audit_rows(session, link, axis=None):
+    q = session.query(CrmStateTransition).filter(CrmStateTransition.lead_link_id == link.id)
+    if axis:
+        q = q.filter(CrmStateTransition.axis == axis)
+    return q.all()
+
+
+def test_handoff_requested_trava_local_e_espelha_dec5(session, tenant_id):
+    link = _link(session, tenant_id, email="pessoa.sintetica@example.test")
+    transition_ownership(session, link, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT)
+
+    assert link.ownership_state == "HANDOFF_REQUESTED"
+    assert link.automation_state == "SUPPRESSION_REQUESTED"  # DEC-1: trava imediata
+    assert link.handoff_requested_at is not None
+    assert link.suppression_requested_at is not None
+    assert outbound_allowed(session, link) == (False, "ownership=HANDOFF_REQUESTED")
+
+    # espelho na lista dura da prospecção em lote (defesa em profundidade)
+    row = (
+        session.query(ProspectSuppression)
+        .filter(ProspectSuppression.email == "pessoa.sintetica@example.test")
+        .one()
+    )
+    assert row.status == "lead_ativo"
+    assert "DEC-5" in row.reason
+
+    assert len(_audit_rows(session, link, "ownership")) == 1
+    assert len(_audit_rows(session, link, "automation")) == 1
+
+
+@pytest.mark.parametrize(
+    ("start", "target", "actor"),
+    [
+        ("HANDOFF_REQUESTED", OwnershipState.AUTOMATED, ActorType.HUMAN),  # timeout ESCALA
+        ("HANDOFF_REQUESTED", OwnershipState.AUTOMATED, ActorType.SYSTEM),
+        ("HUMAN_OWNED", OwnershipState.AUTOMATED, ActorType.HUMAN),  # só via RELEASED
+        ("CLOSED", OwnershipState.AUTOMATED, ActorType.HUMAN),
+        ("CLOSED", OwnershipState.HUMAN_OWNED, ActorType.HUMAN),
+        ("AUTOMATED", OwnershipState.RELEASED, ActorType.HUMAN),
+    ],
+)
+def test_transicoes_proibidas(session, tenant_id, start, target, actor):
+    link = _link(session, tenant_id)
+    link.ownership_state = start
+    with pytest.raises(InvalidTransition):
+        transition_ownership(session, link, target, actor, reason="tentativa proibida")
+
+
+def test_provider_event_nao_pode_aceitar_handoff(session, tenant_id):
+    """Aceite é ato humano: bot jamais 'assume' — invariante E-3/E-5."""
+    link = _link(session, tenant_id)
+    transition_ownership(session, link, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT)
+    with pytest.raises(InvalidTransition):
+        transition_ownership(session, link, OwnershipState.HUMAN_OWNED, ActorType.PROVIDER_EVENT)
+
+
+def test_aceite_humano_estampa_owner_e_aceite(session, tenant_id):
+    link = _link(session, tenant_id)
+    transition_ownership(session, link, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT)
+    transition_ownership(
+        session, link, OwnershipState.HUMAN_OWNED, ActorType.HUMAN, actor_ref="ana.qa@6tech.test"
+    )
+    assert link.handoff_accepted_at is not None
+    assert link.owner_ref == "ana.qa@6tech.test"
+
+
+def test_released_sem_lift_nao_religa_outbound(session, tenant_id):
+    """Round 4 §11: RELEASED ≠ AUTOMATED — dupla trava."""
+    link = _link(session, tenant_id, email="dupla.trava@example.test")
+    transition_ownership(session, link, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT)
+    transition_ownership(session, link, OwnershipState.HUMAN_OWNED, ActorType.HUMAN, actor_ref="ana")
+
+    # liberar exige reason auditável
+    with pytest.raises(InvalidTransition):
+        transition_ownership(session, link, OwnershipState.RELEASED, ActorType.HUMAN)
+    transition_ownership(
+        session, link, OwnershipState.RELEASED, ActorType.HUMAN, reason="lead devolvido [QA]"
+    )
+    assert outbound_allowed(session, link)[0] is False  # liberar não religa
+
+    # re-arme SEM confirmação de supressão desfeita: ownership volta, outbound NÃO
+    transition_ownership(
+        session, link, OwnershipState.AUTOMATED, ActorType.HUMAN,
+        reason="re-arme sem lift [QA]", suppression_lift_confirmed=False,
+    )
+    assert link.ownership_state == "AUTOMATED"
+    assert link.automation_state == "SUPPRESSION_REQUESTED"
+    allowed, why = outbound_allowed(session, link)
+    assert allowed is False and why == "automation=SUPPRESSION_REQUESTED"
+    # a linha DEC-5 na lista de supressão da prospecção permanece
+    assert (
+        session.query(ProspectSuppression)
+        .filter(ProspectSuppression.email == "dupla.trava@example.test")
+        .count()
+        == 1
+    )
+
+
+def test_rearm_com_lift_confirmado_religa_e_limpa_dec5(session, tenant_id):
+    link = _link(session, tenant_id, email="rearme.completo@example.test")
+    transition_ownership(session, link, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT)
+    confirm_suppression(session, link)
+    assert link.automation_state == AutomationState.SUPPRESSION_CONFIRMED.value
+    transition_ownership(session, link, OwnershipState.HUMAN_OWNED, ActorType.HUMAN, actor_ref="ana")
+    transition_ownership(
+        session, link, OwnershipState.RELEASED, ActorType.HUMAN, reason="devolvido [QA]"
+    )
+    transition_ownership(
+        session, link, OwnershipState.AUTOMATED, ActorType.HUMAN,
+        reason="re-arme autorizado [QA]", suppression_lift_confirmed=True,
+    )
+    assert link.automation_state == "ACTIVE"
+    assert outbound_allowed(session, link) == (True, "ok")
+    assert (
+        session.query(ProspectSuppression)
+        .filter(ProspectSuppression.email == "rearme.completo@example.test")
+        .count()
+        == 0
+    )
+
+
+def test_dec5_novo_lead_da_mesma_pessoa_herda_protecao(session, tenant_id):
+    """O núcleo da DEC-5: novo external_lead_id ≠ nova permissão de abordagem."""
+    protegido = _link(session, tenant_id, email="pessoa.protegida@example.test")
+    transition_ownership(
+        session, protegido, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT
+    )
+
+    novo_lead = _link(
+        session, tenant_id, email="pessoa.protegida@example.test", external_id="lead-novo-999"
+    )
+    assert novo_lead.ownership_state == "AUTOMATED"  # o lead em si está livre…
+    allowed, why = outbound_allowed(session, novo_lead)
+    assert allowed is False and why == "person_protected"  # …mas a PESSOA não
+
+
+def test_conflito_de_identidade_bloqueia_outbound(session, tenant_id):
+    link = _link(session, tenant_id)
+    link.identity_conflict = True
+    assert outbound_allowed(session, link) == (False, "identity_conflict")
+
+
+def test_primeira_acao_humana_ignora_administrativo(session, tenant_id):
+    link = _link(session, tenant_id)
+    assert register_human_action(session, link, "assume", "ana") is False
+    assert register_human_action(session, link, "open", "ana") is False
+    assert link.first_human_action_at is None
+    assert register_human_action(session, link, "message", "ana") is True
+    first = link.first_human_action_at
+    assert first is not None
+    assert register_human_action(session, link, "call", "ana") is False  # já contou
+    assert link.first_human_action_at == first
+    with pytest.raises(ValueError):
+        register_human_action(session, link, "telepatia", "ana")
+
+
+def test_horas_uteis_atravessando_fim_de_semana():
+    sexta_17 = datetime(2026, 8, 14, 17, 0, tzinfo=SP)  # sexta
+    segunda_10 = datetime(2026, 8, 17, 10, 0, tzinfo=SP)  # segunda
+    assert business_hours_between(sexta_17, segunda_10) == timedelta(hours=2)
+
+
+def test_sla_de_aceite_estoura_e_escala_nunca_devolve(session, tenant_id):
+    link = _link(session, tenant_id)
+    quarta_9 = datetime(2026, 8, 12, 9, 0, tzinfo=SP)
+    transition_ownership(
+        session, link, OwnershipState.HANDOFF_REQUESTED, ActorType.PROVIDER_EVENT, now=quarta_9
+    )
+    quarta_15 = datetime(2026, 8, 12, 15, 0, tzinfo=SP)  # 6h úteis depois
+    assert accept_sla_breached(link, now=quarta_15) is True
+    # estourado, a única saída continua sendo humana — devolver ao bot é proibido
+    with pytest.raises(InvalidTransition):
+        transition_ownership(
+            session, link, OwnershipState.AUTOMATED, ActorType.SYSTEM, reason="timeout"
+        )

--- a/backend/tests/test_handoff_service.py
+++ b/backend/tests/test_handoff_service.py
@@ -1,0 +1,223 @@
+"""Round 4 F3: ingestão idempotente — replay, fora-de-ordem, quarentena, corrida.
+
+Campanha QA §11: concorrência entre handoff.requested × novo lead × evento
+duplicado × evento atrasado. DB real com rollback por teste; dados sintéticos.
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from app.models.auth import Tenant
+from app.models.crm_handoff import CrmLeadEvent, CrmLeadLink, CrmStateTransition
+from app.models.prospect_suppression import ProspectSuppression
+from app.services.handoff.contract import (
+    CompanyIdentityPayload,
+    HandoffEvent,
+    MaybeStr,
+    PersonIdentityPayload,
+)
+from app.services.handoff.metrics import local_snapshot
+from app.services.handoff.ownership import outbound_allowed
+from app.services.handoff.service import ingest_handoff_event
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://tribultz:tribultz@localhost:5432/tribultz")
+engine = create_engine(DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_ULID_BASE = "01J8ZM7WVX2Q9RKTHB3F6D5A"  # 24 chars; sufixo de 2 completa o ULID
+_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def _ulid(n: int) -> str:
+    return _ULID_BASE + _ALPHABET[n // 32] + _ALPHABET[n % 32]
+
+
+T0 = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(name="tenant_id")
+def tenant_fixture(session):
+    tenant = Tenant(name=f"Tenant QA {uuid.uuid4().hex[:6]}", slug=f"tenant-qa-{uuid.uuid4()}")
+    session.add(tenant)
+    session.flush()
+    return tenant.id
+
+
+def _event(n=0, *, lead="lead-sintetico-001", email="pessoa.sintetica@example.test",
+           linkedin=None, occurred=T0, reason="positive_reply") -> HandoffEvent:
+    person_kwargs = {"full_name": "Pessoa Sintética [QA]"}
+    if email:
+        person_kwargs["email"] = MaybeStr.known(email)
+    if linkedin:
+        person_kwargs["linkedin_url"] = MaybeStr.known(linkedin)
+    return HandoffEvent(
+        event_id=_ulid(n),
+        occurred_at=occurred,
+        external_lead_id=lead,
+        person=PersonIdentityPayload(**person_kwargs),
+        company=CompanyIdentityPayload(name=MaybeStr.known("Empresa Sintética QA Ltda")),
+        reason=reason,
+    )
+
+
+def test_caminho_feliz_um_evento_um_handoff(session, tenant_id):
+    result = ingest_handoff_event(session, tenant_id, _event(0))
+    assert result.status == "applied" and result.detail == "transitioned"
+    assert result.link.ownership_state == "HANDOFF_REQUESTED"
+    assert result.link.automation_state == "SUPPRESSION_REQUESTED"
+    assert result.link.person_identity_id is not None
+    assert result.ledger.applied_at is not None
+    assert outbound_allowed(session, result.link)[0] is False
+    # espelho DEC-5 na lista dura de supressão
+    assert (
+        session.query(ProspectSuppression)
+        .filter(ProspectSuppression.email == "pessoa.sintetica@example.test")
+        .count()
+        == 1
+    )
+
+
+def test_replay_n_vezes_produz_um_unico_handoff(session, tenant_id):
+    first = ingest_handoff_event(session, tenant_id, _event(1))
+    for _ in range(3):
+        dup = ingest_handoff_event(session, tenant_id, _event(1))
+        assert dup.status == "duplicate" and dup.detail == "duplicate"
+    session.flush()
+    assert dup.ledger.id == first.ledger.id
+    assert dup.ledger.attempts == 4
+    # efeitos únicos: 1 linha de ledger, 1 transição de ownership, 1 supressão
+    assert session.query(CrmLeadEvent).filter_by(tenant_id=tenant_id).count() == 1
+    transitions = (
+        session.query(CrmStateTransition)
+        .filter_by(lead_link_id=first.link.id, axis="ownership")
+        .count()
+    )
+    assert transitions == 1
+    assert (
+        session.query(ProspectSuppression)
+        .filter(ProspectSuppression.email == "pessoa.sintetica@example.test")
+        .count()
+        == 1
+    )
+
+
+def test_mesmo_evento_payload_divergente_e_sinalizado(session, tenant_id):
+    ingest_handoff_event(session, tenant_id, _event(2))
+    divergente = ingest_handoff_event(session, tenant_id, _event(2, reason="manual_flag"))
+    assert divergente.status == "duplicate"
+    assert divergente.detail == "duplicate_divergent"
+    assert divergente.ledger.processing_result["divergent_payload_hashes"]
+
+
+def test_evento_atrasado_nao_regride(session, tenant_id):
+    novo = ingest_handoff_event(session, tenant_id, _event(3, occurred=T0))
+    atrasado = ingest_handoff_event(
+        session, tenant_id, _event(4, occurred=T0 - timedelta(hours=2))
+    )
+    assert atrasado.status == "superseded" and atrasado.detail == "out_of_order"
+    assert novo.link.ownership_state == "HANDOFF_REQUESTED"
+    assert novo.link.last_applied_event_id == novo.ledger.id  # o atrasado não vira "último"
+
+
+def test_minimo_ausente_vai_para_quarentena_sem_link(session, tenant_id):
+    sem_chave = _event(5, email=None)
+    result = ingest_handoff_event(session, tenant_id, sem_chave)
+    assert result.status == "quarantined"
+    assert result.link is None
+    assert session.query(CrmLeadLink).filter_by(tenant_id=tenant_id).count() == 0
+    assert result.ledger.processing_result == {"detail": "identity_minimum_missing"}
+
+
+def test_dec5_nova_campanha_novo_lead_mesma_pessoa(session, tenant_id):
+    """Concorrência da campanha §11: handoff.requested × novo external_lead_id."""
+    ingest_handoff_event(session, tenant_id, _event(6, lead="lead-campanha-A"))
+    segundo = ingest_handoff_event(
+        session, tenant_id,
+        _event(7, lead="lead-campanha-B", occurred=T0 + timedelta(minutes=5)),
+    )
+    # o novo lead ganha seu próprio handoff (sinal real), e a pessoa segue protegida
+    assert segundo.status == "applied"
+    links = session.query(CrmLeadLink).filter_by(tenant_id=tenant_id).all()
+    assert len(links) == 2
+    assert len({link.person_identity_id for link in links}) == 1  # mesma pessoa
+    for link in links:
+        assert outbound_allowed(session, link)[0] is False
+
+
+def test_conflito_de_identidade_via_evento(session, tenant_id):
+    ingest_handoff_event(
+        session, tenant_id,
+        _event(8, lead="lead-a", email="pessoa.a@example.test", linkedin="in/pessoa-a-qa"),
+    )
+    ingest_handoff_event(
+        session, tenant_id,
+        _event(9, lead="lead-b", email="pessoa.b@example.test", linkedin="in/pessoa-b-qa",
+               occurred=T0 + timedelta(minutes=1)),
+    )
+    conflitante = ingest_handoff_event(
+        session, tenant_id,
+        _event(10, lead="lead-c", email="pessoa.a@example.test", linkedin="in/pessoa-b-qa",
+               occurred=T0 + timedelta(minutes=2)),
+    )
+    assert conflitante.status == "applied"
+    assert conflitante.link.identity_conflict is True
+    assert conflitante.link.person_identity_id is None  # sem merge silencioso
+    assert outbound_allowed(session, conflitante.link) == (False, "identity_conflict")
+
+
+def test_corrida_unique_constraint_decide(session, tenant_id):
+    result = ingest_handoff_event(session, tenant_id, _event(11))
+    clone = CrmLeadEvent(
+        tenant_id=tenant_id,
+        source_system="rumy",
+        external_lead_id="lead-sintetico-001",
+        idempotency_key=result.ledger.idempotency_key,
+        schema_version="1.1",
+        event_type="handoff.requested",
+        payload_hash="deadbeef",
+    )
+    with pytest.raises(IntegrityError):
+        with session.begin_nested():
+            session.add(clone)
+            session.flush()
+    # o vencedor permanece íntegro
+    assert session.query(CrmLeadEvent).filter_by(
+        idempotency_key=result.ledger.idempotency_key
+    ).count() == 1
+
+
+def test_closed_nao_reabre_por_evento_de_provedor(session, tenant_id):
+    primeiro = ingest_handoff_event(session, tenant_id, _event(12))
+    primeiro.link.ownership_state = "CLOSED"
+    session.flush()
+    sinal = ingest_handoff_event(
+        session, tenant_id, _event(13, occurred=T0 + timedelta(hours=1))
+    )
+    assert sinal.status == "applied" and sinal.detail == "closed_requires_human"
+    assert sinal.link.ownership_state == "CLOSED"
+
+
+def test_metrics_nao_declara_zero_sem_instrumento(session, tenant_id):
+    """Round 4 §5: ausência de evidência ≠ zero."""
+    ingest_handoff_event(session, tenant_id, _event(14))
+    snap = local_snapshot(session, tenant_id)
+    assert snap["links_by_ownership"] == {"HANDOFF_REQUESTED": 1}
+    assert snap["protected_persons"] == 1
+    assert "UNOBSERVABLE" in snap["rumy_send_after_block"]


### PR DESCRIPTION
Implementa o que o **Round 4** (Ermes, 12/08/2026) autorizou — e nada além:

## F1 — Persistência
4 tabelas: `crm_person_identities` (DEC-5), `crm_lead_links` (estado corrente; eixos ownership/automation), `crm_lead_events` (ledger append-only + dedupe), `crm_state_transitions` (auditoria). Identidade lógica `(tenant_id, source_system, external_lead_id)`. **Rollback validado**: `alembic upgrade head → downgrade -1 → upgrade head` limpo (4 tabelas criadas → removidas → recriadas).

## F3 — Domínio local
- **Ownership** `AUTOMATED→HANDOFF_REQUESTED→HUMAN_OWNED→RELEASED→(re-arme)→AUTOMATED` + `CLOSED`; timeout de SLA **escala, nunca devolve ao bot**; `HUMAN_OWNED→AUTOMATED` direto proibido.
- **Dupla trava** (§11): `RELEASED ≠ AUTOMATED` — re-arme sem `suppression_lift_confirmed` mantém outbound bloqueado.
- **DEC-1**: supressão local começa em `HANDOFF_REQUESTED`.
- **DEC-5**: proteção por PESSOA (resolução determinística e-mail/LinkedIn; conflito = fail-safe sem merge; novo `external_lead_id` herda proteção) + espelho na lista dura `ProspectSuppression` (defesa em profundidade no pipeline de lote existente).
- Contrato `HandoffEvent` v1.1 (known/absent explícito; ULID; sem strings vazias) + **interface** do adapter (F2 definitivo BLOQUEADO até payload real — sem ficção).
- Ingestão idempotente: replay N× ⇒ 1 handoff; payload divergente sinalizado; fora-de-ordem ⇒ `superseded`; sem mínimo ⇒ quarentena; corrida decidida por UNIQUE.
- SLA de dois relógios (`time_to_accept` ≤4h úteis / `time_to_human_action`; 'assumir' não conta como ação).
- Métricas locais — `rumy_send_after_block` reportada **UNOBSERVABLE** sem instrumento (§5: ausência de evidência ≠ zero).

## Zero efeito externo (gate do Round)
Nenhum router/task registrado; nenhum import em runtime; flags novas **OFF por padrão** (`RUMY_WEBHOOK_ENABLED`, `HANDOFF_APPLY_ENABLED`, `RUMY_SUPPRESSION_ENABLED`); desligar flag nunca re-permite outbound; nenhuma escrita em Attio/Rumy; Edgard/Rödl fora — dados de teste 100% sintéticos.

## Gates
- pytest: **1053 passed** (45 novos), zero regressão
- ruff: limpo · auditoria arquitetural: nenhum achado

Round 4 §2: F1+F3 autorizadas; F2 bloqueado (só interface/fixtures); F4/F5 não autorizadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)